### PR TITLE
Add a seeded generator for reproducible simulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-jobs renew-frame; do
+          for optional in renew-rhi renew-jobs renew-frame renew-rng; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -48,7 +48,7 @@ jobs:
         # The sanitized feature marks allocation-counting tests ignored:
         # instrumented runtimes allocate on their own, so those counts are
         # meaningless here (the regular CI workflow measures them).
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-rng/sanitized,renew-frame/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,6 +1460,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-rng"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-memory",
+]
+
+[[package]]
 name = "renew-sample-hello-triangle"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bench/suite", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "renew-rng"
+description = "Seeded, reproducible pseudo-random numbers for simulation: PCG32 with derived per-domain streams"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Seeded, reproducible pseudo-random numbers for simulation: PCG32 with per-domain streams derived from one master seed, and bounded draws with no modulo bias."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+[features]
+# Enabled by instrumented (sanitizer) test runs: allocation counting is
+# invalid by construction when the runtime itself allocates.
+sanitized = []
+
+# Deliberately empty, and load-bearing for the same reason as the frame
+# crate's. A generator with no dependency cannot be handed a clock, a
+# thread, or an entropy source by accident: "seeded, always" stops being a
+# promise and becomes a property of the build graph. It also makes the
+# crate byte-identical in every removability configuration.
+[dependencies]
+
+[dev-dependencies]
+renew-memory = { path = "../core/memory" }
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/rng/README.md
+++ b/crates/rng/README.md
@@ -1,0 +1,155 @@
+# renew-rng
+
+Seeded, reproducible pseudo-random numbers for simulation: PCG32 with
+per-domain streams derived from one master seed, and bounded draws with no
+modulo bias.
+
+Randomness in a deterministic simulation is not a source of surprise — it
+is a **function of the seed**, and the whole job of this crate is to keep
+it that way. There is no ambient generator, no way to seed from the clock,
+and no dependency that could offer either.
+
+```rust
+const LOOT: StreamId = StreamId::from_name("loot");     // streams are named where they are used
+let mut loot = Rng::new(seed, LOOT);                    // a pure function of (seed, stream)
+let mut enemy = Rng::new(seed, LOOT.child(entity_id));  // per-entity, order-independent
+
+let roll = loot.below_u32(TABLE_SIZE);                  // uniform, no modulo bias
+let crit = enemy.next_bool();
+```
+
+- `Seed` — the master seed for one run. The application supplies it: a
+  command-line flag, a recorded trace, a lobby handshake.
+- `StreamId` — names one independent sequence. `from_name` for systems
+  (computed at compile time, so no central registry of stream numbers has
+  to exist), `child(index)` for per-entity sequences.
+- `Rng` — the generator. `next_u32` / `next_u64` / `next_bool` for raw
+  draws, `below_u32` / `below_u64` for bounded ones, `parts` /
+  `from_parts` to snapshot and resume.
+
+Machine-readable facts about this crate — maturity, dependencies, core
+status, whether it is simulation code — live in `Cargo.toml` under
+`[package.metadata.renew]`, which is authoritative. This file does not
+restate them.
+
+## Contract
+
+- **A run is a pure function of its seed.** For a fixed build and
+  platform, every number produced is determined by the `(Seed, StreamId)`
+  pair it came from and the number of draws taken before it. Nothing here
+  reads a clock, allocates, spawns a thread, or holds
+  iteration-order-dependent state.
+- **Derivation is order-independent.** `Rng::new` is a pure function of
+  its arguments — building a stream early, late, or twice gives the same
+  generator. A replay can reconstruct one entity's sequence without
+  replaying every other entity's.
+- **Distinct streams under one seed cannot collide.** The derivation is a
+  bijection, so two different `StreamId`s under one `Seed` always start
+  from different internal states. What is *not* claimed is proven
+  statistical independence between streams — see "What this crate does not
+  guarantee" below.
+- **Bounded draws are exactly uniform.** Not nearly uniform. Rejection
+  sampling with a threshold, so the accepted range is an exact multiple of
+  the bound.
+- **Nothing can fail.** Non-zero bounds by type, a total constructor: no
+  method returns a `Result`, nothing panics, nothing unwinds.
+- **No floating point.** Not in the generator, not in the draws, not in
+  the tests. The crate denies float arithmetic at its root, so it is the
+  compiler that holds the line, not review.
+
+## Why PCG32, and how we know it is PCG32
+
+The generator is the XSH-RR 64/32 variant of PCG: a 64-bit linear
+congruential step whose output is a 32-bit xorshift folded down and then
+rotated by an amount taken from the state's own top bits. Integer
+operations only — multiply, add, shift, xor, rotate — which is what lets
+the sequence be described as bit-identical rather than as approximately
+identical.
+
+The reason it is this algorithm rather than one of the equally reasonable
+alternatives is **evidence**. Its reference implementation ships a
+demonstration program with published output, and `tests/known_answer.rs`
+reproduces that output exactly: six raw words, sixty-five coin flips,
+thirty-three dice rolls and a shuffled deck of fifty-two cards, all drawn
+from one continuing stream. Because the stream continues across those
+lines, the dice only come out right if the coins consumed exactly the
+right number of words first, and the deck only comes out right if both
+did.
+
+That matters more than it sounds. A generator with a shift distance off by
+one, or a rotation in the wrong direction, is still perfectly
+deterministic and still passes every statistical and property test in this
+crate — it is simply a *different* generator, one that nobody has
+analysed, whose period nobody has proven. Only somebody else's numbers can
+tell the two apart.
+
+## Seeding: why the algorithm's own stream parameter is not exposed
+
+PCG's native notion of a stream is the increment of its linear
+congruential step. It is real, but it is not independence: two streams
+that differ only in that parameter are related. Measured on the reference
+seeding, the difference between two streams' internal states is a fixed
+constant — the *same* constant for every master seed — and it stays fixed
+as both advance.
+
+Callers therefore never touch it. `Rng::new(seed, stream)` folds both
+inputs through the SplitMix64 mixer and takes the generator's two words
+out of a SplitMix64 walk. Three consequences, all tested:
+
+- **Adjacent inputs decorrelate.** Seeds 1, 2, 3 and entity indices 0, 1,
+  2 are what callers actually pass. After mixing, adjacent seeds differ in
+  about sixteen of the first thirty-two output bits — half, which is what
+  "unrelated" means.
+- **Distinct streams cannot collide**, because every step of the
+  derivation is invertible.
+- **`from_parts` is not a seeder.** It restores a snapshot verbatim, which
+  is exactly what a snapshot needs and exactly what a seed must never get:
+  a generator whose state is set to a small number emits *zero* as its
+  first draw for every value below 2^27. `tests/statistics.rs` pins that
+  trap in place, as a reason and as a regression guard.
+
+## What this crate does not guarantee
+
+Stated plainly, because an unstated limit is how a reproducibility claim
+quietly becomes false:
+
+- **Statistical independence between streams.** PCG's designers do not
+  claim it and neither does this crate. What the mixer buys is that the
+  correlations known to exist between this algorithm's streams cannot be
+  reached by adjacent or patterned identifiers.
+- **Non-overlap between streams.** Two streams that happen to share an
+  increment lie on one cycle at a random offset. With a 64-bit period the
+  chance of overlap within any realistic run is negligible, but it is a
+  probability, not a proof.
+- **Cross-platform bit-identity, today.** The generator is integer-only
+  and has no reason to differ between targets, and `tests/determinism.rs`
+  freezes concrete values so CI checks the claim on every platform it
+  runs. Until those runs exist for a platform, the claim is unverified
+  there.
+- **Cryptographic strength.** None whatsoever. PCG32 is trivially
+  predictable from a few outputs. Nothing security-bearing — matchmaking
+  tokens, anti-cheat nonces, save-file integrity — may use this crate.
+
+## What v0 deliberately does not have
+
+Each of these is a decision, not an oversight, and each names what would
+bring it back:
+
+- **Float draws.** A float in `[0, 1)` can be built exactly from integer
+  bits, so the objection is not that it cannot be done — it is that no
+  consumer exists yet to state which interval, which precision, and which
+  rounding it needs. The recipe lives in the crate documentation until one
+  does.
+- **`shuffle`, `choose`, weighted picks, distributions.** Reductions with
+  no call site. `tests/known_answer.rs` already contains a correct
+  Fisher-Yates shuffle over this API, which is the pattern to copy when
+  the first caller appears.
+- **Signed and offset ranges.** `low + rng.below_u32(span)` is the whole
+  implementation; the version that handles every overflow edge belongs
+  with a caller who has one.
+- **Jump-ahead / stream advance.** Derivation replaces the use case, and
+  the jump polynomials would be one more thing to get right with no
+  published vector to check them against.
+- **Seeding from entropy.** Deliberately impossible: the crate has no
+  dependency that could supply it, and its lint configuration bans the one
+  self-seeding type the standard library offers.

--- a/crates/rng/README.md
+++ b/crates/rng/README.md
@@ -53,9 +53,10 @@ restate them.
   the bound.
 - **Nothing can fail.** Non-zero bounds by type, a total constructor: no
   method returns a `Result`, nothing panics, nothing unwinds.
-- **No floating point.** Not in the generator, not in the draws, not in
-  the tests. The crate denies float arithmetic at its root, so it is the
-  compiler that holds the line, not review.
+- **No floating point.** Not in the generator, not in the draws. The
+  crate denies float *arithmetic* at its root, which the compiler holds;
+  that lint covers operators only, so keeping float-typed signatures out
+  of the API is a review rule rather than a compiled-in guarantee.
 
 ## Why PCG32, and how we know it is PCG32
 

--- a/crates/rng/clippy.toml
+++ b/crates/rng/clippy.toml
@@ -1,0 +1,39 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). This crate is
+# simulation code, and these are the mechanical half of that designation:
+# the obligations the language standard puts on simulation code, made
+# unwritable rather than merely documented.
+#
+# The entry that matters most here is RandomState. On stable Rust with no
+# dependencies, it is the only way to obtain entropy the caller did not
+# supply — `RandomState::new` and `DefaultHasher::new` seed themselves from
+# the operating system. A single one of those inside a generator would
+# make every replay diverge, with no test failing anywhere until months
+# later. Banning the type is how "seeded, always" stops depending on
+# anybody remembering.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
+    { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded until the deterministic parallel-scheduling decision exists" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system; this crate's whole contract is that every bit of randomness traces back to a caller-supplied seed" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same reason as RandomState: self-seeding entropy has no place behind a reproducibility contract" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+# The SAFETY-comment lint accepts the comment above an attribute or
+# on the statement that owns the block.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/rng/src/generator.rs
+++ b/crates/rng/src/generator.rs
@@ -1,0 +1,452 @@
+//! The generator: PCG32 (the XSH-RR 64/32 variant), its derived seeding,
+//! and the draws built on it.
+//!
+//! # Why this algorithm
+//!
+//! Integer operations only — a 64-bit multiply, an add, two shifts, a
+//! xor and a rotate. No floating point appears anywhere in the generator
+//! or in anything reachable from it, which is what lets the sequence be
+//! stated as bit-identical rather than as approximately identical.
+//!
+//! The deciding property, though, was evidence. The algorithm's reference
+//! implementation ships a demonstration program whose output is published,
+//! and this crate reproduces that output exactly — six raw words, then a
+//! run of coin flips, dice rolls and a shuffled deck drawn from the same
+//! continuing stream (`tests/known_answer.rs`). A lookalike that got a
+//! shift distance or the rotation direction wrong would still be a
+//! perfectly deterministic generator, still pass every property test in
+//! this crate, and still be the wrong algorithm. Only a known-answer test
+//! against somebody else's numbers catches that.
+//!
+//! # Why the seeding is not the reference seeding
+//!
+//! The algorithm's own stream parameter is the increment of its
+//! underlying linear congruential step. Two streams that differ in that
+//! parameter are related: measured on the reference seeding, the
+//! difference between two streams' internal states is a fixed constant
+//! that does not depend on the master seed at all, and stays fixed as both
+//! advance. That is a structure a caller can hit accidentally simply by
+//! numbering entities 1, 2, 3. So callers never reach the stream parameter
+//! directly: both words are derived through the mixer in [`crate::mix`],
+//! which costs four multiplies once per generator and removes the
+//! structure entirely.
+
+use core::num::{NonZeroU32, NonZeroU64};
+
+use crate::mix::{GAMMA, SplitMix64, mix};
+use crate::seed::{Seed, StreamId};
+
+/// The multiplier of the 64-bit linear congruential step, fixed by the
+/// algorithm. Not a tunable: change it and every published vector, every
+/// recorded trace and every golden state hash becomes wrong at once.
+const MULTIPLIER: u64 = 6_364_136_223_846_793_005;
+
+/// A seeded generator: one reproducible sequence of numbers.
+///
+/// Sixteen bytes of state, no heap, no interior mutability, no shared
+/// anything. Generators are values a caller owns and passes explicitly —
+/// there is no ambient generator in this engine and no way to ask for one.
+///
+/// `Clone` but deliberately **not** `Copy`. A generator copied by accident
+/// is the quietest bug this crate could ship: both halves continue from
+/// the same state and produce the same "random" numbers forever, with
+/// nothing failing. Requiring `.clone()` makes forking a sentence someone
+/// wrote on purpose.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Rng {
+    state: u64,
+    /// Always odd — the algorithm's period argument depends on it, and
+    /// every constructor enforces it.
+    increment: u64,
+}
+
+impl Rng {
+    /// The generator for one stream of one run.
+    ///
+    /// # Contract
+    ///
+    /// - **A pure function of its two arguments.** Not of call order, not
+    ///   of how many generators were built before it, not of anything
+    ///   ambient. Rebuilding a stream halfway through a replay gives the
+    ///   same generator the recording had.
+    /// - **Distinct streams under one seed cannot collide.** Both words
+    ///   come from a bijective derivation, so two different `StreamId`s
+    ///   under the same `Seed` always produce different starting states.
+    ///   The property those streams do *not* have is proven statistical
+    ///   independence — see the crate documentation, which states the
+    ///   bound honestly.
+    ///
+    /// ```
+    /// use renew_rng::{Rng, Seed, StreamId};
+    ///
+    /// const LOOT: StreamId = StreamId::from_name("loot");
+    /// let seed = Seed::from_u64(20_260_731);
+    ///
+    /// let mut a = Rng::new(seed, LOOT);
+    /// let mut b = Rng::new(seed, LOOT);
+    /// assert_eq!(a.next_u32(), b.next_u32());
+    ///
+    /// let mut other = Rng::new(seed, StreamId::from_name("weather"));
+    /// assert_ne!(a.next_u32(), other.next_u32());
+    /// ```
+    #[must_use]
+    pub const fn new(seed: Seed, stream: StreamId) -> Self {
+        // Bijective in the stream for a fixed seed (mix, an odd multiply
+        // and an add are each invertible), so distinct streams start at
+        // distinct roots; the walk below is bijective too, so distinct
+        // roots stay distinct all the way to the generator.
+        let root = mix(seed.get()).wrapping_add(mix(stream.get()).wrapping_mul(GAMMA));
+        let mut walk = SplitMix64::new(root);
+        let increment = walk.next();
+        let state = walk.next();
+        Self {
+            state,
+            increment: increment | 1,
+        }
+    }
+
+    /// Rebuild a generator from a snapshot taken with [`Rng::parts`].
+    ///
+    /// This is the save-and-resume path: a determinism harness, a replay
+    /// that starts mid-trace, or a save file records the two words and
+    /// hands them back later. The sequence continues exactly where the
+    /// snapshot was taken.
+    ///
+    /// The low bit of `increment` is forced set. The algorithm requires an
+    /// odd increment — an even one walks half the state space and can
+    /// reach zero — and forcing it keeps this constructor total, with no
+    /// error to report and no failure a caller has to handle. Snapshots
+    /// taken from this crate always round-trip exactly, because every
+    /// generator it produces already has an odd increment.
+    #[must_use]
+    pub const fn from_parts(state: u64, increment: u64) -> Self {
+        Self {
+            state,
+            increment: increment | 1,
+        }
+    }
+
+    /// The generator's whole state, as `(state, increment)` — everything
+    /// [`Rng::from_parts`] needs to resume it, and everything a state hash
+    /// needs to fingerprint it.
+    #[must_use]
+    pub const fn parts(&self) -> (u64, u64) {
+        (self.state, self.increment)
+    }
+
+    /// The next 32 bits.
+    ///
+    /// One linear congruential step, then the algorithm's output
+    /// function: xor the state's high bits down over itself, take 32 bits
+    /// of the result, and rotate them by an amount taken from the state's
+    /// top five bits. The data-dependent rotation is the part that makes
+    /// this more than a linear congruential generator, and it is why every
+    /// output bit here is as good as every other — unlike a bare linear
+    /// congruential generator, whose low bit alternates.
+    pub fn next_u32(&mut self) -> u32 {
+        let previous = self.state;
+        self.state = previous
+            .wrapping_mul(MULTIPLIER)
+            .wrapping_add(self.increment);
+        // Both casts drop the high bits on purpose: the output function is
+        // defined as 32 bits taken from a 64-bit intermediate, and a
+        // rotation amount taken from five bits.
+        #[allow(clippy::cast_possible_truncation)]
+        let xorshifted = (((previous >> 18) ^ previous) >> 27) as u32;
+        #[allow(clippy::cast_possible_truncation)]
+        let rotation = (previous >> 59) as u32;
+        xorshifted.rotate_right(rotation)
+    }
+
+    /// The next 64 bits, as two 32-bit draws.
+    ///
+    /// The first draw is the low half. Stated because it is observable:
+    /// the choice fixes what every trace and every state hash contains,
+    /// and it matches the little-endian convention the rest of the tree
+    /// already writes integers with.
+    pub fn next_u64(&mut self) -> u64 {
+        let low = u64::from(self.next_u32());
+        let high = u64::from(self.next_u32());
+        (high << 32) | low
+    }
+
+    /// A coin flip.
+    ///
+    /// Exactly `below_u32(2) != 0`, and the crate's tests assert that
+    /// equality rather than trusting it: for a bound of two the rejection
+    /// threshold is zero, so a bounded draw is one word and its low bit.
+    pub fn next_bool(&mut self) -> bool {
+        self.next_u32() & 1 == 1
+    }
+
+    /// A uniform value in `0..bound`.
+    ///
+    /// # Why the bound is a non-zero type
+    ///
+    /// There is no uniform value below zero, so an empty range is not a
+    /// runtime condition to report — it is a case the caller has to have
+    /// handled before asking. Spelling that in the type keeps this method
+    /// total, and it puts the check where the emptiness is actually known:
+    ///
+    /// ```
+    /// use core::num::NonZeroU32;
+    /// use renew_rng::{Rng, Seed, StreamId};
+    ///
+    /// // A literal bound, fixed at compile time. The `match` is how this
+    /// // tree writes a non-zero constant: engine code has no `unwrap`.
+    /// const SIDES: NonZeroU32 = match NonZeroU32::new(6) {
+    ///     Some(sides) => sides,
+    ///     None => NonZeroU32::MIN,
+    /// };
+    ///
+    /// let mut rng = Rng::new(Seed::from_u64(1), StreamId::from_name("dice"));
+    /// let roll = rng.below_u32(SIDES) + 1;
+    /// assert!((1..=6).contains(&roll));
+    ///
+    /// // A bound that comes from data: the empty case is handled here,
+    /// // where "there is nothing to choose from" means something.
+    /// let candidates = ["a", "b", "c"];
+    /// # #[allow(clippy::cast_possible_truncation)]
+    /// let picked = NonZeroU32::new(candidates.len() as u32)
+    ///     .map(|count| candidates[rng.below_u32(count) as usize]);
+    /// assert!(picked.is_some());
+    /// ```
+    ///
+    /// # No modulo bias
+    ///
+    /// `next_u32() % bound` is not uniform unless `bound` divides 2^32:
+    /// the first `2^32 % bound` outputs get one extra chance each. For
+    /// small bounds the effect is too small to measure, which is exactly
+    /// why it survives in shipped code; for large ones it is gross —
+    /// at `bound = 3 * 2^30` a bare remainder makes the low third of the
+    /// range come up half the time instead of a third, measured in
+    /// `tests/statistics.rs`.
+    ///
+    /// The fix here is rejection sampling with a threshold: refuse the
+    /// first `2^32 % bound` words, leaving an accepted range whose length
+    /// is an exact multiple of `bound`, over which the remainder is
+    /// uniform. This is the technique the algorithm's reference
+    /// implementation uses and the one behind `arc4random_uniform`. It
+    /// costs one remainder per draw and, for the bounds a game actually
+    /// uses, essentially never redraws.
+    ///
+    /// # Consumption is data-dependent
+    ///
+    /// A bounded draw consumes one word *or more*. That is deterministic —
+    /// same seed, same rejections, same everything — but it means a trace
+    /// cannot assume one draw advances the stream by one step. Anything
+    /// that needs to know exactly where the stream is reads
+    /// [`Rng::parts`].
+    pub fn below_u32(&mut self, bound: NonZeroU32) -> u32 {
+        let bound = bound.get();
+        // `-bound % bound` in unsigned arithmetic is `2^32 % bound`: the
+        // size of the short tail that has to be refused.
+        let threshold = bound.wrapping_neg() % bound;
+        loop {
+            let word = self.next_u32();
+            if word >= threshold {
+                return word % bound;
+            }
+        }
+    }
+
+    /// A uniform value in `0..bound`, over the full 64-bit range.
+    ///
+    /// The same technique as [`Rng::below_u32`], one word wider. It is
+    /// written out again rather than sharing an implementation with the
+    /// 32-bit case: the 32-bit path is the one pinned by the published
+    /// known-answer vectors, and expressing it through this one would
+    /// consume two words per draw and change every value in them.
+    pub fn below_u64(&mut self, bound: NonZeroU64) -> u64 {
+        let bound = bound.get();
+        let threshold = bound.wrapping_neg() % bound;
+        loop {
+            let word = self.next_u64();
+            if word >= threshold {
+                return word % bound;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MULTIPLIER, Rng};
+    use crate::seed::{Seed, StreamId};
+    use core::num::{NonZeroU32, NonZeroU64};
+
+    const SEED: Seed = Seed::from_u64(0x0bad_f00d_dead_beef);
+    const STREAM: StreamId = StreamId::from_name("tests");
+
+    #[test]
+    fn the_step_is_the_documented_linear_congruential_step() {
+        let mut rng = Rng::from_parts(12_345, 7);
+        let (before, increment) = rng.parts();
+        let _ = rng.next_u32();
+        let (after, _) = rng.parts();
+        assert_eq!(
+            after,
+            before.wrapping_mul(MULTIPLIER).wrapping_add(increment)
+        );
+    }
+
+    #[test]
+    fn an_even_increment_is_made_odd() {
+        assert_eq!(Rng::from_parts(0, 108).parts(), (0, 109));
+        assert_eq!(Rng::from_parts(0, 109).parts(), (0, 109));
+        assert_eq!(Rng::from_parts(0, 0).parts(), (0, 1));
+    }
+
+    #[test]
+    fn a_snapshot_resumes_the_same_sequence() {
+        let mut rng = Rng::new(SEED, STREAM);
+        for _ in 0..17 {
+            let _ = rng.next_u32();
+        }
+        let (state, increment) = rng.parts();
+        let mut resumed = Rng::from_parts(state, increment);
+        assert_eq!(resumed, rng);
+        let expected: [u32; 8] = core::array::from_fn(|_| rng.next_u32());
+        let got: [u32; 8] = core::array::from_fn(|_| resumed.next_u32());
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn every_derived_increment_is_odd() {
+        for stream in 0..2_000u64 {
+            let (_, increment) = Rng::new(SEED, StreamId::from_u64(stream)).parts();
+            assert_eq!(increment & 1, 1);
+        }
+    }
+
+    #[test]
+    fn sixty_four_bits_are_two_draws_low_half_first() {
+        let mut wide = Rng::new(SEED, STREAM);
+        let mut narrow = Rng::new(SEED, STREAM);
+        let value = wide.next_u64();
+        let low = u64::from(narrow.next_u32());
+        let high = u64::from(narrow.next_u32());
+        assert_eq!(value, (high << 32) | low);
+        assert_eq!(wide.parts(), narrow.parts());
+    }
+
+    #[test]
+    fn a_coin_is_the_bounded_draw_for_two() {
+        let two = NonZeroU32::new(2).expect("non-zero");
+        let mut coins = Rng::new(SEED, STREAM);
+        let mut bounded = Rng::new(SEED, STREAM);
+        for _ in 0..1_000 {
+            assert_eq!(coins.next_bool(), bounded.below_u32(two) != 0);
+        }
+        assert_eq!(coins.parts(), bounded.parts());
+    }
+
+    #[test]
+    fn a_bound_of_one_is_always_zero_and_costs_one_word() {
+        let one = NonZeroU32::new(1).expect("non-zero");
+        let mut bounded = Rng::new(SEED, STREAM);
+        let mut raw = Rng::new(SEED, STREAM);
+        for _ in 0..64 {
+            assert_eq!(bounded.below_u32(one), 0);
+            let _ = raw.next_u32();
+        }
+        assert_eq!(bounded.parts(), raw.parts());
+    }
+
+    #[test]
+    fn bounded_draws_stay_below_their_bound() {
+        let mut rng = Rng::new(SEED, STREAM);
+        for bound in [2u32, 3, 6, 7, 52, 1_000, 1 << 31, (3 << 30) + 1, u32::MAX] {
+            let bound = NonZeroU32::new(bound).expect("non-zero");
+            for _ in 0..200 {
+                assert!(rng.below_u32(bound) < bound.get());
+            }
+        }
+        for bound in [2u64, 6, 1 << 63, (3 << 62) + 1, u64::MAX] {
+            let bound = NonZeroU64::new(bound).expect("non-zero");
+            for _ in 0..200 {
+                assert!(rng.below_u64(bound) < bound.get());
+            }
+        }
+    }
+
+    /// The rejection branch, exercised on purpose rather than by luck. At
+    /// this bound one word in four is refused, so a clone of the same
+    /// generator can be used to count how many refusals the draws below
+    /// actually went through — a test that "covers" the loop without ever
+    /// looping would be worth nothing.
+    #[test]
+    fn the_rejection_path_runs_for_a_bound_that_provokes_it() {
+        let bound = NonZeroU32::new(3 << 30).expect("non-zero");
+        let threshold = bound.get().wrapping_neg() % bound.get();
+        assert_eq!(threshold, 1 << 30);
+
+        let mut rng = Rng::new(SEED, STREAM);
+        let mut words = rng.clone();
+        let mut drawn = 0u32;
+        for _ in 0..256 {
+            assert!(rng.below_u32(bound) < bound.get());
+        }
+        let mut refusals = 0u32;
+        while words.parts() != rng.parts() {
+            if words.next_u32() < threshold {
+                refusals += 1;
+            }
+            drawn += 1;
+        }
+        assert!(refusals > 0, "no word was ever refused");
+        assert_eq!(drawn, 256 + refusals);
+    }
+
+    #[test]
+    fn the_wide_rejection_path_runs_too() {
+        let bound = NonZeroU64::new(3 << 62).expect("non-zero");
+        let threshold = bound.get().wrapping_neg() % bound.get();
+        assert_eq!(threshold, 1 << 62);
+
+        let mut rng = Rng::new(SEED, STREAM);
+        let mut words = rng.clone();
+        let mut drawn = 0u32;
+        for _ in 0..256 {
+            assert!(rng.below_u64(bound) < bound.get());
+        }
+        let mut refusals = 0u32;
+        while words.parts() != rng.parts() {
+            if words.next_u64() < threshold {
+                refusals += 1;
+            }
+            drawn += 1;
+        }
+        assert!(refusals > 0, "no word pair was ever refused");
+        assert_eq!(drawn, 256 + refusals);
+    }
+
+    /// The threshold identity the whole no-bias argument rests on: after
+    /// refusing the tail, the accepted range is an exact multiple of the
+    /// bound, so the remainder over it is uniform. Checked over every
+    /// bound up to a hundred thousand and at the awkward extremes, by
+    /// arithmetic rather than by sampling.
+    #[test]
+    fn the_accepted_range_is_always_a_multiple_of_the_bound() {
+        const RANGE: u64 = 1 << 32;
+        for bound in (1..=100_000u32).chain([1 << 31, (1 << 31) + 1, 3 << 30, u32::MAX]) {
+            let threshold = u64::from(bound.wrapping_neg() % bound);
+            assert_eq!((RANGE - threshold) % u64::from(bound), 0, "bound {bound}");
+            assert!(threshold < u64::from(bound));
+        }
+        for bound in (1..=100_000u64).chain([1 << 63, (1 << 63) + 1, 3 << 62, u64::MAX]) {
+            let threshold = bound.wrapping_neg() % bound;
+            // 2^64 is not representable, so the identity is checked in the
+            // equivalent form: the accepted count is a multiple of bound.
+            assert_eq!(threshold, (u64::MAX % bound + 1) % bound, "bound {bound}");
+        }
+    }
+
+    #[test]
+    fn a_generator_is_comparable_and_printable() {
+        let rng = Rng::new(SEED, STREAM);
+        assert_eq!(rng, rng.clone());
+        assert_ne!(rng, Rng::new(SEED, StreamId::from_name("other")));
+        assert!(format!("{rng:?}").contains("Rng"));
+    }
+}

--- a/crates/rng/src/generator.rs
+++ b/crates/rng/src/generator.rs
@@ -69,9 +69,12 @@ impl Rng {
     ///   of how many generators were built before it, not of anything
     ///   ambient. Rebuilding a stream halfway through a replay gives the
     ///   same generator the recording had.
-    /// - **Distinct streams under one seed cannot collide.** Both words
-    ///   come from a bijective derivation, so two different `StreamId`s
-    ///   under the same `Seed` always produce different starting states.
+    /// - **Distinct streams under one seed cannot collide.** The state
+    ///   word comes from a bijective derivation, so two different
+    ///   `StreamId`s under the same `Seed` always produce different
+    ///   starting states. The increment word is not bijective — it is
+    ///   forced odd, which is two-to-one — so the guarantee rests on the
+    ///   state word alone, not on both.
     ///   The property those streams do *not* have is proven statistical
     ///   independence — see the crate documentation, which states the
     ///   bound honestly.

--- a/crates/rng/src/lib.rs
+++ b/crates/rng/src/lib.rs
@@ -58,9 +58,12 @@
 //! - **Nothing can fail.** Non-zero bounds by type, a total constructor,
 //!   saturating nothing because there is nothing to saturate: no method
 //!   here returns a `Result`, nothing panics, and nothing unwinds.
-//! - **No floating point.** Not in the generator, not in the draws, not
-//!   in the tests. The crate denies float arithmetic at its root, so the
-//!   claim is checked by the compiler rather than by review.
+//! - **No floating point.** Not in the generator, not in the draws. The
+//!   crate denies float *arithmetic* at its root, which the compiler does
+//!   hold — but that lint covers operators only, so a float-typed
+//!   signature, a cast, or a comparison would still pass. Keeping floats
+//!   out of the API surface is a review rule, and saying otherwise would
+//!   overstate what the gate does.
 //!
 //! # No float draws in v0, on purpose
 //!

--- a/crates/rng/src/lib.rs
+++ b/crates/rng/src/lib.rs
@@ -1,0 +1,101 @@
+//! Seeded, reproducible pseudo-random numbers for simulation: PCG32 with
+//! per-domain streams derived from one master seed, and bounded draws with
+//! no modulo bias.
+//!
+//! Randomness in a deterministic simulation is not a source of surprise —
+//! it is a *function of the seed*, and the whole job of this crate is to
+//! keep it that way. There is no ambient generator, no way to seed from
+//! the clock, and no dependency that could offer either: a run's numbers
+//! come from the seed the application supplied, or the crate does not
+//! produce them.
+//!
+//! ```
+//! use renew_rng::{Rng, Seed, StreamId};
+//!
+//! // Streams are named where they are used. Two systems never have to
+//! // agree on a number, and neither can silently draw from the other's
+//! // sequence.
+//! const LOOT: StreamId = StreamId::from_name("loot");
+//! const SPAWN: StreamId = StreamId::from_name("spawn");
+//!
+//! let seed = Seed::from_u64(0x5eed);
+//! let mut loot = Rng::new(seed, LOOT);
+//! let mut spawn = Rng::new(seed, SPAWN);
+//!
+//! // Per-entity sequences hang off a system's stream by index, so an
+//! // entity's rolls are the same however the world was iterated.
+//! let mut enemy = Rng::new(seed, SPAWN.child(17));
+//!
+//! let _roll = loot.next_u32();
+//! let _where = spawn.next_u64();
+//! let _crit = enemy.next_bool();
+//! ```
+//!
+//! Bounded draws take a non-zero bound; [`Rng::below_u32`] shows the
+//! idiom and says why the type is spelled that way.
+//!
+//! # Contract
+//!
+//! - **A run is a pure function of its seed.** For a fixed build and
+//!   platform, every number this crate produces is determined by the
+//!   `(Seed, StreamId)` pair it came from and the number of draws taken
+//!   before it. Nothing here reads a clock, allocates, spawns a thread,
+//!   or holds iteration-order-dependent state.
+//! - **Derivation is order-independent.** [`Rng::new`] is a pure function
+//!   of its arguments. Building a stream early, late, or twice gives the
+//!   same generator, which is what lets a replay reconstruct one entity's
+//!   sequence without replaying every other entity's.
+//! - **Distinct streams under one seed cannot collide.** The derivation is
+//!   a bijection, so two different [`StreamId`]s under one [`Seed`] always
+//!   start from different internal states. What is *not* claimed is proven
+//!   statistical independence between streams: the generator's designers
+//!   do not claim it, and neither does this crate. What it gives instead
+//!   is that the correlations known to exist between this algorithm's
+//!   streams cannot be reached by adjacent or patterned identifiers,
+//!   because no identifier reaches the generator unmixed.
+//! - **Bounded draws are exactly uniform.** Not nearly uniform. See
+//!   [`Rng::below_u32`] for the technique and what it costs.
+//! - **Nothing can fail.** Non-zero bounds by type, a total constructor,
+//!   saturating nothing because there is nothing to saturate: no method
+//!   here returns a `Result`, nothing panics, and nothing unwinds.
+//! - **No floating point.** Not in the generator, not in the draws, not
+//!   in the tests. The crate denies float arithmetic at its root, so the
+//!   claim is checked by the compiler rather than by review.
+//!
+//! # No float draws in v0, on purpose
+//!
+//! There is no `next_f32`. A float in `[0, 1)` *can* be built exactly —
+//! `f32::from_bits(0x3f80_0000 | (bits >> 9)) - 1.0` is bit-exact on every
+//! target this engine supports, because the bit pattern is assembled with
+//! integers and the subtraction is exact — so the objection is not that it
+//! cannot be done. The objection is that this crate has no consumer yet,
+//! so shipping a float faucet now means guessing the precision, the
+//! interval convention (open, half-open, closed) and the rounding
+//! behaviour that some future gameplay system wants, and then owning that
+//! guess in a reproducibility contract that spans platforms this engine
+//! has not yet proven bit-identical.
+//!
+//! Until a caller exists with a stated requirement, the recipe above lives
+//! in documentation, where it can be read and argued with, rather than in
+//! an API, where it would be depended on. Simulation code that needs
+//! fractions should prefer fixed point anyway: draw an integer and divide
+//! by a constant scale.
+//!
+//! # Extension points
+//!
+//! None. No trait, no `dyn`, no runtime polymorphism — the manifest says
+//! so and CI holds the crate to it. Swapping generators is not a designed
+//! extension point and should not become one lightly: the algorithm is
+//! part of what "reproducible" means here, and every recorded trace and
+//! golden state hash in the tree is stated against this one.
+
+// This crate computes; it does not print, and it does not do arithmetic on
+// floats. Both are denied here rather than left to review.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
+
+mod generator;
+mod mix;
+mod seed;
+
+pub use generator::Rng;
+pub use seed::{Seed, StreamId};

--- a/crates/rng/src/mix.rs
+++ b/crates/rng/src/mix.rs
@@ -1,0 +1,142 @@
+//! The bit mixer every derivation in this crate runs through: `SplitMix64`.
+//!
+//! Two jobs, both of them structural rather than statistical.
+//!
+//! The first is decorrelation. Callers hand this crate small, adjacent,
+//! human-chosen numbers — seed 1, entity 2, stream 3 — and a generator
+//! seeded straight from such a number starts in a corner of its state
+//! space. `SplitMix64`'s finalizer is the standard answer: an
+//! xor-shift-multiply avalanche that turns a one-bit input change into a
+//! half-of-the-output change.
+//!
+//! The second is provability. The finalizer is a bijection, so the map
+//! from a stream identifier to a generator's starting point is injective
+//! for a fixed master seed. That turns "different streams are probably
+//! different" into "different streams cannot collide", which is a claim a
+//! test can hold.
+//!
+//! `SplitMix64` rather than something invented here because it is published,
+//! frozen, and has known output for a known seed — the same standard the
+//! generator itself is held to. Its constants are not adjustable and its
+//! output for seed zero is pinned by the unit test below.
+
+/// The golden-ratio odd increment `SplitMix64` walks its state by. Odd, so
+/// stepping it visits all 2^64 values before repeating.
+pub(crate) const GAMMA: u64 = 0x9e37_79b9_7f4a_7c15;
+
+/// `SplitMix64`'s finalizer, applied to one value. A bijection with
+/// avalanche: flipping one input bit flips about half the output bits.
+pub(crate) const fn mix(value: u64) -> u64 {
+    let mixed = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    let mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^ (mixed >> 31)
+}
+
+/// The `SplitMix64` generator: step the state by [`GAMMA`], finalize, emit.
+///
+/// Used only to expand one 64-bit derivation root into the two words a
+/// generator needs. It is never handed to a caller — one published
+/// algorithm is enough to audit, and this one exists to seed the other.
+pub(crate) struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    pub(crate) const fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    pub(crate) const fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(GAMMA);
+        mix(self.state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GAMMA, SplitMix64, mix};
+
+    /// The published `SplitMix64` output for seed zero, pinning the two
+    /// multipliers, the three shift distances and the increment against a
+    /// source outside this repository. Every derived generator in the
+    /// crate walks through this function, so these eight values stand
+    /// behind every stream the engine will ever draw from.
+    #[test]
+    fn the_published_reference_vector_matches() {
+        let mut walk = SplitMix64::new(0);
+        let got: [u64; 8] = core::array::from_fn(|_| walk.next());
+        assert_eq!(
+            got,
+            [
+                0xE220_A839_7B1D_CDAF,
+                0x6E78_9E6A_A1B9_65F4,
+                0x06C4_5D18_8009_454F,
+                0xF88B_B8A8_724C_81EC,
+                0x1B39_896A_51A8_749B,
+                0x53CB_9F0C_747E_A2EA,
+                0x2C82_9ABE_1F45_32E1,
+                0xC584_133A_C916_AB3C,
+            ]
+        );
+    }
+
+    /// The walk is exactly "add gamma, then finalize", so its first output
+    /// is reproducible from the finalizer alone. This is what makes the
+    /// vector above a check on `mix` and not only on the pair.
+    #[test]
+    fn the_walk_is_the_finalizer_over_a_gamma_step() {
+        let mut walk = SplitMix64::new(0x1234_5678_9abc_def0);
+        assert_eq!(
+            walk.next(),
+            mix(0x1234_5678_9abc_def0u64.wrapping_add(GAMMA))
+        );
+        assert_eq!(
+            walk.next(),
+            mix(0x1234_5678_9abc_def0u64
+                .wrapping_add(GAMMA)
+                .wrapping_add(GAMMA))
+        );
+    }
+
+    /// Injectivity is the property the stream-derivation guarantee rests
+    /// on, so it is asserted rather than assumed. Exhaustive proof is out
+    /// of reach for a 64-bit domain; a dense sweep plus the structural
+    /// argument (three invertible steps: xor-shift, odd multiply,
+    /// xor-shift) is what is available.
+    #[test]
+    fn the_finalizer_does_not_collide_over_a_dense_sweep() {
+        // Two disjoint input sets: the small adjacent integers callers
+        // actually pass, and a stride across the whole 64-bit range.
+        let inputs: std::collections::BTreeSet<u64> = (0..40_000u64)
+            .chain((0..40_000u64).map(|step| step.wrapping_mul(GAMMA)))
+            .collect();
+        let outputs: std::collections::BTreeSet<u64> =
+            inputs.iter().map(|&value| mix(value)).collect();
+        assert_eq!(inputs.len(), outputs.len());
+    }
+
+    /// Avalanche, measured rather than asserted from the literature: one
+    /// input bit flipped moves close to half the output bits. A mixer that
+    /// merely permuted bytes would pass injectivity above and fail here.
+    #[test]
+    fn one_input_bit_moves_about_half_the_output_bits() {
+        let mut total = 0u32;
+        let mut samples = 0u32;
+        let mut worst = 64u32;
+        for value in 0..1_000u64 {
+            for bit in 0..64 {
+                let moved = (mix(value) ^ mix(value ^ (1 << bit))).count_ones();
+                total += moved;
+                samples += 1;
+                worst = worst.min(moved);
+            }
+        }
+        // Mean in [30, 34] out of 64, and no single flip moving fewer than
+        // 8 bits. Integer arithmetic on purpose: this crate has no floats.
+        assert!(
+            (30..=34).contains(&(total / samples)),
+            "mean {total}/{samples}"
+        );
+        assert!(worst >= 8, "a one-bit change moved only {worst} bits");
+    }
+}

--- a/crates/rng/src/seed.rs
+++ b/crates/rng/src/seed.rs
@@ -1,0 +1,191 @@
+//! The two identities a generator is built from: the run's master seed and
+//! the stream that names one use of it.
+//!
+//! Separate newtypes over `u64` because `Rng::new(seed, stream)` takes two
+//! of them and swapping the arguments is otherwise silent: the simulation
+//! still runs, still reproduces, and quietly draws from a different
+//! sequence than the recorded trace expects. Distinct types make that a
+//! compile error.
+//!
+//! # Why a stream is a name and not a number a caller invents
+//!
+//! Two systems that both pick `1` share a sequence, and share it
+//! invisibly: nothing fails, the numbers just correlate. Avoiding that
+//! with integers means a central registry — one list every module has to
+//! agree on and keep in step, which is a coupling this engine does not
+//! want. [`StreamId::from_name`] removes the registry: every module names
+//! its own streams in its own file, and the mixer makes collisions between
+//! different names a birthday event over 64 bits rather than a namespace
+//! problem.
+
+use crate::mix::{GAMMA, mix};
+
+/// The master seed for one run of a simulation.
+///
+/// Where it comes from is the application's business — a command-line
+/// flag, a recorded input trace, a lobby handshake. This crate never
+/// invents one, which is why it has no dependency that could supply
+/// entropy: an unseeded run is not something a caller can reach by
+/// forgetting an argument.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Seed(u64);
+
+impl Seed {
+    #[must_use]
+    pub const fn from_u64(value: u64) -> Self {
+        Self(value)
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Names one independent sequence within a run: a system, a subsystem, or
+/// one entity inside one of those.
+///
+/// Identity only — a `StreamId` holds no generator state and never
+/// changes as the run proceeds. That is what makes derivation
+/// order-independent: `Rng::new(seed, id)` answers the same way whether it
+/// is called on frame 1 or frame 900, before or after every other stream
+/// of the run, which is exactly what a replay needs when entities are
+/// created in a different order than they were recorded in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StreamId(u64);
+
+impl StreamId {
+    /// The stream a name refers to, computed at compile time when the
+    /// name is a literal:
+    ///
+    /// ```
+    /// use renew_rng::StreamId;
+    /// const LOOT: StreamId = StreamId::from_name("loot");
+    /// ```
+    ///
+    /// Each byte is folded through the mixer, so two names differing
+    /// anywhere — including in length — land far apart rather than
+    /// adjacent. This is a naming device, not a hash function for general
+    /// use: it is not fast, it is not published, and nothing outside this
+    /// crate should depend on the exact value it produces.
+    #[must_use]
+    pub const fn from_name(name: &str) -> Self {
+        let bytes = name.as_bytes();
+        let mut accumulator = GAMMA;
+        let mut index = 0;
+        while index < bytes.len() {
+            // `u64::from` is not callable in a `const fn` (const trait
+            // impls are unstable), so the widening is written as a cast.
+            #[allow(clippy::cast_lossless)]
+            let byte = bytes[index] as u64;
+            accumulator = mix(accumulator ^ byte);
+            index += 1;
+        }
+        Self(accumulator)
+    }
+
+    /// A stream chosen by number rather than by name — for identifiers
+    /// that are already numbers, such as a recorded trace's stream table.
+    #[must_use]
+    pub const fn from_u64(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// The stream belonging to one index under this one: per-entity,
+    /// per-tile, per-shot.
+    ///
+    /// Injective in `index` for a fixed parent, so no two entities under
+    /// one system can share a sequence. Different parents with different
+    /// indices *can* in principle land on the same child — 128 bits of
+    /// input do not fit in 64 bits of output — and the honest bound is the
+    /// birthday one: a run using a million distinct streams has roughly a
+    /// one-in-forty-million chance of any collision at all.
+    #[must_use]
+    pub const fn child(self, index: u64) -> Self {
+        Self(mix(self.0 ^ mix(index).wrapping_mul(GAMMA)))
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Seed, StreamId};
+
+    #[test]
+    fn a_seed_round_trips() {
+        assert_eq!(Seed::from_u64(0).get(), 0);
+        assert_eq!(Seed::from_u64(u64::MAX).get(), u64::MAX);
+        assert!(Seed::from_u64(1) > Seed::from_u64(0));
+    }
+
+    #[test]
+    fn a_numeric_stream_id_round_trips() {
+        assert_eq!(StreamId::from_u64(7).get(), 7);
+        assert_ne!(StreamId::from_u64(7), StreamId::from_u64(8));
+    }
+
+    #[test]
+    fn a_named_stream_is_computable_at_compile_time() {
+        const LOOT: StreamId = StreamId::from_name("loot");
+        assert_eq!(LOOT, StreamId::from_name("loot"));
+    }
+
+    /// Names that a careless hash would collide on: one-character
+    /// differences, a suffix, an anagram, and the empty name.
+    #[test]
+    fn near_miss_names_land_in_different_streams() {
+        let names = [
+            "",
+            "a",
+            "b",
+            "ai",
+            "ia",
+            "loot",
+            "loots",
+            "loo",
+            "physics",
+            "physic",
+            "spawn",
+            "spawns",
+            "npc_spawn",
+            "spawn_npc",
+        ];
+        let ids: std::collections::BTreeSet<u64> = names
+            .iter()
+            .map(|name| StreamId::from_name(name).get())
+            .collect();
+        assert_eq!(ids.len(), names.len());
+    }
+
+    #[test]
+    fn children_of_one_parent_are_distinct() {
+        let parent = StreamId::from_name("enemies");
+        let ids: std::collections::BTreeSet<u64> = (0..20_000u64)
+            .map(|index| parent.child(index).get())
+            .collect();
+        assert_eq!(ids.len(), 20_000);
+    }
+
+    /// Two systems that happen to use the same entity index must not share
+    /// a sequence — the whole reason a child is derived from its parent
+    /// rather than from the index alone.
+    #[test]
+    fn the_same_index_under_different_parents_is_a_different_stream() {
+        let index = 42;
+        assert_ne!(
+            StreamId::from_name("enemies").child(index),
+            StreamId::from_name("loot").child(index)
+        );
+    }
+
+    #[test]
+    fn children_nest() {
+        let grandchild = StreamId::from_name("enemies").child(3).child(9);
+        assert_ne!(grandchild, StreamId::from_name("enemies").child(9).child(3));
+        assert_ne!(grandchild, StreamId::from_name("enemies").child(3));
+    }
+}

--- a/crates/rng/tests/determinism.rs
+++ b/crates/rng/tests/determinism.rs
@@ -1,0 +1,198 @@
+//! Reproducibility, in the three forms a replay actually needs: the same
+//! seed gives the same numbers, the numbers do not depend on when or in
+//! what order streams were built, and the values are frozen against a
+//! constant so a change to any of it fails here rather than in somebody's
+//! recorded trace six months from now.
+//!
+//! The digest below is folded locally rather than borrowed from the frame
+//! crate's `StateHash`. Not because a second implementation is welcome —
+//! it is not — but because a test-only dependency from this crate to an
+//! optional sibling would put a false edge in the removability graph, and
+//! this fold is six lines. Where a shared digest should live once the
+//! determinism harness needs one across several crates is an open question
+//! in the design note, not something to settle from inside a test file.
+
+use core::num::{NonZeroU32, NonZeroU64};
+
+use renew_rng::{Rng, Seed, StreamId};
+
+const SEED: Seed = Seed::from_u64(0x1234_5678_9abc_def0);
+const PHYSICS: StreamId = StreamId::from_name("physics");
+
+/// FNV-1a-64 over little-endian words, order-sensitive.
+struct Fold(u64);
+
+impl Fold {
+    const fn new() -> Self {
+        Self(0xcbf2_9ce4_8422_2325)
+    }
+
+    fn absorb(&mut self, value: u64) {
+        for byte in value.to_le_bytes() {
+            self.0 = (self.0 ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+}
+
+/// Draw a long, mixed run — raw words, wide words, coins, bounded draws
+/// narrow and wide — and fold everything, including where the generator
+/// ended up. One number that changes if anything at all changes.
+// The tests-only expect allowance covers #[test] fns, not their
+// helpers; this allow extends it, same spirit. Every bound here is a
+// non-zero literal.
+#[allow(clippy::expect_used)]
+fn digest_of_a_mixed_run(mut rng: Rng) -> u64 {
+    let narrow = NonZeroU32::new(6).expect("non-zero");
+    let awkward = NonZeroU32::new(3 << 30).expect("non-zero");
+    let wide = NonZeroU64::new((5 << 60) + 7).expect("non-zero");
+
+    let mut fold = Fold::new();
+    for _ in 0..2_000 {
+        fold.absorb(u64::from(rng.next_u32()));
+        fold.absorb(rng.next_u64());
+        fold.absorb(u64::from(rng.next_bool()));
+        fold.absorb(u64::from(rng.below_u32(narrow)));
+        fold.absorb(u64::from(rng.below_u32(awkward)));
+        fold.absorb(rng.below_u64(wide));
+    }
+    let (state, increment) = rng.parts();
+    fold.absorb(state);
+    fold.absorb(increment);
+    fold.0
+}
+
+/// The frozen oracle. These constants were produced by this crate on
+/// x86-64 Windows and are asserted on every platform CI runs: the point of
+/// freezing them is that the day one platform disagrees, the disagreement
+/// is a red build rather than a divergent replay.
+#[test]
+fn the_sequence_is_frozen_against_published_constants() {
+    let mut rng = Rng::new(SEED, PHYSICS);
+    let first: [u32; 8] = core::array::from_fn(|_| rng.next_u32());
+    assert_eq!(
+        first,
+        [
+            0x05f7_67bf,
+            0xa6d4_1562,
+            0xcfa5_8073,
+            0x544e_bc35,
+            0x93fa_5089,
+            0x2c83_165d,
+            0x584b_8dee,
+            0x513c_045b,
+        ]
+    );
+    assert_eq!(
+        digest_of_a_mixed_run(Rng::new(SEED, PHYSICS)),
+        0x682b_a758_cdb0_1ce9
+    );
+    assert_eq!(
+        Rng::new(SEED, PHYSICS).parts(),
+        (0xf60b_d34d_8990_bec7, 0xa544_b2cf_968b_f449)
+    );
+}
+
+/// The same seed and stream, built five separate times, produce the same
+/// run — the base case, and the one a determinism harness multiplies by a
+/// seed matrix.
+#[test]
+fn the_same_seed_and_stream_replay_identically() {
+    let expected = digest_of_a_mixed_run(Rng::new(SEED, PHYSICS));
+    for _ in 0..5 {
+        assert_eq!(digest_of_a_mixed_run(Rng::new(SEED, PHYSICS)), expected);
+    }
+}
+
+/// Every seed in a small matrix gives a different run, and each of those
+/// runs is itself repeatable. A generator that ignored its seed would pass
+/// the test above and fail this one.
+#[test]
+fn different_seeds_give_different_runs_and_each_repeats() {
+    let mut digests = std::collections::BTreeSet::new();
+    for value in 0..32u64 {
+        let seed = Seed::from_u64(value);
+        let digest = digest_of_a_mixed_run(Rng::new(seed, PHYSICS));
+        assert_eq!(digest_of_a_mixed_run(Rng::new(seed, PHYSICS)), digest);
+        assert!(digests.insert(digest), "seed {value} repeated a run");
+    }
+}
+
+/// Derivation is a pure function of `(seed, stream)`, so the order streams
+/// are created in cannot matter. This is the property that lets a replay
+/// reconstruct one entity's generator without reconstructing the world
+/// that was around when it was first created.
+#[test]
+fn stream_derivation_does_not_depend_on_creation_order() {
+    let forward: Vec<(u64, u64)> = (0..500u64)
+        .map(|index| Rng::new(SEED, PHYSICS.child(index)).parts())
+        .collect();
+
+    // Backwards, then a stride that visits the same indices in a third
+    // order, then again after unrelated generators have been built and
+    // drawn from.
+    let mut backward: Vec<(u64, u64)> = (0..500u64)
+        .rev()
+        .map(|index| Rng::new(SEED, PHYSICS.child(index)).parts())
+        .collect();
+    backward.reverse();
+    assert_eq!(backward, forward);
+
+    let mut noise = Rng::new(SEED, StreamId::from_name("noise"));
+    for index in (0..500usize).map(|step| (step * 337) % 500) {
+        let _ = noise.next_u64();
+        assert_eq!(
+            Rng::new(SEED, PHYSICS.child(index as u64)).parts(),
+            forward[index]
+        );
+    }
+}
+
+/// Interleaving draws from other streams changes nothing about a stream's
+/// own sequence. Obvious from the types — each generator owns its state —
+/// and asserted anyway, because it is the assumption every system-per-
+/// stream design rests on.
+#[test]
+fn streams_do_not_disturb_each_other() {
+    let alone: [u32; 64] = {
+        let mut rng = Rng::new(SEED, PHYSICS);
+        core::array::from_fn(|_| rng.next_u32())
+    };
+
+    let mut rng = Rng::new(SEED, PHYSICS);
+    let mut neighbours: Vec<Rng> = (0..8)
+        .map(|index| Rng::new(SEED, PHYSICS.child(index)))
+        .collect();
+    let interleaved: [u32; 64] = core::array::from_fn(|step| {
+        for neighbour in &mut neighbours {
+            let _ = neighbour.next_u64();
+        }
+        let _ = step;
+        rng.next_u32()
+    });
+    assert_eq!(interleaved, alone);
+}
+
+/// A snapshot taken anywhere resumes the same run. The determinism harness
+/// and any mid-trace replay entry point depend on this.
+#[test]
+fn a_run_can_be_suspended_and_resumed_at_any_point() {
+    let expected = digest_of_a_mixed_run(Rng::new(SEED, PHYSICS));
+    for cut in [0u32, 1, 7, 64] {
+        let mut rng = Rng::new(SEED, PHYSICS);
+        for _ in 0..cut {
+            let _ = rng.next_u32();
+        }
+        let (state, increment) = rng.parts();
+        let resumed = Rng::from_parts(state, increment);
+
+        let mut original = Rng::new(SEED, PHYSICS);
+        for _ in 0..cut {
+            let _ = original.next_u32();
+        }
+        assert_eq!(
+            digest_of_a_mixed_run(resumed),
+            digest_of_a_mixed_run(original)
+        );
+    }
+    assert_eq!(digest_of_a_mixed_run(Rng::new(SEED, PHYSICS)), expected);
+}

--- a/crates/rng/tests/determinism.rs
+++ b/crates/rng/tests/determinism.rs
@@ -8,9 +8,9 @@
 //! crate's `StateHash`. Not because a second implementation is welcome —
 //! it is not — but because a test-only dependency from this crate to an
 //! optional sibling would put a false edge in the removability graph, and
-//! this fold is six lines. Where a shared digest should live once the
-//! determinism harness needs one across several crates is an open question
-//! in the design note, not something to settle from inside a test file.
+//! this fold is six lines. Where a shared digest should live once several
+//! crates need one is deliberately unsettled — not something to decide from
+//! inside a test file.
 
 use core::num::{NonZeroU32, NonZeroU64};
 
@@ -90,6 +90,20 @@ fn the_sequence_is_frozen_against_published_constants() {
         Rng::new(SEED, PHYSICS).parts(),
         (0xf60b_d34d_8990_bec7, 0xa544_b2cf_968b_f449)
     );
+    // The per-entity derivation is frozen too, and it has to be. `child`
+    // is the path a replay leans on hardest: one stream per entity, drawn
+    // from a parent stream. Every other test of it asserts only that
+    // children differ from each other and from their parent, which holds
+    // for any injective avalanching function — so a future simplification
+    // of `child` would keep the whole suite green and silently invalidate
+    // every trace ever recorded against it. Verified by mutation:
+    // replacing the derivation with `mix(self.0 ^ index)` passes all the
+    // inequality tests and fails exactly these two.
+    assert_eq!(
+        Rng::new(SEED, PHYSICS.child(7)).parts(),
+        (0x481b_ac75_3e91_dd4d, 0xf7dd_bfb1_d3fc_68ef)
+    );
+    assert_eq!(PHYSICS.child(3).child(9).get(), 0x61ae_595c_4f48_7703);
 }
 
 /// The same seed and stream, built five separate times, produce the same

--- a/crates/rng/tests/known_answer.rs
+++ b/crates/rng/tests/known_answer.rs
@@ -1,0 +1,159 @@
+//! Known-answer tests: this is the published algorithm, not a lookalike.
+//!
+//! Every other test in this crate would pass on a generator with a shift
+//! distance off by one, a rotation in the wrong direction, or a multiplier
+//! with two digits transposed. Such a generator would be perfectly
+//! deterministic, perfectly reproducible, and perfectly wrong — its
+//! statistical guarantees would be nobody's, its period unknown, and the
+//! decades of analysis behind the real algorithm would not apply to it.
+//! Only somebody else's numbers can tell the two apart.
+//!
+//! The numbers below are the first round of output from the demonstration
+//! program shipped with the algorithm's reference implementation, seeded
+//! with 42 and 54. Four lines of it, all drawn from one continuing stream:
+//! six raw 32-bit words, sixty-five coin flips, thirty-three dice rolls,
+//! and a shuffled deck of fifty-two cards. Because the stream continues
+//! across the lines, the dice rolls only come out right if the coin flips
+//! consumed exactly the right number of words before them, and the deck
+//! only comes out right if both did. Any error anywhere in the generator
+//! or in the bounded-draw reduction breaks everything downstream of it.
+//!
+//! Two things these vectors deliberately do not pin:
+//!
+//! * **The seeding this crate actually uses.** The reference's seeding
+//!   procedure is reproduced below out of the public API, because that is
+//!   what the published numbers are stated against. Callers never use it;
+//!   `Rng::new` derives both words through the mixer instead, for the
+//!   reasons in the design note. What the vectors pin is the *generator* —
+//!   the step and the output function — which is the part the seeding then
+//!   feeds.
+//! * **The wide draws.** The reference is a 32-bit generator and publishes
+//!   no 64-bit vectors, so `next_u64` and `below_u64` are pinned by their
+//!   construction from the 32-bit path instead (`src/generator.rs`), plus
+//!   the frozen digest at the end of this file.
+
+use core::num::NonZeroU32;
+
+use renew_rng::Rng;
+
+/// The reference implementation's seeding routine, written out through
+/// this crate's public API so the published vectors can be stated against
+/// it: start at state zero with the sequence selector as an odd
+/// increment, step once, add the seed to the state, step again.
+///
+/// This is the one place in the tree that reproduces it. It exists for the
+/// vectors and for nothing else.
+fn reference_seeded(seed: u64, sequence: u64) -> Rng {
+    let mut rng = Rng::from_parts(0, (sequence << 1) | 1);
+    let _ = rng.next_u32();
+    let (state, increment) = rng.parts();
+    let mut rng = Rng::from_parts(state.wrapping_add(seed), increment);
+    let _ = rng.next_u32();
+    rng
+}
+
+// The tests-only expect allowance covers #[test] fns, not their
+// helpers; this allow extends it, same spirit.
+#[allow(clippy::expect_used)]
+fn bound(value: u32) -> NonZeroU32 {
+    NonZeroU32::new(value).expect("bounds in this file are literals and non-zero")
+}
+
+/// The published first round, in full and in order.
+#[test]
+fn the_published_demonstration_round_is_reproduced_exactly() {
+    let mut rng = reference_seeded(42, 54);
+
+    // Line 1: six raw 32-bit draws.
+    let words: [u32; 6] = core::array::from_fn(|_| rng.next_u32());
+    assert_eq!(
+        words,
+        [
+            0xa15c_02b7,
+            0x7b47_f409,
+            0xba1d_3330,
+            0x83d2_f293,
+            0xbfa4_784b,
+            0xcbed_606e,
+        ],
+        "the generator itself"
+    );
+
+    // Line 2: sixty-five coin flips. The count is part of the vector, and
+    // it is settled by the stream rather than by preference: the rolls and
+    // the deck below continue from the same words, and they only come out
+    // right if exactly sixty-five were consumed here.
+    let coins: String = (0..65)
+        .map(|_| if rng.next_bool() { 'H' } else { 'T' })
+        .collect();
+    assert_eq!(
+        coins, "HHTTTHTHHHTHTTTHHHHHTTTHHHTHTHTHTTHTTTHHHHHHTTTTHHTTTTTHTTTTTTTHT",
+        "coin flips, which are also the bounded draw for two"
+    );
+
+    // Line 3: thirty-three dice rolls — the bounded-draw path, for a
+    // bound that does not divide the word range.
+    let rolls: Vec<u32> = (0..33).map(|_| rng.below_u32(bound(6)) + 1).collect();
+    assert_eq!(
+        rolls,
+        vec![
+            3, 4, 1, 1, 2, 2, 3, 2, 4, 3, 2, 4, 3, 3, 5, 2, 3, 1, 3, 1, 5, 1, 4, 1, 5, 6, 4, 6, 6,
+            2, 6, 3, 3
+        ],
+        "bounded draws"
+    );
+
+    // Line 4: a shuffled deck. The reference's demonstration shuffles with
+    // the standard Fisher-Yates loop, drawing a fresh bound on every step,
+    // so this pins fifty-one consecutive bounded draws with fifty-one
+    // different bounds.
+    let mut deck: Vec<u32> = (0..52).collect();
+    for upper in (2..=52u32).rev() {
+        let chosen = rng.below_u32(bound(upper)) as usize;
+        deck.swap(chosen, (upper - 1) as usize);
+    }
+    let ranks = [
+        'A', '2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K',
+    ];
+    let suits = ['h', 'c', 'd', 's'];
+    let hand: Vec<String> = deck
+        .iter()
+        .map(|card| {
+            format!(
+                "{}{}",
+                ranks[(card / 4) as usize],
+                suits[(card % 4) as usize]
+            )
+        })
+        .collect();
+    assert_eq!(
+        hand.join(" "),
+        "Qd Ks 6d 3s 3d 4c 3h Td Kc 5c Jh Kd Jd As 4s 4h Ad Th Ac Jc 7s Qs \
+         2s 7h Kh 2d 6c Ah 4d Qh 9h 6s 5s 2c 9c Ts 8d 9s 3c 8c Js 5d 2h 6h \
+         7d 8s 9d 5h 8h Qc 7c Tc",
+        "fifty-one bounded draws with fifty-one different bounds"
+    );
+}
+
+/// The vectors again, reached the way a caller reaches the generator —
+/// through the state pair rather than through the reference's seeding
+/// dance. This is what makes `from_parts` a supported entry point rather
+/// than a test hook: the same words in, the same sequence out.
+#[test]
+fn the_same_stream_comes_back_from_a_snapshot_of_it() {
+    let reference = reference_seeded(42, 54);
+    let (state, increment) = reference.parts();
+    let mut restored = Rng::from_parts(state, increment);
+    let words: [u32; 6] = core::array::from_fn(|_| restored.next_u32());
+    assert_eq!(
+        words,
+        [
+            0xa15c_02b7,
+            0x7b47_f409,
+            0xba1d_3330,
+            0x83d2_f293,
+            0xbfa4_784b,
+            0xcbed_606e,
+        ]
+    );
+}

--- a/crates/rng/tests/known_answer.rs
+++ b/crates/rng/tests/known_answer.rs
@@ -23,8 +23,9 @@
 //! * **The seeding this crate actually uses.** The reference's seeding
 //!   procedure is reproduced below out of the public API, because that is
 //!   what the published numbers are stated against. Callers never use it;
-//!   `Rng::new` derives both words through the mixer instead, for the
-//!   reasons in the design note. What the vectors pin is the *generator* —
+//!   `Rng::new` derives both words through the mixer instead, because a
+//!   seed used raw leaves the first output at zero for a wide range of
+//!   small seeds. What the vectors pin is the *generator* —
 //!   the step and the output function — which is the part the seeding then
 //!   feeds.
 //! * **The wide draws.** The reference is a 32-bit generator and publishes

--- a/crates/rng/tests/properties.rs
+++ b/crates/rng/tests/properties.rs
@@ -1,0 +1,224 @@
+//! Property coverage over inputs no hand-written case would reach: the
+//! bounded draws across the whole range of bounds and seeds, the wide
+//! draw's construction from the narrow one, snapshot round-trips, and the
+//! two structural guarantees the stream design rests on.
+//!
+//! What these properties cannot do is tell a correct generator from a
+//! wrong one — every one of them passes on any deterministic sequence of
+//! bits. That job belongs to `tests/known_answer.rs`. These hold the
+//! *reductions* built on top of the sequence, which is where the bugs a
+//! known-answer test cannot see live: an off-by-one bound, a rejection
+//! loop that rejects the wrong side, a snapshot that drops the low bit of
+//! an increment.
+
+use core::num::{NonZeroU32, NonZeroU64};
+
+use proptest::prelude::*;
+use proptest::test_runner::RngSeed;
+use renew_rng::{Rng, Seed, StreamId};
+
+// Test helpers (called only from #[test] fns): the tests-only expect
+// allowance covers #[test] fns, not their helpers; this allow extends it,
+// same spirit. Both generators produce non-zero values by construction.
+#[allow(clippy::expect_used)]
+fn narrow(value: u32) -> NonZeroU32 {
+    NonZeroU32::new(value).expect("non-zero")
+}
+
+#[allow(clippy::expect_used)]
+fn wide(value: u64) -> NonZeroU64 {
+    NonZeroU64::new(value).expect("non-zero")
+}
+
+proptest! {
+    // Fixed RNG seed: the suite explores the same inputs on every run and
+    // every machine, so a property failure anywhere reproduces everywhere.
+    // Fresh exploration is a deliberate act (change the seed), never an
+    // ambient one.
+    #![proptest_config(ProptestConfig {
+        rng_seed: RngSeed::Fixed(0x0000_2607),
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    /// The whole point of a bounded draw. Checked across the range of
+    /// bounds where the rejection threshold matters most — everything
+    /// above 2^31 refuses a large share of words.
+    #[test]
+    fn a_narrow_bounded_draw_is_always_below_its_bound(
+        seed in any::<u64>(),
+        stream in any::<u64>(),
+        bounds in prop::collection::vec(1u32..=u32::MAX, 1..12),
+    ) {
+        let mut rng = Rng::new(Seed::from_u64(seed), StreamId::from_u64(stream));
+        for value in bounds {
+            let bound = narrow(value);
+            for _ in 0..8 {
+                prop_assert!(rng.below_u32(bound) < value);
+            }
+        }
+    }
+
+    #[test]
+    fn a_wide_bounded_draw_is_always_below_its_bound(
+        seed in any::<u64>(),
+        bounds in prop::collection::vec(1u64..=u64::MAX, 1..12),
+    ) {
+        let mut rng = Rng::new(Seed::from_u64(seed), StreamId::from_name("wide"));
+        for value in bounds {
+            let bound = wide(value);
+            for _ in 0..8 {
+                prop_assert!(rng.below_u64(bound) < value);
+            }
+        }
+    }
+
+    /// A bound of one has one answer and must not cost more than one word:
+    /// its rejection threshold is zero, so the loop can never turn.
+    #[test]
+    fn a_bound_of_one_never_rejects(seed in any::<u64>()) {
+        let mut bounded = Rng::new(Seed::from_u64(seed), StreamId::from_name("one"));
+        let mut raw = bounded.clone();
+        for _ in 0..32 {
+            prop_assert_eq!(bounded.below_u32(narrow(1)), 0);
+            prop_assert_eq!(bounded.below_u64(wide(1)), 0);
+            let _ = raw.next_u32();
+            let _ = raw.next_u64();
+        }
+        prop_assert_eq!(bounded.parts(), raw.parts());
+    }
+
+    /// A bound that is an exact power of two divides the word range, so
+    /// its threshold is zero as well — the common case in game code, and
+    /// the one where the rejection loop must stay out of the way.
+    #[test]
+    fn a_power_of_two_bound_never_rejects(seed in any::<u64>(), exponent in 0u32..32) {
+        let bound = narrow(1u32 << exponent);
+        let mut bounded = Rng::new(Seed::from_u64(seed), StreamId::from_name("pow2"));
+        let mut raw = bounded.clone();
+        for _ in 0..32 {
+            let value = bounded.below_u32(bound);
+            let word = raw.next_u32();
+            prop_assert_eq!(value, word % bound.get());
+        }
+        prop_assert_eq!(bounded.parts(), raw.parts());
+    }
+
+    /// The wide draw is exactly two narrow ones, low half first. Stated in
+    /// the documentation, so it is asserted rather than trusted.
+    #[test]
+    fn a_wide_draw_is_two_narrow_draws_low_half_first(seed in any::<u64>()) {
+        let mut widely = Rng::new(Seed::from_u64(seed), StreamId::from_name("halves"));
+        let mut narrowly = widely.clone();
+        for _ in 0..16 {
+            let value = widely.next_u64();
+            let low = u64::from(narrowly.next_u32());
+            let high = u64::from(narrowly.next_u32());
+            prop_assert_eq!(value, (high << 32) | low);
+        }
+        prop_assert_eq!(widely.parts(), narrowly.parts());
+    }
+
+    /// A coin is the bounded draw for two, everywhere, not just for the
+    /// seed the known-answer test uses.
+    #[test]
+    fn a_coin_is_the_bounded_draw_for_two(seed in any::<u64>()) {
+        let mut coins = Rng::new(Seed::from_u64(seed), StreamId::from_name("coins"));
+        let mut bounded = coins.clone();
+        for _ in 0..64 {
+            prop_assert_eq!(coins.next_bool(), bounded.below_u32(narrow(2)) != 0);
+        }
+    }
+
+    /// Snapshots round-trip exactly for every generator this crate
+    /// produces, including after an arbitrary number of draws of every
+    /// shape.
+    #[test]
+    fn a_snapshot_round_trips(
+        seed in any::<u64>(),
+        stream in any::<u64>(),
+        draws in 0u32..64,
+    ) {
+        let mut rng = Rng::new(Seed::from_u64(seed), StreamId::from_u64(stream));
+        for step in 0..draws {
+            match step % 3 {
+                0 => { let _ = rng.next_u32(); }
+                1 => { let _ = rng.next_u64(); }
+                _ => { let _ = rng.below_u32(narrow(7)); }
+            }
+        }
+        let (state, increment) = rng.parts();
+        let mut resumed = Rng::from_parts(state, increment);
+        prop_assert_eq!(resumed.clone(), rng.clone());
+        for _ in 0..8 {
+            prop_assert_eq!(resumed.next_u64(), rng.next_u64());
+        }
+    }
+
+    /// Restoring from an arbitrary pair — including an even increment,
+    /// which no generator here produces — is total and stays odd.
+    #[test]
+    fn an_arbitrary_pair_restores_to_a_usable_generator(
+        state in any::<u64>(),
+        increment in any::<u64>(),
+    ) {
+        let mut rng = Rng::from_parts(state, increment);
+        let (restored_state, restored_increment) = rng.parts();
+        prop_assert_eq!(restored_state, state);
+        prop_assert_eq!(restored_increment, increment | 1);
+        prop_assert_eq!(restored_increment & 1, 1);
+        let _ = rng.next_u64();
+    }
+
+    /// The guarantee the stream design is stated on: under one seed, two
+    /// different stream identifiers never start from the same place.
+    #[test]
+    fn distinct_streams_under_one_seed_never_collide(
+        seed in any::<u64>(),
+        streams in prop::collection::btree_set(any::<u64>(), 2..48),
+    ) {
+        let seed = Seed::from_u64(seed);
+        let starts: std::collections::BTreeSet<(u64, u64)> = streams
+            .iter()
+            .map(|&stream| Rng::new(seed, StreamId::from_u64(stream)).parts())
+            .collect();
+        prop_assert_eq!(starts.len(), streams.len());
+    }
+
+    /// And the same for one stream across seeds: changing the seed
+    /// changes every stream of the run, which is what makes a seed worth
+    /// recording.
+    #[test]
+    fn one_stream_moves_when_the_seed_moves(
+        seeds in prop::collection::btree_set(any::<u64>(), 2..48),
+        stream in any::<u64>(),
+    ) {
+        let stream = StreamId::from_u64(stream);
+        let starts: std::collections::BTreeSet<(u64, u64)> = seeds
+            .iter()
+            .map(|&seed| Rng::new(Seed::from_u64(seed), stream).parts())
+            .collect();
+        prop_assert_eq!(starts.len(), seeds.len());
+    }
+
+    /// Children of one parent are distinct, and the same index under two
+    /// different parents is two different streams.
+    #[test]
+    fn child_streams_are_distinct(
+        parent in any::<u64>(),
+        other in any::<u64>(),
+        indices in prop::collection::btree_set(any::<u64>(), 2..48),
+    ) {
+        prop_assume!(parent != other);
+        let parent = StreamId::from_u64(parent);
+        let other = StreamId::from_u64(other);
+        let children: std::collections::BTreeSet<u64> = indices
+            .iter()
+            .map(|&index| parent.child(index).get())
+            .collect();
+        prop_assert_eq!(children.len(), indices.len());
+        for &index in &indices {
+            prop_assert_ne!(parent.child(index), other.child(index));
+        }
+    }
+}

--- a/crates/rng/tests/statistics.rs
+++ b/crates/rng/tests/statistics.rs
@@ -1,0 +1,231 @@
+//! The measured evidence: the things that are true of this crate's output
+//! and false of the plausible wrong versions of it.
+//!
+//! Every test here is a fixed-seed measurement, so none of them can flake:
+//! the sample is the same sequence on every machine and every run. Where a
+//! test names a tolerance, the tolerance is many standard deviations wide
+//! for the correct implementation and hopelessly narrow for the wrong one,
+//! and the comment says which.
+//!
+//! Two of them compute the wrong answer alongside the right one, from the
+//! same words. A test that only checks the correct path leaves the reader
+//! to take on trust that the wrong path would have been caught; these show
+//! it, in the same output.
+
+// The crate's no-floating-point rule extends to its tests: statistics
+// about a bit-exact generator are counted in integers or not at all.
+#![deny(clippy::float_arithmetic)]
+
+use core::num::NonZeroU32;
+
+use renew_rng::{Rng, Seed, StreamId};
+
+#[allow(clippy::expect_used)]
+fn narrow(value: u32) -> NonZeroU32 {
+    NonZeroU32::new(value).expect("non-zero")
+}
+
+/// The bound where modulo bias stops being academic. `3 * 2^30` leaves a
+/// tail of `2^30` words, so a bare remainder hands the bottom third of the
+/// range a second chance: it comes up half the time instead of a third.
+const AWKWARD: u32 = 3 << 30;
+
+/// Bounded draws are uniform, and the same words reduced with a bare
+/// remainder are not. Both counts come out of one measurement so the
+/// comparison is exact rather than rhetorical.
+#[test]
+fn the_bounded_draw_is_uniform_where_a_bare_remainder_is_not() {
+    const DRAWS: u32 = 90_000;
+    let third = AWKWARD / 3;
+
+    for seed in 0..3u64 {
+        let mut correct = Rng::new(Seed::from_u64(seed), StreamId::from_name("bias"));
+        let mut naive = correct.clone();
+
+        let mut correct_low = 0u32;
+        let mut naive_low = 0u32;
+        for _ in 0..DRAWS {
+            if correct.below_u32(narrow(AWKWARD)) < third {
+                correct_low += 1;
+            }
+            // The wrong reduction, on this crate's own words.
+            if naive.next_u32() % AWKWARD < third {
+                naive_low += 1;
+            }
+        }
+
+        // Uniform: 30_000 of 90_000 in the bottom third. One standard
+        // deviation is about 141, so 1_500 is more than ten of them.
+        let expected = DRAWS / 3;
+        assert!(
+            correct_low.abs_diff(expected) < 1_500,
+            "seed {seed}: {correct_low} of {DRAWS} in the bottom third, expected about {expected}"
+        );
+        // Biased: about 45_000 — half. Nowhere near the window above, and
+        // that gap is the whole reason the rejection loop exists.
+        assert!(
+            naive_low > DRAWS / 2 - 1_500,
+            "seed {seed}: a bare remainder produced {naive_low}, which is not the bias this test exists to demonstrate"
+        );
+    }
+}
+
+/// A small bound, the case where bias is real but far too small to
+/// measure: six does not divide the word range, and the excess is four
+/// words out of four billion. This test cannot tell a biased
+/// implementation from an unbiased one — it is here to say so, and to
+/// catch a reduction that is grossly wrong rather than subtly biased.
+#[test]
+fn a_small_bound_is_flat_across_its_buckets() {
+    const DRAWS: u32 = 600_000;
+    let mut rng = Rng::new(Seed::from_u64(7), StreamId::from_name("dice"));
+    let mut buckets = [0u32; 6];
+    for _ in 0..DRAWS {
+        buckets[rng.below_u32(narrow(6)) as usize] += 1;
+    }
+    let expected = DRAWS / 6;
+    for (face, count) in buckets.iter().enumerate() {
+        // One standard deviation is about 289; the window is over ten.
+        assert!(
+            count.abs_diff(expected) < 3_000,
+            "face {face}: {count} of {DRAWS}, expected about {expected} — buckets {buckets:?}"
+        );
+    }
+}
+
+/// The rejection loop turns about a third of the time at this bound (one
+/// word in four is refused, so four words buy three draws). Measured,
+/// because a rejection loop that never rejects and a rejection loop that
+/// rejects everything both produce plausible-looking values.
+#[test]
+fn the_rejection_rate_matches_the_threshold() {
+    const DRAWS: u32 = 60_000;
+    let mut rng = Rng::new(Seed::from_u64(11), StreamId::from_name("rate"));
+    let mut words = rng.clone();
+    for _ in 0..DRAWS {
+        let _ = rng.below_u32(narrow(AWKWARD));
+    }
+    let mut consumed = 0u32;
+    while words.parts() != rng.parts() {
+        let _ = words.next_u32();
+        consumed += 1;
+    }
+    // Expected 4/3 words per draw: 80_000 for 60_000 draws, within 1%.
+    assert!(
+        consumed.abs_diff(80_000) < 800,
+        "{consumed} words for {DRAWS} draws"
+    );
+}
+
+/// Adjacent master seeds — 1, 2, 3, the ones people actually type —
+/// produce unrelated first draws. About half the bits differ, which is
+/// what "unrelated" means for 32 bits.
+#[test]
+fn adjacent_seeds_produce_unrelated_streams() {
+    const PAIRS: u32 = 4_000;
+    let stream = StreamId::from_name("physics");
+    let mut total = 0u32;
+    let mut closest = 32u32;
+    for value in 0..u64::from(PAIRS) {
+        let mut left = Rng::new(Seed::from_u64(value), stream);
+        let mut right = Rng::new(Seed::from_u64(value + 1), stream);
+        let differing = (left.next_u32() ^ right.next_u32()).count_ones();
+        total += differing;
+        closest = closest.min(differing);
+    }
+    // Mean of 16 out of 32 bits; the window is 15 to 17, and the closest
+    // of four thousand pairs still differs in at least four bits.
+    assert!((15..=17).contains(&(total / PAIRS)), "mean {total}/{PAIRS}");
+    assert!(closest >= 4, "one pair differed in only {closest} bits");
+}
+
+/// The same for adjacent stream identifiers under one seed — the
+/// per-entity case, where identifiers are literally 0, 1, 2, 3.
+#[test]
+fn adjacent_streams_produce_unrelated_sequences() {
+    const PAIRS: u32 = 4_000;
+    let seed = Seed::from_u64(0xfeed_face);
+    let parent = StreamId::from_name("enemies");
+    let mut total = 0u32;
+    let mut closest = 32u32;
+    for index in 0..u64::from(PAIRS) {
+        let mut left = Rng::new(seed, parent.child(index));
+        let mut right = Rng::new(seed, parent.child(index + 1));
+        let differing = (left.next_u32() ^ right.next_u32()).count_ones();
+        total += differing;
+        closest = closest.min(differing);
+    }
+    assert!((15..=17).contains(&(total / PAIRS)), "mean {total}/{PAIRS}");
+    assert!(closest >= 4, "one pair differed in only {closest} bits");
+}
+
+/// Why the derivation exists, demonstrated on the failure it prevents.
+///
+/// `from_parts` restores a snapshot: it takes the generator's internal
+/// state verbatim and mixes nothing, which is exactly what a snapshot
+/// needs and exactly what a seed must never get. Feed a small number in as
+/// state and the first draw is not merely predictable — for every value
+/// below 2^27 it is *the same value*, zero, because the output function
+/// shifts those bits away before it ever reaches the rotation.
+///
+/// This is a real regression guard in both directions: it fails if someone
+/// starts mixing inside `from_parts` (which would break every snapshot),
+/// and it stands as the reason nobody should reach for `from_parts` when
+/// they mean `new`.
+#[test]
+fn seeding_a_generator_with_a_raw_small_number_is_the_trap_the_mixer_avoids() {
+    for state in 0..3_000u64 {
+        assert_eq!(
+            Rng::from_parts(state, 1).next_u32(),
+            0,
+            "state {state} should expose the unmixed-seed trap"
+        );
+    }
+    // The trap has an exact edge, which is worth pinning: the first
+    // non-zero first-draw appears once the state reaches 2^27.
+    assert_eq!(Rng::from_parts((1 << 27) - 1, 1).next_u32(), 0);
+    assert_eq!(Rng::from_parts(1 << 27, 1).next_u32(), 1);
+
+    // The supported path, on the same numbers.
+    let distinct: std::collections::BTreeSet<u32> = (0..3_000u64)
+        .map(|value| Rng::new(Seed::from_u64(value), StreamId::from_u64(0)).next_u32())
+        .collect();
+    assert!(
+        distinct.len() > 2_990,
+        "only {} distinct first draws from 3000 seeds",
+        distinct.len()
+    );
+}
+
+/// Coin flips are balanced. A generator whose low bit was weak — a bare
+/// linear congruential generator's low bit alternates — would fail here
+/// while passing every other test in this file.
+#[test]
+fn coin_flips_are_balanced_and_not_alternating() {
+    const FLIPS: u32 = 200_000;
+    let mut rng = Rng::new(Seed::from_u64(3), StreamId::from_name("coins"));
+    let mut heads = 0u32;
+    let mut alternations = 0u32;
+    let mut previous = rng.next_bool();
+    for _ in 0..FLIPS {
+        let flip = rng.next_bool();
+        if flip {
+            heads += 1;
+        }
+        if flip != previous {
+            alternations += 1;
+        }
+        previous = flip;
+    }
+    // Balanced to within ten standard deviations (one is about 224).
+    assert!(
+        heads.abs_diff(FLIPS / 2) < 2_500,
+        "{heads} heads of {FLIPS}"
+    );
+    // A strictly alternating low bit would give 200_000 alternations; a
+    // stuck one would give zero. Both are far outside this window.
+    assert!(
+        alternations.abs_diff(FLIPS / 2) < 2_500,
+        "{alternations} alternations of {FLIPS}"
+    );
+}

--- a/crates/rng/tests/zero_alloc.rs
+++ b/crates/rng/tests/zero_alloc.rs
@@ -1,0 +1,91 @@
+//! The allocation contract, pinned: seeding a generator and drawing from
+//! it performs zero heap allocations. Own process on purpose (the counters
+//! are process-wide); single test so no sibling allocates alongside.
+//!
+//! Measurement protocol: warmup first (lazy initialization measured out),
+//! then retry windows — the counters see every thread in the process,
+//! including the test harness's own output thread, so one-shot neighbor
+//! noise rides out while a genuine per-draw allocation reproduces in every
+//! window and still fails.
+//!
+//! This crate has no runtime allocation to remove — a generator is two
+//! integers and every draw returns one — so the test is a tripwire rather
+//! than a discovery. It fails the day someone adds a shuffle with a
+//! scratch buffer, a boxed generator behind a trait, or a formatted
+//! message on an error path. Randomness sits in the innermost simulation
+//! loop; there is no more expensive place to start allocating.
+
+use core::num::{NonZeroU32, NonZeroU64};
+
+use renew_memory::{CountingAllocator, counters};
+use renew_rng::{Rng, Seed, StreamId};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const SPAWN: StreamId = StreamId::from_name("spawn");
+
+fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
+    let mut last = (0u64, 0u64);
+    for _ in 0..attempts {
+        let before = counters::snapshot();
+        window();
+        let after = counters::snapshot();
+        if after.allocations == before.allocations && after.deallocations == before.deallocations {
+            return Ok(());
+        }
+        last = (
+            after.allocations - before.allocations,
+            after.deallocations - before.deallocations,
+        );
+    }
+    Err(format!(
+        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
+        last.0, last.1
+    ))
+}
+
+/// Everything a simulation does with this crate in one frame: derive a
+/// per-entity stream, draw every shape, snapshot, resume. A future
+/// allocation anywhere on that path is caught here.
+fn draw_body(sink: &mut u64, seed: Seed, entity: u64, narrow: NonZeroU32, wide: NonZeroU64) {
+    let mut rng = Rng::new(seed, SPAWN.child(entity));
+    *sink = sink
+        .wrapping_add(u64::from(rng.next_u32()))
+        .wrapping_add(rng.next_u64())
+        .wrapping_add(u64::from(rng.next_bool()))
+        .wrapping_add(u64::from(rng.below_u32(narrow)))
+        .wrapping_add(rng.below_u64(wide));
+    let (state, increment) = rng.parts();
+    let mut resumed = Rng::from_parts(state, increment);
+    *sink = sink.wrapping_add(resumed.next_u64());
+}
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn seeding_and_drawing_allocate_exactly_nothing() {
+    let seed = Seed::from_u64(0x5eed_5eed_5eed_5eed);
+    // A bound that provokes the rejection loop, so the retry path is
+    // inside the measured window rather than beside it.
+    let narrow = NonZeroU32::new(3 << 30).expect("non-zero");
+    let wide = NonZeroU64::new((3 << 62) + 1).expect("non-zero");
+    let mut sink = 0u64;
+
+    for entity in 0..4 {
+        draw_body(&mut sink, seed, entity, narrow, wide);
+    }
+
+    quiet_window(5, || {
+        for entity in 0..4_000 {
+            draw_body(&mut sink, seed, entity, narrow, wide);
+        }
+    })
+    .expect("seeding, deriving and drawing stay heap-silent");
+
+    // The window did real work: without this the test would pass on a
+    // generator that returned zero forever.
+    assert_ne!(sink, 0);
+}


### PR DESCRIPTION
Simulation must never draw from an unseeded source, and nothing in the tree offered a seeded one. This adds PCG32 with per-domain streams derived from one run seed.

**The algorithm was chosen on evidence, not speed.** Its reference implementation publishes a demo whose entire first round is reproduced here as known-answer vectors — raw words, 65 coin flips, 33 dice rolls and a 52-card shuffle, all drawn from one continuing stream, so the vectors chain and one wrong constant breaks everything downstream. That matters because a shift of 17 instead of 18, or a left rotation instead of a right one, passes every property and statistical test in the suite and is caught *only* by those vectors.

**Stream derivation mixes the seed and the stream id before either reaches the generator**, because the two obvious schemes are both broken and both look fine at a glance. Feeding a seed straight into the state gives a first output of zero for every seed below 2^27. Feeding an entity index into the stream parameter looks statistically healthy, but leaves an internal state delta between adjacent streams that is *identical across every master seed*. Both are measured in the test suite rather than asserted.

**Bounded draws use rejection sampling against a threshold.** It is unbiased, and unlike the multiply-shift alternative it is the method the published vectors exercise — so the bounded path is covered by known answers rather than only by statistics.

**No floating-point draws in v0.** No consumer exists yet to fix the interval, precision and rounding, and this crate sits in a spine that deliberately keeps time in integer nanoseconds.

**Zero dependencies**, which is what turns "seeded, always" into a property of the build graph rather than a promise: a generator that depends on nothing cannot be handed a clock or an entropy source by accident.

Also closes a pre-existing gap found while wiring the sanitizer feature list: the frame crate's allocation-counting test was missing from it, so that test had been running under instrumented allocators where its counts are meaningless.

## Verified locally (Windows, rustc 1.97.1)

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p renew-rng` — 54 tests across 7 suites, 0 failures
- `renew check` — workspace structure healthy
- `cargo deny check` — advisories, bans, licenses, sources all ok
- No new dependency; dev-dependencies are proptest (already in the tree) and the in-tree memory crate

Not merging until an independent read of the branch is done and the matrix is green.
