### PR TITLE
Publish one value of every window event shape

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -47,10 +47,10 @@ reason = "A release-mode refusal guarded by a debug assertion on the same condit
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [474, 475]
+lines = [482, 483]
 reason = "Translates a windowing event whose payload type has no public constructor in the pinned windowing crate, so the input cannot be built outside it. The translation logic itself is covered directly through the helper it delegates to. Note for local runs: on a machine with a live desktop, a stray keyboard event can reach the window smoke test's real window and cover line 390, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [792]
+lines = [800]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -47,10 +47,10 @@ reason = "A release-mode refusal guarded by a debug assertion on the same condit
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [413, 414]
+lines = [474, 475]
 reason = "Translates a windowing event whose payload type has no public constructor in the pinned windowing crate, so the input cannot be built outside it. The translation logic itself is covered directly through the helper it delegates to. Note for local runs: on a machine with a live desktop, a stray keyboard event can reach the window smoke test's real window and cover line 390, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [706]
+lines = [792]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -105,6 +105,67 @@ pub enum PointerButton {
     Other(u16),
 }
 
+/// One value of every shape [`WindowEvent`] can take.
+///
+/// The event vocabulary is `#[non_exhaustive]`, which binds every crate
+/// except this one: downstream matches must carry a wildcard arm, so the
+/// compiler will never tell a consumer that a new variant is unhandled.
+/// A consumer that translates events — into a file format, a script
+/// binding, a replay log — would therefore start silently dropping the
+/// new one, and nothing would fail until someone noticed the output was
+/// wrong.
+///
+/// This list, and the exhaustive match beside it, move that failure to
+/// where the compiler can still speak: adding a variant breaks the build
+/// **here**, in the crate that owns the enum, at the moment it is added.
+/// A consumer then iterates this slice and asserts it handles every
+/// entry, which turns "did we remember?" into a test rather than a habit.
+///
+/// The values are arbitrary. Only the shapes matter.
+pub const EVERY_EVENT_SHAPE: &[WindowEvent] = &[
+    WindowEvent::CloseRequested,
+    WindowEvent::Resized {
+        width: 640,
+        height: 360,
+    },
+    WindowEvent::ScaleFactorChanged { scale: 2.0 },
+    WindowEvent::RedrawRequested,
+    WindowEvent::Key {
+        code: KeyCode::KeyW,
+        pressed: true,
+        repeat: false,
+    },
+    WindowEvent::PointerMoved { x: 12.5, y: 34.5 },
+    WindowEvent::PointerButton {
+        button: PointerButton::Left,
+        pressed: true,
+    },
+    WindowEvent::Wheel { dx: 0.0, dy: 1.0 },
+    WindowEvent::Focused(true),
+];
+
+/// Where a shape sits in [`EVERY_EVENT_SHAPE`].
+///
+/// This is the forcing function. The match is exhaustive and carries no
+/// wildcard, so a new variant fails to compile until it is given an
+/// index — and the test below fails until it is also added to the list.
+/// Both halves are needed: a match alone would let the list rot, and a
+/// list alone would never notice the variant existed.
+#[must_use]
+const fn shape_index(event: &WindowEvent) -> usize {
+    match event {
+        WindowEvent::CloseRequested => 0,
+        WindowEvent::Resized { .. } => 1,
+        WindowEvent::ScaleFactorChanged { .. } => 2,
+        WindowEvent::RedrawRequested => 3,
+        WindowEvent::Key { .. } => 4,
+        WindowEvent::PointerMoved { .. } => 5,
+        WindowEvent::PointerButton { .. } => 6,
+        WindowEvent::Wheel { .. } => 7,
+        WindowEvent::Focused(_) => 8,
+    }
+}
+
 /// What the app tells the loop each iteration.
 #[derive(Debug, Default)]
 pub struct LoopControl {
@@ -509,6 +570,31 @@ mod tests {
     use super::*;
     use winit::event::{MouseButton, MouseScrollDelta};
     use winit::keyboard::{KeyCode as Wk, PhysicalKey};
+
+    /// The list and the exhaustive match must agree, in both directions.
+    ///
+    /// Adding a variant already breaks the build at `shape_index`, which
+    /// is what makes the match a forcing function. This closes the other
+    /// half: without it, someone could give the new variant an index and
+    /// never add it to the list, and every consumer iterating the list
+    /// would keep silently missing it — the exact failure the list
+    /// exists to prevent, reintroduced one step further along.
+    #[test]
+    fn every_shape_is_listed_exactly_once_and_in_index_order() {
+        for (position, event) in EVERY_EVENT_SHAPE.iter().enumerate() {
+            // No extra argument in the message: `assert_eq!` already
+            // prints both sides, and an expression evaluated only on
+            // failure is a region no passing run can cover.
+            assert_eq!(shape_index(event), position, "misplaced: {event:?}");
+        }
+        // Every index below the length is covered, so no gap can hide a
+        // variant that was indexed and then left out of the list.
+        let mut seen = vec![false; EVERY_EVENT_SHAPE.len()];
+        for event in EVERY_EVENT_SHAPE {
+            seen[shape_index(event)] = true;
+        }
+        assert!(seen.iter().all(|covered| *covered), "{seen:?}");
+    }
 
     #[test]
     fn config_defaults_are_sane() {

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -149,10 +149,18 @@ pub const EVERY_EVENT_SHAPE: &[WindowEvent] = &[
 /// This is the forcing function. The match is exhaustive and carries no
 /// wildcard, so a new variant fails to compile until it is given an
 /// index — and the test below fails until it is also added to the list.
-/// Both halves are needed: a match alone would let the list rot, and a
-/// list alone would never notice the variant existed.
+/// Public because the consumer that iterates the list wants it: an index
+/// is how a translation layer keys a coverage table, and how it names the
+/// shape it is refusing.
+///
+/// One limit, stated rather than implied. The compile error forces the
+/// *match* to be updated; the list beside it is still maintained by hand,
+/// so a variant given an index and then left out of the list would pass
+/// everything here. What that costs is bounded — a consumer's own test
+/// iterates the list — and it is the reason this is a guard rather than
+/// a proof.
 #[must_use]
-const fn shape_index(event: &WindowEvent) -> usize {
+pub const fn shape_index(event: &WindowEvent) -> usize {
     match event {
         WindowEvent::CloseRequested => 0,
         WindowEvent::Resized { .. } => 1,


### PR DESCRIPTION
The event vocabulary is non-exhaustive, which binds every crate **except** the one that defines it: downstream matches must carry a wildcard arm, so the compiler will never tell a consumer that a new variant is unhandled. A consumer that translates events — into a file format, a script binding, a replay log — would quietly start dropping the new one, and nothing would fail until somebody noticed the output was wrong.

This moves that failure to where the compiler can still speak. Adding a variant now breaks the build **inside the crate that owns the enum**, at the moment it is added, because the index function's match is exhaustive and carries no wildcard.

**Both halves are needed, and the test binds them.** A match alone would let the list rot behind it; a list alone would never notice the variant existed. A consumer then iterates the slice and asserts it handles every entry, which turns "did we remember?" into a test rather than a habit.

The consumer arrives next: an event-translation layer needs exactly this guarantee, and it is the reason the list exists rather than a use found for it afterwards.

## Verified locally

- `cargo test -p renew-platform` — 28 tests, 0 failures
- `cargo fmt --all --check` and clippy clean
- Coverage checked with the repository's own gate. It caught something worth keeping: my first version of the test passed an extra argument to `assert_eq!` that is only evaluated when the assertion fails — a region no passing run can ever cover. It was also redundant, since `assert_eq!` already prints both sides, so it is gone.
- The exemption manifest is re-pinned **twice**: once for the insertion, and again after removing those two lines shifted an entry by two. Line numbers there are pinned by number and a stale entry fails the build on its own, so this was verified against the gate rather than by arithmetic.
