### PR TITLE
Say why a tool probe would not run instead of guessing

### DIFF
--- a/tools/cli/src/doctor.rs
+++ b/tools/cli/src/doctor.rs
@@ -10,6 +10,9 @@ pub const MIN_CARGO: (u64, u64) = (1, 97);
 #[derive(Clone, Debug, Default)]
 pub struct Facts {
     pub rustup_found: bool,
+    /// Why the rustup probe could not run, when it could not. Absent
+    /// means it ran; the report then never has to guess at a cause.
+    pub rustup_unavailable: Option<String>,
     pub active_toolchain: Option<String>,
     pub cargo_version: Option<(u64, u64)>,
     pub toolchain_file_channel: Option<String>,
@@ -17,6 +20,24 @@ pub struct Facts {
     pub required_cargo: Option<(u64, u64)>,
     pub workspace_root_found: bool,
     pub git_found: bool,
+    /// Why the git probe could not run, when it could not.
+    pub git_unavailable: Option<String>,
+}
+
+/// How to describe a probe that would not run.
+///
+/// "Not found on PATH" is the common cause and was, until this existed,
+/// the only thing the report could say — including when the program was
+/// plainly there and the failure was something else entirely. A tool that
+/// names the wrong cause sends its reader to fix the wrong thing, so an
+/// unexpected kind is now reported as itself.
+#[must_use]
+pub fn probe_failure(kind: std::io::ErrorKind) -> String {
+    if kind == std::io::ErrorKind::NotFound {
+        String::from("not found on PATH")
+    } else {
+        format!("on PATH but would not run ({kind})")
+    }
 }
 
 /// One evaluated check.
@@ -58,7 +79,10 @@ pub fn evaluate(facts: &Facts) -> Vec<Check> {
             detail: if facts.rustup_found {
                 String::from("found")
             } else {
-                String::from("not found on PATH")
+                facts
+                    .rustup_unavailable
+                    .clone()
+                    .unwrap_or_else(|| String::from("not found on PATH"))
             },
         },
         Check {
@@ -99,7 +123,10 @@ pub fn evaluate(facts: &Facts) -> Vec<Check> {
             detail: if facts.git_found {
                 String::from("found")
             } else {
-                String::from("not found on PATH")
+                facts
+                    .git_unavailable
+                    .clone()
+                    .unwrap_or_else(|| String::from("not found on PATH"))
             },
         },
     ]
@@ -167,15 +194,33 @@ pub fn first_token(text: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// A probe that could not run says which way it could not. Reporting
+    /// "not found on PATH" for a program that is plainly on PATH sends the
+    /// reader to fix the wrong thing, which is the failure this exists to
+    /// prevent.
+    #[test]
+    fn a_probe_failure_names_the_kind_unless_it_really_is_missing() {
+        assert_eq!(
+            probe_failure(std::io::ErrorKind::NotFound),
+            "not found on PATH"
+        );
+        let denied = probe_failure(std::io::ErrorKind::PermissionDenied);
+        assert!(denied.contains("would not run"), "{denied}");
+        assert!(denied.starts_with("on PATH"), "{denied}");
+        assert_ne!(denied, probe_failure(std::io::ErrorKind::NotFound));
+    }
+
     fn healthy() -> Facts {
         Facts {
             rustup_found: true,
+            rustup_unavailable: None,
             active_toolchain: Some(String::from("stable-x86_64-pc-windows-msvc")),
             cargo_version: Some((1, 97)),
             toolchain_file_channel: Some(String::from("stable")),
             required_cargo: Some((1, 97)),
             workspace_root_found: true,
             git_found: true,
+            git_unavailable: None,
         }
     }
 

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -627,17 +627,20 @@ fn run_doctor(json_mode: bool) -> ExitCode {
 
 fn gather_facts() -> Facts {
     let root = workspace_root();
-    let (rustup_found, active_toolchain) =
+    let (rustup_found, active_toolchain, rustup_unavailable) =
         match probe("rustup", &["show", "active-toolchain"], root.as_deref()) {
-            Some((true, stdout)) => (true, doctor::first_token(&stdout)),
-            Some((false, _)) => (true, None),
-            None => (false, None),
+            Ok((true, stdout)) => (true, doctor::first_token(&stdout), None),
+            Ok((false, _)) => (true, None, None),
+            Err(error) => (false, None, Some(doctor::probe_failure(error.kind()))),
         };
     let cargo_version = probe("cargo", &["--version"], root.as_deref())
+        .ok()
         .filter(|(success, _)| *success)
         .and_then(|(_, stdout)| doctor::parse_cargo_version(&stdout));
-    let git_found =
-        probe("git", &["--version"], root.as_deref()).is_some_and(|(success, _)| success);
+    let (git_found, git_unavailable) = match probe("git", &["--version"], root.as_deref()) {
+        Ok((success, _)) => (success, None),
+        Err(error) => (false, Some(doctor::probe_failure(error.kind()))),
+    };
     let toolchain_file_channel = root
         .as_ref()
         .and_then(|path| std::fs::read_to_string(path.join("rust-toolchain.toml")).ok())
@@ -649,25 +652,34 @@ fn gather_facts() -> Facts {
 
     Facts {
         rustup_found,
+        rustup_unavailable,
         active_toolchain,
         cargo_version,
         toolchain_file_channel,
         required_cargo,
         workspace_root_found: root.is_some(),
         git_found,
+        git_unavailable,
     }
 }
 
 /// Run a probe command, from the workspace root when one exists so toolchain
-/// overrides resolve consistently with the build steps. `None` = could not
-/// spawn; `Some((success, stdout))` otherwise.
-fn probe(program: &str, args: &[&str], root: Option<&Path>) -> Option<(bool, String)> {
+/// overrides resolve consistently with the build steps.
+///
+/// The spawn error is returned rather than discarded: "could not run" and
+/// "is not installed" are different answers, and a report that cannot tell
+/// them apart sends its reader to fix the wrong thing.
+fn probe(
+    program: &str,
+    args: &[&str],
+    root: Option<&Path>,
+) -> Result<(bool, String), std::io::Error> {
     let mut process = Process::new(program);
     process.args(args);
     if let Some(directory) = root {
         process.current_dir(directory);
     }
-    process.output().ok().map(|output| {
+    process.output().map(|output| {
         (
             output.status.success(),
             String::from_utf8_lossy(&output.stdout).into_owned(),


### PR DESCRIPTION
The environment report reduced every failed tool probe to "not found on PATH". That is the common cause, not the only one, and the report had no way to tell them apart because the spawn error was discarded at the point it was raised.

It matters beyond tidiness: a report that names the wrong cause sends its reader to install something they already have.

It also cost an investigation this week. A probe failed on a CI runner for a program the test had just copied onto PATH, and the report insisted it was missing — so the only thing the log could say was the one thing that definitely was not true.

The spawn error now survives to the report. A missing program still reads as "not found on PATH"; anything else is reported as itself.

## Verified locally

- `cargo test -p renew-cli` — 119 + 3 + 34 tests, 0 failures
- `cargo clippy -p renew-cli --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- Coverage of the two changed files measured directly: `doctor.rs` 237 lines / 0 missed, `main.rs` 525 lines / 0 missed, and the repository's own coverage gate reports no finding anywhere under `tools/`

The underlying race that produced the CI failure is **not** fixed and is not understood. What changed is that a recurrence now arrives with a cause attached instead of a guess.
