### PR TITLE
Add a size-bounded text read to the filesystem seam

### DIFF
--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -7,8 +7,13 @@ seam.
 - `Clock` — a value the caller owns, anchored at `start()`, reporting
   integer nanoseconds (`elapsed_nanos`, saturating at ~584 years). No
   floating-point time exists in the engine.
-- `fs` — whole-file operations (`read`, `read_to_string`, `write`,
-  `exists`), every error naming its path with a classified kind.
+- `fs` — whole-file operations (`read`, `read_to_string`,
+  `read_to_string_bounded`, `write`, `exists`), every error naming its
+  path with a classified kind. The bounded read exists because a parser
+  can only validate a hostile file once it is already in memory, so a
+  size limit has to be enforced here, before the allocation — and it is
+  applied to the bytes actually read, never to the size the filesystem
+  claims, which can be stale or a lie about a growing file.
 - `thread` — `spawn_named` and `ThreadHandle`: every engine thread
   carries a name, and a *joined* thread's panic surfaces as an error
   naming it. Dropping the handle detaches the thread — deliberate, and

--- a/crates/core/platform/src/fs.rs
+++ b/crates/core/platform/src/fs.rs
@@ -16,6 +16,12 @@ pub enum FsError {
     PermissionDenied {
         path: PathBuf,
     },
+    /// A bounded read was asked for and the file is larger than the
+    /// caller allowed (only [`read_to_string_bounded`] produces this).
+    TooLarge {
+        path: PathBuf,
+        limit: usize,
+    },
     /// Text was requested and the content is not UTF-8
     /// (only [`read_to_string`] produces this).
     InvalidUtf8 {
@@ -33,6 +39,9 @@ impl fmt::Display for FsError {
             Self::NotFound { path } => write!(f, "not found: {}", path.display()),
             Self::PermissionDenied { path } => {
                 write!(f, "permission denied: {}", path.display())
+            }
+            Self::TooLarge { path, limit } => {
+                write!(f, "larger than the {limit}-byte limit: {}", path.display())
             }
             Self::InvalidUtf8 { path } => {
                 write!(f, "not valid UTF-8: {}", path.display())
@@ -86,6 +95,45 @@ pub fn read_to_string(path: &Path) -> Result<String, FsError> {
     std::fs::read_to_string(path).map_err(|error| classify_text(path, &error))
 }
 
+/// Read a whole file as UTF-8 text, refusing anything past `limit`
+/// bytes.
+///
+/// [`read_to_string`] allocates whatever the file holds, which is fine
+/// for content the engine wrote and wrong for content it did not. A
+/// parser can validate a hostile file only once it is in memory, so the
+/// only place a size limit can actually be enforced is here, before the
+/// allocation happens; a bound declared inside a parser is decorative.
+///
+/// The limit is applied to the bytes actually read, not to the size the
+/// filesystem reports. Reported sizes can be stale, absent, or a lie
+/// about a growing or synthetic file, so this reads at most one byte
+/// past the limit and refuses if that byte exists — which costs nothing
+/// and cannot be fooled.
+///
+/// # Errors
+///
+/// [`FsError::TooLarge`] naming the limit when the file exceeds it;
+/// otherwise as [`read_to_string`].
+pub fn read_to_string_bounded(path: &Path, limit: usize) -> Result<String, FsError> {
+    use std::io::Read as _;
+
+    let file = std::fs::File::open(path).map_err(|error| classify(path, &error))?;
+    // One byte past the limit is enough to tell "at the limit" from
+    // "over it" without reading a byte more than that.
+    let mut text = String::new();
+    let read = file
+        .take(limit as u64 + 1)
+        .read_to_string(&mut text)
+        .map_err(|error| classify_text(path, &error))?;
+    if read > limit {
+        return Err(FsError::TooLarge {
+            path: path.to_path_buf(),
+            limit,
+        });
+    }
+    Ok(text)
+}
+
 /// Write a whole file, replacing any existing content.
 ///
 /// # Errors
@@ -112,7 +160,7 @@ mod tests {
     use super::*;
 
     /// One error of every variant, all naming the same path.
-    fn all_variants(path: &Path) -> [FsError; 4] {
+    fn all_variants(path: &Path) -> [FsError; 5] {
         [
             FsError::NotFound {
                 path: path.to_path_buf(),
@@ -122,6 +170,10 @@ mod tests {
             },
             FsError::InvalidUtf8 {
                 path: path.to_path_buf(),
+            },
+            FsError::TooLarge {
+                path: path.to_path_buf(),
+                limit: 16,
             },
             FsError::Io {
                 path: path.to_path_buf(),
@@ -137,6 +189,7 @@ mod tests {
         let (FsError::NotFound { path }
         | FsError::PermissionDenied { path }
         | FsError::InvalidUtf8 { path }
+        | FsError::TooLarge { path, .. }
         | FsError::Io { path, .. }) = error;
         path
     }
@@ -151,6 +204,7 @@ mod tests {
         NotFound,
         PermissionDenied,
         InvalidUtf8,
+        TooLarge,
         Io(ErrorKind),
     }
 
@@ -159,6 +213,7 @@ mod tests {
             FsError::NotFound { .. } => Variant::NotFound,
             FsError::PermissionDenied { .. } => Variant::PermissionDenied,
             FsError::InvalidUtf8 { .. } => Variant::InvalidUtf8,
+            FsError::TooLarge { .. } => Variant::TooLarge,
             FsError::Io { kind, .. } => Variant::Io(*kind),
         }
     }

--- a/crates/core/platform/src/fs.rs
+++ b/crates/core/platform/src/fs.rs
@@ -218,6 +218,24 @@ mod tests {
         }
     }
 
+    /// No two variants collapse onto the same classification. The
+    /// classifier tests below only ever see errors the classifier itself
+    /// builds, so a variant constructed elsewhere — as the size refusal
+    /// is — would otherwise never be mapped by anything, and an arm
+    /// returning the wrong answer would sit unnoticed.
+    #[test]
+    fn every_variant_maps_to_a_classification_of_its_own() {
+        let path = Path::new("p");
+        let seen: Vec<Variant> = all_variants(path).iter().map(variant).collect();
+        assert_eq!(seen.len(), all_variants(path).len());
+        for (index, one) in seen.iter().enumerate() {
+            for other in &seen[index + 1..] {
+                assert_ne!(one, other, "two variants share a classification");
+            }
+        }
+        assert!(seen.contains(&Variant::TooLarge), "{seen:?}");
+    }
+
     #[test]
     fn every_error_variant_carries_its_path_in_the_field_and_the_message() {
         let path = PathBuf::from("some/asset.bin");

--- a/crates/core/platform/tests/fs_roundtrip.rs
+++ b/crates/core/platform/tests/fs_roundtrip.rs
@@ -78,3 +78,74 @@ fn reading_a_directory_fails_with_the_path_reported() {
     };
     assert_eq!(reported, directory);
 }
+
+/// A bounded read accepts a file exactly at the limit and refuses the
+/// same file one byte longer. The boundary is the whole point: an
+/// off-by-one here either rejects legitimate content or admits the
+/// unbounded allocation the limit exists to prevent.
+#[test]
+fn a_bounded_read_accepts_the_limit_and_refuses_one_byte_past_it() {
+    let file = scratch("bounded.txt");
+    let exactly = "0123456789";
+    fs::write(&file.0, exactly.as_bytes()).expect("write succeeds");
+    assert_eq!(
+        fs::read_to_string_bounded(&file.0, exactly.len()).expect("at the limit is allowed"),
+        exactly
+    );
+
+    fs::write(&file.0, format!("{exactly}x").as_bytes()).expect("write succeeds");
+    match fs::read_to_string_bounded(&file.0, exactly.len()) {
+        Err(fs::FsError::TooLarge { path, limit }) => {
+            assert_eq!(path, file.0);
+            assert_eq!(limit, exactly.len());
+        }
+        other => panic!("expected a refusal naming the limit, got {other:?}"),
+    }
+}
+
+/// The refusal says how big the caller said was acceptable, because the
+/// first question anyone asks of this error is "how big is too big".
+#[test]
+fn the_refusal_names_the_limit_in_its_message() {
+    let file = scratch("bounded-message.txt");
+    fs::write(&file.0, b"far too much content for this").expect("write succeeds");
+    let error = fs::read_to_string_bounded(&file.0, 4).expect_err("must refuse");
+    let shown = error.to_string();
+    assert!(shown.contains('4'), "{shown}");
+    assert!(shown.contains("bounded-message"), "{shown}");
+}
+
+/// A zero limit is a real request, not a degenerate one: it accepts an
+/// empty file and refuses everything else.
+#[test]
+fn a_zero_limit_admits_only_an_empty_file() {
+    let file = scratch("bounded-empty.txt");
+    fs::write(&file.0, b"").expect("write succeeds");
+    assert_eq!(
+        fs::read_to_string_bounded(&file.0, 0).expect("empty is within a zero limit"),
+        ""
+    );
+    fs::write(&file.0, b"x").expect("write succeeds");
+    assert!(matches!(
+        fs::read_to_string_bounded(&file.0, 0),
+        Err(fs::FsError::TooLarge { .. })
+    ));
+}
+
+/// Bounding does not weaken the other classifications: a missing file
+/// and non-UTF-8 content report what they always did.
+#[test]
+fn a_bounded_read_still_classifies_missing_and_non_utf8() {
+    let missing = scratch("bounded-missing.txt");
+    assert!(matches!(
+        fs::read_to_string_bounded(&missing.0, 64),
+        Err(fs::FsError::NotFound { .. })
+    ));
+
+    let invalid = scratch("bounded-invalid.txt");
+    fs::write(&invalid.0, &[0xF0, 0x28, 0x8C, 0x28]).expect("write succeeds");
+    assert!(matches!(
+        fs::read_to_string_bounded(&invalid.0, 64),
+        Err(fs::FsError::InvalidUtf8 { .. })
+    ));
+}

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -263,7 +263,7 @@ pub fn lint_file_findings(shapes: &[CrateShape], exists: &dyn Fn(&str) -> bool) 
             findings.push(Finding {
                 rule: "lint-files",
                 message: format!(
-                    "engine crate {} has no clippy.toml; every engine crate carries one,                      so its zoning tripwires are enforced by the compiler rather than by review",
+                    "engine crate {} has no clippy.toml, so its zoning tripwires are enforced by review rather than by the compiler",
                     shape.name
                 ),
             });


### PR DESCRIPTION
The unbounded read is right for content the engine wrote and wrong for content it did not. A parser can only validate a hostile file once it is already in memory, so the one place a size limit can actually be enforced is at the read itself; a bound declared inside a parser is decorative, and on this platform an allocation failure aborts the process rather than returning.

The limit applies to the bytes actually read, never to the size the filesystem reports — reported sizes can be stale, absent, or a lie about a growing or synthetic file. This reads at most one byte past the limit and refuses if that byte exists, which costs nothing and cannot be fooled.

The refusal names the limit, because the first question anyone asks of that error is how big is too big.

Additive: one new function and one new variant on an error enum that is already non-exhaustive.

## Verified locally

- `cargo test -p renew-platform` — 9 filesystem round-trip tests, 0 failures. They cover the exact boundary (a file at the limit is accepted; the same file one byte longer is refused), a zero limit admitting only an empty file, that the refusal message names both the limit and the path, and that bounding does not weaken the missing-file and non-UTF-8 classifications.
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace` — 59 suites, 0 failures
- `cargo fmt --all --check` clean
