### PR TITLE
Repair the padding in the lint-file message

### DIFF
--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -263,7 +263,7 @@ pub fn lint_file_findings(shapes: &[CrateShape], exists: &dyn Fn(&str) -> bool) 
             findings.push(Finding {
                 rule: "lint-files",
                 message: format!(
-                    "engine crate {} has no clippy.toml; every engine crate carries one,                      so its zoning tripwires are enforced by the compiler rather than by review",
+                    "engine crate {} has no clippy.toml, so its zoning tripwires are enforced by review rather than by the compiler",
                     shape.name
                 ),
             });


### PR DESCRIPTION
The finding message was written with a line continuation inside a string literal. The continuation did not survive formatting, so the text that shipped carried twenty-two literal spaces in the middle of a sentence someone reads when their build fails.

Verified by removing a crate's clippy.toml and reading the real output.