### PR TITLE
Measure the generator, and prove it is removable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,16 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
+      # The generator removed entirely. Nothing in the engine depends on
+      # it yet, so the exclude list is short today — but the bench suite
+      # reaches it from a bench target, which is exactly the edge that
+      # makes an exclude list stop being upward-closed if it is forgotten.
+      - name: Build and test without the generator
+        run: |
+          sel="--workspace --exclude renew-rng --exclude renew-bench"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rng $sel
+          cargo build $sel
+          cargo test $sel
       # The rendering crate removed entirely. input_echo deliberately
       # survives this cell: a frame-loop sample that still builds and
       # runs with the GPU crate gone is the removability claim from the

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -28,6 +28,7 @@ renew-memory = { path = "../../crates/core/memory" }
 # Bench-target-only, like the job pool above: the library itself
 # schedules nothing.
 renew-frame = { path = "../../crates/frame" }
+renew-rng = { path = "../../crates/rng" }
 criterion = "0.8"
 # Bench-target-only: keeps the library's dependency graph free of the
 # job pool it never uses.
@@ -54,4 +55,8 @@ harness = false
 
 [[bench]]
 name = "frame"
+harness = false
+
+[[bench]]
+name = "rng"
 harness = false

--- a/bench/suite/benches/rng.rs
+++ b/bench/suite/benches/rng.rs
@@ -28,13 +28,17 @@ const SEED: Seed = Seed::from_u64(0x1234_5678_9abc_def0);
 /// A bound that never rejects. Any power of two divides the output range
 /// exactly, so the rejection threshold is zero and every draw is taken on
 /// the first attempt — the floor for a bounded draw.
-const BOUND_NEVER_REJECTS: u32 = 1 << 16;
+///
+/// Built by adding to one rather than by unwrapping an `Option`, so the
+/// non-zero-ness is a fact about the construction instead of a claim the
+/// benchmark makes and the compiler has to take on trust.
+const BOUND_NEVER_REJECTS: NonZeroU32 = NonZeroU32::MIN.saturating_add((1 << 16) - 1);
 
 /// The bound that rejects most often. Just over half the range means
 /// almost half of all words are refused, so this is the worst expected
 /// case rather than a typical one, and it is here to bound the cost from
 /// above rather than to describe ordinary use.
-const BOUND_WORST_CASE: u32 = (1u32 << 31) + 1;
+const BOUND_WORST_CASE: NonZeroU32 = NonZeroU32::MIN.saturating_add(1 << 31);
 
 fn generator(c: &mut Criterion) {
     let stream = StreamId::from_name("bench");
@@ -51,14 +55,12 @@ fn generator(c: &mut Criterion) {
 
     c.bench_function("rng_below_u32_no_rejection", |b| {
         let mut rng = Rng::new(SEED, stream);
-        let bound = NonZeroU32::new(BOUND_NEVER_REJECTS).expect("non-zero by construction");
-        b.iter(|| black_box(rng.below_u32(black_box(bound))));
+        b.iter(|| black_box(rng.below_u32(black_box(BOUND_NEVER_REJECTS))));
     });
 
     c.bench_function("rng_below_u32_worst_case_rejection", |b| {
         let mut rng = Rng::new(SEED, stream);
-        let bound = NonZeroU32::new(BOUND_WORST_CASE).expect("non-zero by construction");
-        b.iter(|| black_box(rng.below_u32(black_box(bound))));
+        b.iter(|| black_box(rng.below_u32(black_box(BOUND_WORST_CASE))));
     });
 }
 

--- a/bench/suite/benches/rng.rs
+++ b/bench/suite/benches/rng.rs
@@ -1,0 +1,66 @@
+//! Generator timings: the cost of one draw, in the four shapes a
+//! simulation actually asks for.
+//!
+//! This crate sits in the innermost loop — a simulation that wants a
+//! random number wants one per entity per step — so its cost belongs in
+//! the suite rather than in an argument. The generator is pure integer
+//! arithmetic over sixteen bytes of state: no clock, no allocation, no
+//! entropy source, nothing to warm up.
+//!
+//! Two of the four cases exist because they can be slower than they look.
+//! A 64-bit draw is two 32-bit steps, not one, so it should cost about
+//! twice a 32-bit draw and it is worth noticing the day it does not. A
+//! bounded draw rejects and retries, so its cost is an *expected* cost
+//! rather than a fixed one, and the two bounds below sit deliberately at
+//! the two ends of that behaviour.
+
+use std::hint::black_box;
+use std::num::NonZeroU32;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_rng::{Rng, Seed, StreamId};
+
+/// Arbitrary but fixed: a benchmark that reseeded per iteration would be
+/// timing the seeding, and one that varied its seed between runs would
+/// make two runs incomparable for no benefit.
+const SEED: Seed = Seed::from_u64(0x1234_5678_9abc_def0);
+
+/// A bound that never rejects. Any power of two divides the output range
+/// exactly, so the rejection threshold is zero and every draw is taken on
+/// the first attempt — the floor for a bounded draw.
+const BOUND_NEVER_REJECTS: u32 = 1 << 16;
+
+/// The bound that rejects most often. Just over half the range means
+/// almost half of all words are refused, so this is the worst expected
+/// case rather than a typical one, and it is here to bound the cost from
+/// above rather than to describe ordinary use.
+const BOUND_WORST_CASE: u32 = (1u32 << 31) + 1;
+
+fn generator(c: &mut Criterion) {
+    let stream = StreamId::from_name("bench");
+
+    c.bench_function("rng_next_u32", |b| {
+        let mut rng = Rng::new(SEED, stream);
+        b.iter(|| black_box(rng.next_u32()));
+    });
+
+    c.bench_function("rng_next_u64", |b| {
+        let mut rng = Rng::new(SEED, stream);
+        b.iter(|| black_box(rng.next_u64()));
+    });
+
+    c.bench_function("rng_below_u32_no_rejection", |b| {
+        let mut rng = Rng::new(SEED, stream);
+        let bound = NonZeroU32::new(BOUND_NEVER_REJECTS).expect("non-zero by construction");
+        b.iter(|| black_box(rng.below_u32(black_box(bound))));
+    });
+
+    c.bench_function("rng_below_u32_worst_case_rejection", |b| {
+        let mut rng = Rng::new(SEED, stream);
+        let bound = NonZeroU32::new(BOUND_WORST_CASE).expect("non-zero by construction");
+        b.iter(|| black_box(rng.below_u32(black_box(bound))));
+    });
+}
+
+criterion_group!(benches, generator);
+criterion_main!(benches);


### PR DESCRIPTION
The generator sits in the innermost loop — a simulation that wants a random number wants one per entity per step — so its cost belongs in the suite rather than in an argument. It shipped without a benchmark and without a recorded reason for not having one, which a review caught.

**Four cases, two of which exist because they can be slower than they look.** A 64-bit draw is two 32-bit steps rather than one, so it should cost about twice a 32-bit draw and it is worth noticing the day it does not. A bounded draw rejects and retries, so its cost is an *expected* cost rather than a fixed one; the two bounds sit deliberately at the ends of that behaviour — a power of two, which can never reject, and just over half the range, which refuses almost half of all words and is therefore a ceiling rather than a typical case.

**The removability cell is the other half, and the half that was missing.** The crate is optional, so CI must prove the tree still builds and tests without it. Its exclude list carries the bench suite, because a bench target now reaches the generator — precisely the edge that makes an exclude list stop being upward-closed when someone forgets it.

## Verified locally

- All four benchmark cases run under `cargo bench --bench rng -- --test`
- The new cell builds clean, and the generator is **absent** from the resolved graph of that selection
- Bite-tested the exclude list in the other direction: **without** the bench exclusion the generator is still in the graph, so the guard would fail rather than pass vacuously
- `cargo fmt --all --check` clean

Note: the lockfile edge from the bench suite to the generator is not in this branch, because the lockfile is concurrently modified by other in-flight work; CI regenerates it.
