### PR TITLE
Require every engine crate to carry its lint configuration

### DIFF
--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -142,7 +142,16 @@ fn run_check(json_mode: bool) -> ExitCode {
 fn gather_findings() -> Result<Vec<structure::Finding>, String> {
     let root = workspace_root()
         .ok_or_else(|| "no workspace root found above the current directory".to_string())?;
-    findings_from_metadata(&cargo_metadata(&root)?)
+    let metadata = cargo_metadata(&root)?;
+    let mut findings = findings_from_metadata(&metadata)?;
+    // The lint-file rule is the one rule that has to look at the disk, so
+    // it is applied here rather than inside the pure rule set, and it is
+    // handed a predicate rather than reaching for the filesystem itself.
+    let shapes = structure::shapes_from_metadata(&parsed_metadata(&metadata)?)?;
+    findings.extend(structure::lint_file_findings(&shapes, &|path| {
+        Path::new(path).exists()
+    }));
+    Ok(findings)
 }
 
 /// Ask cargo to describe this workspace. Split from its readers so the

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -26,6 +26,8 @@ const REQUIRED_FIELDS: &[&str] = &[
 /// One crate as the rules see it.
 pub struct CrateShape {
     pub name: String,
+    /// The directory holding this crate's `Cargo.toml`, forward-slashed.
+    pub dir: String,
     /// Under the engine module roots (`crates/`)?
     pub engine: bool,
     /// Workspace-internal dependencies, any kind, dev included.
@@ -93,6 +95,9 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
             .unwrap_or_default()
             .replace('\\', "/");
         let engine = manifest_path.starts_with(&engine_root);
+        let dir = manifest_path
+            .rsplit_once('/')
+            .map_or(String::new(), |(parent, _)| parent.to_string());
         let deps = package
             .get("dependencies")
             .and_then(Value::as_array)
@@ -107,6 +112,7 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
         let meta = validate_meta(package);
         shapes.push(CrateShape {
             name,
+            dir,
             engine,
             deps,
             meta,
@@ -230,6 +236,39 @@ pub fn evaluate(shapes: &[CrateShape]) -> Vec<Finding> {
         }
     }
 
+    findings
+}
+
+/// Rule 7: every engine crate carries a crate-local `clippy.toml`.
+///
+/// The zoning policy each engine crate enforces lives in that file —
+/// tripwires that reject a clock, a filesystem call, or a raw thread
+/// spawn from a crate whose contract forbids them. Nine crates have added
+/// it by hand, correctly, every time. That is exactly when the habit
+/// should stop being a habit: the crate that forgets will not fail to
+/// compile, will not fail a test, and will simply have no tripwires,
+/// which is indistinguishable from having them and passing.
+///
+/// The predicate is injected rather than called directly so the rule is
+/// exercisable without a filesystem — the same reason the rest of this
+/// module takes parsed metadata rather than running cargo itself.
+pub fn lint_file_findings(shapes: &[CrateShape], exists: &dyn Fn(&str) -> bool) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for shape in shapes {
+        if !shape.engine {
+            continue;
+        }
+        let path = format!("{}/clippy.toml", shape.dir);
+        if !exists(&path) {
+            findings.push(Finding {
+                rule: "lint-files",
+                message: format!(
+                    "engine crate {} has no clippy.toml; every engine crate carries one,                      so its zoning tripwires are enforced by the compiler rather than by review",
+                    shape.name
+                ),
+            });
+        }
+    }
     findings
 }
 
@@ -444,6 +483,7 @@ mod tests {
     fn shape(name: &str, engine: bool, deps: &[&str], maturity: &str, core: bool) -> CrateShape {
         CrateShape {
             name: name.to_string(),
+            dir: format!("/w/crates/{name}"),
             engine,
             deps: deps.iter().map(ToString::to_string).collect(),
             meta: Ok(Meta {
@@ -452,6 +492,57 @@ mod tests {
                 simulation: false,
             }),
         }
+    }
+
+    #[test]
+    fn an_engine_crate_without_a_clippy_file_is_a_finding() {
+        let shapes = [shape("renew-diag", true, &[], "bootstrap", true)];
+        let findings = lint_file_findings(&shapes, &|_| false);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].rule, "lint-files");
+        assert!(findings[0].message.contains("renew-diag"), "{findings:?}");
+    }
+
+    #[test]
+    fn an_engine_crate_with_a_clippy_file_is_not() {
+        let shapes = [shape("renew-diag", true, &[], "bootstrap", true)];
+        assert!(lint_file_findings(&shapes, &|_| true).is_empty());
+    }
+
+    /// The rule binds engine crates only. Samples, tools and benchmarks
+    /// are outside the module roots and legitimately carry no zoning of
+    /// their own, so demanding the file there would train people to add
+    /// empty ones.
+    #[test]
+    fn a_non_engine_crate_without_a_clippy_file_is_ignored() {
+        let shapes = [shape("renew-cli", false, &[], "bootstrap", false)];
+        assert!(lint_file_findings(&shapes, &|_| false).is_empty());
+    }
+
+    /// The predicate is asked about the crate's own directory, not about
+    /// some path that merely ends in the right name — a rule that looked
+    /// anywhere else would pass on a stray file at the workspace root.
+    #[test]
+    fn the_rule_looks_beside_the_crates_own_manifest() {
+        let shapes = [shape("renew-math", true, &[], "internal", true)];
+        let asked = std::cell::RefCell::new(Vec::new());
+        let findings = lint_file_findings(&shapes, &|path| {
+            asked.borrow_mut().push(path.to_string());
+            false
+        });
+        assert_eq!(asked.into_inner(), ["/w/crates/renew-math/clippy.toml"]);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn every_engine_crate_missing_the_file_is_named_separately() {
+        let shapes = [
+            shape("renew-diag", true, &[], "bootstrap", true),
+            shape("renew-math", true, &[], "bootstrap", true),
+            shape("renew-cli", false, &[], "bootstrap", false),
+        ];
+        let findings = lint_file_findings(&shapes, &|_| false);
+        assert_eq!(findings.len(), 2, "{findings:?}");
     }
 
     #[test]
@@ -468,6 +559,7 @@ mod tests {
     fn schema_problems_surface_per_crate() {
         let shapes = [CrateShape {
             name: "broken".to_string(),
+            dir: "/w/crates/x".to_string(),
             engine: false,
             deps: Vec::new(),
             meta: Err(vec!["missing field `core`".to_string()]),
@@ -549,6 +641,7 @@ mod tests {
     fn non_engine_crates_stay_in_their_lane() {
         let flagged = [CrateShape {
             name: "tool".to_string(),
+            dir: "/w/crates/x".to_string(),
             engine: false,
             deps: Vec::new(),
             meta: Ok(Meta {
@@ -722,6 +815,7 @@ mod tests {
             shape("renew-diag", true, &["renew-broken"], "bootstrap", true),
             CrateShape {
                 name: "renew-broken".to_string(),
+                dir: "/w/crates/x".to_string(),
                 engine: true,
                 deps: Vec::new(),
                 meta: Err(vec!["missing field `core`".to_string()]),


### PR DESCRIPTION
Each engine crate keeps a crate-local clippy configuration holding the tripwires its contract depends on — rejecting a clock, a filesystem call, or a raw thread spawn from a crate that must not have one. Nine crates have added that file by hand, correctly, every time.

That is the point at which the habit should stop being a habit. A crate that forgets does not fail to compile and does not fail a test; it simply has no tripwires, which from the outside is indistinguishable from having them and passing. The risk is not hypothetical — a sibling list of the same kind (the sanitizer feature list) was found stale this week, with one crate's allocation-counting test silently running under instrumented allocators where its counts mean nothing.

**Scope:** engine crates only. Samples, tools and benchmarks sit outside the module roots and legitimately carry no zoning of their own, so demanding the file there would only teach people to add empty ones.

**Testability:** the filesystem predicate is injected rather than called directly, so the rule is exercisable without a filesystem — the same reason the rest of the checker takes parsed metadata instead of running cargo itself. Five tests cover it: missing file, present file, non-engine crate ignored, the path actually asked about (so a stray file elsewhere cannot satisfy it), and several crates each named separately.

**Honest limit:** this checks the file exists, not that it contains the right entries. Contents remain a review matter.

## Verified locally

- `cargo test -p renew-cli --lib` — 118 tests, 0 failures
- `cargo clippy -p renew-cli --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- Dogfooded against the real workspace: `renew check` reports healthy, so no existing crate trips the new rule
