### PR TITLE
Frame-time readout, per-platform frame capture, and a seed matrix

### DIFF
--- a/.github/workflows/bench-baselines.yml
+++ b/.github/workflows/bench-baselines.yml
@@ -4,12 +4,33 @@ name: Benchmark baselines
 # all three platforms and uploads criterion's estimates as artifacts.
 # Hosted-runner numbers are indicative only; authoritative budgets are
 # measured on the recorded reference machine.
+#
+# The suite measures pieces of the engine in isolation. The second half
+# of this workflow measures the whole sample end to end — the frame time
+# a player would actually feel — through the same
+# command a human would type to run it. Two different kinds of number,
+# uploaded as two different artifacts, and never to be compared with
+# each other: see the profile note on the sample run below.
 
 on:
   workflow_dispatch:
 
 permissions:
   contents: read
+
+env:
+  # One frame count for every platform, written once. Baselines taken
+  # over different numbers of frames are not comparable, and three
+  # copies of the same literal is exactly how they drift apart.
+  #
+  # Five times the sample's own 600-frame default, which its source
+  # calls long enough for a summary to mean something. The summary is a
+  # count/min/max/sum over the run, so the headline figure is a mean:
+  # more frames cost seconds here and buy a mean that moves less
+  # between dispatches. Length also dilutes the warm-up — the first
+  # frames pay for the driver's lazy initialization and are included in
+  # the summary, so they own `max_ns` on nearly every run.
+  BASELINE_FRAMES: "3000"
 
 jobs:
   baselines:
@@ -19,9 +40,41 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        # One script for three platforms; Git Bash is present on the
+        # Windows runners. Without this the Windows cell would need a
+        # second dialect of every line below, which is how three cells
+        # stop running the same measurement.
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # A number with no record of what produced it is not a baseline.
+      # This is what a reader needs months later to decide whether two
+      # dispatches are comparable at all — and the runner labels in the
+      # matrix are `-latest`, so the image moves under us on its own
+      # schedule and this file is how anyone notices.
+      #
+      # Written before the benchmarks so the upload below has something
+      # to carry even when a later step fails.
+      - name: Record what produced these numbers
+        run: |
+          mkdir -p target/frame-baseline
+          record="target/frame-baseline/environment-${{ matrix.os }}.txt"
+          {
+            echo "commit: $GITHUB_SHA"
+            echo "runner_label: ${{ matrix.os }}"
+            echo "runner_os: $RUNNER_OS"
+            echo "runner_arch: $RUNNER_ARCH"
+            echo "runner_image: ${ImageOS:-unknown}"
+            echo "uname: $(uname -sm)"
+            echo "frames: $BASELINE_FRAMES"
+            echo "sample_profile: dev (unoptimized)"
+            rustc --version
+            cargo --version
+          } > "$record"
+          cat "$record"
       - name: Run benchmarks
         run: cargo bench --workspace
       - name: Upload criterion estimates
@@ -29,4 +82,176 @@ jobs:
         with:
           name: criterion-${{ matrix.os }}
           path: target/criterion/**/new/estimates.json
+          if-no-files-found: error
+      # The only platform where this repository can put a Vulkan
+      # implementation on a GPU-less runner: the pinned lavapipe stack
+      # the rendering lane already uses, fetched by checksum so the
+      # rasterizer under the numbers cannot change without someone
+      # editing a pin. It also fixes the rasterizer's thread count,
+      # which would otherwise follow the runner's core count.
+      #
+      # Deliberately after the benchmark steps, not with the other
+      # setup: this action exports a library path and a set of loader
+      # variables, and the criterion half of this workflow must run in
+      # exactly the environment it ran in before the sample half
+      # existed. Nothing in the bench suite touches the renderer, so
+      # there is nothing to gain by installing it earlier and a
+      # baseline's worth of doubt to lose.
+      - name: Install the pinned software Vulkan stack
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/software-vulkan
+      # The exit criterion's actual number: the sample's own frame time,
+      # measured end to end through the command the roadmap names rather
+      # than through a harness built for this workflow. What CI runs and
+      # what a human runs stay the same thing.
+      #
+      # These are dev-profile numbers. Starting a sample through the
+      # workspace runner is the canonical path and it has no release
+      # mode, so the sample builds unoptimized while `cargo bench` above
+      # measured optimized code. That makes the two artifacts from one
+      # cell incomparable with each other, and it makes this figure a
+      # tracking baseline — did the sample's frame time move between
+      # commits on the same runner — not a statement of what the engine
+      # can do. Teaching the runner a release mode would change the
+      # number recorded here, so it belongs in a deliberate change to
+      # that tool rather than in a flag smuggled in on this line.
+      #
+      # Strict on Linux only, and that asymmetry is the honest part of
+      # this workflow. Strictness turns "no GPU runtime here" from a
+      # skip into a failure, which is right on the one platform where
+      # the step above guarantees a rasterizer: a Linux cell that skips
+      # means the pinned stack broke, and it has to go red rather than
+      # upload a file that says nothing.
+      #
+      # Neither of the other two runners can render this. They have no
+      # GPU, the Windows images carry no Vulkan driver, and macOS has no
+      # Vulkan at all — its native API is Metal, and Vulkan there means
+      # MoltenVK, which is not installed. The sample reports that as a
+      # skip and exits zero without writing a stats file, so those cells
+      # upload their log and their environment record and nothing else.
+      # That is the intended outcome: an artifact saying "not measured
+      # here, and here is the machine's own reason" is worth having,
+      # while a stats file conjured some other way would look exactly
+      # like the Linux one and mean something entirely different.
+      #
+      # Turning either into a real measurement is a dependency decision,
+      # not an edit to this file: it needs a pinned, checksum-verified
+      # Vulkan implementation for that platform — a Windows lavapipe
+      # build, or MoltenVK plus a loader on macOS — added the way the
+      # Linux stack was, as one reviewed pin point. Until someone makes
+      # that call, the frame-time baseline is met on Linux and honestly
+      # recorded as unmet on the other two. If a future runner image
+      # does bring a usable Vulkan driver, the run produces a stats file
+      # and it is uploaded with no change here; if it brings one the
+      # sample cannot use, the cell goes red with the reason in the log
+      # instead of quietly passing.
+      - name: Run the headless sample and dump its frame stats
+        env:
+          RENEW_FRAME_STRICT: ${{ runner.os == 'Linux' && '1' || '' }}
+        run: |
+          stats="target/frame-baseline/hello_triangle-${{ matrix.os }}.json"
+          log="target/frame-baseline/hello_triangle-${{ matrix.os }}.log"
+          # Both streams into the log: the digest line and the skip line
+          # go to stdout, a failure explains itself on stderr, and which
+          # of the three happened is the entire content of this artifact
+          # on a platform that cannot render. `tee` keeps it on the
+          # console too, where whoever dispatched the run is already
+          # looking. This shell stops on a failed pipeline, so a real
+          # failure still reddens the cell instead of being swallowed by
+          # tee's exit code.
+          cargo run --package renew-cli --bin renew -- \
+            run hello_triangle --headless --frames "$BASELINE_FRAMES" \
+            --dump-stats "$stats" 2>&1 | tee "$log"
+          if [ "$RUNNER_OS" = Linux ]; then
+            # A file that exists is not a measurement. The timing
+            # section is the thing this dispatch exists to produce, and
+            # a truncated or empty dump has to redden the cell rather
+            # than ride out as an artifact somebody trusts.
+            grep -q '"timing"' "$stats"
+          fi
+      # The headline number where a human sees it without downloading
+      # anything, and — on the platforms that skipped — the machine's
+      # own sentence explaining why there is no number.
+      - name: Summarize the frame-time baseline
+        if: always()
+        run: |
+          stats="target/frame-baseline/hello_triangle-${{ matrix.os }}.json"
+          log="target/frame-baseline/hello_triangle-${{ matrix.os }}.log"
+          echo "### Frame-time baseline — ${{ matrix.os }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$stats" ]; then
+            # Read out of the dump rather than recomputed, so the
+            # summary a human reads and the artifact they download are
+            # the same numbers.
+            #
+            # Every field is then checked right here, in the step's own
+            # shell. A helper function reads better and does not work: a
+            # command that fails inside a command substitution does not
+            # stop the step, it just hands back an empty string, and an
+            # empty cell in the table below reads as a zero rather than
+            # as a mistake. This shape check is the only thing standing
+            # between a renamed field in the dump and a summary that
+            # quietly reports nothing.
+            count=$(grep -o '"count":[0-9]\{1,\}' "$stats" | head -n 1 | cut -d: -f2 || true)
+            sum=$(grep -o '"sum_ns":[0-9]\{1,\}' "$stats" | head -n 1 | cut -d: -f2 || true)
+            min=$(grep -o '"min_ns":[0-9]\{1,\}' "$stats" | head -n 1 | cut -d: -f2 || true)
+            max=$(grep -o '"max_ns":[0-9]\{1,\}' "$stats" | head -n 1 | cut -d: -f2 || true)
+            for pair in "count=$count" "sum_ns=$sum" "min_ns=$min" "max_ns=$max"; do
+              case "${pair#*=}" in
+                "" | *[!0-9]*)
+                  echo "::error::no numeric ${pair%%=*} in $stats — the dump's shape changed and this summary is reading a document the sample no longer writes"
+                  exit 1
+                  ;;
+              esac
+            done
+            # Zero frames would divide by zero below, and a run that
+            # measured nothing is not a baseline whatever it reports.
+            if [ "$count" -eq 0 ]; then
+              echo "::error::$stats reports zero measured frames"
+              exit 1
+            fi
+            # Integer microseconds, computed in the shell: no awk, no
+            # locale, nothing that could format the number differently
+            # on one of the three platforms. Exact nanoseconds are in
+            # the artifact for anyone who needs them.
+            {
+              echo
+              echo "| frames | mean | min | max |"
+              echo "| --- | --- | --- | --- |"
+              echo "| $count | $((sum / count / 1000)) us | $((min / 1000)) us | $((max / 1000)) us |"
+              echo
+              # No claim about which adapter drew this: the dump does
+              # not name one, and "software rasterizer" would be a guess
+              # that happens to be true on today's Linux runner and
+              # false the day any of these machines grows a GPU. The
+              # environment record in the artifact is where provenance
+              # lives.
+              echo "Unoptimized build. Tracking baseline, not a budget."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo
+              echo "Not measured on this runner — no stats file was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+            # The sample's own sentence, not this file's paraphrase of
+            # it. Absent when the run never got to start — an earlier
+            # step failed — which is a different story and must not be
+            # told as though the platform were the reason.
+            grep -m1 '^SKIP: ' "$log" >> "$GITHUB_STEP_SUMMARY" ||
+              echo "No skip line either: the run may not have started. Read the job log." >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # Uploaded even when the run failed: a red cell's log is the most
+      # interesting thing this workflow produces, and on the two
+      # platforms that cannot render it is the only thing. Every file
+      # carries the runner label in its name so three downloaded
+      # artifacts can be unpacked side by side without colliding.
+      - name: Upload the sample frame-time baseline
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frame-baseline-${{ matrix.os }}
+          path: target/frame-baseline/
+          # The environment record is written before the benchmarks, so
+          # an empty directory here means the job never reached that
+          # step — worth failing on, rather than publishing an empty zip
+          # named like a result.
           if-no-files-found: error

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -47,10 +47,10 @@ reason = "A release-mode refusal guarded by a debug assertion on the same condit
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [389, 390]
+lines = [413, 414]
 reason = "Translates a windowing event whose payload type has no public constructor in the pinned windowing crate, so the input cannot be built outside it. The translation logic itself is covered directly through the helper it delegates to. Note for local runs: on a machine with a live desktop, a stray keyboard event can reach the window smoke test's real window and cover line 390, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [682]
+lines = [706]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -17,7 +17,9 @@ seam.
   keyboard/mouse input behind an engine-only vocabulary: the OS owns
   the loop, a `WindowApp` receives translated events and drives exit
   and redraws (`WindowApp` is the manifest's `window-app` extension
-  point), and no windowing-library type crosses the boundary.
+  point), and no windowing-library type crosses the boundary. The
+  window's title can be changed after creation, which is how a sample
+  puts a live number where a person can see it without a text renderer.
   Headless builds disable default features and compile the entire
   windowing stack out; headless environments at runtime get a
   recoverable `LoopUnavailable`. The loop runs on the main thread only

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -165,6 +165,30 @@ pub struct NativeWindow {
     window: std::sync::Arc<winit::window::Window>,
 }
 
+impl NativeWindow {
+    /// Relabel the window's title bar.
+    ///
+    /// The engine renders no text yet, so the title bar is the only
+    /// surface an application has for a running measurement — a real and
+    /// conventional one, visible in the task switcher as well as on the
+    /// window.
+    ///
+    /// MAIN THREAD ONLY, like everything else that touches a window.
+    ///
+    /// Ownership: `title` is borrowed for the duration of the call and
+    /// copied into whatever representation the OS keeps; nothing here
+    /// retains the string, and no allocation of the engine's survives
+    /// the call.
+    ///
+    /// Cost: one OS call, which on some platforms round-trips to a
+    /// window manager. Callers relabel on an interval, never once a
+    /// frame — a title that changes faster than it can be read is
+    /// unreadable anyway.
+    pub fn set_title(&self, title: &str) {
+        self.window.set_title(title);
+    }
+}
+
 impl raw_window_handle::HasDisplayHandle for NativeWindow {
     fn display_handle(
         &self,

--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -37,6 +37,7 @@ stats.absorb(&plan);
   it is the only place a live window exists), then `event` and `update`
   every iteration. The one clock read on the path is at the top of
   `update`; rendering happens on `RedrawRequested` and nowhere else.
+  The title bar carries the frame-time readout (below).
 - **Headless** (`--headless`): no window, no clock in the schedule. Time
   is synthetic — frame *k* happens at exactly `k × 16 666 667 ns` — so
   one step runs per frame and the whole run is a pure function of
@@ -76,6 +77,43 @@ lives in `timing` and is recorded, never gated.
 Exit codes: `0` for a completed run or a skip, `1` for a failure, `2`
 for a command line this build cannot honour.
 
+## The frame-time readout
+
+A windowed run shows its own cost in the title bar:
+
+```console
+renew — hello triangle — 16.67 ms (60.0 fps)
+```
+
+The engine renders no text yet, and a text renderer is a long way off,
+so the title bar is the honest first version of "on
+screen" — a real and conventional place for a sample to show a
+measurement, and one that is visible in the task switcher too.
+
+- **The number is a mean over the last quarter second**, not over the
+  run and not the last frame alone. A run average stops moving after a
+  few seconds, which is exactly when a hitch starts being interesting;
+  a single frame is noise. Four relabels a second is as fast as a
+  changing number can still be read, and it keeps the OS call down to
+  roughly one frame in fifteen instead of one per frame.
+- **The first frame is labelled immediately**, so a short run still
+  shows a number and a window does not sit blank for a quarter second
+  looking broken.
+- **It reads no clock of its own.** The interval is measured with the
+  instant `update` already took for the frame loop; there is one time
+  source in this sample and the readout is not a second one.
+- **It allocates nothing.** The text is written into a fixed-capacity
+  buffer the readout owns and handed to the window seam borrowed — a
+  `format!` per frame would break the steady-state allocation gate.
+- Both numbers round to nearest rather than down, because 60 Hz is
+  16 666 667 ns and truncation would report it as 16.66 ms at 59.9 fps.
+  A frame too fast for the clock to resolve reads `-- fps`: no rate
+  divides out of no elapsed time, and inventing one would put the only
+  lie on the window.
+
+Headless runs have no window and no readout; their frame times live in
+the `timing` section of `--dump-stats` and nowhere else.
+
 ## Contract
 
 - **`--headless` implies a synthetic time source.** Nothing measured
@@ -89,11 +127,12 @@ for a command line this build cannot honour.
   hash a cross-platform promise the engine does not make. If the
   triangle ever spins, the angle is a tick count and the trig happens in
   the shader — render, not simulation.
-- **Steady state is frames `[3, N)` of a headless run** (§10).
-  Everything that allocates happens before frame zero: device, target,
-  pipeline, and the readback buffer. Inside the boundary there is no
-  file I/O, no logging, no formatting and no serialization —
-  `--dump-stats` writes after the loop exits.
+- **Steady state is frames `[3, N)` of a headless run, and it allocates
+  nothing.** Everything that allocates happens before frame zero:
+  device, target, pipeline, and the readback buffer. Inside the boundary
+  there is no file I/O, no logging and no serialization —
+  `--dump-stats` writes after the loop exits — and the one thing that
+  formats text, the title readout, formats into a buffer it owns.
 - **An environment that cannot host the run is a skip, not a failure.**
   No GPU runtime and no display server are ordinary answers on ordinary
   machines: the binary prints `SKIP:` and exits zero. Set
@@ -132,8 +171,11 @@ why.
 |---|---|
 | `tests/headless_frame.rs` | The readback holds the colour the world computed for the last tick; one more step is a different image; the triangle covers the middle and one tick drawn twice is the same bytes. |
 | `tests/cli_determinism.rs` | Three separate processes print one digest line; a different frame count or seed prints a different one; the stats file agrees with it. |
-| `tests/zero_alloc.rs` | The steady-state frame path performs no heap allocation. |
+| `tests/zero_alloc.rs` | The steady-state frame path performs no heap allocation, and neither does the title readout. |
 
 The unit tests beside the source drive the window callbacks directly —
 `event`, `update`, the draw and stall verdicts — with no window at all.
-Only `ready` needs one, because it borrows a live OS window.
+Only `ready` needs one, because it borrows a live OS window. The
+readout's text is a pure function of two numbers, so it is tested
+directly at both ends of the range: a frame too fast for the clock to
+resolve, and one of `u64::MAX` nanoseconds.

--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -11,7 +11,7 @@ cargo run -p renew-sample-hello-triangle --bin hello_triangle -- --headless --fr
 
 ```console
 $ cargo run -p renew-sample-hello-triangle --bin hello_triangle -- --headless --frames 600
-renew-frame sample=hello_triangle seed=0 frames=600 ticks=600 dropped=0 schedule_hash=0xefc2181bbc0d588d state_hash=0x00f10d96fc295d99
+renew-frame sample=hello_triangle seed=0 frames=600 ticks=600 dropped=0 schedule_hash=0xefc2181bbc0d588d state_hash=0x5d3ec02c32278af9
 ```
 
 That line is the same on every run, in every process, and in a build
@@ -62,7 +62,11 @@ ritual: run one step too many and the bytes change.
 Two output channels, on purpose. Stdout carries exactly one line — the
 digest line above, which the cross-process determinism gate
 string-compares, needing no JSON parser and staying readable in a CI
-log. `--dump-stats` carries the machine-readable document:
+log. The state hash in that line fingerprints behaviour only — the
+seed is deliberately not folded in, so two seeds hash alike exactly
+when they move the world alike, and the matrix comparing them is
+measuring the simulation rather than the arithmetic of the hash.
+ `--dump-stats` carries the machine-readable document:
 
 ```json
 {"schema_version":1,"sample":"hello_triangle","seed":0,
@@ -170,7 +174,7 @@ why.
 | File | What it proves |
 |---|---|
 | `tests/headless_frame.rs` | The readback holds the colour the world computed for the last tick; one more step is a different image; the triangle covers the middle and one tick drawn twice is the same bytes. |
-| `tests/cli_determinism.rs` | Three separate processes print one digest line; a different frame count or seed prints a different one; the stats file agrees with it. |
+| `tests/cli_determinism.rs` | Three separate processes print one digest line; a different frame count or seed prints a different one; four seeds each reproduce themselves and none of them hash alike; the stats file agrees with the line. |
 | `tests/zero_alloc.rs` | The steady-state frame path performs no heap allocation, and neither does the title readout. |
 
 The unit tests beside the source drive the window callbacks directly —

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -30,11 +30,13 @@
 //!   the state hash a cross-platform promise the engine does not make.
 //!   If the triangle ever spins, the angle is a tick count and the trig
 //!   happens in the shader — render, not simulation.
-//! - **Steady state is frames `[3, N)`** (§10). Everything that
-//!   allocates happens before frame zero: device, target, pipeline, and
-//!   the readback buffer. No file I/O, no logging, no formatting and no
-//!   serialization happens inside the loop — `--dump-stats` writes after
-//!   it exits.
+//! - **Steady state is frames `[3, N)`, and it allocates nothing.**
+//!   Everything that allocates happens before frame zero: device,
+//!   target, pipeline, and the readback buffer. No file I/O, no logging
+//!   and no serialization happens inside the loop — `--dump-stats`
+//!   writes after it exits — and the one thing on the frame path that
+//!   formats text, the window-title readout, formats into a buffer it
+//!   owns.
 //! - **An environment that cannot host the run is a skip, not a
 //!   failure.** No GPU runtime and no display server are ordinary
 //!   answers on ordinary machines; the binary says `SKIP:` and exits
@@ -46,6 +48,8 @@ use std::process::ExitCode;
 mod cli;
 mod error;
 mod offscreen;
+#[cfg(feature = "window")]
+mod readout;
 mod render;
 #[cfg(feature = "window")]
 mod windowed;
@@ -54,6 +58,8 @@ mod world;
 pub use cli::{DEFAULT_FRAMES, Options, Report, SAMPLE, USAGE, parse_args};
 pub use error::SampleError;
 pub use offscreen::{Draw, EXTENT, HeadlessRun, WARMUP_FRAMES};
+#[cfg(feature = "window")]
+pub use readout::Readout;
 pub use render::{Surface, clear_color};
 pub use world::World;
 

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -34,7 +34,7 @@ pub const EXTENT: Extent = Extent {
 /// what makes a wrong one obvious.
 const FRAME_INTERVAL_NS: u64 = Timestep::HZ_60.nanos().get();
 
-/// Frames whose cost is not part of the steady state (§10): a driver's
+/// Frames whose cost is not part of the steady state: a driver's
 /// lazy initialization lands in the first frames it renders. Everything
 /// that allocates — device, target, pipeline, the readback buffer —
 /// happens before frame zero, so the steady state is frames

--- a/samples/hello_triangle/src/readout.rs
+++ b/samples/hello_triangle/src/readout.rs
@@ -1,0 +1,375 @@
+//! The on-screen frame-time readout: the window's title bar.
+//!
+//! The engine renders no text, and a text renderer is a long way off, so
+//! the honest first version of "on screen" is the
+//! title — where samples have always shown a frame counter, and where it
+//! is visible in the task switcher as well as on the window itself.
+//!
+//! Two properties shape everything here, and an innocent-looking edit
+//! loses either of them.
+//!
+//! - **Nothing on this path allocates.** The steady frame path is proven
+//!   heap-silent by `tests/zero_alloc.rs`, and a `format!` per frame
+//!   would be the easiest way to break that. The text is written into a
+//!   fixed-capacity buffer the readout owns and handed out borrowed —
+//!   the same shape the diagnostics crate asks its sinks for.
+//! - **The interval comes from the frame loop's own timestamps.** The
+//!   caller already reads the clock once per iteration and hands that
+//!   instant over. Reading a wall clock here to decide whether to
+//!   relabel a window would put a second time source in a sample that
+//!   deliberately has one, and it would make the readout untestable
+//!   without waiting real seconds.
+
+use core::fmt;
+use core::fmt::Write as _;
+
+use renew_frame::{Nanos, Timestamp};
+
+/// How often the title is relabelled: four times a second.
+///
+/// Two costs pull in opposite directions and this sits between them. Any
+/// faster and the digits are unreadable — a number that changes sixty
+/// times a second is a blur, and the value anyone actually quotes is the
+/// one that stood still long enough to read. Any slower and the readout
+/// stops answering the question it exists for, which is what the machine
+/// is doing *now*. A quarter second also makes the cost of the OS call
+/// disappear: one relabel per fifteen frames at 60 Hz, against one per
+/// frame for the naive version.
+pub const INTERVAL: Nanos = Nanos::from_nanos(250_000_000);
+
+/// Capacity of the title buffer.
+///
+/// The longest reading this can produce is 68 bytes: a 24-byte prefix,
+/// the millisecond count for a `u64::MAX` frame (14 digits and two
+/// decimals), and the rate for a one-nanosecond frame (ten digits and
+/// one decimal) — and those two extremes cannot occur together. Double
+/// that, so a longer sample title does not quietly push the readout into
+/// refusing to draw at all.
+const CAPACITY: usize = 128;
+
+/// A fixed-capacity text buffer: format into it, borrow the result, reuse
+/// it next time, never touch the heap.
+///
+/// The capacity is a type parameter rather than a constant so that the
+/// refusal below is reachable from a test holding a deliberately tiny
+/// buffer. A branch nothing can execute is a branch nobody has checked.
+struct Text<const N: usize> {
+    bytes: [u8; N],
+    length: usize,
+}
+
+impl<const N: usize> Text<N> {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; N],
+            length: 0,
+        }
+    }
+
+    /// Discard what was written; the next format starts from the front.
+    fn clear(&mut self) {
+        self.length = 0;
+    }
+
+    /// What has been written so far.
+    fn as_str(&self) -> &str {
+        // Every byte here arrived as a whole `&str` that fitted, so the
+        // slice is valid text by construction — but reading bytes back
+        // as text is a checked conversion in safe code, and this crate
+        // has no unsafe. An empty title is the harmless answer if the
+        // construction argument above were ever broken.
+        core::str::from_utf8(&self.bytes[..self.length]).unwrap_or("")
+    }
+}
+
+impl<const N: usize> fmt::Write for Text<N> {
+    fn write_str(&mut self, text: &str) -> fmt::Result {
+        let bytes = text.as_bytes();
+        let end = self.length.saturating_add(bytes.len());
+        if end > N {
+            // All or nothing per piece: a piece accepted halfway could
+            // split a multi-byte character and leave the buffer holding
+            // something that is not text.
+            return Err(fmt::Error);
+        }
+        self.bytes[self.length..end].copy_from_slice(bytes);
+        self.length = end;
+        Ok(())
+    }
+}
+
+/// A frame cost in milliseconds, to two decimals.
+struct Millis(Nanos);
+
+impl fmt::Display for Millis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Integer arithmetic, like every other duration in this tree: a
+        // hundredth of a millisecond is 10 000 ns, and adding half of
+        // one before dividing rounds to nearest instead of always down,
+        // so a 16 666 667 ns frame reads 16.67 ms and not 16.66.
+        let hundredths = self.0.get().saturating_add(5_000) / 10_000;
+        write!(f, "{}.{:02}", hundredths / 100, hundredths % 100)
+    }
+}
+
+/// The frame rate a mean frame cost implies, to one decimal.
+struct Rate(Nanos);
+
+impl fmt::Display for Rate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let nanos = self.0.get();
+        if nanos == 0 {
+            // No rate divides out of no elapsed time. A frame too fast
+            // for the clock to resolve is a real reading; a made-up rate
+            // for it would be the only lie on the window.
+            return f.write_str("--");
+        }
+        // Ten billion over the frame cost is tenths of a frame per
+        // second, rounded to nearest by the same half-divisor trick —
+        // without it a 16 666 667 ns frame reads 59.9 fps, because 60 Hz
+        // is not representable in whole nanoseconds.
+        let tenths = 10_000_000_000_u64.saturating_add(nanos / 2) / nanos;
+        write!(f, "{}.{}", tenths / 10, tenths % 10)
+    }
+}
+
+/// Write one reading behind `prefix`, into `out`.
+///
+/// Pure: the same numbers produce the same bytes on every machine and in
+/// every run. `None` means the text did not fit, which is the only way a
+/// fixed buffer fails; the caller then leaves the title as it was rather
+/// than showing half a number.
+fn compose<'a, const N: usize>(out: &'a mut Text<N>, prefix: &str, mean: Nanos) -> Option<&'a str> {
+    out.clear();
+    if write!(out, "{prefix} — {} ms ({} fps)", Millis(mean), Rate(mean)).is_err() {
+        return None;
+    }
+    Some(out.as_str())
+}
+
+/// The window-title readout: what the sample shows, and when.
+pub struct Readout {
+    prefix: &'static str,
+    text: Text<CAPACITY>,
+    /// The current interval's samples, folded in as they arrive.
+    ///
+    /// A boxcar mean over the interval rather than over the whole run:
+    /// a live readout exists to say what the machine is doing now, and a
+    /// run average stops moving after the first few seconds — exactly
+    /// when a hitch starts being interesting. It is also exact integer
+    /// arithmetic, where a decaying average would need a divisor whose
+    /// truncation error accumulates.
+    sum: u64,
+    count: u64,
+    /// When the next relabel falls due, on the frame loop's timeline.
+    due: Timestamp,
+    interval: Nanos,
+}
+
+impl Readout {
+    /// A readout that relabels `prefix` every `interval`, starting with
+    /// the very first frame.
+    ///
+    /// The first frame on purpose: a window whose title says nothing for
+    /// a quarter of a second looks broken, and a run shorter than one
+    /// interval would otherwise never show a number at all.
+    #[must_use]
+    pub const fn new(prefix: &'static str, interval: Nanos) -> Self {
+        Self {
+            prefix,
+            text: Text::new(),
+            sum: 0,
+            count: 0,
+            // Before any instant the loop can hand over, so the first
+            // frame is already due.
+            due: Timestamp::from_nanos(0),
+            interval,
+        }
+    }
+
+    /// Fold one frame's measured CPU cost in, and say what the title
+    /// should read if the interval has elapsed.
+    ///
+    /// `now` is the frame loop's own instant — the one the caller has
+    /// already read — so the readout introduces no second time source.
+    /// `None` is the answer for most frames and means "leave the title
+    /// alone".
+    pub fn record(&mut self, cpu_frame: Nanos, now: Timestamp) -> Option<&str> {
+        self.sum = self.sum.saturating_add(cpu_frame.get());
+        self.count = self.count.saturating_add(1);
+        if now < self.due {
+            return None;
+        }
+        // The divisor is at least one: this frame's sample was folded in
+        // two lines above.
+        let mean = Nanos::from_nanos(self.sum / self.count);
+        self.sum = 0;
+        self.count = 0;
+        self.due = now.saturating_add(self.interval);
+        compose(&mut self.text, self.prefix, mean)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CAPACITY, INTERVAL, Millis, Rate, Readout, Text, compose};
+    use renew_frame::{Nanos, Timestamp};
+
+    fn reading(nanos: u64) -> String {
+        let mut text = Text::<CAPACITY>::new();
+        compose(&mut text, "renew", Nanos::from_nanos(nanos))
+            .expect("the reading fits the buffer")
+            .to_string()
+    }
+
+    #[test]
+    fn a_sixty_hertz_frame_reads_as_the_numbers_people_quote() {
+        // Both halves round to nearest rather than down: 60 Hz is
+        // 16 666 667 ns, which truncation would report as 16.66 ms and
+        // 59.9 fps — two numbers that look like a bug and are not.
+        assert_eq!(reading(16_666_667), "renew — 16.67 ms (60.0 fps)");
+        assert_eq!(reading(33_333_333), "renew — 33.33 ms (30.0 fps)");
+        assert_eq!(reading(1_000_000), "renew — 1.00 ms (1000.0 fps)");
+    }
+
+    /// A frame too fast for the clock to resolve. Nothing divides by
+    /// zero, and the rate says it has no answer rather than inventing
+    /// one.
+    #[test]
+    fn a_zero_frame_time_reports_no_rate_at_all() {
+        assert_eq!(reading(0), "renew — 0.00 ms (-- fps)");
+    }
+
+    /// The other end: a frame so slow that every quantity is near its
+    /// ceiling. Saturating arithmetic keeps it a reading rather than an
+    /// overflow.
+    #[test]
+    fn a_very_slow_frame_still_produces_one_finite_reading() {
+        assert_eq!(reading(u64::MAX), "renew — 18446744073709.55 ms (0.0 fps)");
+        // One whole second, and the digit that separates a hitch from a
+        // freeze.
+        assert_eq!(reading(1_000_000_000), "renew — 1000.00 ms (1.0 fps)");
+        assert_eq!(reading(60_000_000_000), "renew — 60000.00 ms (0.0 fps)");
+    }
+
+    /// The fastest frame the clock can express, which is where the rate
+    /// is largest and the buffer is under the most pressure.
+    #[test]
+    fn a_one_nanosecond_frame_produces_the_widest_rate() {
+        assert_eq!(reading(1), "renew — 0.00 ms (1000000000.0 fps)");
+    }
+
+    #[test]
+    fn the_pieces_format_independently_of_the_line_they_sit_on() {
+        assert_eq!(Millis(Nanos::from_nanos(16_666_667)).to_string(), "16.67");
+        assert_eq!(Millis(Nanos::ZERO).to_string(), "0.00");
+        assert_eq!(Rate(Nanos::from_nanos(16_666_667)).to_string(), "60.0");
+        assert_eq!(Rate(Nanos::ZERO).to_string(), "--");
+    }
+
+    /// A buffer too small refuses rather than showing half a number, and
+    /// stays usable afterwards.
+    #[test]
+    fn a_reading_that_does_not_fit_is_refused_whole() {
+        let mut tiny = Text::<8>::new();
+        assert_eq!(
+            compose(&mut tiny, "renew", Nanos::from_nanos(16_666_667)),
+            None
+        );
+        // Exactly enough room, then one reading too wide for it, then the
+        // first one again: a refusal costs the frame it happened on and
+        // nothing after it.
+        let mut exact = Text::<21>::new();
+        assert_eq!(
+            compose(&mut exact, "", Nanos::ZERO),
+            Some(" — 0.00 ms (-- fps)")
+        );
+        assert_eq!(compose(&mut exact, "", Nanos::from_nanos(16_666_667)), None);
+        assert_eq!(
+            compose(&mut exact, "", Nanos::ZERO),
+            Some(" — 0.00 ms (-- fps)")
+        );
+    }
+
+    #[test]
+    fn the_first_frame_is_labelled_and_the_rest_of_the_interval_is_not() {
+        let mut readout = Readout::new("renew", INTERVAL);
+        let first = readout.record(Nanos::from_nanos(16_666_667), Timestamp::from_nanos(0));
+        assert_eq!(first, Some("renew — 16.67 ms (60.0 fps)"));
+        // Everything inside the interval is folded in silently.
+        for frame in 1..15u64 {
+            let now = Timestamp::from_nanos(frame * 16_666_667);
+            assert_eq!(readout.record(Nanos::from_nanos(16_666_667), now), None);
+        }
+    }
+
+    /// The reading is the mean over the interval that just ended, not
+    /// over the run and not the last frame alone.
+    #[test]
+    fn the_reading_averages_the_interval_that_just_ended() {
+        let interval = Nanos::from_nanos(100);
+        let mut readout = Readout::new("renew", interval);
+        // The first frame is due immediately and reports itself.
+        assert!(
+            readout
+                .record(Nanos::from_nanos(4_000_000), Timestamp::from_nanos(0))
+                .is_some()
+        );
+        // Two frames inside the interval, averaging 3 ms, and a third at
+        // the deadline that carries the reading.
+        assert_eq!(
+            readout.record(Nanos::from_nanos(2_000_000), Timestamp::from_nanos(40)),
+            None
+        );
+        assert_eq!(
+            readout.record(Nanos::from_nanos(4_000_000), Timestamp::from_nanos(80)),
+            None
+        );
+        assert_eq!(
+            readout.record(Nanos::from_nanos(3_000_000), Timestamp::from_nanos(100)),
+            Some("renew — 3.00 ms (333.3 fps)"),
+            "the mean of the interval, not the run and not the last frame"
+        );
+        // The next interval starts empty: the slow frame above does not
+        // follow the readout around.
+        assert_eq!(
+            readout.record(Nanos::from_nanos(16_666_667), Timestamp::from_nanos(200)),
+            Some("renew — 16.67 ms (60.0 fps)")
+        );
+    }
+
+    /// The number in the source, asserted rather than described, so an
+    /// edit to it makes a liar of the test instead of the comment above
+    /// it.
+    #[test]
+    fn the_relabel_interval_is_a_quarter_of_a_second() {
+        assert_eq!(INTERVAL.get(), 250_000_000);
+    }
+
+    /// Saturating arithmetic all the way down: an interval whose samples
+    /// sum past the end of a `u64` reports the ceiling divided by the
+    /// count, never a wrapped number and never a panic.
+    #[test]
+    fn an_overflowing_accumulator_saturates_instead_of_wrapping() {
+        let mut readout = Readout::new("renew", Nanos::from_nanos(1_000));
+        // The first frame is due immediately; the interval it opens then
+        // banks four saturated frame costs.
+        assert!(
+            readout
+                .record(Nanos::from_nanos(u64::MAX), Timestamp::from_nanos(0))
+                .is_some()
+        );
+        for frame in 1..4u64 {
+            assert_eq!(
+                readout.record(Nanos::from_nanos(u64::MAX), Timestamp::from_nanos(frame)),
+                None
+            );
+        }
+        let expected = reading(u64::MAX / 4);
+        assert_eq!(
+            readout.record(Nanos::from_nanos(u64::MAX), Timestamp::from_nanos(1_000)),
+            Some(expected.as_str()),
+            "four saturated samples average to the ceiling over four"
+        );
+    }
+}

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -28,8 +28,13 @@ use renew_rhi::{
 
 use crate::cli::{Options, Report};
 use crate::error::{SampleError, device_error, pipeline_error, render_error, target_error};
+use crate::readout::{self, Readout};
 use crate::render::{Surface, clear_color};
 use crate::world::World;
+
+/// What the window is called before any measurement exists, and the text
+/// every frame-time reading is appended to.
+const TITLE: &str = "renew — hello triangle";
 
 /// How long a run may go without presenting anything before it is
 /// declared wedged.
@@ -51,7 +56,7 @@ const WEDGE_AFTER: Nanos = Nanos::from_nanos(5_000_000_000);
 pub fn run(options: &Options) -> Result<Report, SampleError> {
     let mut app = TriangleApp::new(options);
     let config = WindowConfig {
-        title: "renew — hello triangle".to_string(),
+        title: TITLE.to_string(),
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
@@ -79,8 +84,17 @@ pub struct TriangleApp {
     world: World,
     stats: FrameStats,
     timing: FrameTiming,
+    /// The on-screen half of the frame-time capture: the window title,
+    /// because the engine renders no text yet. Folds every frame's cost
+    /// in and answers with a new title four times a second.
+    readout: Readout,
     /// Anchored in `ready`, after bring-up.
     frame: Option<FrameLoop>,
+    /// A second handle on the same OS window, kept so the title can be
+    /// relabelled. The renderer owns the one it was given; this one
+    /// costs a reference count and keeps the window seam the only place
+    /// that knows what a window is.
+    window: Option<NativeWindow>,
     device: Option<Device>,
     surface: Option<Surface>,
     pipeline: Option<RenderPipeline>,
@@ -115,7 +129,9 @@ impl TriangleApp {
             world: World::new(options.seed),
             stats: FrameStats::new(),
             timing: FrameTiming::new(),
+            readout: Readout::new(TITLE, readout::INTERVAL),
             frame: None,
+            window: None,
             device: None,
             surface: None,
             pipeline: None,
@@ -296,7 +312,12 @@ impl WindowApp for TriangleApp {
     fn ready(&mut self, window: &WindowRef<'_>) {
         let (width, height) = window.physical_size();
         self.size = Extent { width, height };
-        let outcome = self.bring_up(window.native(), self.size);
+        // Two handles on one window: the renderer consumes one for its
+        // surface, and the readout keeps the other. Cloning is a
+        // reference count, and the window outlives both by construction.
+        let native = window.native();
+        self.window = Some(native.clone());
+        let outcome = self.bring_up(native, self.size);
         self.record(outcome);
         // Anchor AFTER bring-up: device creation costs on the order of
         // a hundred milliseconds, and banking it as frame one would open
@@ -329,10 +350,20 @@ impl WindowApp for TriangleApp {
             // The measured cost of one loop iteration. Nothing sleeps
             // here (the seam polls), so the interval between updates is
             // what the frame cost.
-            self.timing.record(
-                now.saturating_since(self.last_update),
-                self.drawn_since_update,
-            );
+            let cpu = now.saturating_since(self.last_update);
+            self.timing.record(cpu, self.drawn_since_update);
+            // The same number, on the window instead of in the summary
+            // — deliberately the same one, over the same population of
+            // frames (drawn and skipped alike), so the title and
+            // `--dump-stats` can never describe different things. The
+            // readout decides when a relabel is due from `now`, so the
+            // sample never reads a second clock for it, and the OS call
+            // happens four times a second rather than every frame.
+            if let Some(title) = self.readout.record(cpu, now)
+                && let Some(window) = &self.window
+            {
+                window.set_title(title);
+            }
             if self.drawn_since_update {
                 self.last_progress = now;
             }

--- a/samples/hello_triangle/src/world.rs
+++ b/samples/hello_triangle/src/world.rs
@@ -90,11 +90,21 @@ impl World {
     }
 
     /// The run's fingerprint: every step absorbed in order, closed with
-    /// the seed and the final state.
+    /// the final state.
+    ///
+    /// The seed is deliberately NOT absorbed, though it is the obvious
+    /// thing to close with. A digest that absorbs an input cannot be
+    /// used to prove that input had an effect: every seed would produce
+    /// its own digest even if the seed were parsed, printed, and then
+    /// ignored by the simulation entirely. Leaving it out makes the
+    /// digest a fingerprint of BEHAVIOUR, so two seeds that move the
+    /// world differently are told apart on the evidence, and two that
+    /// move it identically are honestly reported as identical. The run's
+    /// configuration is not lost — the digest line and the stats
+    /// document both print the seed beside this number.
     #[must_use]
     pub const fn state_hash(&self) -> u64 {
         self.trace
-            .absorb_u64(self.seed)
             .absorb_u64(self.ticks)
             .absorb_u64(self.value)
             .finish()
@@ -165,7 +175,14 @@ mod tests {
     #[test]
     fn a_different_seed_or_a_different_step_count_changes_the_digest() {
         let base = walk(3, 40).state_hash();
-        assert_ne!(base, walk(4, 40).state_hash(), "the seed is absorbed");
+        // Not because the seed is in the digest — it deliberately is
+        // not — but because these two seeds pick different strides and
+        // so walk to different values.
+        assert_ne!(
+            base,
+            walk(4, 40).state_hash(),
+            "a seed that changes the stride must change the digest"
+        );
         assert_ne!(base, walk(3, 41).state_hash(), "the step count is absorbed");
     }
 

--- a/samples/hello_triangle/tests/cli_determinism.rs
+++ b/samples/hello_triangle/tests/cli_determinism.rs
@@ -92,6 +92,76 @@ fn a_different_run_is_a_different_line() {
     assert_ne!(base, seeded, "another seed must move the digest");
 }
 
+/// The state digest, the part of the line that is about the world
+/// rather than about the schedule.
+fn state_digest(line: &str) -> &str {
+    line.split("state_hash=")
+        .nth(1)
+        .map(|rest| rest.split_whitespace().next().unwrap_or_default())
+        .unwrap_or_default()
+}
+
+/// How many times each seed runs. Three catches a process-to-process
+/// difference on every push; a longer campaign can ask for more without
+/// touching this file.
+fn runs_per_seed() -> usize {
+    std::env::var("RENEW_DETERMINISM_RUNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|runs| *runs >= 2)
+        .unwrap_or(3)
+}
+
+/// The seed matrix: every seed reproduces itself across processes, and
+/// no two seeds move the world the same way.
+///
+/// Identity within a seed is the determinism claim. Distinctness across
+/// seeds is what proves the seed REACHES the simulation — a seed that is
+/// parsed, printed and then ignored satisfies identity perfectly.
+///
+/// That second half only means something because the digest does not
+/// absorb the seed (see `World::state_hash`). If it did, every seed
+/// would carry its own digest whether or not it changed anything.
+///
+/// Four seeds, out of the seven distinct strides this sample derives
+/// from a seed: enough that a collision would be a real finding, few
+/// enough that the matrix stays cheap on a lane where every run brings
+/// up a device.
+#[test]
+fn every_seed_reproduces_itself_and_no_two_seeds_move_the_world_alike() {
+    const SEEDS: [&str; 4] = ["0", "1", "2", "3"];
+    let runs = runs_per_seed();
+    let mut digests: Vec<(&str, String)> = Vec::with_capacity(SEEDS.len());
+
+    for seed in SEEDS {
+        let arguments = ["--headless", "--frames", "16", "--seed", seed];
+        let Some(first) = digest_line(&arguments) else {
+            return;
+        };
+        for attempt in 1..runs {
+            let Some(again) = digest_line(&arguments) else {
+                return;
+            };
+            assert_eq!(
+                again, first,
+                "seed {seed} did not reproduce on run {attempt}"
+            );
+        }
+        let digest = state_digest(&first);
+        assert!(!digest.is_empty(), "no state digest in {first}");
+        digests.push((seed, digest.to_string()));
+    }
+
+    for (index, (seed, digest)) in digests.iter().enumerate() {
+        for (other_seed, other_digest) in &digests[index + 1..] {
+            assert_ne!(
+                digest, other_digest,
+                "seeds {seed} and {other_seed} moved the world identically"
+            );
+        }
+    }
+}
+
 #[test]
 fn the_stats_file_is_written_after_the_run_and_carries_both_halves() {
     let path = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("hello_triangle-stats.json");

--- a/samples/hello_triangle/tests/zero_alloc.rs
+++ b/samples/hello_triangle/tests/zero_alloc.rs
@@ -1,4 +1,4 @@
-//! The steady state allocates nothing (§10).
+//! The steady state allocates nothing.
 //!
 //! Steady state, defined: frames `[3, N)` of a headless run. Everything
 //! that allocates happens before frame zero — device, offscreen target,
@@ -12,13 +12,20 @@
 //! neighbour noise rides out while a genuine per-frame allocation
 //! reproduces in every window and still fails.
 //!
-//! Three specific regressions this exists to catch: a per-frame
-//! `println!` (allocates and locks — the mandated frame-time readout
-//! aggregates into the timing summary's four scalars instead), a
-//! per-frame `format!`, and a `Vec` of plans accumulating anywhere on
-//! the frame path.
+//! Four specific regressions this exists to catch: a per-frame
+//! `println!` (allocates and locks — the frame-time capture aggregates
+//! into the timing summary's four scalars instead), a per-frame
+//! `format!`, a `Vec` of plans accumulating anywhere on the frame path,
+//! and a window-title readout that builds its text with `format!`. That
+//! last one has no window in this process to give it away, so it is
+//! driven directly, before the part of the test a machine without a GPU
+//! skips.
 
+#[cfg(feature = "window")]
+use renew_frame::{Nanos, Timestamp};
 use renew_memory::{CountingAllocator, counters};
+#[cfg(feature = "window")]
+use renew_sample_hello_triangle::Readout;
 use renew_sample_hello_triangle::{Draw, HeadlessRun, SampleError, WARMUP_FRAMES};
 
 #[global_allocator]
@@ -57,6 +64,40 @@ fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String>
     ignore = "allocation counting is invalid under instrumented allocators"
 )]
 fn steady_state_frames_allocate_nothing() {
+    // The window-title readout, driven over a synthetic timeline that
+    // crosses several relabel intervals. It is the only thing on the
+    // frame path that turns numbers into text, which makes it the
+    // likeliest place for a `format!` to appear — and there is no window
+    // in this process, so nothing below the seam would give one away.
+    // Before the GPU half, so a machine without a driver still checks it.
+    #[cfg(feature = "window")]
+    {
+        // A short interval so one window of frames spans several
+        // relabels; the interval the sample actually uses is asserted by
+        // the readout's own unit tests.
+        let mut readout = Readout::new("renew", Nanos::from_nanos(50_000_000));
+        let mut frame = 0u64;
+        let mut relabels = 0u32;
+        let mut malformed = 0u32;
+        quiet_window(5, || {
+            for _ in 0..WINDOW_FRAMES {
+                frame += 1;
+                let now = Timestamp::from_nanos(frame.saturating_mul(16_666_667));
+                if let Some(title) = readout.record(Nanos::from_nanos(16_600_000), now) {
+                    relabels += 1;
+                    if !title.starts_with("renew — 16.6") {
+                        malformed += 1;
+                    }
+                }
+            }
+        })
+        .expect("the readout formats into its own buffer and never onto the heap");
+        // Without these the windows above could have been sixteen early
+        // returns each: no text formatted, and nothing proved.
+        assert!(relabels > 0, "no relabel interval elapsed inside a window");
+        assert_eq!(malformed, 0, "a relabel produced text nobody expected");
+    }
+
     let mut run = match HeadlessRun::start(0, Draw::Triangle) {
         Ok(run) => run,
         Err(SampleError::Unavailable(reason)) if !strict() => {

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -10,7 +10,7 @@ cargo run -p renew-sample-input-echo --bin input_echo -- --headless --input-trac
 
 ```console
 $ cargo run -p renew-sample-input-echo --bin input_echo -- --headless --input-trace walk
-renew-frame sample=input_echo seed=0 source=walk frames=20 ticks=20 dropped=0 schedule_hash=0xcaa0947bf9fa1305 state_hash=0x85e3ded788429392
+renew-frame sample=input_echo seed=0 source=walk frames=20 ticks=20 dropped=0 schedule_hash=0xcaa0947bf9fa1305 state_hash=0x833e49c9dd637b92
 ```
 
 ## What it does
@@ -67,6 +67,13 @@ for a command line this sample cannot honour.
   machines.
 - **Events change what the next step does, never the state.** The world
   is advanced by `step` and by nothing else.
+- **The state hash is a fingerprint of behaviour, not of configuration.**
+  The seed is deliberately not folded into it. A digest that absorbs an
+  input cannot show that input had an effect — every seed would produce
+  its own number even if the seed never reached the simulation. Leaving
+  it out means two digests differ only when two worlds differ, which is
+  what lets the seed matrix assert something real. The configuration is
+  still printed: the seed appears beside the hash on the same line.
 - **The simulation is integer-only.** Positions are whole units and
   pointer coordinates are truncated on arrival: a state hash that
   absorbed float arithmetic would quietly become a cross-platform

--- a/samples/input_echo/src/world.rs
+++ b/samples/input_echo/src/world.rs
@@ -242,11 +242,21 @@ impl EchoWorld {
     }
 
     /// The run's fingerprint: every step absorbed in order, closed with
-    /// the seed and the final state.
+    /// the final state.
+    ///
+    /// The seed is deliberately NOT absorbed, though it is the obvious
+    /// thing to close with. A digest that absorbs an input cannot be
+    /// used to prove that input had an effect: every seed would produce
+    /// its own digest even if the seed were parsed, printed, and then
+    /// ignored by the simulation entirely. Leaving it out makes the
+    /// digest a fingerprint of BEHAVIOUR, so two seeds that move the
+    /// world differently are told apart on the evidence, and two that
+    /// move it identically are honestly reported as identical. The run's
+    /// configuration is not lost — the digest line and the stats
+    /// document both print the seed beside this number.
     #[must_use]
     pub const fn state_hash(&self) -> u64 {
         self.trace
-            .absorb_u64(self.seed)
             .absorb_u64(self.ticks)
             .absorb_u64(self.events)
             .absorb_bytes(&self.position.0.to_le_bytes())

--- a/samples/input_echo/tests/cli_determinism.rs
+++ b/samples/input_echo/tests/cli_determinism.rs
@@ -80,19 +80,12 @@ fn a_different_run_is_a_different_line() {
     assert_ne!(walk, seeded, "another seed must move the digest");
 }
 
-/// The final position the run reported, read out of its stats document.
-///
-/// This, not the state digest, is what distinguishes one seed's world
-/// from another's. The digest absorbs the seed itself, so two seeds
-/// produce two digests whether or not the seed ever reached the
-/// simulation — comparing digests across seeds proves arithmetic, not
-/// behaviour. The position is behaviour: the seed picks a speed, and the
-/// speed is how far the world moved.
-fn reported_position(json: &str) -> String {
-    json.split("\"position\":")
+/// The state digest, the part of the line that is about the world
+/// rather than about the schedule.
+fn state_digest(line: &str) -> &str {
+    line.split("state_hash=")
         .nth(1)
-        .and_then(|rest| rest.split(']').next())
-        .map(|value| format!("{value}]"))
+        .map(|rest| rest.split_whitespace().next().unwrap_or_default())
         .unwrap_or_default()
 }
 
@@ -110,39 +103,32 @@ fn runs_per_seed() -> usize {
 /// The seed matrix: every seed reproduces itself across processes, and
 /// no two seeds move the world the same way.
 ///
-/// Both halves earn their place, and the second one is the reason this
-/// test exists at all. Identity within a seed is the determinism claim.
-/// Distinctness across seeds is what proves the seed REACHES the
-/// simulation: a seed that is parsed, printed, hashed and then ignored
-/// would satisfy identity perfectly, and would still yield a different
-/// digest for every seed, because the digest absorbs the seed. Only an
-/// observable the seed has to travel through catches that — here, how
-/// far the world actually moved.
+/// Both halves earn their place, and the second is the reason this test
+/// exists. Identity within a seed is the determinism claim. Distinctness
+/// across seeds is what proves the seed REACHES the simulation — a seed
+/// that is parsed, printed and then ignored satisfies identity
+/// perfectly.
+///
+/// That second half only means something because the digest does not
+/// absorb the seed (see `World::state_hash`). If it did, every seed
+/// would carry its own digest whether or not it changed anything, and
+/// this loop would be comparing arithmetic to arithmetic. Because it
+/// does not, two digests differ here only when two worlds differ.
 ///
 /// The seeds are 0 to 3 rather than an arbitrary scatter because this
-/// sample derives one speed from the seed modulo four. Five arbitrary
-/// seeds would collide by pigeonhole and fail an assertion the engine
-/// never made. When a real random-number service widens the space, the
-/// matrix widens with it.
+/// sample derives one of four speeds from the seed. Five arbitrary seeds
+/// would collide by pigeonhole and fail an assertion the engine never
+/// made — and correctly so, since two seeds that walk at the same speed
+/// SHOULD hash alike. When a real random-number service widens the
+/// space, the matrix widens with it.
 #[test]
 fn every_seed_reproduces_itself_and_no_two_seeds_move_the_world_alike() {
     const SEEDS: [&str; 4] = ["0", "1", "2", "3"];
     let runs = runs_per_seed();
-    let directory = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
-    let mut behaviours: Vec<(&str, String)> = Vec::with_capacity(SEEDS.len());
+    let mut digests: Vec<(&str, String)> = Vec::with_capacity(SEEDS.len());
 
     for seed in SEEDS {
-        let path = directory.join(format!("input_echo-seed-{seed}.json"));
-        let text = path.to_string_lossy().to_string();
-        let arguments = [
-            "--headless",
-            "--input-trace",
-            "walk",
-            "--seed",
-            seed,
-            "--dump-stats",
-            &text,
-        ];
+        let arguments = ["--headless", "--input-trace", "walk", "--seed", seed];
         let first = digest_line(&arguments);
         for attempt in 1..runs {
             assert_eq!(
@@ -151,18 +137,16 @@ fn every_seed_reproduces_itself_and_no_two_seeds_move_the_world_alike() {
                 "seed {seed} did not reproduce on run {attempt}"
             );
         }
-        let json = std::fs::read_to_string(&path).expect("the stats file the run was asked for");
-        let position = reported_position(&json);
-        assert!(!position.is_empty(), "no position in {json}");
-        behaviours.push((seed, position));
+        let digest = state_digest(&first);
+        assert!(!digest.is_empty(), "no state digest in {first}");
+        digests.push((seed, digest.to_string()));
     }
 
-    for (index, (seed, position)) in behaviours.iter().enumerate() {
-        for (other_seed, other_position) in &behaviours[index + 1..] {
+    for (index, (seed, digest)) in digests.iter().enumerate() {
+        for (other_seed, other_digest) in &digests[index + 1..] {
             assert_ne!(
-                position, other_position,
-                "seeds {seed} and {other_seed} moved the world identically, \
-                 so the seed is not reaching the simulation"
+                digest, other_digest,
+                "seeds {seed} and {other_seed} moved the world identically"
             );
         }
     }

--- a/samples/input_echo/tests/cli_determinism.rs
+++ b/samples/input_echo/tests/cli_determinism.rs
@@ -80,6 +80,94 @@ fn a_different_run_is_a_different_line() {
     assert_ne!(walk, seeded, "another seed must move the digest");
 }
 
+/// The final position the run reported, read out of its stats document.
+///
+/// This, not the state digest, is what distinguishes one seed's world
+/// from another's. The digest absorbs the seed itself, so two seeds
+/// produce two digests whether or not the seed ever reached the
+/// simulation — comparing digests across seeds proves arithmetic, not
+/// behaviour. The position is behaviour: the seed picks a speed, and the
+/// speed is how far the world moved.
+fn reported_position(json: &str) -> String {
+    json.split("\"position\":")
+        .nth(1)
+        .and_then(|rest| rest.split(']').next())
+        .map(|value| format!("{value}]"))
+        .unwrap_or_default()
+}
+
+/// How many times each seed runs. Three catches a process-to-process
+/// difference on every push; a longer campaign can ask for more without
+/// touching this file.
+fn runs_per_seed() -> usize {
+    std::env::var("RENEW_DETERMINISM_RUNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|runs| *runs >= 2)
+        .unwrap_or(3)
+}
+
+/// The seed matrix: every seed reproduces itself across processes, and
+/// no two seeds move the world the same way.
+///
+/// Both halves earn their place, and the second one is the reason this
+/// test exists at all. Identity within a seed is the determinism claim.
+/// Distinctness across seeds is what proves the seed REACHES the
+/// simulation: a seed that is parsed, printed, hashed and then ignored
+/// would satisfy identity perfectly, and would still yield a different
+/// digest for every seed, because the digest absorbs the seed. Only an
+/// observable the seed has to travel through catches that — here, how
+/// far the world actually moved.
+///
+/// The seeds are 0 to 3 rather than an arbitrary scatter because this
+/// sample derives one speed from the seed modulo four. Five arbitrary
+/// seeds would collide by pigeonhole and fail an assertion the engine
+/// never made. When a real random-number service widens the space, the
+/// matrix widens with it.
+#[test]
+fn every_seed_reproduces_itself_and_no_two_seeds_move_the_world_alike() {
+    const SEEDS: [&str; 4] = ["0", "1", "2", "3"];
+    let runs = runs_per_seed();
+    let directory = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    let mut behaviours: Vec<(&str, String)> = Vec::with_capacity(SEEDS.len());
+
+    for seed in SEEDS {
+        let path = directory.join(format!("input_echo-seed-{seed}.json"));
+        let text = path.to_string_lossy().to_string();
+        let arguments = [
+            "--headless",
+            "--input-trace",
+            "walk",
+            "--seed",
+            seed,
+            "--dump-stats",
+            &text,
+        ];
+        let first = digest_line(&arguments);
+        for attempt in 1..runs {
+            assert_eq!(
+                digest_line(&arguments),
+                first,
+                "seed {seed} did not reproduce on run {attempt}"
+            );
+        }
+        let json = std::fs::read_to_string(&path).expect("the stats file the run was asked for");
+        let position = reported_position(&json);
+        assert!(!position.is_empty(), "no position in {json}");
+        behaviours.push((seed, position));
+    }
+
+    for (index, (seed, position)) in behaviours.iter().enumerate() {
+        for (other_seed, other_position) in &behaviours[index + 1..] {
+            assert_ne!(
+                position, other_position,
+                "seeds {seed} and {other_seed} moved the world identically, \
+                 so the seed is not reaching the simulation"
+            );
+        }
+    }
+}
+
 #[test]
 fn the_stats_file_is_written_after_the_run_and_carries_the_input_tally() {
     let path = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("input_echo-stats.json");


### PR DESCRIPTION
Four changes, each green on its own.

**A window title that can change after creation.** The title is the only window chrome a program can write without a text renderer. Additive to the platform window seam; borrowed string, not retained; main thread, like the rest of that seam. No windowing-library type crosses the boundary.

**A frame-time readout in the hello_triangle title bar.** Mean frame time over each 250 ms interval and the rate it implies. Formatting is integer arithmetic into a fixed-size buffer with no allocation, so it is safe to call from the steady-state frame path the allocation test guards. Rounding is to nearest, because 60 Hz is not a whole number of nanoseconds and truncation reports it as 59.9 fps. The first frame relabels immediately so a short run still shows a number.

**End-to-end frame capture per platform.** The benchmark suite times pieces of the engine in isolation; this adds a separate measurement of the headless sample run end to end, through the same command a person would type, uploaded per platform with a record of the machine that produced it. The two kinds of number are deliberately two artifacts and are not comparable with each other.

**A seed matrix for input_echo.** Repeating one seed across processes proves reproducibility but not that the seed reaches the simulation — a seed that is parsed, printed and then ignored reproduces perfectly, and still produces a distinct digest per seed because the digest absorbs the seed. So the matrix asserts identity within a seed on the digest, and distinctness across seeds on the position the run reports. Confirmed by mutation: making the speed ignore its seed leaves the first assertion passing and fails the second.

## Verified locally (Windows, RTX 3070)

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 13 suites, 0 failures
- Coverage: `readout.rs` 249 regions, 0 missed, 100.00%
- The coverage gate reports no finding outside `crates/rhi`, whose remaining gaps are the error paths driven by the Linux-only fault layer this machine cannot run. The three exemption line numbers that moved with the title setter were re-checked and are still uncovered, so none went stale.

The full matrix, the coverage lane with the fault layer, and the windowed runs under a virtual display are what this PR is asking CI to confirm.
