### PR TITLE
Add a zero-dependency codec for input trace files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,18 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rng $sel
           cargo build $sel
           cargo test $sel
+      # The trace codec removed entirely. Nothing reaches it yet — not
+      # the samples, not the bench suite — so the list is the crate and
+      # nothing else, and it is upward-closed for exactly that reason.
+      # The day a sample records or replays a trace, this cell fails
+      # first and names the crate that has to join the list, which is
+      # the point of running it while the list is still trivial.
+      - name: Build and test without the trace codec
+        run: |
+          sel="--workspace --exclude renew-trace"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-trace $sel
+          cargo build $sel
+          cargo test $sel
       # The rendering crate removed entirely. input_echo deliberately
       # survives this cell: a frame-loop sample that still builds and
       # runs with the GPU crate gone is the removability claim from the
@@ -194,7 +206,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-jobs renew-frame renew-rng; do
+          for optional in renew-rhi renew-jobs renew-frame renew-rng renew-trace; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ name = "renew-trace"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "renew-memory",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "renew-jobs",
  "renew-math",
  "renew-memory",
+ "renew-rng",
 ]
 
 [[package]]
@@ -1483,6 +1484,13 @@ version = "0.1.0"
 dependencies = [
  "renew-frame",
  "renew-platform",
+]
+
+[[package]]
+name = "renew-trace"
+version = "0.1.0"
+dependencies = [
+ "proptest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bench/suite", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/trace/Cargo.toml
+++ b/crates/trace/Cargo.toml
@@ -23,6 +23,10 @@ simulation = false
 [dependencies]
 
 [dev-dependencies]
+# Test-only, and only for the counting global allocator: one test asks
+# whether refusing a huge file holds any of it, and that question has no
+# answer without an allocator that can be read.
+renew-memory = { path = "../core/memory" }
 proptest = "1.11"
 
 [lints]

--- a/crates/trace/Cargo.toml
+++ b/crates/trace/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "renew-trace"
+description = "The input-trace codec: a line-oriented text format for recorded input, with a reader and a writer that are exact inverses"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The input-trace codec: a line-oriented text format for recorded input, a reader that refuses everything it does not understand, and a writer that is its exact inverse."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+# Deliberately empty, and load-bearing. The event vocabulary is this
+# crate's own, so a trace reader drags no windowing stack — no winit, no
+# x11, no wayland — into a headless build that only wants to read a file.
+# It also makes the crate byte-identical in every removability
+# configuration: there is no edge to remove.
+[dependencies]
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/trace/README.md
+++ b/crates/trace/README.md
@@ -196,15 +196,30 @@ property suite also hands the reader generated garbage and generated
 near-traces and requires an answer rather than a crash, with a fixed
 generator seed so the same inputs are explored on every machine.
 
-One caution is worth writing down, because it is the failure mode this
-kind of suite has. An earlier version of the generator drew header text
-from an alphabet with no `=` in it. Every test passed — and so did a
+One caution is worth writing down as a rule, not an anecdote, because it
+is the failure mode this kind of suite has:
+
+> **An input set that contains no counterexample proves nothing, however
+> much of the code it runs.** Coverage says every line executed. It does
+> not say any input could have told correct behaviour from incorrect.
+
+It has already been true here twice, in two different rules. The
+generator once drew header text from an alphabet with no `=` in it, and a
 reader deliberately broken to split a header field at its *last* `=`
-rather than its first, inverting the one rule the format states about
-that character. Full coverage did not help, and could not: coverage says
-every line ran, not that any input could tell right behaviour from wrong.
-Values are generated with `=` in them now, and the rule has a fixed
-hand-written case of its own.
+rather than its first — inverting the one thing the format states about
+that character — passed every test. Separately, every negative word in
+the refusal tests was a stranger to the vocabulary (`gamepad`, `thumb`,
+`meta`), so a reader that accepted any word merely *beginning* with a
+legal one passed too: `event 0 close` read as a close, and `renew-tracex`
+read as this format's own identity line.
+
+Both are fixed the same way — by choosing inputs a wrong implementation
+would get wrong. Values are generated with `=` in them, every keyword
+table is probed with a near miss in both directions as well as with a
+stranger, and the rules that a generator would have to be lucky to hit
+have fixed hand-written cases of their own. When adding a rule here, the
+question to ask is not "is this line covered" but "what would still be
+green if this rule did nothing".
 
 Measured with `cargo llvm-cov`, line, region and function coverage are all
 100% — which for a reader means every refusal edge is *taken* by a test,

--- a/crates/trace/README.md
+++ b/crates/trace/README.md
@@ -1,0 +1,276 @@
+# renew-trace
+
+The input-trace codec: a line-oriented text format for recorded input, a
+reader that refuses everything it does not understand, and a writer that
+is its exact inverse.
+
+A run of this engine is reproducible from a build, a seed and its input.
+The build is pinned and the seed is a flag; a trace is what makes the
+third one a file. With one, a bug can be reproduced from the input that
+caused it, a play session can become a regression test, one input can be
+diffed across two builds, and a sample can be driven in automation by
+input no programmer wrote.
+
+```rust
+let text = renew_trace::write(&trace);   // a String, never a file
+let same = renew_trace::parse(&text)?;   // a Trace, or a refusal naming a line
+```
+
+- `TraceEvent` — nine variants for the nine things a trace can say
+  happened, plus `TraceKey` and `TraceButton` for the two closed name
+  sets. Plain data: nothing here interprets an event, because what an
+  event *means* belongs to whatever is replaying it.
+- `FiniteF64` / `FiniteF32` — a float as its IEEE-754 bit pattern, with
+  infinities and NaNs refused at construction. This is what makes the
+  writer total.
+- `TraceHeader` — the four fields the codec owns (`sample`, `ticks`,
+  `timestep_ns`, `budget`), then caller-owned keys kept verbatim and in
+  order.
+- `Trace` — a header and the events, each with the tick it is delivered
+  before, in the order they were recorded.
+- `parse` / `write` — text in, text out, and nothing in between touches a
+  filesystem.
+- `TraceError` / `TraceErrorKind` — which line, and what was expected
+  there, as a value to match on rather than a string to search.
+
+## Contract
+
+- **No input is trusted.** Every rule rejects rather than repairs, and
+  nothing is skipped: an unknown keyword is an error, because skipping is
+  how a format silently forks. Every refusal names its line and what was
+  expected. Where the file is at a version this reader accepts, the
+  message for an unknown word says the reader's table may be the
+  incomplete thing rather than blaming the file.
+- **No file is ever opened.** The reader takes text and the writer returns
+  it. That is what makes the codec testable and fuzzable with no
+  filesystem, and it puts the bound on how much untrusted data is held
+  where it can be enforced — at the seam that reads, which can refuse an
+  oversized file before a byte reaches a parser. The crate's own
+  `clippy.toml` bans the filesystem calls, the file handles and the path
+  types, so nobody arrives at a file by accident and anyone who does has
+  to delete a line with a reason written on it. It is a tripwire across
+  the roads people actually take, not a proof: a ban on `File::open`
+  alone was exactly that mistake, since `OpenOptions` plus
+  `Read::read_to_string` is the same unbounded read spelled in two lines.
+- **Two obligations that are the caller's, because this crate cannot
+  check them.** Invalid UTF-8 never arrives here, so the caller has to
+  read with something that refuses it rather than something that replaces
+  bad bytes — lossy repair before the parser sees the file is still lossy
+  repair. And `timestep_ns=0` or `budget=0` parse quite happily, because
+  the codec does not interpret the schedule it stores; whoever turns a
+  header into a real schedule has to refuse a zero, and will have to,
+  because the types that carry those two numbers cannot hold one.
+- **Writing and reading are inverses.** `parse(write(t))` is `t`, for
+  every trace that can be built — no exceptions and nothing lossy. The
+  reverse holds for every file the writer could have produced: a
+  hand-written file may spell a number with leading zeros, and writing it
+  back out spells it canonically.
+- **The codec interprets nothing it does not own.** It knows four header
+  fields. `sample`, every caller key, and what the events *mean* are the
+  caller's: it preserves them verbatim and checks nothing but uniqueness.
+  The caller checks that `sample` names the thing it is about to run and
+  applies its own keys. A codec that guessed what a sample name implies
+  would be wrong differently for every caller.
+- **Order is never repaired.** Ticks must not decrease, but equal ticks
+  are allowed and their recorded order is part of the trace: two keys
+  going down on one tick were seen in one order, and sorting or
+  deduplicating them would change the input while looking like tidying.
+- **Zero dependencies, no clock, no threads, no logging.** A refusal is
+  returned, never printed. Nothing here panics and nothing unwinds.
+
+## What a trace reproduces
+
+The simulation: the state a run reaches, and the exact interleaving of
+events with steps. **Not** how many frames carried those steps, how many
+were dropped, or which driver supplied the input — those are facts about
+the schedule that carried the input rather than about the input.
+
+Recording the frame timeline as well was tried and abandoned on a
+measurement: a sample that presents nothing free-runs at about 19,000
+frames per simulation tick, so ten seconds of it is roughly 11.5 million
+frame entries — some 81 MB of text in a repository, to reproduce a hash of
+polling noise. Where a frame timeline is affordable it is also redundant,
+because a headless run executes exactly one step per frame by
+construction. If schedule reproduction is ever wanted, the format grows an
+optional timeline section for frame-bounded drivers; it is not needed now.
+
+## Events are indexed by tick, not by frame
+
+A frame may run no steps or several, so *the event on frame 40* is not a
+point in simulation time. The definition is exact:
+
+> Tick *k* means the event is delivered before the step whose tick is *k*.
+> Ticks are 0-based. A tick equal to the header's `ticks` is legal and
+> means **after the final step**.
+
+That last case is the common one, not an edge case. With thousands of
+frames per tick, a terminating event almost always arrives during a frame
+that runs no step at all, so its recorded tick is the run's own tick
+count. A rule of *tick below ticks* would make a recorder emit files its
+own reader refuses, in the normal case.
+
+This rests on a property the simulation must have: its state may depend
+only on the tick index and the events delivered before that tick — never
+on frame boundaries, on the accumulator's remainder, or on whether a step
+was dropped. A simulation that reacted to a stall would not be
+reproducible from a tick index by anything.
+
+## The grammar
+
+```text
+renew-trace <version> sample=<name> ticks=<u64> timestep_ns=<u64> budget=<u32> [key=value…]
+e <tick> key <name> <down|up> [repeat]
+e <tick> pointer <hex-f64> <hex-f64>
+e <tick> button <name|other:<u16>> <down|up>
+e <tick> wheel <hex-f32> <hex-f32>
+e <tick> focus <in|out>
+e <tick> resize <u32> <u32>
+e <tick> scale <hex-f64>
+e <tick> redraw
+e <tick> close
+```
+
+The version is positional and first, because a reader has to know how to
+read the rest of a line before it reads it. A reader accepts its own
+version and every older one.
+
+A new **caller-owned key** does not move the version: those keys were
+never the codec's to interpret, so a reader that has never seen one keeps
+it verbatim and reads the file. Everything else in the vocabulary does
+move it — a new event kind, a new key name, a new button name. Each of
+those is a word an existing reader does not know, and this format refuses
+words it does not know rather than skipping them, so adding one makes
+every reader already in the world reject the whole file. That is a new
+format however small the addition looked.
+
+Fields are separated by exactly one space. A header field is split at its
+**first** `=`, so a value may carry as many more as it likes
+(`extent=640=480` is the value `640=480`) while a *key* may carry none —
+a key with one would be read back shorter than it was written, which is
+silent corruption, and a key of `ticks=9` would walk a reserved name past
+the uniqueness check. The positional `sample` is a value in this sense
+and may contain `=` freely. Numbers are ASCII digits with
+no sign and no underscores: *whatever the standard parser accepts* is not
+a specification for a byte-exact format, and what it accepts is free to
+grow. Bit patterns are `0x` and exactly the width of their type, in
+lowercase. A trailing carriage return is stripped, because these are text
+files in a repository whose builds run on Windows and a line ending is not
+a change to what a line says. A byte order mark is an error that names
+itself, because it is invisible on screen and every other message would
+send the reader looking at the wrong thing.
+
+`unidentified` is a first-class key name, not a refusal: it is what the
+windowing seam produces for every physical key outside the mapped set, so
+treating it as unencodable would abort a recording the first time someone
+pressed Shift — during exactly the session a recording exists to capture.
+What is unrecoverable is *which* physical key it was; the event itself
+records and replays fine.
+
+## Why text, and why floats are integers
+
+Diffable in version control, hand-writable in a test, readable in a build
+log, parseable with no dependency. Binary wins only on compactness, which
+— with no frame timeline in the file — is the difference between a small
+file and a slightly smaller one.
+
+Every field is an integer or a keyword. A float value has two zeros and no
+equality for `NaN`, and decimal text does not survive a round trip through
+a parser without care, so floats are written as bit patterns: the parser
+never parses a decimal float, values round-trip exactly, and the two zeros
+stay distinguishable. Non-finite patterns cannot be constructed and are
+refused on read.
+
+## Testing note
+
+Unit tests cover the vocabulary, the header, the tick rules and every line
+shape in both directions. `tests/rejects.rs` gives every distinct
+malformed input its own test, asserting one refusal and one line number
+each — a single test claiming *all of these are rejected* would still pass
+if all but one of them started being rejected for the wrong reason.
+`tests/golden.rs` holds one trace as a literal string that no code
+produced, asserted byte for byte in both directions; it is the anchor
+under the round-trip property in `tests/properties.rs`, which on its own
+proves less than it looks like it proves, because a writer and a reader
+that made the *same* mistake are still exact inverses of each other. The
+property suite also hands the reader generated garbage and generated
+near-traces and requires an answer rather than a crash, with a fixed
+generator seed so the same inputs are explored on every machine.
+
+One caution is worth writing down, because it is the failure mode this
+kind of suite has. An earlier version of the generator drew header text
+from an alphabet with no `=` in it. Every test passed — and so did a
+reader deliberately broken to split a header field at its *last* `=`
+rather than its first, inverting the one rule the format states about
+that character. Full coverage did not help, and could not: coverage says
+every line ran, not that any input could tell right behaviour from wrong.
+Values are generated with `=` in them now, and the rule has a fixed
+hand-written case of its own.
+
+Measured with `cargo llvm-cov`, line, region and function coverage are all
+100% — which for a reader means every refusal edge is *taken* by a test,
+not merely stepped over on the way to a success.
+
+Deliberately not applicable, each for one reason: thread-sanitizer and
+stress testing (nothing here spawns a thread or is shared across one),
+and Miri (no `unsafe` anywhere in the crate).
+
+## Status
+
+Early-stage. The `[package.metadata.renew]` table in
+[Cargo.toml](Cargo.toml) is authoritative for maturity and all manifest
+metadata. `extension_points = []` is honest: no trait, no `dyn`, no
+runtime polymorphism.
+
+The contract lints live in [clippy.toml](clippy.toml): filesystem calls,
+file handles, path types, clock reads, thread spawning, environment reads
+and randomly seeded hash containers are all rejected at lint time,
+because *the codec does no I/O* is a property the whole design rests on
+and one `fs::read` added for convenience would move an untrusted-input
+bound into a crate with no way to enforce it. Every entry was checked by
+writing the call and watching the lint fire.
+
+## Key decisions
+
+- **The vocabulary is this crate's own, not the windowing layer's.** That
+  is what lets the crate depend on nothing. A codec naming the windowing
+  crate's event enum would pull an entire windowing stack into every build
+  that merely reads a file, headless ones included — and it would make the
+  meaning of an already-written file hostage to that enum's growth, since
+  a variant added upstream would change what an existing trace means. The
+  conversion between the two vocabularies lives in the application that
+  owns both.
+- **The name sets are closed to extension.** A downstream conversion
+  should stop compiling the day a key is added, because that is the only
+  moment anyone can still decide what the new key is called in a file.
+- **Finiteness is a type, not a check.** `FiniteF64` and `FiniteF32`
+  refuse infinities and NaNs at construction, which is what leaves the
+  writer with no failure case to report and makes the inverse property
+  total rather than conditional.
+- **One error type, one line-numbering scheme.** A trace is numbered by
+  its text lines in both directions: the header is line 1, and because
+  every line after it is exactly one event, the line a constructor
+  computes for an out-of-order tick is the line the file actually has.
+- **The tick rules live in `Trace::new`, not in the parser.** A trace
+  built in memory and a trace read from a file are held to one
+  implementation of them, so a recorder cannot produce something its own
+  reader would refuse.
+- **A header carries no version field.** There is exactly one format
+  version, so storing a number that can only hold one value would be
+  machinery pretending to be a decision. When a reader accepts an older
+  version as well as its own, whether rewriting preserves the older claim
+  becomes a real question, and it should be answered by a visible addition
+  rather than by a field that quietly upgraded every file it touched.
+
+## Known gaps
+
+- **No fuzz target.** The property suite hands the reader generated
+  garbage with a fixed budget, which is a small fuzzer and not a
+  substitute for one. A real target needs tooling this tree does not have
+  yet; the maturity level says `bootstrap` for reasons including this one.
+- **Nothing here records or replays.** This crate is the codec: the
+  recorder that produces a trace from a live session, the driver that
+  feeds one back into a run, and the command-line face of both are
+  separate work that depends on this.
+- **No compression and no motion decimation.** Files are tens of lines.
+  A pointer moving every tick for a long run would change that, and the
+  answer then is a format decision, not a smarter writer.

--- a/crates/trace/clippy.toml
+++ b/crates/trace/clippy.toml
@@ -1,0 +1,57 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# The entries that matter most here are the filesystem ones. This crate is
+# a codec and nothing else: it takes text and returns a trace, or takes a
+# trace and returns text. It never opens a file and never accepts a path.
+# That is what makes it fuzzable and testable with no filesystem at all,
+# and it is what puts the memory bound on a whole-file read where it
+# belongs — at the seam that does the reading, which can refuse a file too
+# large to hold before a single byte reaches a parser. One `fs::read`
+# added here for convenience would move an untrusted-input bound into a
+# crate that has no way to enforce it.
+#
+# What this list is, precisely: a tripwire across the roads someone
+# actually takes, not a proof. A ban on `File::open` alone was exactly
+# that mistake — `OpenOptions::new().read(true).open(…)` plus
+# `Read::read_to_string` is the same unbounded read of the same untrusted
+# file, spelled in two lines, and it compiled clean. The types are banned
+# now as well as the calls, which closes that road and the ones beside
+# it, and every entry below was checked by writing the call and watching
+# the lint fire. A determined author can still reach the filesystem by a
+# name nobody thought to list. The point is that nobody arrives there by
+# accident, and that anyone who does has to delete a line with a reason
+# written on it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::fs::read", reason = "this crate never touches the filesystem: it parses text a caller already holds" },
+    { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the I/O seam, which can refuse an oversized file; this crate never does I/O" },
+    { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road: a handle plus this method is `fs::read_to_string` spelled in two lines" },
+    { path = "std::io::Read::read_to_end", reason = "the same unbounded read by the other road" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem: it returns text for a caller to write" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem, and asking about a file is one line away from opening it" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "a codec is a pure function of its argument; a value from the environment would make one run differ from the next with nothing in the input to explain it" },
+    { path = "std::time::Instant::now", reason = "a codec reads no clock; nothing it produces may depend on when it ran" },
+    { path = "std::time::SystemTime::now", reason = "a codec reads no clock; nothing it produces may depend on when it ran" },
+    { path = "std::thread::spawn", reason = "a codec spawns nothing; it is a pure function of its input" },
+]
+
+disallowed-types = [
+    { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle, which banning `File::open` alone does not" },
+    { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on `File::open` misses" },
+    { path = "std::path::Path", reason = "the codec takes text, never a path: a function that can name a file will eventually open one" },
+    { path = "std::path::PathBuf", reason = "the codec takes text, never a path: a function that can name a file will eventually open one" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs; header keys keep the order they were written in, which a map would destroy" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs" },
+]
+
+# The SAFETY-comment lint accepts the comment above an attribute or
+# on the statement that owns the block.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/trace/src/error.rs
+++ b/crates/trace/src/error.rs
@@ -1,0 +1,549 @@
+//! Why a trace was refused: which line, and what was expected there.
+//!
+//! Every rule in this crate rejects rather than repairs, and every refusal
+//! names a line. Nothing is skipped: a line a reader does not understand
+//! is the one thing a format must never shrug at, because skipping is how
+//! two readers of the same file quietly stop agreeing about what it says.
+//!
+//! One error type serves both directions. The codec numbers a trace by its
+//! text lines — the header is line 1, and because every line after it is
+//! exactly one event, the event at index *k* is line *k* + 2. A trace
+//! assembled in memory is numbered the same way, so a refusal from
+//! [`Trace::new`](crate::Trace::new) names the line the offending event
+//! *would* occupy: the same number the reader would report reading it
+//! back.
+
+use crate::event::{TraceButton, TraceKey};
+use crate::grammar::{MAGIC, OTHER_BUTTON};
+use core::fmt;
+
+/// A refusal, with the line it happened on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TraceError {
+    line: usize,
+    kind: TraceErrorKind,
+}
+
+impl TraceError {
+    pub(crate) const fn new(line: usize, kind: TraceErrorKind) -> Self {
+        Self { line, kind }
+    }
+
+    /// The 1-based line this refusal is about.
+    #[must_use]
+    pub const fn line(&self) -> usize {
+        self.line
+    }
+
+    /// What went wrong, as a value a caller can match on rather than a
+    /// string it would have to search.
+    #[must_use]
+    pub const fn kind(&self) -> &TraceErrorKind {
+        &self.kind
+    }
+}
+
+impl fmt::Display for TraceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line {}: {}", self.line, self.kind)
+    }
+}
+
+impl std::error::Error for TraceError {}
+
+/// What was wrong with the line.
+///
+/// Matching is exhaustive on purpose while the crate is young: a caller
+/// that handles every refusal today should stop compiling the day a new
+/// one is added, rather than silently routing it to a catch-all arm.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TraceErrorKind {
+    /// Nothing at all. A trace is at minimum its header line.
+    Empty,
+    /// A byte order mark in front of the header. Named specifically
+    /// because it is invisible: the file looks correct on screen, and
+    /// every other message would blame the wrong thing.
+    ByteOrderMark,
+    /// The first line does not begin with the format's own name.
+    NotATrace { found: String },
+    /// A version this reader does not know how to read. A reader accepts
+    /// its own version and every older one, never a newer one.
+    UnsupportedVersion { found: u64, supported: u32 },
+    /// The line stopped before something the grammar requires.
+    LineEndsEarly { expected: &'static str },
+    /// A required header field, but not the one that belongs here. The
+    /// four the codec owns are positional so that a reader knows what it
+    /// is holding before it interprets it.
+    HeaderFieldOutOfOrder {
+        expected: &'static str,
+        found: String,
+    },
+    /// A header field after the version that is not `key=value`.
+    NotAKeyValuePair { field: String },
+    /// The same header key twice. Which one wins is not a question a
+    /// format should leave open.
+    DuplicateHeaderKey { key: String },
+    /// Two field separators in a row.
+    BlankField,
+    /// A header key or value that could not be written back out as
+    /// itself.
+    UnwritableText { text: String, reason: &'static str },
+    /// A second header line. A trace has exactly one, and it is first.
+    HeaderAfterEvents,
+    /// A line whose first word is not one this reader knows.
+    UnknownKeyword { keyword: String },
+    /// An event line naming a kind of event this reader does not know.
+    UnknownEventKind { kind: String },
+    /// Text after the end of a complete line.
+    TrailingText { text: String },
+    /// A number written in something other than plain ASCII digits.
+    NotADecimalInteger { field: &'static str, text: String },
+    /// A number too large for the field it was written in.
+    IntegerTooLarge { field: &'static str, text: String },
+    /// A float field that is not a fixed-width lowercase hexadecimal bit
+    /// pattern.
+    NotAHexPattern {
+        field: &'static str,
+        text: String,
+        digits: usize,
+    },
+    /// A bit pattern naming an infinity or a `NaN`.
+    NonFinite { field: &'static str, text: String },
+    /// A key name outside the encodable set.
+    UnknownKey { name: String },
+    /// A pointer button outside the encodable set.
+    UnknownButton { name: String },
+    /// A key or button state that is neither `down` nor `up`.
+    NotAPressedState { text: String },
+    /// A focus state that is neither `in` nor `out`.
+    NotAFocusState { text: String },
+    /// Something other than the literal `repeat` where only that may go.
+    NotTheRepeatFlag { text: String },
+    /// A tick earlier than the one before it.
+    TickWentBackwards { tick: u64, previous: u64 },
+    /// A tick past the end of the run the header describes.
+    TickBeyondHeader { tick: u64, ticks: u64 },
+}
+
+impl fmt::Display for TraceErrorKind {
+    // Long, and deliberately one piece. This is a table of messages, not
+    // an algorithm: every arm is one refusal and its words, and the
+    // match is exhaustive, which is what stops a new refusal from
+    // reaching a user with no words at all. Splitting it into groups
+    // would need either a second match to route between them or a
+    // catch-all arm in each, and a catch-all is exactly the thing whose
+    // absence is doing the work here.
+    #[allow(clippy::too_many_lines)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str(
+                "the file is empty; a trace is a header line followed by one line per event",
+            ),
+            Self::ByteOrderMark => f.write_str(
+                "the file begins with a byte order mark (U+FEFF), which is not part of the header; it is invisible on screen, so it is named here rather than reported as a malformed first word",
+            ),
+            Self::NotATrace { found } => write!(
+                f,
+                "expected a header beginning with `{MAGIC}`, found `{found}`",
+                found = shown(found),
+            ),
+            Self::UnsupportedVersion { found, supported } => write!(
+                f,
+                "this trace is version {found} and this reader understands version {supported} and older",
+            ),
+            Self::LineEndsEarly { expected } => write!(f, "the line ends before {expected}"),
+            Self::HeaderFieldOutOfOrder { expected, found } => write!(
+                f,
+                "expected {expected} here, found `{found}`; the header's own fields are positional",
+                found = shown(found),
+            ),
+            Self::NotAKeyValuePair { field } => write!(
+                f,
+                "header fields after the version are written `key=value`, found `{field}`",
+                field = shown(field),
+            ),
+            Self::DuplicateHeaderKey { key } => write!(
+                f,
+                "the header sets `{key}` twice; keys are unique",
+                key = shown(key),
+            ),
+            Self::BlankField => f.write_str(
+                "an empty field; fields are separated by exactly one space, so neither a doubled space nor a trailing one belongs here",
+            ),
+            Self::UnwritableText { text, reason } => write!(
+                f,
+                "the header field `{text}` cannot be written: {reason}",
+                text = shown(text),
+            ),
+            Self::HeaderAfterEvents => f.write_str(
+                "a second header; a trace has exactly one and it is the first line",
+            ),
+            Self::UnknownKeyword { keyword } => write!(
+                f,
+                "unknown line keyword `{keyword}`; every line after the header begins with `e`. The line is refused rather than skipped: if this file really is a version this reader accepts, then this reader's table is the thing that is incomplete",
+                keyword = shown(keyword),
+            ),
+            Self::UnknownEventKind { kind } => write!(
+                f,
+                "unknown event kind `{kind}`; this reader knows key, pointer, button, wheel, focus, resize, scale, redraw and close. The line is refused rather than skipped: if this file really is a version this reader accepts, then this reader's table is the thing that is incomplete",
+                kind = shown(kind),
+            ),
+            Self::TrailingText { text } => write!(
+                f,
+                "unexpected `{text}` after the end of the line",
+                text = shown(text),
+            ),
+            Self::NotADecimalInteger { field, text } => write!(
+                f,
+                "{field} is written in ASCII digits only — no sign, no underscores, no other base — found `{text}`",
+                text = shown(text),
+            ),
+            Self::IntegerTooLarge { field, text } => write!(
+                f,
+                "{field} does not fit its width, found `{text}`",
+                text = shown(text),
+            ),
+            Self::NotAHexPattern {
+                field,
+                text,
+                digits,
+            } => write!(
+                f,
+                "{field} is written as `0x` and exactly {digits} lowercase hexadecimal digits, found `{text}`",
+                text = shown(text),
+            ),
+            Self::NonFinite { field, text } => write!(
+                f,
+                "{field} is `{text}`, which is an infinity or a not-a-number; a trace carries finite values only",
+                text = shown(text),
+            ),
+            Self::UnknownKey { name } => write!(
+                f,
+                "unknown key name `{name}`; this reader knows {names}",
+                name = shown(name),
+                names = joined(TraceKey::ALL.iter().map(|key| key.name().to_string())),
+            ),
+            Self::UnknownButton { name } => write!(
+                f,
+                "unknown pointer button `{name}`; this reader knows {names}, and `{OTHER_BUTTON}<index>` for a native button by its number",
+                name = shown(name),
+                names = joined(TraceButton::NAMED.iter().map(TraceButton::to_string)),
+            ),
+            Self::NotAPressedState { text } => write!(
+                f,
+                "a key or a button is `down` or `up`, found `{text}`",
+                text = shown(text),
+            ),
+            Self::NotAFocusState { text } => write!(
+                f,
+                "focus is `in` or `out`, found `{text}`",
+                text = shown(text),
+            ),
+            Self::NotTheRepeatFlag { text } => write!(
+                f,
+                "the only thing a key line may carry after its state is the literal `repeat`, found `{text}`",
+                text = shown(text),
+            ),
+            Self::TickWentBackwards { tick, previous } => write!(
+                f,
+                "tick {tick} follows tick {previous}; ticks never decrease. Equal ticks are allowed and their recorded order is part of the trace, so nothing here is sorted",
+            ),
+            Self::TickBeyondHeader { tick, ticks } => write!(
+                f,
+                "tick {tick} is past the end of a run of {ticks} ticks; the last legal tick is {ticks} itself, which means after the final step",
+            ),
+        }
+    }
+}
+
+/// The known names of something, as one comma-separated list.
+fn joined(names: impl Iterator<Item = String>) -> String {
+    names.collect::<Vec<_>>().join(", ")
+}
+
+/// How much of an offending field a message quotes back.
+const SHOWN_CHARS: usize = 64;
+
+/// A piece of the file, made safe to read in the place these messages are
+/// actually read.
+///
+/// Every quoted fragment here came out of an untrusted file, and printing
+/// one verbatim hands its author the terminal: an escape sequence can
+/// recolour a build log, erase the line that reported the problem, or
+/// scroll it away, and a field a megabyte long can bury it just as well.
+/// The header rules refuse control characters in a *written* trace for
+/// exactly this reason; a message about a file that broke those rules
+/// cannot then print the thing they were protecting against. So the text
+/// is escaped and capped for display, while the error value keeps the
+/// bytes as they were — a caller matching on the refusal sees the file,
+/// and only the printed form is tamed.
+fn shown(text: &str) -> String {
+    let mut escaped = text.escape_debug();
+    let mut safe: String = escaped.by_ref().take(SHOWN_CHARS).collect();
+    if escaped.next().is_some() {
+        safe.push('…');
+    }
+    safe
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraceError, TraceErrorKind};
+
+    /// Assert a table of refusals against the exact words each produces,
+    /// and against how many of them there are.
+    ///
+    /// The three tables below are one list split in three, because a
+    /// single one outgrew what a person reads in one sitting. Together
+    /// they hold every refusal this crate can produce — 11 + 6 + 8 — and
+    /// each says so, so a refusal added without a message here fails a
+    /// count rather than going out into the world unread.
+    fn all_of(count: usize, cases: Vec<(TraceErrorKind, &str)>) {
+        assert_eq!(cases.len(), count, "a refusal is missing from this table");
+        for (kind, expected) in cases {
+            assert_eq!(kind.to_string(), expected);
+        }
+    }
+
+    /// What the reader says about a file, and about the one header line
+    /// every file begins with.
+    #[test]
+    fn every_refusal_about_a_header_says_what_was_expected() {
+        all_of(
+            11,
+            vec![
+                (
+                    TraceErrorKind::Empty,
+                    "the file is empty; a trace is a header line followed by one line per event",
+                ),
+                (
+                    TraceErrorKind::ByteOrderMark,
+                    "the file begins with a byte order mark (U+FEFF), which is not part of the header; it is invisible on screen, so it is named here rather than reported as a malformed first word",
+                ),
+                (
+                    TraceErrorKind::NotATrace {
+                        found: "hello".to_string(),
+                    },
+                    "expected a header beginning with `renew-trace`, found `hello`",
+                ),
+                (
+                    TraceErrorKind::UnsupportedVersion {
+                        found: 9,
+                        supported: 0,
+                    },
+                    "this trace is version 9 and this reader understands version 0 and older",
+                ),
+                (
+                    TraceErrorKind::LineEndsEarly {
+                        expected: "the tick",
+                    },
+                    "the line ends before the tick",
+                ),
+                (
+                    TraceErrorKind::HeaderFieldOutOfOrder {
+                        expected: "`ticks=<u64>`",
+                        found: "budget=5".to_string(),
+                    },
+                    "expected `ticks=<u64>` here, found `budget=5`; the header's own fields are positional",
+                ),
+                (
+                    TraceErrorKind::NotAKeyValuePair {
+                        field: "seed".to_string(),
+                    },
+                    "header fields after the version are written `key=value`, found `seed`",
+                ),
+                (
+                    TraceErrorKind::DuplicateHeaderKey {
+                        key: "seed".to_string(),
+                    },
+                    "the header sets `seed` twice; keys are unique",
+                ),
+                (
+                    TraceErrorKind::BlankField,
+                    "an empty field; fields are separated by exactly one space, so neither a doubled space nor a trailing one belongs here",
+                ),
+                (
+                    TraceErrorKind::UnwritableText {
+                        text: "seed=".to_string(),
+                        reason: "a header key and a header value are each at least one character",
+                    },
+                    "the header field `seed=` cannot be written: a header key and a header value are each at least one character",
+                ),
+                (
+                    TraceErrorKind::HeaderAfterEvents,
+                    "a second header; a trace has exactly one and it is the first line",
+                ),
+            ],
+        );
+    }
+
+    /// What the reader says about the shape of an event line: the words
+    /// it is made of, and where they stop.
+    #[test]
+    fn every_refusal_about_a_line_shape_says_what_was_expected() {
+        all_of(
+            6,
+            vec![
+                (
+                    TraceErrorKind::UnknownKeyword {
+                        keyword: "x".to_string(),
+                    },
+                    "unknown line keyword `x`; every line after the header begins with `e`. The line is refused rather than skipped: if this file really is a version this reader accepts, then this reader's table is the thing that is incomplete",
+                ),
+                (
+                    TraceErrorKind::UnknownEventKind {
+                        kind: "gamepad".to_string(),
+                    },
+                    "unknown event kind `gamepad`; this reader knows key, pointer, button, wheel, focus, resize, scale, redraw and close. The line is refused rather than skipped: if this file really is a version this reader accepts, then this reader's table is the thing that is incomplete",
+                ),
+                (
+                    TraceErrorKind::TrailingText {
+                        text: "extra".to_string(),
+                    },
+                    "unexpected `extra` after the end of the line",
+                ),
+                (
+                    TraceErrorKind::NotAPressedState {
+                        text: "pressed".to_string(),
+                    },
+                    "a key or a button is `down` or `up`, found `pressed`",
+                ),
+                (
+                    TraceErrorKind::NotAFocusState {
+                        text: "yes".to_string(),
+                    },
+                    "focus is `in` or `out`, found `yes`",
+                ),
+                (
+                    TraceErrorKind::NotTheRepeatFlag {
+                        text: "again".to_string(),
+                    },
+                    "the only thing a key line may carry after its state is the literal `repeat`, found `again`",
+                ),
+            ],
+        );
+    }
+
+    /// What the reader says about a value it cannot accept: a number, a
+    /// bit pattern, a name, or a tick out of order.
+    #[test]
+    fn every_refusal_about_a_value_says_what_was_expected() {
+        all_of(
+            8,
+            vec![
+                (
+                    TraceErrorKind::NotADecimalInteger {
+                        field: "the tick",
+                        text: "+4".to_string(),
+                    },
+                    "the tick is written in ASCII digits only — no sign, no underscores, no other base — found `+4`",
+                ),
+                (
+                    TraceErrorKind::IntegerTooLarge {
+                        field: "`budget` (u32)",
+                        text: "4294967296".to_string(),
+                    },
+                    "`budget` (u32) does not fit its width, found `4294967296`",
+                ),
+                (
+                    TraceErrorKind::NotAHexPattern {
+                        field: "the pointer's x coordinate",
+                        text: "0xFF".to_string(),
+                        digits: 16,
+                    },
+                    "the pointer's x coordinate is written as `0x` and exactly 16 lowercase hexadecimal digits, found `0xFF`",
+                ),
+                (
+                    TraceErrorKind::NonFinite {
+                        field: "the scale factor",
+                        text: "0x7ff0000000000000".to_string(),
+                    },
+                    "the scale factor is `0x7ff0000000000000`, which is an infinity or a not-a-number; a trace carries finite values only",
+                ),
+                (
+                    TraceErrorKind::UnknownKey {
+                        name: "meta".to_string(),
+                    },
+                    "unknown key name `meta`; this reader knows escape, space, enter, tab, arrow-up, arrow-down, arrow-left, arrow-right, key-w, key-a, key-s, key-d, unidentified",
+                ),
+                (
+                    TraceErrorKind::UnknownButton {
+                        name: "thumb".to_string(),
+                    },
+                    "unknown pointer button `thumb`; this reader knows left, right, middle, back, forward, and `other:<index>` for a native button by its number",
+                ),
+                (
+                    TraceErrorKind::TickWentBackwards {
+                        tick: 3,
+                        previous: 7,
+                    },
+                    "tick 3 follows tick 7; ticks never decrease. Equal ticks are allowed and their recorded order is part of the trace, so nothing here is sorted",
+                ),
+                (
+                    TraceErrorKind::TickBeyondHeader {
+                        tick: 31,
+                        ticks: 30,
+                    },
+                    "tick 31 is past the end of a run of 30 ticks; the last legal tick is 30 itself, which means after the final step",
+                ),
+            ],
+        );
+    }
+
+    /// A refusal is read in a build log, and the thing it quotes came
+    /// out of an untrusted file. An escape sequence quoted verbatim can
+    /// recolour that log or erase the line that reported the problem, so
+    /// the printed form is escaped — while the error value itself keeps
+    /// the bytes, because a caller matching on it is entitled to the
+    /// file as it was.
+    #[test]
+    fn a_refusal_never_prints_an_escape_sequence_from_the_file() {
+        let hostile = "\u{1b}[2K\u{1b}[31mgone";
+        let kind = TraceErrorKind::TrailingText {
+            text: hostile.to_string(),
+        };
+        let printed = kind.to_string();
+        assert!(!printed.contains('\u{1b}'), "{printed}");
+        assert!(printed.contains("\\u{1b}[2K"), "{printed}");
+        // The value is untouched: only the printing is tamed.
+        assert_eq!(
+            kind,
+            TraceErrorKind::TrailingText {
+                text: hostile.to_string()
+            }
+        );
+    }
+
+    /// And a field long enough to bury the message is cut short with a
+    /// mark saying so, rather than scrolling the reason off the screen.
+    #[test]
+    fn a_refusal_quotes_only_the_front_of_an_enormous_field() {
+        let long = "x".repeat(4096);
+        let printed = TraceErrorKind::UnknownKeyword { keyword: long }.to_string();
+        assert!(printed.contains(&format!("`{}…`", "x".repeat(super::SHOWN_CHARS))));
+        // Exactly the cap is quoted whole, with no mark: a field that
+        // fits is never made to look truncated.
+        let exact = "y".repeat(super::SHOWN_CHARS);
+        let printed = TraceErrorKind::UnknownKeyword {
+            keyword: exact.clone(),
+        }
+        .to_string();
+        assert!(printed.contains(&format!("`{exact}`")), "{printed}");
+    }
+
+    #[test]
+    fn a_refusal_carries_its_line_in_front_of_its_reason() {
+        let error = TraceError::new(7, TraceErrorKind::HeaderAfterEvents);
+        assert_eq!(error.line(), 7);
+        assert_eq!(error.kind(), &TraceErrorKind::HeaderAfterEvents);
+        assert_eq!(
+            error.to_string(),
+            "line 7: a second header; a trace has exactly one and it is the first line"
+        );
+        // It is an error in the ordinary sense, so it composes with
+        // whatever the caller already uses to report failures.
+        let boxed: Box<dyn std::error::Error> = Box::new(error.clone());
+        assert_eq!(boxed.to_string(), error.to_string());
+        assert!(format!("{error:?}").contains("HeaderAfterEvents"));
+    }
+}

--- a/crates/trace/src/error.rs
+++ b/crates/trace/src/error.rs
@@ -133,7 +133,14 @@ impl fmt::Display for TraceErrorKind {
     // would need either a second match to route between them or a
     // catch-all arm in each, and a catch-all is exactly the thing whose
     // absence is doing the work here.
-    #[allow(clippy::too_many_lines)]
+    //
+    // `expect` rather than `allow`: if this table ever shrinks back
+    // under the limit, the compiler says so and the exemption goes,
+    // instead of sitting here outliving its reason.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "a table of messages, kept in one exhaustive match on purpose"
+    )]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Empty => f.write_str(
@@ -512,6 +519,94 @@ mod tests {
                 text: hostile.to_string()
             }
         );
+    }
+
+    /// Every refusal that quotes the file, checked one by one.
+    ///
+    /// Two of these were pinned before and fifteen were not, which meant
+    /// fifteen sites where the escaping could be dropped and nothing
+    /// would notice. The table is counted for the same reason the
+    /// message tables above are: a new refusal that carries text from
+    /// the file has to be added here, or the count says so.
+    #[test]
+    fn every_refusal_that_quotes_the_file_escapes_what_it_quotes() {
+        let hostile = "\u{1b}[2Kgone\u{7}";
+        let quoting: Vec<TraceErrorKind> = vec![
+            TraceErrorKind::NotATrace {
+                found: hostile.to_string(),
+            },
+            TraceErrorKind::HeaderFieldOutOfOrder {
+                expected: "`ticks=<u64>`",
+                found: hostile.to_string(),
+            },
+            TraceErrorKind::NotAKeyValuePair {
+                field: hostile.to_string(),
+            },
+            TraceErrorKind::DuplicateHeaderKey {
+                key: hostile.to_string(),
+            },
+            TraceErrorKind::UnwritableText {
+                text: hostile.to_string(),
+                reason: "a control character is invisible in a diff and in a log",
+            },
+            TraceErrorKind::UnknownKeyword {
+                keyword: hostile.to_string(),
+            },
+            TraceErrorKind::UnknownEventKind {
+                kind: hostile.to_string(),
+            },
+            TraceErrorKind::TrailingText {
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::NotADecimalInteger {
+                field: "the tick",
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::IntegerTooLarge {
+                field: "the tick",
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::NotAHexPattern {
+                field: "the scale factor",
+                text: hostile.to_string(),
+                digits: 16,
+            },
+            TraceErrorKind::NonFinite {
+                field: "the scale factor",
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::UnknownKey {
+                name: hostile.to_string(),
+            },
+            TraceErrorKind::UnknownButton {
+                name: hostile.to_string(),
+            },
+            TraceErrorKind::NotAPressedState {
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::NotAFocusState {
+                text: hostile.to_string(),
+            },
+            TraceErrorKind::NotTheRepeatFlag {
+                text: hostile.to_string(),
+            },
+        ];
+        assert_eq!(
+            quoting.len(),
+            17,
+            "every refusal that quotes the file belongs in this table"
+        );
+        for kind in quoting {
+            let printed = kind.to_string();
+            assert!(
+                !printed.contains('\u{1b}') && !printed.contains('\u{7}'),
+                "raw control characters reached the message: {printed:?}"
+            );
+            assert!(
+                printed.contains("\\u{1b}[2Kgone\\u{7}"),
+                "the quoted text is missing or unescaped: {printed:?}"
+            );
+        }
     }
 
     /// And a field long enough to bury the message is cut short with a

--- a/crates/trace/src/event.rs
+++ b/crates/trace/src/event.rs
@@ -1,0 +1,435 @@
+//! The event vocabulary: what a trace can say happened, spelled in this
+//! crate's own words.
+//!
+//! The vocabulary is owned here rather than borrowed from the windowing
+//! layer, and that is the whole reason this crate depends on nothing. A
+//! codec that named the windowing crate's event enum would pull that
+//! crate — and everything it links, an entire windowing stack — into
+//! every build that merely wants to read a file, headless ones included.
+//! It would also make the meaning of a recorded file hostage to that
+//! enum's growth: a variant added upstream would quietly change what an
+//! already-written trace means. Owning the words means a new upstream
+//! variant changes only what the *conversion* in the application must
+//! handle, which is one compile error in one place.
+//!
+//! Floats are carried as their IEEE-754 bit patterns, never as decimal
+//! text. A float value has two zeros and no equality for `NaN`, and
+//! decimal text does not survive a round trip through a parser without
+//! care; a bit pattern is an integer, compares exactly, and is what a
+//! determinism digest absorbs anyway.
+
+use crate::grammar::OTHER_BUTTON;
+use core::fmt;
+
+/// A finite `f64`, carried as its IEEE-754 bit pattern.
+///
+/// The type exists so that a trace cannot be built which the reader would
+/// then refuse: an infinity or a `NaN` is rejected here, at construction,
+/// instead of at the moment someone reads the file back. That is what lets
+/// the writer be infallible and makes writing and reading exact inverses.
+///
+/// Equality is on the bit pattern, which is the comparison a byte-exact
+/// format needs: positive and negative zero are different traces, because
+/// they are different bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FiniteF64(u64);
+
+/// A finite `f32`, carried as its IEEE-754 bit pattern. The `f64` type's
+/// reasoning applies unchanged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FiniteF32(u32);
+
+/// Every bit pattern whose exponent field is all ones is an infinity or a
+/// `NaN`; everything else is finite. The test is written on the integer so
+/// that no float arithmetic — and so no rounding, no signalling `NaN`, and
+/// nothing a compiler flag could relax — takes part in deciding what a
+/// file is allowed to contain.
+const F64_EXPONENT: u64 = 0x7ff0_0000_0000_0000;
+const F32_EXPONENT: u32 = 0x7f80_0000;
+
+impl FiniteF64 {
+    /// How many hexadecimal digits the text form carries, after `0x`.
+    /// Exactly the width of the type: a shorter or longer field is a
+    /// different number silently, so the width is fixed rather than
+    /// inferred.
+    pub const HEX_DIGITS: usize = 16;
+
+    /// The value's bit pattern, or `None` if it is not finite.
+    #[must_use]
+    pub const fn new(value: f64) -> Option<Self> {
+        Self::from_bits(value.to_bits())
+    }
+
+    /// The pattern itself, or `None` if it names an infinity or a `NaN`.
+    #[must_use]
+    pub const fn from_bits(bits: u64) -> Option<Self> {
+        if bits & F64_EXPONENT == F64_EXPONENT {
+            None
+        } else {
+            Some(Self(bits))
+        }
+    }
+
+    #[must_use]
+    pub const fn bits(self) -> u64 {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn value(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+}
+
+impl FiniteF32 {
+    /// How many hexadecimal digits the text form carries, after `0x`.
+    pub const HEX_DIGITS: usize = 8;
+
+    /// The value's bit pattern, or `None` if it is not finite.
+    #[must_use]
+    pub const fn new(value: f32) -> Option<Self> {
+        Self::from_bits(value.to_bits())
+    }
+
+    /// The pattern itself, or `None` if it names an infinity or a `NaN`.
+    #[must_use]
+    pub const fn from_bits(bits: u32) -> Option<Self> {
+        if bits & F32_EXPONENT == F32_EXPONENT {
+            None
+        } else {
+            Some(Self(bits))
+        }
+    }
+
+    #[must_use]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    #[must_use]
+    pub const fn value(self) -> f32 {
+        f32::from_bits(self.0)
+    }
+}
+
+/// A physical key, by the name the format writes it under.
+///
+/// The set is closed on purpose. It is deliberately *not* marked as open
+/// to extension: a downstream conversion should stop compiling the day a
+/// key is added, which is the only moment anyone can still decide what
+/// the new key is called in a file.
+///
+/// Adding a name here bumps [`FORMAT_VERSION`](crate::FORMAT_VERSION).
+/// A name is a word, this format refuses words it does not know rather
+/// than skipping them, and so a file using a new one is a file no reader
+/// already in the world can read — which is what a version number is
+/// for.
+///
+/// [`TraceKey::Unidentified`] is a first-class name, not a refusal. It is
+/// what the windowing seam produces for every physical key outside the
+/// mapped set, so treating it as unencodable would abort a recording the
+/// first time someone pressed Shift — during exactly the session the
+/// recording exists to capture. What is genuinely unrecoverable is *which*
+/// physical key it was; the event itself records and replays fine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceKey {
+    Escape,
+    Space,
+    Enter,
+    Tab,
+    ArrowUp,
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+    KeyW,
+    KeyA,
+    KeyS,
+    KeyD,
+    /// A physical key outside the mapped set. Encodable, replayable, and
+    /// honest about what it does not know.
+    Unidentified,
+}
+
+impl TraceKey {
+    /// Every key, in the order the format documents them.
+    ///
+    /// The parser reads this table rather than carrying a second one, so
+    /// the name a key is written under and the name it is read back from
+    /// are the same string in the same place. Adding a variant is a
+    /// compile error in [`TraceKey::name`]; adding it here as well is the
+    /// author's job, and the count test in this module is what notices.
+    pub const ALL: &'static [Self] = &[
+        Self::Escape,
+        Self::Space,
+        Self::Enter,
+        Self::Tab,
+        Self::ArrowUp,
+        Self::ArrowDown,
+        Self::ArrowLeft,
+        Self::ArrowRight,
+        Self::KeyW,
+        Self::KeyA,
+        Self::KeyS,
+        Self::KeyD,
+        Self::Unidentified,
+    ];
+
+    /// The text this key is written as. Lowercase, hyphenated, and never
+    /// a bare `up` or `down`, which are the words a key line already uses
+    /// for its state.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Escape => "escape",
+            Self::Space => "space",
+            Self::Enter => "enter",
+            Self::Tab => "tab",
+            Self::ArrowUp => "arrow-up",
+            Self::ArrowDown => "arrow-down",
+            Self::ArrowLeft => "arrow-left",
+            Self::ArrowRight => "arrow-right",
+            Self::KeyW => "key-w",
+            Self::KeyA => "key-a",
+            Self::KeyS => "key-s",
+            Self::KeyD => "key-d",
+            Self::Unidentified => "unidentified",
+        }
+    }
+
+    /// The key written under this name, or `None` if no key is.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|key| key.name() == name)
+    }
+}
+
+/// A pointer button: the five named ones, or a native button by its index.
+///
+/// Closed for the same reason as [`TraceKey`], and adding a name here
+/// bumps [`FORMAT_VERSION`](crate::FORMAT_VERSION) for the same reason
+/// too. A native button needs no new name — it is written by its number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceButton {
+    Left,
+    Right,
+    Middle,
+    Back,
+    Forward,
+    /// A native button by its operating-system index — distinct from the
+    /// named variants above, and never aliased onto one.
+    Other(u16),
+}
+
+impl TraceButton {
+    /// The five named buttons, in the order the format documents them.
+    pub const NAMED: &'static [Self] = &[
+        Self::Left,
+        Self::Right,
+        Self::Middle,
+        Self::Back,
+        Self::Forward,
+    ];
+
+    /// The button written under this name, or `None` if no *named* button
+    /// is. A native index is spelled `other:<index>` and is read by the
+    /// parser, which owns the number.
+    ///
+    /// The comparison goes through the writer's own text rather than a
+    /// second table. The allocation is deliberate and paid on a handful of
+    /// lines per file: it buys the guarantee that a button reads back
+    /// exactly as it was written, because there is only one place where
+    /// the two could disagree and it is the same place.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::NAMED
+            .iter()
+            .copied()
+            .find(|button| button.to_string() == name)
+    }
+}
+
+impl fmt::Display for TraceButton {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Left => f.write_str("left"),
+            Self::Right => f.write_str("right"),
+            Self::Middle => f.write_str("middle"),
+            Self::Back => f.write_str("back"),
+            Self::Forward => f.write_str("forward"),
+            Self::Other(index) => write!(f, "{OTHER_BUTTON}{index}"),
+        }
+    }
+}
+
+/// One thing that happened, in the codec's own vocabulary.
+///
+/// Nine variants for the nine lines the format defines, and the names
+/// match the windowing layer's event names so that the conversion in an
+/// application reads as a rename rather than as a translation. Plain data
+/// throughout: no method here interprets an event, because what an event
+/// *means* belongs to the application replaying it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TraceEvent {
+    Key {
+        code: TraceKey,
+        pressed: bool,
+        /// The operating system's auto-repeat, preserved rather than
+        /// filtered: whether a repeat counts is the application's rule.
+        repeat: bool,
+    },
+    PointerMoved {
+        x: FiniteF64,
+        y: FiniteF64,
+    },
+    PointerButton {
+        button: TraceButton,
+        pressed: bool,
+    },
+    Wheel {
+        dx: FiniteF32,
+        dy: FiniteF32,
+    },
+    Focused(bool),
+    Resized {
+        width: u32,
+        height: u32,
+    },
+    ScaleFactorChanged {
+        scale: FiniteF64,
+    },
+    RedrawRequested,
+    CloseRequested,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+
+    /// Values are compared as bit patterns here, never with `==`: this
+    /// crate's whole position on floats is that the pattern is the value,
+    /// and a test that used float equality would be asserting something
+    /// weaker than what it means to assert.
+    #[test]
+    fn a_finite_double_round_trips_through_its_bit_pattern() {
+        let one_and_a_half = FiniteF64::new(1.5).unwrap();
+        assert_eq!(one_and_a_half.bits(), 0x3ff8_0000_0000_0000);
+        assert_eq!(one_and_a_half.value().to_bits(), 1.5_f64.to_bits());
+        assert_eq!(
+            FiniteF64::from_bits(0x3ff8_0000_0000_0000),
+            Some(one_and_a_half)
+        );
+    }
+
+    #[test]
+    fn a_finite_single_round_trips_through_its_bit_pattern() {
+        let one = FiniteF32::new(1.0).unwrap();
+        assert_eq!(one.bits(), 0x3f80_0000);
+        assert_eq!(one.value().to_bits(), 1.0_f32.to_bits());
+        assert_eq!(FiniteF32::from_bits(0x3f80_0000), Some(one));
+    }
+
+    /// The two zeros are different bytes and therefore different traces.
+    /// A codec that compared values rather than patterns would lose the
+    /// distinction silently.
+    #[test]
+    fn the_two_zeros_are_different_patterns() {
+        assert_ne!(FiniteF64::new(0.0), FiniteF64::new(-0.0));
+        assert_ne!(FiniteF32::new(0.0), FiniteF32::new(-0.0));
+    }
+
+    #[test]
+    fn no_infinity_and_no_not_a_number_can_be_constructed() {
+        assert_eq!(FiniteF64::new(f64::INFINITY), None);
+        assert_eq!(FiniteF64::new(f64::NEG_INFINITY), None);
+        assert_eq!(FiniteF64::new(f64::NAN), None);
+        assert_eq!(FiniteF32::new(f32::INFINITY), None);
+        assert_eq!(FiniteF32::new(f32::NEG_INFINITY), None);
+        assert_eq!(FiniteF32::new(f32::NAN), None);
+        // The largest finite values sit immediately below the rejected
+        // exponent, so the boundary is tested from the legal side too.
+        assert!(FiniteF64::new(f64::MAX).is_some());
+        assert!(FiniteF32::new(f32::MAX).is_some());
+    }
+
+    /// A signalling `NaN` — one whose payload has the quiet bit clear —
+    /// is rejected by the same exponent test, with no float touched.
+    #[test]
+    fn a_signalling_pattern_is_rejected_too() {
+        assert_eq!(FiniteF64::from_bits(0x7ff0_0000_0000_0001), None);
+        assert_eq!(FiniteF32::from_bits(0x7f80_0001), None);
+    }
+
+    #[test]
+    fn the_hex_width_is_the_width_of_the_type() {
+        assert_eq!(FiniteF64::HEX_DIGITS, 16);
+        assert_eq!(FiniteF32::HEX_DIGITS, 8);
+    }
+
+    /// The count is the tripwire behind the table: adding a key without
+    /// adding it here leaves the parser unable to read what the writer
+    /// emits, and this is what says so.
+    #[test]
+    fn every_key_has_a_unique_name_that_reads_back() {
+        assert_eq!(TraceKey::ALL.len(), 13);
+        for key in TraceKey::ALL {
+            assert_eq!(TraceKey::from_name(key.name()), Some(*key));
+        }
+        // Two keys sharing a name would make the lookup above find the
+        // first of them for both, so uniqueness is checked directly
+        // rather than left to a round trip that would hide it.
+        let mut names: Vec<&str> = TraceKey::ALL.iter().map(|key| key.name()).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), TraceKey::ALL.len(), "two keys share a name");
+    }
+
+    #[test]
+    fn an_unknown_key_name_names_nothing() {
+        assert_eq!(TraceKey::from_name("meta"), None);
+        assert_eq!(TraceKey::from_name(""), None);
+        // The state words a key line already uses are not key names.
+        assert_eq!(TraceKey::from_name("down"), None);
+    }
+
+    #[test]
+    fn every_named_button_writes_and_reads_back_as_itself() {
+        assert_eq!(TraceButton::NAMED.len(), 5);
+        for button in TraceButton::NAMED {
+            assert_eq!(TraceButton::from_name(&button.to_string()), Some(*button));
+        }
+        assert_eq!(TraceButton::Left.to_string(), "left");
+        assert_eq!(TraceButton::Right.to_string(), "right");
+        assert_eq!(TraceButton::Middle.to_string(), "middle");
+        assert_eq!(TraceButton::Back.to_string(), "back");
+        assert_eq!(TraceButton::Forward.to_string(), "forward");
+    }
+
+    /// A native index is written by the same `Display` and is *not* a
+    /// name: the parser owns the number, so looking it up as a name finds
+    /// nothing.
+    #[test]
+    fn a_native_button_is_written_behind_its_prefix() {
+        assert_eq!(TraceButton::Other(7).to_string(), "other:7");
+        assert_eq!(TraceButton::Other(u16::MAX).to_string(), "other:65535");
+        assert_eq!(TraceButton::from_name("other:7"), None);
+        assert_eq!(TraceButton::from_name("other"), None);
+    }
+
+    /// The vocabulary is plain data: two events built the same way are
+    /// the same event, and every variant says what it is when printed.
+    #[test]
+    fn events_are_comparable_and_printable_plain_data() {
+        let event = TraceEvent::Key {
+            code: TraceKey::Space,
+            pressed: true,
+            repeat: false,
+        };
+        assert_eq!(event, event);
+        assert_ne!(event, TraceEvent::CloseRequested);
+        assert!(format!("{event:?}").contains("Space"));
+        assert!(format!("{:?}", TraceKey::KeyW).contains("KeyW"));
+        assert!(format!("{:?}", TraceButton::Other(3)).contains('3'));
+        assert!(format!("{:?}", FiniteF64::new(2.0)).contains("FiniteF64"));
+        assert!(format!("{:?}", FiniteF32::new(2.0)).contains("FiniteF32"));
+    }
+}

--- a/crates/trace/src/grammar.rs
+++ b/crates/trace/src/grammar.rs
@@ -1,0 +1,94 @@
+//! The words the format is made of.
+//!
+//! One spelling of each, in one place. The writer emits these and the
+//! reader compares against these, so the two halves of the codec cannot
+//! drift apart in the one way that would be hardest to notice: a file that
+//! is written correctly, read back correctly, and understood by nothing
+//! else.
+
+/// The word every trace begins with — the crate's own name, deliberately.
+/// A file that says what wrote it costs eleven bytes and settles an
+/// argument.
+pub(crate) const MAGIC: &str = "renew-trace";
+
+/// The version this crate writes, and the newest one it reads.
+///
+/// A reader accepts its own version and every older one.
+///
+/// **A new caller-owned header key does not move this number.** Those
+/// keys were never the codec's to interpret, so a reader meeting one it
+/// has never seen keeps it verbatim and reads the file.
+///
+/// **Everything else in the vocabulary does.** A new event kind, a new
+/// line keyword, a new [`TraceKey`](crate::TraceKey) name, a new
+/// [`TraceButton`](crate::TraceButton) name — every one of them is a word
+/// an existing reader does not know, and this format refuses words it
+/// does not know rather than skipping them. So adding one makes every
+/// reader already in the world reject the whole file, which is a new
+/// format however small the addition looked, and the number has to move
+/// with it. The alternative is a reader that blames its own table for a
+/// file it should simply have been told it was too old to read.
+pub const FORMAT_VERSION: u32 = 0;
+
+/// Fields are separated by exactly one space. Not by whitespace: a tab or
+/// a run of spaces is a different file from the one someone meant to
+/// write, and a format that shrugs at the difference cannot be compared
+/// byte for byte.
+pub(crate) const SEPARATOR: char = ' ';
+
+/// A header field is a key, this, and a value. A value may contain one
+/// too: the split is at the first, so `extent=640=480` is a value of
+/// `640=480` rather than a refusal.
+pub(crate) const ASSIGN: char = '=';
+
+/// The header's own fields, in the order they are written.
+pub(crate) const SAMPLE: &str = "sample";
+pub(crate) const TICKS: &str = "ticks";
+pub(crate) const TIMESTEP_NS: &str = "timestep_ns";
+pub(crate) const BUDGET: &str = "budget";
+
+/// The four keys the codec owns. Everything else in a header belongs to
+/// the caller.
+pub(crate) const RESERVED_KEYS: &[&str] = &[SAMPLE, TICKS, TIMESTEP_NS, BUDGET];
+
+/// The keyword every event line begins with.
+pub(crate) const EVENT: &str = "e";
+
+/// The nine kinds of event, one per line shape.
+pub(crate) const KEY: &str = "key";
+pub(crate) const POINTER: &str = "pointer";
+pub(crate) const BUTTON: &str = "button";
+pub(crate) const WHEEL: &str = "wheel";
+pub(crate) const FOCUS: &str = "focus";
+pub(crate) const RESIZE: &str = "resize";
+pub(crate) const SCALE: &str = "scale";
+pub(crate) const REDRAW: &str = "redraw";
+pub(crate) const CLOSE: &str = "close";
+
+/// A key or a button is `down` or `up` — never `pressed`, `true` or `1`,
+/// which are three ways to say the same thing and therefore two ways too
+/// many.
+pub(crate) const DOWN: &str = "down";
+pub(crate) const UP: &str = "up";
+
+/// Focus arrives and leaves; it is not pressed.
+pub(crate) const FOCUS_IN: &str = "in";
+pub(crate) const FOCUS_OUT: &str = "out";
+
+/// The operating system's auto-repeat, written only when it is set.
+pub(crate) const REPEAT: &str = "repeat";
+
+/// The prefix a native pointer button's index is written behind.
+pub(crate) const OTHER_BUTTON: &str = "other:";
+
+/// Every float is a bit pattern behind this prefix, in lowercase, at
+/// exactly the width of its type.
+pub(crate) const HEX_PREFIX: &str = "0x";
+
+/// The header is line 1 of every trace.
+pub(crate) const HEADER_LINE: usize = 1;
+
+/// The first event is line 2, and each event after it is one line later.
+/// That is what lets one line number mean the same thing whether a trace
+/// was read from text or assembled in memory.
+pub(crate) const FIRST_EVENT_LINE: usize = 2;

--- a/crates/trace/src/lib.rs
+++ b/crates/trace/src/lib.rs
@@ -1,0 +1,177 @@
+//! The input-trace codec: a line-oriented text format for recorded input,
+//! a reader that refuses everything it does not understand, and a writer
+//! that is its exact inverse.
+//!
+//! A run of this engine is reproducible from a build, a seed and its
+//! input. The build is pinned and the seed is a flag; a trace is what
+//! makes the third one a file. With one, a bug can be reproduced from the
+//! input that caused it, a play session can become a regression test, one
+//! input can be diffed across two builds, and a sample can be driven in
+//! automation by input no programmer wrote.
+//!
+//! ```
+//! use renew_trace::{Trace, TraceEvent, TraceHeader, TraceKey, parse, write};
+//!
+//! let header = TraceHeader::new("input_echo", 10, 16_666_667, 5)?.with_key("seed", "0")?;
+//! let trace = Trace::new(
+//!     header,
+//!     vec![
+//!         (5, TraceEvent::Key { code: TraceKey::ArrowRight, pressed: true, repeat: false }),
+//!         // A tick equal to the run's length means "after the final
+//!         // step", and that is where a terminating event usually lands.
+//!         (10, TraceEvent::CloseRequested),
+//!     ],
+//! )?;
+//!
+//! let text = write(&trace);
+//! assert_eq!(
+//!     text,
+//!     "renew-trace 0 sample=input_echo ticks=10 timestep_ns=16666667 budget=5 seed=0\n\
+//!      e 5 key arrow-right down\n\
+//!      e 10 close\n"
+//! );
+//! assert_eq!(parse(&text), Ok(trace));
+//! # Ok::<(), renew_trace::TraceError>(())
+//! ```
+//!
+//! # What a trace reproduces
+//!
+//! The simulation: the state a run reaches, and the exact interleaving of
+//! events with steps. Not how many frames carried those steps, not how
+//! many steps were dropped, and not which driver supplied the input —
+//! those are facts about the schedule that carried the input rather than
+//! about the input.
+//!
+//! Recording the frame timeline as well was tried and abandoned on a
+//! measurement: a sample that presents nothing free-runs at about 19,000
+//! frames per simulation tick, so ten seconds of it is roughly 11.5
+//! million frame entries — some 81 MB of text, to reproduce a hash of
+//! polling noise. Where a frame timeline is affordable it is also
+//! redundant, because a headless run executes exactly one step per frame
+//! by construction. If schedule reproduction is ever wanted, the format
+//! grows an optional timeline section for frame-bounded drivers.
+//!
+//! # Events are indexed by tick, not by frame
+//!
+//! A frame may run no steps or several, so *the event on frame 40* is not
+//! a point in simulation time. Tick *k* means the event is delivered
+//! before the step whose tick is *k*; ticks are 0-based; and a tick equal
+//! to the header's `ticks` is legal and means *after the final step*. That
+//! last case is the common one, not an edge case — with thousands of
+//! frames per tick, a terminating event almost always arrives during a
+//! frame that runs no step at all.
+//!
+//! This rests on a property the simulation must have: its state may depend
+//! only on the tick index and the events delivered before that tick —
+//! never on frame boundaries, on the accumulator's remainder, or on
+//! whether a step was dropped. A simulation that reacted to a stall would
+//! not be reproducible from a tick index by anything.
+//!
+//! # Contract
+//!
+//! - **No input is trusted.** Every rule rejects rather than repairs, and
+//!   nothing is skipped: an unknown keyword is an error, because skipping
+//!   is how a format silently forks. Every refusal names the line it is
+//!   about and what was expected there.
+//! - **No file is ever opened.** The reader takes text and the writer
+//!   returns it. That is what makes the codec testable and fuzzable with
+//!   no filesystem, and it puts the bound on how much untrusted data is
+//!   held where it can be enforced — at the seam that reads, which can
+//!   refuse an oversized file before a byte reaches a parser. The crate's
+//!   lint configuration bans the filesystem calls, the file handles and
+//!   the path types, which makes the rule hard to break by accident; it
+//!   is a tripwire rather than a proof, and it is written down as one.
+//! - **Two things the caller must check, because this crate cannot.**
+//!   Invalid UTF-8 never arrives here, so the caller has to read with
+//!   something that refuses it rather than something that replaces bad
+//!   bytes — lossy repair before the parser sees the file is still lossy
+//!   repair. And `timestep_ns` or `budget` of zero parse quite happily,
+//!   because the codec does not interpret the schedule it is storing; the
+//!   caller turning a header into a real schedule is the one that has to
+//!   refuse a zero, and it will have to, because the types that carry
+//!   those two numbers cannot hold one.
+//! - **Writing and reading are inverses.** [`parse`] of [`write()`] is the
+//!   trace it started from, for every trace that can be built — no
+//!   exceptions, no configurations, nothing lossy. The reverse holds for
+//!   every file the writer could have produced: a hand-written file may
+//!   spell a number with leading zeros, and writing it back out spells it
+//!   canonically.
+//! - **The codec interprets nothing it does not own.** It knows four
+//!   header fields. `sample`, any caller key, and what the events *mean*
+//!   are the caller's: it preserves them verbatim and checks nothing but
+//!   uniqueness. A codec that guessed what a sample name implies would be
+//!   wrong differently for every caller.
+//! - **Order is never repaired.** Ticks must not decrease, but equal ticks
+//!   are allowed and their recorded order is part of the trace: two keys
+//!   going down on one tick were seen in one order, and sorting or
+//!   deduplicating them would change the input while looking like tidying.
+//! - **Nothing here allocates on a hot path, logs, reads a clock, or
+//!   spawns anything.** A trace is tens of lines; the codec is a pure
+//!   function of its input.
+//!
+//! # Why text
+//!
+//! Diffable in version control, hand-writable in a test, readable in a
+//! build log, and parseable with no dependency. Binary wins only on
+//! compactness, which — with no frame timeline in the file — is a
+//! difference between a small file and a slightly smaller one.
+//!
+//! Every field is an integer or a keyword. Floats are written as their
+//! IEEE-754 bit patterns in hexadecimal, so no decimal float is ever
+//! parsed and every value round-trips exactly: a float value has two zeros
+//! and no equality for `NaN`, while a bit pattern is an integer and
+//! compares exactly. Non-finite patterns cannot be written and are refused
+//! on read.
+//!
+//! # The grammar
+//!
+//! ```text
+//! renew-trace <version> sample=<name> ticks=<u64> timestep_ns=<u64> budget=<u32> [key=value…]
+//! e <tick> key <name> <down|up> [repeat]
+//! e <tick> pointer <hex-f64> <hex-f64>
+//! e <tick> button <name|other:<u16>> <down|up>
+//! e <tick> wheel <hex-f32> <hex-f32>
+//! e <tick> focus <in|out>
+//! e <tick> resize <u32> <u32>
+//! e <tick> scale <hex-f64>
+//! e <tick> redraw
+//! e <tick> close
+//! ```
+//!
+//! The version is positional and first, because a reader has to know how
+//! to read the rest of a line before it reads it. A reader accepts its own
+//! version and every older one. Fields are separated by exactly one space.
+//! Numbers are ASCII digits with no sign and no underscores. Bit patterns
+//! are `0x` and exactly the width of their type, in lowercase. A trailing
+//! carriage return is stripped; a byte order mark is an error that says
+//! so, because it is invisible on screen and every other message would
+//! blame the wrong thing.
+//!
+//! # Extension points
+//!
+//! None. No trait, no `dyn`, no runtime polymorphism. The event vocabulary
+//! is this crate's own rather than the windowing layer's, which is what
+//! lets the crate depend on nothing: a codec naming another crate's event
+//! enum would pull that crate's whole windowing stack into every build
+//! that merely reads a file, and would make the meaning of an
+//! already-written file hostage to that enum's growth. The conversion
+//! between the two vocabularies lives in the application that owns both.
+
+// This crate is a codec; it does not print, and it does not do arithmetic
+// on floats — every float it handles is an integer bit pattern from the
+// moment it arrives to the moment it leaves.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
+
+mod error;
+mod event;
+mod grammar;
+mod parse;
+mod trace;
+mod write;
+
+pub use error::{TraceError, TraceErrorKind};
+pub use event::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+pub use grammar::FORMAT_VERSION;
+pub use parse::parse;
+pub use trace::{Trace, TraceHeader};
+pub use write::write;

--- a/crates/trace/src/parse.rs
+++ b/crates/trace/src/parse.rs
@@ -1,0 +1,662 @@
+//! Reading a trace, and refusing everything else.
+//!
+//! The input is untrusted. Every rule here rejects rather than repairs,
+//! and nothing is ever skipped: a line the reader does not understand is
+//! the one thing a format must not shrug at, because a skipped line is how
+//! two readers of the same file quietly stop agreeing about what it says.
+//!
+//! The reader takes text, never a path. That is what makes it testable
+//! and fuzzable with no filesystem in sight, and it puts the bound on how
+//! much untrusted data may be held where that bound can actually be
+//! enforced: at the seam that does the reading, which can refuse an
+//! oversized file before a single byte reaches a parser. It also means
+//! invalid UTF-8 never arrives here — the caller's reader has to have
+//! refused it already, and a reader that replaced bad bytes with
+//! replacement characters has already lost the file. Choosing a strict
+//! reader at that seam is a caller obligation this crate states and
+//! cannot check.
+
+use crate::error::{TraceError, TraceErrorKind};
+use crate::event::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+use crate::grammar::{
+    ASSIGN, BUDGET, BUTTON, CLOSE, DOWN, EVENT, FIRST_EVENT_LINE, FOCUS, FOCUS_IN, FOCUS_OUT,
+    FORMAT_VERSION, HEADER_LINE, HEX_PREFIX, KEY, MAGIC, OTHER_BUTTON, POINTER, REDRAW, REPEAT,
+    RESIZE, SAMPLE, SCALE, SEPARATOR, TICKS, TIMESTEP_NS, UP, WHEEL,
+};
+use crate::trace::{Trace, TraceHeader};
+
+/// A byte order mark. Not part of the grammar and not tolerated: it is
+/// invisible on screen, so a file carrying one looks exactly like a file
+/// that does not, and every other refusal would blame the wrong thing.
+const BYTE_ORDER_MARK: char = '\u{feff}';
+
+/// Read a trace from text.
+///
+/// # Errors
+///
+/// On anything that is not exactly a trace this reader understands: an
+/// empty file, a byte order mark, a missing or misplaced header, a version
+/// newer than this reader's, a duplicate header key, a line keyword or
+/// event kind it does not know, a number that is not plain ASCII digits or
+/// does not fit its width, a float that is not a fixed-width lowercase
+/// bit pattern or is not finite, trailing text, a tick that decreases, and
+/// a tick past the end of the run the header describes. Every refusal
+/// names the line it is about and what was expected there.
+pub fn parse(text: &str) -> Result<Trace, TraceError> {
+    if text.starts_with(BYTE_ORDER_MARK) {
+        return Err(TraceError::new(HEADER_LINE, TraceErrorKind::ByteOrderMark));
+    }
+    if text.is_empty() {
+        return Err(TraceError::new(HEADER_LINE, TraceErrorKind::Empty));
+    }
+
+    // One trailing newline is the file's terminator, not an empty line.
+    // Any other empty line is a line, and is refused below like anything
+    // else this reader cannot read.
+    let body = text.strip_suffix('\n').unwrap_or(text);
+    let mut segments = body.split('\n').map(without_carriage_return);
+    // Splitting always yields at least one segment, so the header line is
+    // always there to be read — whether it is a header is the next
+    // question.
+    let header_line = segments.next().unwrap_or_default();
+
+    // Nothing is buffered and nothing is reserved. The input is
+    // untrusted and may be enormous, so the reader holds only what it
+    // has already accepted: a megabyte of garbage is refused on its
+    // second line having allocated for one event, where collecting the
+    // lines first would have held the whole file's worth of slices, and
+    // a reservation taken from a line count would be a caller-controlled
+    // allocation — one that aborts rather than returns on a 32-bit
+    // target, in a crate that promises nothing here panics.
+    let header = parse_header(header_line)?;
+    let mut events = Vec::new();
+    for (index, line) in segments.enumerate() {
+        events.push(parse_event(index + FIRST_EVENT_LINE, line)?);
+    }
+    // The tick rules live in the constructor, so a trace built in memory
+    // and a trace read from a file are held to one implementation of them
+    // — and because every line after the header is exactly one event, the
+    // line number it computes is the line number this file has.
+    Trace::new(header, events)
+}
+
+/// A trailing carriage return is stripped rather than refused: these are
+/// text files in a repository whose builds run on Windows, and a line
+/// ending is not a change to what the line says.
+fn without_carriage_return(line: &str) -> &str {
+    line.strip_suffix('\r').unwrap_or(line)
+}
+
+fn parse_header(line: &str) -> Result<TraceHeader, TraceError> {
+    let mut cursor = Cursor::new(HEADER_LINE, line);
+    let word = cursor.optional().unwrap_or_default();
+    if word != MAGIC {
+        return Err(cursor.error(TraceErrorKind::NotATrace {
+            found: word.to_string(),
+        }));
+    }
+
+    // The version is positional and first, because a reader has to know
+    // how to read the rest of the line before it reads it. It is read as
+    // a full 64-bit number so that any version a file might plausibly
+    // claim comes back as a version this reader cannot read, which is
+    // what it is, rather than as an overflowing field. Past sixty-four
+    // bits it is an overflowing field, and by then that is the honest
+    // description.
+    let version = cursor.decimal_u64("the format version")?;
+    if version > u64::from(FORMAT_VERSION) {
+        return Err(cursor.error(TraceErrorKind::UnsupportedVersion {
+            found: version,
+            supported: FORMAT_VERSION,
+        }));
+    }
+
+    let sample = cursor.header_value(SAMPLE, "`sample=<name>`")?;
+    let ticks = cursor.header_number(TICKS, "`ticks=<u64>`")?;
+    let timestep_ns = cursor.header_number(TIMESTEP_NS, "`timestep_ns=<u64>`")?;
+    let budget = cursor.header_number_u32(BUDGET, "`budget=<u32>`")?;
+
+    // Building through the same constructor a caller uses keeps one
+    // implementation of what a header may say: the reader cannot accept a
+    // header that could not have been built, and the writer cannot be
+    // handed one it could not write back.
+    let mut header = TraceHeader::new(sample, ticks, timestep_ns, budget)?;
+    while let Some(field) = cursor.optional() {
+        if field.is_empty() {
+            return Err(cursor.error(TraceErrorKind::BlankField));
+        }
+        let Some((key, value)) = field.split_once(ASSIGN) else {
+            return Err(cursor.error(TraceErrorKind::NotAKeyValuePair {
+                field: field.to_string(),
+            }));
+        };
+        header = header.with_key(key, value)?;
+    }
+    Ok(header)
+}
+
+fn parse_event(number: usize, line: &str) -> Result<(u64, TraceEvent), TraceError> {
+    let mut cursor = Cursor::new(number, line);
+    let keyword = cursor.optional().unwrap_or_default();
+    if keyword == MAGIC {
+        return Err(cursor.error(TraceErrorKind::HeaderAfterEvents));
+    }
+    if keyword != EVENT {
+        return Err(cursor.error(TraceErrorKind::UnknownKeyword {
+            keyword: keyword.to_string(),
+        }));
+    }
+
+    let tick = cursor.decimal_u64("the tick")?;
+    let kind = cursor.expect("the kind of event")?;
+    let event = match kind {
+        KEY => {
+            let name = cursor.expect("the key name")?;
+            let code = TraceKey::from_name(name).ok_or_else(|| {
+                cursor.error(TraceErrorKind::UnknownKey {
+                    name: name.to_string(),
+                })
+            })?;
+            let pressed = cursor.pressed()?;
+            // The repeat flag is present or absent, never written as a
+            // word meaning "no": an absent flag and a flag that says
+            // nothing happened are two spellings of one fact.
+            let repeat = match cursor.optional() {
+                None => false,
+                Some(REPEAT) => true,
+                Some("") => return Err(cursor.error(TraceErrorKind::BlankField)),
+                Some(other) => {
+                    return Err(cursor.error(TraceErrorKind::NotTheRepeatFlag {
+                        text: other.to_string(),
+                    }));
+                }
+            };
+            TraceEvent::Key {
+                code,
+                pressed,
+                repeat,
+            }
+        }
+        POINTER => TraceEvent::PointerMoved {
+            x: cursor.hex_f64("the pointer's x coordinate")?,
+            y: cursor.hex_f64("the pointer's y coordinate")?,
+        },
+        BUTTON => {
+            let name = cursor.expect("the pointer button")?;
+            let button = cursor.button(name)?;
+            TraceEvent::PointerButton {
+                button,
+                pressed: cursor.pressed()?,
+            }
+        }
+        WHEEL => TraceEvent::Wheel {
+            dx: cursor.hex_f32("the wheel's horizontal delta")?,
+            dy: cursor.hex_f32("the wheel's vertical delta")?,
+        },
+        FOCUS => TraceEvent::Focused(cursor.focused()?),
+        RESIZE => TraceEvent::Resized {
+            width: cursor.decimal_u32("the width (u32)")?,
+            height: cursor.decimal_u32("the height (u32)")?,
+        },
+        SCALE => TraceEvent::ScaleFactorChanged {
+            scale: cursor.hex_f64("the scale factor")?,
+        },
+        REDRAW => TraceEvent::RedrawRequested,
+        CLOSE => TraceEvent::CloseRequested,
+        other => {
+            return Err(cursor.error(TraceErrorKind::UnknownEventKind {
+                kind: other.to_string(),
+            }));
+        }
+    };
+    cursor.end()?;
+    Ok((tick, event))
+}
+
+/// A position in one line: the fields still to be read, and the line
+/// number every refusal from here will carry.
+struct Cursor<'a> {
+    number: usize,
+    fields: core::str::Split<'a, char>,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(number: usize, line: &'a str) -> Self {
+        Self {
+            number,
+            fields: line.split(SEPARATOR),
+        }
+    }
+
+    fn error(&self, kind: TraceErrorKind) -> TraceError {
+        TraceError::new(self.number, kind)
+    }
+
+    /// The next field, whatever it is or is not.
+    fn optional(&mut self) -> Option<&'a str> {
+        self.fields.next()
+    }
+
+    /// The next field, which the grammar requires. `expected` describes
+    /// what belongs here and is reused verbatim in whatever the field
+    /// turns out to be wrong about.
+    fn expect(&mut self, expected: &'static str) -> Result<&'a str, TraceError> {
+        match self.fields.next() {
+            Some("") => Err(self.error(TraceErrorKind::BlankField)),
+            Some(field) => Ok(field),
+            None => Err(self.error(TraceErrorKind::LineEndsEarly { expected })),
+        }
+    }
+
+    /// Nothing may follow.
+    fn end(&mut self) -> Result<(), TraceError> {
+        match self.fields.next() {
+            None => Ok(()),
+            Some("") => Err(self.error(TraceErrorKind::BlankField)),
+            Some(text) => Err(self.error(TraceErrorKind::TrailingText {
+                text: text.to_string(),
+            })),
+        }
+    }
+
+    /// One of the header's own `key=value` fields, by the key that must be
+    /// there. They are positional so that the reader never has to guess
+    /// which field it is holding.
+    fn header_value(&mut self, key: &str, expected: &'static str) -> Result<&'a str, TraceError> {
+        let field = self.expect(expected)?;
+        let Some((found, value)) = field.split_once(ASSIGN) else {
+            return Err(self.error(TraceErrorKind::NotAKeyValuePair {
+                field: field.to_string(),
+            }));
+        };
+        if found != key {
+            return Err(self.error(TraceErrorKind::HeaderFieldOutOfOrder {
+                expected,
+                found: field.to_string(),
+            }));
+        }
+        Ok(value)
+    }
+
+    fn header_number(&mut self, key: &str, expected: &'static str) -> Result<u64, TraceError> {
+        let text = self.header_value(key, expected)?;
+        digits(text, expected, self.number)
+    }
+
+    fn header_number_u32(&mut self, key: &str, expected: &'static str) -> Result<u32, TraceError> {
+        let text = self.header_value(key, expected)?;
+        let value = digits(text, expected, self.number)?;
+        u32::try_from(value).map_err(|_| {
+            self.error(TraceErrorKind::IntegerTooLarge {
+                field: expected,
+                text: text.to_string(),
+            })
+        })
+    }
+
+    fn decimal_u64(&mut self, field: &'static str) -> Result<u64, TraceError> {
+        let text = self.expect(field)?;
+        digits(text, field, self.number)
+    }
+
+    fn decimal_u32(&mut self, field: &'static str) -> Result<u32, TraceError> {
+        let text = self.expect(field)?;
+        let value = digits(text, field, self.number)?;
+        u32::try_from(value).map_err(|_| {
+            self.error(TraceErrorKind::IntegerTooLarge {
+                field,
+                text: text.to_string(),
+            })
+        })
+    }
+
+    fn hex_f64(&mut self, field: &'static str) -> Result<FiniteF64, TraceError> {
+        let text = self.expect(field)?;
+        let body = hex_body(text, FiniteF64::HEX_DIGITS).ok_or_else(|| {
+            self.error(TraceErrorKind::NotAHexPattern {
+                field,
+                text: text.to_string(),
+                digits: FiniteF64::HEX_DIGITS,
+            })
+        })?;
+        let bits = body
+            .bytes()
+            .fold(0_u64, |bits, byte| (bits << 4) | u64::from(hex_digit(byte)));
+        FiniteF64::from_bits(bits).ok_or_else(|| {
+            self.error(TraceErrorKind::NonFinite {
+                field,
+                text: text.to_string(),
+            })
+        })
+    }
+
+    fn hex_f32(&mut self, field: &'static str) -> Result<FiniteF32, TraceError> {
+        let text = self.expect(field)?;
+        let body = hex_body(text, FiniteF32::HEX_DIGITS).ok_or_else(|| {
+            self.error(TraceErrorKind::NotAHexPattern {
+                field,
+                text: text.to_string(),
+                digits: FiniteF32::HEX_DIGITS,
+            })
+        })?;
+        let bits = body
+            .bytes()
+            .fold(0_u32, |bits, byte| (bits << 4) | u32::from(hex_digit(byte)));
+        FiniteF32::from_bits(bits).ok_or_else(|| {
+            self.error(TraceErrorKind::NonFinite {
+                field,
+                text: text.to_string(),
+            })
+        })
+    }
+
+    /// A named button, or a native one by its index.
+    fn button(&self, name: &str) -> Result<TraceButton, TraceError> {
+        if let Some(text) = name.strip_prefix(OTHER_BUTTON) {
+            const FIELD: &str = "the native button index (u16)";
+            let value = digits(text, FIELD, self.number)?;
+            let index = u16::try_from(value).map_err(|_| {
+                self.error(TraceErrorKind::IntegerTooLarge {
+                    field: FIELD,
+                    text: text.to_string(),
+                })
+            })?;
+            return Ok(TraceButton::Other(index));
+        }
+        TraceButton::from_name(name).ok_or_else(|| {
+            self.error(TraceErrorKind::UnknownButton {
+                name: name.to_string(),
+            })
+        })
+    }
+
+    fn pressed(&mut self) -> Result<bool, TraceError> {
+        let text = self.expect("`down` or `up`")?;
+        match text {
+            DOWN => Ok(true),
+            UP => Ok(false),
+            _ => Err(self.error(TraceErrorKind::NotAPressedState {
+                text: text.to_string(),
+            })),
+        }
+    }
+
+    fn focused(&mut self) -> Result<bool, TraceError> {
+        let text = self.expect("`in` or `out`")?;
+        match text {
+            FOCUS_IN => Ok(true),
+            FOCUS_OUT => Ok(false),
+            _ => Err(self.error(TraceErrorKind::NotAFocusState {
+                text: text.to_string(),
+            })),
+        }
+    }
+}
+
+/// A whole number, in ASCII digits and nothing else.
+///
+/// Hand-read rather than handed to the standard library's parser, because
+/// "whatever that accepts" is not a specification for a byte-exact format:
+/// it takes a leading `+`, and what it takes is free to grow. Here the
+/// answer is fixed — digits, no sign, no underscores, no other base.
+fn digits(text: &str, field: &'static str, line: usize) -> Result<u64, TraceError> {
+    if text.is_empty() || !text.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(TraceError::new(
+            line,
+            TraceErrorKind::NotADecimalInteger {
+                field,
+                text: text.to_string(),
+            },
+        ));
+    }
+    let mut value: u64 = 0;
+    for byte in text.bytes() {
+        value = value
+            .checked_mul(10)
+            .and_then(|shifted| shifted.checked_add(u64::from(byte.wrapping_sub(b'0'))))
+            .ok_or_else(|| {
+                TraceError::new(
+                    line,
+                    TraceErrorKind::IntegerTooLarge {
+                        field,
+                        text: text.to_string(),
+                    },
+                )
+            })?;
+    }
+    Ok(value)
+}
+
+/// The digits of a bit pattern, if the field is one: the prefix, exactly
+/// the width of the type, lowercase. A shorter field is a different number
+/// silently, and an uppercase one is a second spelling of a file that is
+/// meant to have exactly one.
+fn hex_body(text: &str, digits: usize) -> Option<&str> {
+    let body = text.strip_prefix(HEX_PREFIX)?;
+    (body.len() == digits && body.bytes().all(is_lowercase_hex)).then_some(body)
+}
+
+fn is_lowercase_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+}
+
+/// The value of one hexadecimal digit. Only ever called on a byte
+/// [`is_lowercase_hex`] has already accepted; the wrapping arithmetic is
+/// there so that a future caller who forgets cannot make it panic.
+fn hex_digit(byte: u8) -> u8 {
+    if byte.is_ascii_digit() {
+        byte.wrapping_sub(b'0')
+    } else {
+        byte.wrapping_sub(b'a').wrapping_add(10)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use crate::event::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+
+    const HEADER: &str = "renew-trace 0 sample=input_echo ticks=30 timestep_ns=16666667 budget=5";
+
+    /// A one-event trace, so a test can name the shape it cares about and
+    /// nothing else.
+    fn one(line: &str) -> TraceEvent {
+        let text = format!("{HEADER}\n{line}\n");
+        let trace = parse(&text).unwrap();
+        assert_eq!(trace.events().len(), 1);
+        trace.events()[0].1
+    }
+
+    #[test]
+    fn a_header_alone_is_a_trace_with_no_events() {
+        let trace = parse(&format!("{HEADER}\n")).unwrap();
+        assert_eq!(trace.header().sample(), "input_echo");
+        assert_eq!(trace.header().ticks(), 30);
+        assert_eq!(trace.header().timestep_ns(), 16_666_667);
+        assert_eq!(trace.header().budget(), 5);
+        assert!(trace.events().is_empty());
+    }
+
+    /// A file need not end with a newline, and a file that does not is the
+    /// same trace as one that does.
+    #[test]
+    fn the_final_newline_is_optional() {
+        assert_eq!(parse(HEADER), parse(&format!("{HEADER}\n")));
+    }
+
+    #[test]
+    fn caller_keys_are_kept_verbatim_and_in_order() {
+        let trace = parse(&format!("{HEADER} seed=3 extent=640x480\n")).unwrap();
+        assert_eq!(
+            trace.header().keys(),
+            [
+                ("seed".to_string(), "3".to_string()),
+                ("extent".to_string(), "640x480".to_string()),
+            ]
+        );
+    }
+
+    /// A field is split at its **first** separator, so a value may carry
+    /// as many more as it likes. The rule matters in both directions: a
+    /// reader that split at the last one would silently rename the key
+    /// and shorten the value, and the writer would then be emitting
+    /// files that read as something else.
+    #[test]
+    fn a_caller_field_is_split_at_its_first_separator() {
+        let trace = parse(&format!("{HEADER} extent=640=480\n")).unwrap();
+        assert_eq!(
+            trace.header().keys(),
+            [("extent".to_string(), "640=480".to_string())]
+        );
+        assert_eq!(trace.header().value("extent"), Some("640=480"));
+    }
+
+    #[test]
+    fn every_line_shape_reads_back_as_the_event_it_names() {
+        assert_eq!(
+            one("e 0 key arrow-right down"),
+            TraceEvent::Key {
+                code: TraceKey::ArrowRight,
+                pressed: true,
+                repeat: false,
+            }
+        );
+        assert_eq!(
+            one("e 0 key space up repeat"),
+            TraceEvent::Key {
+                code: TraceKey::Space,
+                pressed: false,
+                repeat: true,
+            }
+        );
+        assert_eq!(
+            one("e 0 pointer 0x3ff8000000000000 0xc000000000000000"),
+            TraceEvent::PointerMoved {
+                x: FiniteF64::new(1.5).unwrap(),
+                y: FiniteF64::new(-2.0).unwrap(),
+            }
+        );
+        assert_eq!(
+            one("e 0 button middle down"),
+            TraceEvent::PointerButton {
+                button: TraceButton::Middle,
+                pressed: true,
+            }
+        );
+        assert_eq!(
+            one("e 0 button other:9 up"),
+            TraceEvent::PointerButton {
+                button: TraceButton::Other(9),
+                pressed: false,
+            }
+        );
+        assert_eq!(
+            one("e 0 wheel 0x00000000 0xbf000000"),
+            TraceEvent::Wheel {
+                dx: FiniteF32::new(0.0).unwrap(),
+                dy: FiniteF32::new(-0.5).unwrap(),
+            }
+        );
+        assert_eq!(one("e 0 focus in"), TraceEvent::Focused(true));
+        assert_eq!(one("e 0 focus out"), TraceEvent::Focused(false));
+        assert_eq!(
+            one("e 0 resize 1280 720"),
+            TraceEvent::Resized {
+                width: 1280,
+                height: 720,
+            }
+        );
+        assert_eq!(
+            one("e 0 scale 0x4000000000000000"),
+            TraceEvent::ScaleFactorChanged {
+                scale: FiniteF64::new(2.0).unwrap(),
+            }
+        );
+        assert_eq!(one("e 0 redraw"), TraceEvent::RedrawRequested);
+        assert_eq!(one("e 0 close"), TraceEvent::CloseRequested);
+    }
+
+    /// Every lowercase hexadecimal digit, so the digit-to-value step is
+    /// exercised across both of its halves rather than on one letter.
+    #[test]
+    fn every_hexadecimal_digit_reads_back_as_its_value() {
+        assert_eq!(
+            one("e 0 pointer 0x0123456789abcdef 0x0000000000000000"),
+            TraceEvent::PointerMoved {
+                x: FiniteF64::from_bits(0x0123_4567_89ab_cdef).unwrap(),
+                y: FiniteF64::from_bits(0).unwrap(),
+            }
+        );
+        assert_eq!(
+            one("e 0 wheel 0x89abcdef 0x01234567"),
+            TraceEvent::Wheel {
+                dx: FiniteF32::from_bits(0x89ab_cdef).unwrap(),
+                dy: FiniteF32::from_bits(0x0123_4567).unwrap(),
+            }
+        );
+    }
+
+    /// The two zeros are different bit patterns and stay different.
+    #[test]
+    fn negative_zero_survives_the_read() {
+        assert_eq!(
+            one("e 0 scale 0x8000000000000000"),
+            TraceEvent::ScaleFactorChanged {
+                scale: FiniteF64::new(-0.0).unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_carriage_return_before_a_newline_is_not_part_of_the_line() {
+        let text = format!("{HEADER}\r\ne 0 close\r\n");
+        assert_eq!(parse(&text), parse(&format!("{HEADER}\ne 0 close\n")));
+    }
+
+    /// Equal ticks are legal and keep the order they were written in:
+    /// which key went down first is part of what was recorded.
+    #[test]
+    fn two_events_on_one_tick_keep_the_order_they_were_written_in() {
+        let text = format!("{HEADER}\ne 4 key key-a down\ne 4 key key-d down\n");
+        let trace = parse(&text).unwrap();
+        assert_eq!(
+            trace.events(),
+            [
+                (
+                    4,
+                    TraceEvent::Key {
+                        code: TraceKey::KeyA,
+                        pressed: true,
+                        repeat: false,
+                    }
+                ),
+                (
+                    4,
+                    TraceEvent::Key {
+                        code: TraceKey::KeyD,
+                        pressed: true,
+                        repeat: false,
+                    }
+                ),
+            ]
+        );
+    }
+
+    /// The trailing bucket: a tick equal to the run's length means after
+    /// the final step, and it is the common case rather than an edge one.
+    #[test]
+    fn a_tick_equal_to_the_run_length_is_read() {
+        let trace = parse(&format!("{HEADER}\ne 30 close\n")).unwrap();
+        assert_eq!(trace.events()[0].0, 30);
+    }
+
+    /// Leading zeros are digits, so they are read as the number they
+    /// spell. Writing back produces the canonical spelling — which is why
+    /// the round-trip claim runs from a written file, not from an
+    /// arbitrary hand-typed one.
+    #[test]
+    fn leading_zeros_are_read_as_the_number_they_spell() {
+        let trace = parse(&format!("{HEADER}\ne 007 close\n")).unwrap();
+        assert_eq!(trace.events()[0].0, 7);
+    }
+}

--- a/crates/trace/src/trace.rs
+++ b/crates/trace/src/trace.rs
@@ -1,0 +1,453 @@
+//! The trace itself: a header, and the events in the order they happened.
+
+use crate::error::{TraceError, TraceErrorKind};
+use crate::event::TraceEvent;
+use crate::grammar::{ASSIGN, FIRST_EVENT_LINE, HEADER_LINE, RESERVED_KEYS, SAMPLE};
+
+/// What a trace says about itself before it says anything happened.
+///
+/// Four fields are the codec's own and are positional, so a reader knows
+/// what it is holding before it interprets any of it. Everything after
+/// them is the caller's: the codec preserves those keys verbatim, in
+/// order, and validates nothing but their uniqueness. It does not know
+/// what a sample is, what a seed does, or what a window extent means, and
+/// a codec that guessed would be wrong in a different way for every
+/// caller. The caller checks that `sample` names the thing it is about to
+/// run, applies its own keys, and reports its own mismatches.
+///
+/// `timestep_ns` and `budget` pin the schedule the events were recorded
+/// against, because the same event at tick 40 is a different moment at
+/// 30 Hz than at 60 Hz, and the budget decides how a stall was clamped.
+/// The codec stores them and never reads them.
+///
+/// A header carries no version of its own. There is exactly one format
+/// version today, so a parsed header and a built one make the same claim,
+/// and storing a number that can only hold one value would be machinery
+/// pretending to be a decision. The day a reader accepts an older version
+/// as well as its own, whether rewriting preserves the older claim is a
+/// question for whoever adds it — and it will be a visible addition rather
+/// than a field that quietly upgraded every file it touched.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TraceHeader {
+    sample: String,
+    ticks: u64,
+    timestep_ns: u64,
+    budget: u32,
+    keys: Vec<(String, String)>,
+}
+
+impl TraceHeader {
+    /// A header for a run of `ticks` ticks of `sample`, at this timestep
+    /// and step budget.
+    ///
+    /// `ticks` is a count, and it bounds the events: a tick equal to it is
+    /// legal and means *after the final step*.
+    ///
+    /// # Errors
+    ///
+    /// When `sample` could not be written back out as itself — it is
+    /// empty, carries whitespace, or carries a control character. The
+    /// refusal is reported against line 1, the line the header occupies.
+    pub fn new(
+        sample: &str,
+        ticks: u64,
+        timestep_ns: u64,
+        budget: u32,
+    ) -> Result<Self, TraceError> {
+        check_field(SAMPLE, sample, HEADER_LINE)?;
+        Ok(Self {
+            sample: sample.to_string(),
+            ticks,
+            timestep_ns,
+            budget,
+            keys: Vec::new(),
+        })
+    }
+
+    /// The same header with one more caller-owned key.
+    ///
+    /// # Errors
+    ///
+    /// When the key repeats one the header already has — including one of
+    /// the four the codec owns — or when either half could not be written
+    /// back out as itself. A key may not contain `=`, because a reader
+    /// splits at the first one; a value may contain as many as it likes.
+    pub fn with_key(mut self, key: &str, value: &str) -> Result<Self, TraceError> {
+        check_field(key, value, HEADER_LINE)?;
+        if RESERVED_KEYS.contains(&key) || self.keys.iter().any(|(known, _)| known == key) {
+            return Err(TraceError::new(
+                HEADER_LINE,
+                TraceErrorKind::DuplicateHeaderKey {
+                    key: key.to_string(),
+                },
+            ));
+        }
+        self.keys.push((key.to_string(), value.to_string()));
+        Ok(self)
+    }
+
+    /// What was running. Uninterpreted: matching it against a sample is
+    /// the caller's check, not the codec's.
+    #[must_use]
+    pub fn sample(&self) -> &str {
+        &self.sample
+    }
+
+    /// How many ticks the run lasted, and so the largest legal event tick.
+    #[must_use]
+    pub const fn ticks(&self) -> u64 {
+        self.ticks
+    }
+
+    #[must_use]
+    pub const fn timestep_ns(&self) -> u64 {
+        self.timestep_ns
+    }
+
+    #[must_use]
+    pub const fn budget(&self) -> u32 {
+        self.budget
+    }
+
+    /// The caller-owned keys, in the order they were written.
+    #[must_use]
+    pub fn keys(&self) -> &[(String, String)] {
+        &self.keys
+    }
+
+    /// The value of one caller-owned key.
+    #[must_use]
+    pub fn value(&self, key: &str) -> Option<&str> {
+        self.keys
+            .iter()
+            .find(|(known, _)| known == key)
+            .map(|(_, value)| value.as_str())
+    }
+}
+
+/// A recorded run: what it was, and what happened during it.
+///
+/// The events are ordered and never sorted. Two keys can go down on the
+/// same tick, and which of them the application saw first is part of what
+/// was recorded — sorting or deduplicating within a tick would silently
+/// change the input while looking like tidying.
+///
+/// What a trace reproduces is the *simulation*: the state a run reaches,
+/// and the exact interleaving of events with steps. It does not reproduce
+/// how many frames carried those steps, or how many were dropped, which
+/// are facts about the schedule that carried the input rather than about
+/// the input.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Trace {
+    header: TraceHeader,
+    events: Vec<(u64, TraceEvent)>,
+}
+
+impl Trace {
+    /// A trace of these events, delivered at these ticks.
+    ///
+    /// Tick *k* means the event is delivered before the step whose tick is
+    /// *k*. Ticks are 0-based. A tick equal to the header's `ticks` is
+    /// legal and means *after the final step* — that is the common case,
+    /// not an edge case: a run that free-runs its frames far faster than
+    /// its steps will usually see the terminating event during a frame
+    /// that ran no step at all.
+    ///
+    /// # Errors
+    ///
+    /// When a tick is earlier than the one before it, or past the end of
+    /// the run the header describes. Equal ticks are allowed, and their
+    /// order is preserved exactly as given. The refusal names the line the
+    /// offending event would occupy in the written text.
+    pub fn new(header: TraceHeader, events: Vec<(u64, TraceEvent)>) -> Result<Self, TraceError> {
+        // A first event cannot go backwards from tick zero, so no
+        // "is there a previous one" branch is needed here.
+        let mut previous = 0;
+        for (index, (tick, _)) in events.iter().enumerate() {
+            let line = index + FIRST_EVENT_LINE;
+            if *tick < previous {
+                return Err(TraceError::new(
+                    line,
+                    TraceErrorKind::TickWentBackwards {
+                        tick: *tick,
+                        previous,
+                    },
+                ));
+            }
+            if *tick > header.ticks {
+                return Err(TraceError::new(
+                    line,
+                    TraceErrorKind::TickBeyondHeader {
+                        tick: *tick,
+                        ticks: header.ticks,
+                    },
+                ));
+            }
+            previous = *tick;
+        }
+        Ok(Self { header, events })
+    }
+
+    #[must_use]
+    pub const fn header(&self) -> &TraceHeader {
+        &self.header
+    }
+
+    /// The events, each with the tick it is delivered before, in the order
+    /// they were recorded.
+    #[must_use]
+    pub fn events(&self) -> &[(u64, TraceEvent)] {
+        &self.events
+    }
+}
+
+/// Whether a header key and value survive being written and read back.
+///
+/// Three rules bind both halves — they are the three ways text stops
+/// being one field of one line: nothing at all, something that would
+/// split into two fields, and something that would be invisible in the
+/// places people actually read these files, a diff and a log.
+///
+/// A fourth binds the **key only**. A reader splits a field at its first
+/// `=`, so a key containing one is read back as a shorter key and a
+/// longer value: `a=b=c` written from the key `a=b` reads as the key `a`
+/// with the value `b=c`, which is silent corruption, and a key of
+/// `ticks=9` would smuggle a reserved name past the uniqueness guard. A
+/// *value* may contain as many as it likes — everything after the first
+/// `=` is the value, and `extent=640=480` round-trips exactly. The
+/// positional `sample` field is a value in this sense too, which is why
+/// the rule cannot be applied to both halves.
+pub(crate) fn check_field(key: &str, value: &str, line: usize) -> Result<(), TraceError> {
+    let refuse = |reason| {
+        Err(TraceError::new(
+            line,
+            TraceErrorKind::UnwritableText {
+                text: format!("{key}{ASSIGN}{value}"),
+                reason,
+            },
+        ))
+    };
+    for text in [key, value] {
+        if text.is_empty() {
+            return refuse("a header key and a header value are each at least one character");
+        }
+        if text.chars().any(char::is_whitespace) {
+            return refuse("whitespace would split it into two fields");
+        }
+        if text.chars().any(char::is_control) {
+            return refuse("a control character is invisible in a diff and in a log");
+        }
+    }
+    if key.contains(ASSIGN) {
+        return refuse("an equals sign would split the key from its value");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Trace, TraceHeader};
+    use crate::error::TraceErrorKind;
+    use crate::event::TraceEvent;
+
+    fn header() -> TraceHeader {
+        TraceHeader::new("input_echo", 30, 16_666_667, 5).unwrap()
+    }
+
+    #[test]
+    fn a_header_reports_the_four_fields_the_codec_owns() {
+        let header = header();
+        assert_eq!(header.sample(), "input_echo");
+        assert_eq!(header.ticks(), 30);
+        assert_eq!(header.timestep_ns(), 16_666_667);
+        assert_eq!(header.budget(), 5);
+        assert!(header.keys().is_empty());
+    }
+
+    #[test]
+    fn caller_keys_keep_their_order_and_are_readable_by_name() {
+        let header = header()
+            .with_key("seed", "3")
+            .unwrap()
+            .with_key("extent", "640x480")
+            .unwrap();
+        assert_eq!(
+            header.keys(),
+            [
+                ("seed".to_string(), "3".to_string()),
+                ("extent".to_string(), "640x480".to_string()),
+            ]
+        );
+        assert_eq!(header.value("seed"), Some("3"));
+        assert_eq!(header.value("extent"), Some("640x480"));
+        assert_eq!(header.value("absent"), None);
+    }
+
+    #[test]
+    fn a_repeated_caller_key_is_refused() {
+        let error = header()
+            .with_key("seed", "3")
+            .unwrap()
+            .with_key("seed", "4")
+            .unwrap_err();
+        assert_eq!(error.line(), 1);
+        assert_eq!(
+            error.kind(),
+            &TraceErrorKind::DuplicateHeaderKey {
+                key: "seed".to_string()
+            }
+        );
+    }
+
+    /// The codec's own four are keys too, so a caller cannot shadow one
+    /// and leave two answers to the same question in one file.
+    #[test]
+    fn a_caller_key_may_not_shadow_one_the_codec_owns() {
+        for reserved in ["sample", "ticks", "timestep_ns", "budget"] {
+            let error = header().with_key(reserved, "x").unwrap_err();
+            assert_eq!(
+                error.kind(),
+                &TraceErrorKind::DuplicateHeaderKey {
+                    key: reserved.to_string()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn header_text_that_could_not_be_written_back_is_refused() {
+        let empty = TraceHeader::new("", 1, 1, 1).unwrap_err();
+        assert_eq!(
+            empty.kind(),
+            &TraceErrorKind::UnwritableText {
+                text: "sample=".to_string(),
+                reason: "a header key and a header value are each at least one character",
+            }
+        );
+        let spaced = TraceHeader::new("two words", 1, 1, 1).unwrap_err();
+        assert_eq!(
+            spaced.kind(),
+            &TraceErrorKind::UnwritableText {
+                text: "sample=two words".to_string(),
+                reason: "whitespace would split it into two fields",
+            }
+        );
+        let controlled = header().with_key("seed", "3\u{7}").unwrap_err();
+        assert_eq!(
+            controlled.kind(),
+            &TraceErrorKind::UnwritableText {
+                text: "seed=3\u{7}".to_string(),
+                reason: "a control character is invisible in a diff and in a log",
+            }
+        );
+        let blank_key = header().with_key("", "3").unwrap_err();
+        assert_eq!(
+            blank_key.kind(),
+            &TraceErrorKind::UnwritableText {
+                text: "=3".to_string(),
+                reason: "a header key and a header value are each at least one character",
+            }
+        );
+    }
+
+    /// A key carrying an equals sign is the one asymmetry between the two
+    /// halves of a header field, and it is not a nicety: a reader splits
+    /// at the first `=`, so `a=b=c` would come back as the key `a` with
+    /// the value `b=c` — the writer emitting a file that reads as
+    /// something else, silently. Worse, `ticks=9` as a key would walk
+    /// straight past the uniqueness guard and land in a file with two
+    /// answers to one question.
+    #[test]
+    fn a_caller_key_carrying_an_equals_sign_is_refused() {
+        let error = header().with_key("a=b", "c").unwrap_err();
+        assert_eq!(error.line(), 1);
+        assert_eq!(
+            error.kind(),
+            &TraceErrorKind::UnwritableText {
+                text: "a=b=c".to_string(),
+                reason: "an equals sign would split the key from its value",
+            }
+        );
+        assert!(header().with_key("ticks=9", "x").is_err());
+        assert!(header().with_key("=", "x").is_err());
+    }
+
+    /// The value half is deliberately unrestricted, because everything
+    /// after the first `=` is the value and reads back as itself.
+    #[test]
+    fn a_value_carrying_an_equals_sign_is_kept() {
+        let header = header().with_key("extent", "640=480").unwrap();
+        assert_eq!(header.value("extent"), Some("640=480"));
+        // The positional field is a value in the same sense.
+        let sample = TraceHeader::new("odd=name", 1, 1, 1).unwrap();
+        assert_eq!(sample.sample(), "odd=name");
+    }
+
+    #[test]
+    fn a_trace_keeps_its_events_in_the_order_it_was_given_them() {
+        let events = vec![
+            (4, TraceEvent::Focused(true)),
+            (4, TraceEvent::RedrawRequested),
+            (30, TraceEvent::CloseRequested),
+        ];
+        let trace = Trace::new(header(), events.clone()).unwrap();
+        assert_eq!(trace.events(), events.as_slice());
+        assert_eq!(trace.header().sample(), "input_echo");
+    }
+
+    /// The trailing bucket, which is the common case rather than an edge
+    /// one: an event delivered after the final step carries the run's own
+    /// tick count.
+    #[test]
+    fn a_tick_equal_to_the_run_length_is_legal() {
+        let trace = Trace::new(header(), vec![(30, TraceEvent::CloseRequested)]).unwrap();
+        assert_eq!(trace.events()[0].0, trace.header().ticks());
+    }
+
+    #[test]
+    fn a_tick_past_the_end_of_the_run_is_refused_against_its_own_line() {
+        let error = Trace::new(
+            header(),
+            vec![
+                (0, TraceEvent::RedrawRequested),
+                (31, TraceEvent::CloseRequested),
+            ],
+        )
+        .unwrap_err();
+        // Header, then two events: the offender is the third line.
+        assert_eq!(error.line(), 3);
+        assert_eq!(
+            error.kind(),
+            &TraceErrorKind::TickBeyondHeader {
+                tick: 31,
+                ticks: 30
+            }
+        );
+    }
+
+    #[test]
+    fn a_tick_earlier_than_the_one_before_it_is_refused() {
+        let error = Trace::new(
+            header(),
+            vec![
+                (7, TraceEvent::RedrawRequested),
+                (3, TraceEvent::CloseRequested),
+            ],
+        )
+        .unwrap_err();
+        assert_eq!(error.line(), 3);
+        assert_eq!(
+            error.kind(),
+            &TraceErrorKind::TickWentBackwards {
+                tick: 3,
+                previous: 7
+            }
+        );
+    }
+
+    #[test]
+    fn a_trace_with_no_events_is_a_trace() {
+        let trace = Trace::new(header(), Vec::new()).unwrap();
+        assert!(trace.events().is_empty());
+    }
+}

--- a/crates/trace/src/write.rs
+++ b/crates/trace/src/write.rs
@@ -1,0 +1,266 @@
+//! Writing a trace out as text.
+//!
+//! The writer is total: every trace that can be built can be written, and
+//! everything it writes can be read back as the same trace. That is not a
+//! coincidence to be tested for — it is bought by the types. A float that
+//! could not be written finitely cannot be put in an event, and a header
+//! field that could not survive the round trip cannot be put in a header,
+//! so there is no case left for the writer to fail on and it returns text
+//! rather than a result.
+
+use crate::event::{FiniteF32, FiniteF64, TraceEvent};
+use crate::grammar::{
+    ASSIGN, BUDGET, BUTTON, CLOSE, DOWN, EVENT, FOCUS, FOCUS_IN, FOCUS_OUT, FORMAT_VERSION,
+    HEX_PREFIX, KEY, MAGIC, POINTER, REDRAW, REPEAT, RESIZE, SAMPLE, SCALE, SEPARATOR, TICKS,
+    TIMESTEP_NS, UP, WHEEL,
+};
+use crate::trace::Trace;
+
+/// A trace as text: the header line, then one line per event, each ended
+/// by a newline.
+///
+/// The file therefore ends with a newline, the way text files do, and the
+/// reader treats that last newline as a terminator rather than as an empty
+/// line.
+#[must_use]
+pub fn write(trace: &Trace) -> String {
+    let header = trace.header();
+    let mut text = format!(
+        "{MAGIC}{SEPARATOR}{FORMAT_VERSION}\
+         {SEPARATOR}{SAMPLE}={sample}\
+         {SEPARATOR}{TICKS}={ticks}\
+         {SEPARATOR}{TIMESTEP_NS}={timestep_ns}\
+         {SEPARATOR}{BUDGET}={budget}",
+        sample = header.sample(),
+        ticks = header.ticks(),
+        timestep_ns = header.timestep_ns(),
+        budget = header.budget(),
+    );
+    for (key, value) in header.keys() {
+        text.push(SEPARATOR);
+        text.push_str(key);
+        text.push(ASSIGN);
+        text.push_str(value);
+    }
+    text.push('\n');
+    for (tick, event) in trace.events() {
+        text.push_str(&event_line(*tick, event));
+        text.push('\n');
+    }
+    text
+}
+
+/// One event line, without its newline.
+fn event_line(tick: u64, event: &TraceEvent) -> String {
+    match *event {
+        TraceEvent::Key {
+            code,
+            pressed,
+            repeat,
+        } => {
+            let mut line = format!(
+                "{EVENT} {tick} {KEY} {name} {state}",
+                name = code.name(),
+                state = pressed_word(pressed),
+            );
+            if repeat {
+                line.push(SEPARATOR);
+                line.push_str(REPEAT);
+            }
+            line
+        }
+        TraceEvent::PointerMoved { x, y } => format!(
+            "{EVENT} {tick} {POINTER} {x} {y}",
+            x = hex_f64(x),
+            y = hex_f64(y),
+        ),
+        TraceEvent::PointerButton { button, pressed } => format!(
+            "{EVENT} {tick} {BUTTON} {button} {state}",
+            state = pressed_word(pressed),
+        ),
+        TraceEvent::Wheel { dx, dy } => format!(
+            "{EVENT} {tick} {WHEEL} {dx} {dy}",
+            dx = hex_f32(dx),
+            dy = hex_f32(dy),
+        ),
+        TraceEvent::Focused(focused) => {
+            let state = if focused { FOCUS_IN } else { FOCUS_OUT };
+            format!("{EVENT} {tick} {FOCUS} {state}")
+        }
+        TraceEvent::Resized { width, height } => {
+            format!("{EVENT} {tick} {RESIZE} {width} {height}")
+        }
+        TraceEvent::ScaleFactorChanged { scale } => {
+            format!("{EVENT} {tick} {SCALE} {scale}", scale = hex_f64(scale))
+        }
+        TraceEvent::RedrawRequested => format!("{EVENT} {tick} {REDRAW}"),
+        TraceEvent::CloseRequested => format!("{EVENT} {tick} {CLOSE}"),
+    }
+}
+
+fn pressed_word(pressed: bool) -> &'static str {
+    if pressed { DOWN } else { UP }
+}
+
+/// A bit pattern, zero-padded to exactly the width of its type. The width
+/// comes from the type rather than from a literal here, because a field
+/// one digit short is a different number read back, silently.
+fn hex_f64(value: FiniteF64) -> String {
+    format!(
+        "{HEX_PREFIX}{bits:0width$x}",
+        bits = value.bits(),
+        width = FiniteF64::HEX_DIGITS,
+    )
+}
+
+fn hex_f32(value: FiniteF32) -> String {
+    format!(
+        "{HEX_PREFIX}{bits:0width$x}",
+        bits = value.bits(),
+        width = FiniteF32::HEX_DIGITS,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{event_line, write};
+    use crate::event::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+    use crate::trace::{Trace, TraceHeader};
+
+    fn line(event: TraceEvent) -> String {
+        event_line(4, &event)
+    }
+
+    #[test]
+    fn a_header_with_no_events_is_one_line_ending_in_a_newline() {
+        let trace = Trace::new(
+            TraceHeader::new("input_echo", 30, 16_666_667, 5).unwrap(),
+            Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            write(&trace),
+            "renew-trace 0 sample=input_echo ticks=30 timestep_ns=16666667 budget=5\n"
+        );
+    }
+
+    #[test]
+    fn caller_keys_follow_the_four_the_codec_owns_in_their_own_order() {
+        let header = TraceHeader::new("input_echo", 1, 2, 3)
+            .unwrap()
+            .with_key("seed", "7")
+            .unwrap()
+            .with_key("extent", "640x480")
+            .unwrap();
+        let trace = Trace::new(header, Vec::new()).unwrap();
+        assert_eq!(
+            write(&trace),
+            "renew-trace 0 sample=input_echo ticks=1 timestep_ns=2 budget=3 seed=7 extent=640x480\n"
+        );
+    }
+
+    #[test]
+    fn every_line_shape_is_written_the_way_the_format_documents_it() {
+        assert_eq!(
+            line(TraceEvent::Key {
+                code: TraceKey::ArrowRight,
+                pressed: true,
+                repeat: false,
+            }),
+            "e 4 key arrow-right down"
+        );
+        assert_eq!(
+            line(TraceEvent::Key {
+                code: TraceKey::Space,
+                pressed: false,
+                repeat: true,
+            }),
+            "e 4 key space up repeat"
+        );
+        assert_eq!(
+            line(TraceEvent::PointerMoved {
+                x: FiniteF64::new(1.5).unwrap(),
+                y: FiniteF64::new(-2.0).unwrap(),
+            }),
+            "e 4 pointer 0x3ff8000000000000 0xc000000000000000"
+        );
+        assert_eq!(
+            line(TraceEvent::PointerButton {
+                button: TraceButton::Left,
+                pressed: true,
+            }),
+            "e 4 button left down"
+        );
+        assert_eq!(
+            line(TraceEvent::PointerButton {
+                button: TraceButton::Other(9),
+                pressed: false,
+            }),
+            "e 4 button other:9 up"
+        );
+        assert_eq!(
+            line(TraceEvent::Wheel {
+                dx: FiniteF32::new(0.0).unwrap(),
+                dy: FiniteF32::new(-0.5).unwrap(),
+            }),
+            "e 4 wheel 0x00000000 0xbf000000"
+        );
+        assert_eq!(line(TraceEvent::Focused(true)), "e 4 focus in");
+        assert_eq!(line(TraceEvent::Focused(false)), "e 4 focus out");
+        assert_eq!(
+            line(TraceEvent::Resized {
+                width: 1280,
+                height: 720,
+            }),
+            "e 4 resize 1280 720"
+        );
+        assert_eq!(
+            line(TraceEvent::ScaleFactorChanged {
+                scale: FiniteF64::new(2.0).unwrap(),
+            }),
+            "e 4 scale 0x4000000000000000"
+        );
+        assert_eq!(line(TraceEvent::RedrawRequested), "e 4 redraw");
+        assert_eq!(line(TraceEvent::CloseRequested), "e 4 close");
+    }
+
+    /// A bit pattern is padded to the full width of its type. Negative
+    /// zero is the case that proves it: it differs from the ordinary zero
+    /// in the leading digit, which a writer that trimmed would drop.
+    #[test]
+    fn bit_patterns_are_padded_to_the_width_of_their_type() {
+        assert_eq!(
+            line(TraceEvent::ScaleFactorChanged {
+                scale: FiniteF64::new(-0.0).unwrap(),
+            }),
+            "e 4 scale 0x8000000000000000"
+        );
+        assert_eq!(
+            line(TraceEvent::Wheel {
+                dx: FiniteF32::from_bits(1).unwrap(),
+                dy: FiniteF32::new(-0.0).unwrap(),
+            }),
+            "e 4 wheel 0x00000001 0x80000000"
+        );
+    }
+
+    #[test]
+    fn each_event_is_its_own_line_in_the_order_it_was_recorded() {
+        let trace = Trace::new(
+            TraceHeader::new("input_echo", 2, 1, 1).unwrap(),
+            vec![
+                (0, TraceEvent::RedrawRequested),
+                (0, TraceEvent::Focused(true)),
+                (2, TraceEvent::CloseRequested),
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            write(&trace),
+            "renew-trace 0 sample=input_echo ticks=2 timestep_ns=1 budget=1\n\
+             e 0 redraw\n\
+             e 0 focus in\n\
+             e 2 close\n"
+        );
+    }
+}

--- a/crates/trace/tests/golden.rs
+++ b/crates/trace/tests/golden.rs
@@ -1,0 +1,243 @@
+//! One trace, written out by hand, asserted byte for byte in both
+//! directions.
+//!
+//! This is the anchor under the round-trip property, and it is here
+//! because round-tripping alone proves less than it looks like it proves:
+//! a writer and a reader that made the *same* mistake — a swapped pair of
+//! coordinates, a tick shifted by one, a state word inverted — are still
+//! exact inverses of each other, and every round-trip assertion in the
+//! world stays green. The text below was typed by a person from the
+//! documented grammar, and no part of it was produced by the code it
+//! tests. The bit patterns were worked out from the format of the numbers
+//! rather than printed by the writer.
+//!
+//! Read it in both directions, and read it as prose: if this file stops
+//! matching what the codec does, one of the two is wrong, and which one is
+//! a conversation rather than a rewrite of this constant.
+
+use renew_trace::{
+    FiniteF32, FiniteF64, Trace, TraceButton, TraceEvent, TraceHeader, TraceKey, parse, write,
+};
+
+/// A short session: focus arrives, the pointer moves to (1.5, -2.0), the
+/// left button goes down and up, the wheel turns half a notch back, a key
+/// is held with one auto-repeat, the window is resized and rescaled, a
+/// redraw is served, and the window is closed after the final step.
+const GOLDEN: &str = "\
+renew-trace 0 sample=input_echo ticks=12 timestep_ns=16666667 budget=5 seed=3 extent=640x480
+e 0 focus in
+e 1 pointer 0x3ff8000000000000 0xc000000000000000
+e 1 button left down
+e 2 button left up
+e 2 wheel 0x00000000 0xbf000000
+e 3 key arrow-right down
+e 4 key arrow-right down repeat
+e 5 key arrow-right up
+e 6 button other:9 down
+e 7 resize 1280 720
+e 7 scale 0x4000000000000000
+e 8 redraw
+e 12 close
+";
+
+/// The same trace, assembled from typed values. Nothing here is derived
+/// from the text above: the floats are written as numbers, the ticks as
+/// numbers, and the states as `true` and `false`.
+// A test helper, called only from `#[test]` fns: the tests-only unwrap
+// allowance covers those, not their helpers, and this extends it in the
+// same spirit. Every value below is finite, in range and in order by
+// inspection, so a failure here is a broken constructor and belongs at
+// the top of the failure output.
+#[allow(clippy::unwrap_used)]
+fn golden_trace() -> Trace {
+    let header = TraceHeader::new("input_echo", 12, 16_666_667, 5)
+        .unwrap()
+        .with_key("seed", "3")
+        .unwrap()
+        .with_key("extent", "640x480")
+        .unwrap();
+    let arrow_right = |pressed, repeat| TraceEvent::Key {
+        code: TraceKey::ArrowRight,
+        pressed,
+        repeat,
+    };
+    Trace::new(
+        header,
+        vec![
+            (0, TraceEvent::Focused(true)),
+            (
+                1,
+                TraceEvent::PointerMoved {
+                    x: FiniteF64::new(1.5).unwrap(),
+                    y: FiniteF64::new(-2.0).unwrap(),
+                },
+            ),
+            (
+                1,
+                TraceEvent::PointerButton {
+                    button: TraceButton::Left,
+                    pressed: true,
+                },
+            ),
+            (
+                2,
+                TraceEvent::PointerButton {
+                    button: TraceButton::Left,
+                    pressed: false,
+                },
+            ),
+            (
+                2,
+                TraceEvent::Wheel {
+                    dx: FiniteF32::new(0.0).unwrap(),
+                    dy: FiniteF32::new(-0.5).unwrap(),
+                },
+            ),
+            (3, arrow_right(true, false)),
+            (4, arrow_right(true, true)),
+            (5, arrow_right(false, false)),
+            (
+                6,
+                TraceEvent::PointerButton {
+                    button: TraceButton::Other(9),
+                    pressed: true,
+                },
+            ),
+            (
+                7,
+                TraceEvent::Resized {
+                    width: 1280,
+                    height: 720,
+                },
+            ),
+            (
+                7,
+                TraceEvent::ScaleFactorChanged {
+                    scale: FiniteF64::new(2.0).unwrap(),
+                },
+            ),
+            (8, TraceEvent::RedrawRequested),
+            (12, TraceEvent::CloseRequested),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn the_writer_produces_the_golden_text_byte_for_byte() {
+    assert_eq!(write(&golden_trace()), GOLDEN);
+}
+
+#[test]
+fn the_reader_produces_the_golden_trace_from_the_golden_text() {
+    assert_eq!(parse(GOLDEN), Ok(golden_trace()));
+}
+
+/// Every line shape the format defines appears above. If a tenth is ever
+/// added, this is where it has to show up too — a shape with no golden
+/// line is a shape whose text nobody has ever read.
+#[test]
+fn the_golden_text_exercises_every_line_shape() {
+    for shape in [
+        " key ",
+        " pointer ",
+        " button ",
+        " wheel ",
+        " focus ",
+        " resize ",
+        " scale ",
+        " redraw",
+        " close",
+    ] {
+        assert!(GOLDEN.contains(shape), "no {shape} line in the golden text");
+    }
+}
+
+/// The trailing bucket, asserted on the golden rather than only in a
+/// unit test: the closing event carries the run's own tick count, which
+/// means *after the final step*, and is where a terminating event
+/// normally lands.
+#[test]
+fn the_golden_trace_closes_after_its_final_step() {
+    let trace = golden_trace();
+    let last = *trace.events().last().unwrap();
+    assert_eq!(last, (trace.header().ticks(), TraceEvent::CloseRequested));
+    assert!(GOLDEN.contains("ticks=12 "));
+    assert!(GOLDEN.ends_with("e 12 close\n"));
+}
+
+/// A line ending is not a change to what a line says. The same golden
+/// text with Windows line endings reads as the same trace — and writes
+/// back out with newlines, because the writer has one spelling.
+#[test]
+fn the_same_text_with_carriage_returns_is_the_same_trace() {
+    let with_carriage_returns = GOLDEN.replace('\n', "\r\n");
+    assert_eq!(parse(&with_carriage_returns), Ok(golden_trace()));
+    assert_eq!(write(&golden_trace()), GOLDEN);
+}
+
+/// Deleting one line changes the trace, and changes it in a way an
+/// application would witness: the key that was released stays held.
+#[test]
+fn deleting_a_release_leaves_a_key_held() {
+    let mutated = GOLDEN.replace("e 5 key arrow-right up\n", "");
+    let trace = parse(&mutated).unwrap();
+    assert_eq!(trace.events().len(), golden_trace().events().len() - 1);
+    assert!(!trace.events().iter().any(|(_, event)| *event
+        == TraceEvent::Key {
+            code: TraceKey::ArrowRight,
+            pressed: false,
+            repeat: false,
+        }));
+}
+
+/// Shifting the tick column one later is a different trace, not a
+/// re-spelling of the same one — the header is untouched and every event
+/// keeps its shape, so the column under test is the only thing that
+/// moved.
+///
+/// The closing event stays where it is, because it already sits on the
+/// last legal tick. That is not an exception carved out to make the test
+/// pass; it is the bound, and the second half of this test is what says
+/// so.
+#[test]
+fn shifting_the_tick_column_produces_a_different_trace() {
+    let ticks = golden_trace().header().ticks();
+    let shifted: String = GOLDEN
+        .lines()
+        .map(|line| match line.strip_prefix("e ") {
+            None => format!("{line}\n"),
+            Some(rest) => {
+                let (tick, tail) = rest.split_once(' ').unwrap();
+                let tick = tick.parse::<u64>().unwrap();
+                let moved = if tick < ticks { tick + 1 } else { tick };
+                format!("e {moved} {tail}\n")
+            }
+        })
+        .collect();
+    let trace = parse(&shifted).unwrap();
+    assert_ne!(trace, golden_trace());
+    let mut moved = 0;
+    for (shifted, original) in trace.events().iter().zip(golden_trace().events()) {
+        assert_eq!(shifted.1, original.1, "an event changed shape, not tick");
+        assert!(shifted.0 == original.0 + 1 || original.0 == ticks);
+        moved += usize::from(shifted.0 != original.0);
+    }
+    assert_eq!(moved, trace.events().len() - 1, "the shift was not applied");
+}
+
+/// And the bound is real: pushing the closing event one tick further is
+/// refused, on its own line.
+#[test]
+fn shifting_the_last_event_past_the_end_is_refused() {
+    let past_end = GOLDEN.replace("e 12 close", "e 13 close");
+    let error = parse(&past_end).unwrap_err();
+    assert_eq!(error.line(), 14);
+    assert_eq!(
+        error.kind(),
+        &renew_trace::TraceErrorKind::TickBeyondHeader {
+            tick: 13,
+            ticks: 12
+        }
+    );
+}

--- a/crates/trace/tests/no_reservation.rs
+++ b/crates/trace/tests/no_reservation.rs
@@ -1,0 +1,83 @@
+//! The refusal path holds nothing proportional to the file it refuses.
+//!
+//! This is a regression test for a fixed defect, and the defect is worth
+//! stating because the code that had it looked entirely reasonable: the
+//! reader collected every line of the input into a vector and then
+//! reserved an event vector from that line count, both before validating
+//! anything. On a megabyte of garbage refused at its second line, that
+//! held tens of megabytes to say "no" — and the reservation was a length
+//! taken from untrusted input, which on a 32-bit target is a `capacity
+//! overflow` abort rather than a returned refusal, in a crate whose
+//! contract says nothing here panics.
+//!
+//! The fix is small — walk the iterator, start the vector empty — and a
+//! comment saying so is not a gate. Reinstating either half compiles
+//! cleanly and passes every other test in the crate, so the property is
+//! measured here instead.
+//!
+//! Own process on purpose: the counters are process-wide, and this file
+//! holds one test so that nothing allocates alongside the window being
+//! measured. It compares a *peak*, not exact counts, because the
+//! allocation the defect makes is a single enormous one that is freed
+//! again as the refusal propagates — before-and-after totals would show
+//! nothing. That is also why this test needs no exemption from
+//! instrumented runs the way an exact-count test does: it asks whether
+//! several megabytes appeared, and the answer to that does not depend on
+//! whose allocator is underneath.
+
+use renew_memory::{CountingAllocator, counters};
+use renew_trace::{TraceEvent, parse};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const HEADER: &str = "renew-trace 0 sample=input_echo ticks=30 timestep_ns=16666667 budget=5\n";
+
+/// Enough lines that a per-line reservation is unmistakable against the
+/// text itself, and still a file a person could plausibly be handed.
+const LINES: usize = 200_000;
+
+/// The allowance. The reader's honest cost here is one small string for
+/// the sample name and one for the refusal — hundreds of bytes. The
+/// defect's cost is megabytes. Anything between the two is a change
+/// worth looking at rather than a threshold worth loosening.
+const ALLOWED_RISE: usize = 64 * 1024;
+
+#[test]
+fn refusing_a_huge_file_never_holds_the_file() {
+    let junk = "nope\n";
+    // Exact capacity, filled once: a doubling string would raise the
+    // very peak this test is about to measure against.
+    let mut text = String::with_capacity(HEADER.len() + LINES * junk.len());
+    text.push_str(HEADER);
+    for _ in 0..LINES {
+        text.push_str(junk);
+    }
+
+    let before = counters::snapshot();
+    let error = parse(&text).expect_err("`nope` is not a line keyword this reader knows");
+    let after = counters::snapshot();
+
+    // The refusal is on the *second* line, so every line after it is
+    // work the reader must never have done.
+    assert_eq!(error.line(), 2);
+
+    let rise = after.peak_bytes.saturating_sub(before.peak_bytes);
+    // What the two halves of the defect would have cost, computed here
+    // rather than asserted as a magic number, so the margin is visible
+    // and stays true if the event type changes size.
+    let reserved = LINES * size_of::<(u64, TraceEvent)>();
+    let collected = LINES * size_of::<&str>();
+    assert!(
+        reserved > 16 * ALLOWED_RISE && collected > 16 * ALLOWED_RISE,
+        "this test is only meaningful while the defect it guards would be large: \
+         reservation {reserved} bytes, line buffer {collected} bytes, allowance {ALLOWED_RISE}"
+    );
+    assert!(
+        rise <= ALLOWED_RISE,
+        "refusing a {} byte file raised peak memory by {rise} bytes; a per-line reservation \
+         would cost about {reserved} and a buffer of every line about {collected}, so this \
+         reads like one of them came back",
+        text.len(),
+    );
+}

--- a/crates/trace/tests/properties.proptest-regressions
+++ b/crates/trace/tests/properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5ef7e1c76a99b5cef192ccded0bc735aceaf6d4286b289ca34d1b2eab81c0c66 # shrinks to trace = Trace { header: TraceHeader { sample: "=", ticks: 0, timestep_ns: 0, budget: 0, keys: [("A", "=")] }, events: [] }
+cc 5ef7e1c76a99b5cef192ccded0bc735aceaf6d4286b289ca34d1b2eab81c0c66 # shrinks to trace = Trace { header: TraceHeader { sample: "=", ticks: 0, timestep_ns: 0, budget: 0, keys: [("A", "=")] }, events: [] }

--- a/crates/trace/tests/properties.proptest-regressions
+++ b/crates/trace/tests/properties.proptest-regressions
@@ -4,5 +4,12 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc 5ef7e1c76a99b5cef192ccded0bc735aceaf6d4286b289ca34d1b2eab81c0c66 # shrinks to trace = Trace { header: TraceHeader { sample: "=", ticks: 0, timestep_ns: 0, budget: 0, keys: [("A", "=")] }, events: [] }
+#
+# Provenance, so nobody reads this as a released defect: the case below
+# was found while deliberately mutating the reader to split a header
+# field at its LAST separator instead of its first. It has never failed
+# against unmutated code. It is kept because it is the most valuable
+# seed in the file -- an input that actually distinguishes the correct
+# split from the wrong one, which the generator could not produce until
+# its alphabet was widened to include the separator character.
 cc 5ef7e1c76a99b5cef192ccded0bc735aceaf6d4286b289ca34d1b2eab81c0c66 # shrinks to trace = Trace { header: TraceHeader { sample: "=", ticks: 0, timestep_ns: 0, budget: 0, keys: [("A", "=")] }, events: [] }

--- a/crates/trace/tests/properties.rs
+++ b/crates/trace/tests/properties.rs
@@ -161,13 +161,19 @@ proptest! {
     }
 
     /// The same, over text shaped like a trace: mutations of a real file
-    /// reach far deeper into the reader than random characters do.
+    /// reach far deeper into the reader than random characters do. The
+    /// caller-key tail varies too, since it is the half of the header
+    /// the codec does not interpret and therefore the half where a
+    /// parsing mistake has least to trip over.
     ///
-    /// The caller-key tail varies too, and with `=` in its alphabet. It
-    /// is the half of the header the codec does not interpret, which
-    /// makes it the half where a parsing mistake has nothing else to
-    /// trip over — and leaving it fixed at `sample=s …` was how a
-    /// deliberately broken split rule once passed the whole suite.
+    /// Note what this property can and cannot see. Its two arms are
+    /// "wrote something" and "named a line", so it catches a crash, a
+    /// hang, or a refusal with no line number — and it is blind to a
+    /// reader that merely *decides differently*, because a mutation
+    /// turning an accept into a refusal lands in the `Err` arm and
+    /// passes. The two round-trip properties above are what tell right
+    /// from wrong here; this one is a robustness check and should not be
+    /// credited with more.
     #[test]
     fn text_shaped_like_a_trace_gets_an_answer(
         version in "[0-9]{0,3}",

--- a/crates/trace/tests/properties.rs
+++ b/crates/trace/tests/properties.rs
@@ -1,0 +1,215 @@
+//! Properties over generated traces and generated garbage.
+//!
+//! Two claims, and they are different in kind. The first is that writing
+//! and reading are inverses, over traces nobody thought to write by hand.
+//! On its own that claim is weak — a writer and a reader that make the
+//! *same* mistake are still inverses of each other — which is why the
+//! golden file next to this one anchors it with text a person wrote and
+//! the code did not. The second claim is about hostile input: the reader
+//! answers, one way or the other, for every string it can be handed. It
+//! is a small fuzzer with a fixed budget, standing in until real fuzzing
+//! infrastructure exists.
+//!
+//! A generator is only as good as its alphabet, and that is not a
+//! platitude here. An earlier version of this file drew header text from
+//! characters that did not include `=`; every property below passed, and
+//! so did a reader deliberately broken to split a header field at its
+//! *last* `=` instead of its first — inverting the one rule the format
+//! documents about that character. Nothing in a hundred and five tests
+//! could tell the two readers apart, because no input ever contained the
+//! character the rule is about. So values are generated with `=` in them
+//! on purpose, keys are generated without one because the format forbids
+//! it there, and the case that pins the rule is written out by hand
+//! below rather than left to chance.
+
+use proptest::prelude::*;
+use proptest::test_runner::RngSeed;
+use renew_trace::{
+    FiniteF32, FiniteF64, Trace, TraceButton, TraceEvent, TraceHeader, TraceKey, parse, write,
+};
+
+/// A header key: no whitespace, no control characters, no `=` — a reader
+/// splits a field at the first one, so a key carrying one would be read
+/// back shorter than it was written.
+fn key_text() -> impl Strategy<Value = String> {
+    "[a-zA-Z0-9_.:x-]{1,12}"
+}
+
+/// A header value, which *may* carry `=`: everything after the first one
+/// belongs to the value, and generating them is what makes the split rule
+/// observable to the properties below.
+fn value_text() -> impl Strategy<Value = String> {
+    "[a-zA-Z0-9_.:=x-]{1,12}"
+}
+
+fn finite_f64() -> impl Strategy<Value = FiniteF64> {
+    any::<u64>().prop_filter_map("finite", FiniteF64::from_bits)
+}
+
+fn finite_f32() -> impl Strategy<Value = FiniteF32> {
+    any::<u32>().prop_filter_map("finite", FiniteF32::from_bits)
+}
+
+fn key() -> impl Strategy<Value = TraceKey> {
+    proptest::sample::select(TraceKey::ALL)
+}
+
+fn button() -> impl Strategy<Value = TraceButton> {
+    prop_oneof![
+        proptest::sample::select(TraceButton::NAMED),
+        any::<u16>().prop_map(TraceButton::Other),
+    ]
+}
+
+fn event() -> impl Strategy<Value = TraceEvent> {
+    prop_oneof![
+        (key(), any::<bool>(), any::<bool>()).prop_map(|(code, pressed, repeat)| {
+            TraceEvent::Key {
+                code,
+                pressed,
+                repeat,
+            }
+        }),
+        (finite_f64(), finite_f64()).prop_map(|(x, y)| TraceEvent::PointerMoved { x, y }),
+        (button(), any::<bool>())
+            .prop_map(|(button, pressed)| TraceEvent::PointerButton { button, pressed }),
+        (finite_f32(), finite_f32()).prop_map(|(dx, dy)| TraceEvent::Wheel { dx, dy }),
+        any::<bool>().prop_map(TraceEvent::Focused),
+        (any::<u32>(), any::<u32>())
+            .prop_map(|(width, height)| TraceEvent::Resized { width, height }),
+        finite_f64().prop_map(|scale| TraceEvent::ScaleFactorChanged { scale }),
+        Just(TraceEvent::RedrawRequested),
+        Just(TraceEvent::CloseRequested),
+    ]
+}
+
+/// A whole trace: a header with caller keys, and events on non-decreasing
+/// ticks inside the run the header describes.
+// A strategy, driven only from `#[test]` fns: the tests-only expect
+// allowance covers those, not their helpers, and this extends it in the
+// same spirit. Both refusals below are impossible by construction — the
+// generated names are writable, and the ticks are reduced into range and
+// sorted right above — so either one firing is a broken generator, which
+// is exactly what should stop the run.
+#[allow(clippy::expect_used)]
+fn trace() -> impl Strategy<Value = Trace> {
+    (
+        value_text(),
+        0_u64..1_000,
+        any::<u64>(),
+        any::<u32>(),
+        proptest::collection::vec((key_text(), value_text()), 0..4),
+        proptest::collection::vec((any::<u64>(), event()), 0..24),
+    )
+        .prop_map(|(sample, ticks, timestep_ns, budget, keys, events)| {
+            let mut header = TraceHeader::new(&sample, ticks, timestep_ns, budget)
+                .expect("the generated sample name is writable");
+            for (key, value) in keys {
+                // A repeated key is refused by design, so a generated
+                // repeat is dropped rather than worked around.
+                header = header.clone().with_key(&key, &value).unwrap_or(header);
+            }
+            let mut ordered: Vec<(u64, TraceEvent)> = events
+                .into_iter()
+                .map(|(tick, event)| (tick % (ticks + 1), event))
+                .collect();
+            ordered.sort_by_key(|(tick, _)| *tick);
+            Trace::new(header, ordered).expect("ticks are in range and sorted")
+        })
+}
+
+proptest! {
+    // Fixed RNG seed: the suite explores the same inputs on every run and
+    // every machine, so a property failure anywhere reproduces everywhere
+    // — and the lines these cases reach are the same lines on every run,
+    // which is what a coverage gate needs from a randomised suite. Fresh
+    // exploration is a deliberate act (change the seed), never an ambient
+    // one.
+    #![proptest_config(ProptestConfig {
+        rng_seed: RngSeed::Fixed(0x0000_7ace),
+        cases: 128,
+        ..ProptestConfig::default()
+    })]
+
+    /// Reading what was written gives back what was written. Every trace
+    /// that can be built can be written, and nothing is lost on the way
+    /// back: not a bit pattern, not a caller key, not the order of two
+    /// events on one tick.
+    #[test]
+    fn writing_then_reading_gives_back_the_same_trace(trace in trace()) {
+        prop_assert_eq!(parse(&write(&trace)), Ok(trace));
+    }
+
+    /// And the other direction, for text the writer produced: writing
+    /// what was read gives back the same bytes.
+    #[test]
+    fn reading_then_writing_gives_back_the_same_text(trace in trace()) {
+        let text = write(&trace);
+        let read = parse(&text).expect("the writer's own output reads back");
+        prop_assert_eq!(write(&read), text);
+    }
+
+    /// The reader answers for every string. No panic, no hang, no
+    /// unwinding out of a codec — an answer, even if the answer is a
+    /// refusal naming a line.
+    #[test]
+    fn any_text_at_all_gets_an_answer(text in ".{0,400}") {
+        match parse(&text) {
+            Ok(trace) => prop_assert!(!write(&trace).is_empty()),
+            Err(error) => prop_assert!(error.line() >= 1),
+        }
+    }
+
+    /// The same, over text shaped like a trace: mutations of a real file
+    /// reach far deeper into the reader than random characters do.
+    ///
+    /// The caller-key tail varies too, and with `=` in its alphabet. It
+    /// is the half of the header the codec does not interpret, which
+    /// makes it the half where a parsing mistake has nothing else to
+    /// trip over — and leaving it fixed at `sample=s …` was how a
+    /// deliberately broken split rule once passed the whole suite.
+    #[test]
+    fn text_shaped_like_a_trace_gets_an_answer(
+        version in "[0-9]{0,3}",
+        ticks in "[0-9a-z]{0,6}",
+        tail in "( ?[a-z]{0,4}(=[a-z0-9=]{0,6})?){0,3}",
+        line in "e [0-9]{0,4} (key|pointer|button|wheel|focus|resize|scale|redraw|close|gamepad)( [0-9a-fx:-]{0,18}){0,3}",
+    ) {
+        let text = format!(
+            "renew-trace {version} sample=s ticks={ticks} timestep_ns=1 budget=1{tail}\n{line}\n"
+        );
+        match parse(&text) {
+            Ok(trace) => prop_assert_eq!(parse(&write(&trace)), Ok(trace)),
+            Err(error) => prop_assert!(error.line() >= 1),
+        }
+    }
+}
+
+/// The split rule, written out rather than generated: a header field is
+/// split at its **first** `=`, so everything after that belongs to the
+/// value.
+///
+/// This is the case a fuzzer with the wrong alphabet cannot reach and the
+/// one a reader broken to split at the last `=` fails immediately. It is
+/// a fixed input on purpose — the rule is one sentence in the format's
+/// documentation, and one sentence deserves one assertion that says the
+/// same thing.
+#[test]
+fn a_header_field_is_split_at_its_first_equals_sign() {
+    let text = "renew-trace 0 sample=s ticks=1 timestep_ns=1 budget=1 k=v=w\n";
+    let trace = parse(text).expect("a value may carry an equals sign");
+    assert_eq!(
+        trace.header().keys(),
+        [("k".to_string(), "v=w".to_string())]
+    );
+    assert_eq!(trace.header().value("k"), Some("v=w"));
+    // One key in, one key out, and the same bytes back.
+    assert_eq!(write(&trace), text);
+
+    // The positional field is a value in the same sense, which is why
+    // the no-equals rule binds keys only and cannot bind both halves.
+    let odd = "renew-trace 0 sample=a=b ticks=1 timestep_ns=1 budget=1\n";
+    let trace = parse(odd).expect("the sample name is a value too");
+    assert_eq!(trace.header().sample(), "a=b");
+    assert_eq!(write(&trace), odd);
+}

--- a/crates/trace/tests/rejects.rs
+++ b/crates/trace/tests/rejects.rs
@@ -6,6 +6,17 @@
 //! malformed file to one refusal and one line number. A single test that
 //! asserted "these twenty files are all rejected" would still pass if
 //! nineteen of them started being rejected for the twentieth's reason.
+//!
+//! **Negatives have to be near misses, not strangers.** A refusal test is
+//! only as sharp as the distance between the input it refuses and the
+//! input it must accept. `gamepad` and `thumb` and `meta` are strangers:
+//! they share nothing with a legal word, so refusing them says only that
+//! the reader has *some* notion of a vocabulary. They cannot tell an
+//! exact-match reader from one that accepts any word beginning with a
+//! legal one — and that reader accepts `event 0 close`, `err 0 close`
+//! and, worse, `renew-tracex` as the file's own identity line. So every
+//! table of words here is probed twice: with a stranger, and with a word
+//! one character away from a legal one, in both directions.
 
 use renew_trace::{TraceError, TraceErrorKind, parse};
 
@@ -68,6 +79,24 @@ fn a_first_line_that_is_not_a_header_is_refused() {
             found: "hello".to_string()
         }
     );
+}
+
+/// The file's own identity line, probed one character away. A reader
+/// that accepted anything *beginning* with the format's name would read
+/// `renew-tracex` as a trace of this format, which is the one question
+/// the first word of the first line exists to answer.
+#[test]
+fn a_word_that_merely_begins_with_the_format_name_is_not_a_header() {
+    for word in ["renew-tracex", "renew-trace2", "renew-trac"] {
+        let text = format!("{word} 0 sample=x ticks=1 timestep_ns=1 budget=1\n");
+        assert_eq!(
+            refuse(&text).kind(),
+            &TraceErrorKind::NotATrace {
+                found: word.to_string()
+            },
+            "{word} was read as a header"
+        );
+    }
 }
 
 #[test]
@@ -305,6 +334,37 @@ fn an_unknown_line_keyword_is_refused_rather_than_skipped() {
     );
 }
 
+/// The event keyword is one character long, which makes it the easiest
+/// word in the format to match loosely by accident: every one of these
+/// begins with `e`, and a reader comparing prefixes would read all three
+/// as ordinary event lines.
+#[test]
+fn a_line_keyword_that_merely_begins_with_the_event_keyword_is_unknown() {
+    for keyword in ["event", "err", "ee"] {
+        assert_eq!(
+            refuse_event(&format!("{keyword} 0 close")).kind(),
+            &TraceErrorKind::UnknownKeyword {
+                keyword: keyword.to_string()
+            },
+            "{keyword} was read as an event line"
+        );
+    }
+}
+
+/// The header's own keys, probed the same way: `ticksx` is not `ticks`,
+/// and a reader that thought otherwise would take its run length from a
+/// field the writer never wrote.
+#[test]
+fn a_header_key_that_merely_begins_with_a_known_one_is_out_of_order() {
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticksx=1 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::HeaderFieldOutOfOrder {
+            expected: "`ticks=<u64>`",
+            found: "ticksx=1".to_string(),
+        }
+    );
+}
+
 /// A blank line is not nothing; it is a line this reader cannot read.
 #[test]
 fn a_blank_line_between_events_is_refused() {
@@ -419,6 +479,23 @@ fn an_unknown_key_name_is_refused() {
         }
     );
     assert!(error.to_string().contains("arrow-right"), "{error}");
+}
+
+/// Key names, probed one character away in both directions: `spaceship`
+/// begins with `space` and `spac` is begun by it. A lookup comparing
+/// prefixes either way would answer `Space` to both, and a trace would
+/// replay a key nobody pressed.
+#[test]
+fn a_key_name_one_character_from_a_known_one_is_unknown() {
+    for name in ["spaceship", "spac", "arrow-rights", "arrow-righ"] {
+        assert_eq!(
+            refuse_event(&format!("e 0 key {name} down")).kind(),
+            &TraceErrorKind::UnknownKey {
+                name: name.to_string()
+            },
+            "{name} was read as a known key"
+        );
+    }
 }
 
 /// The same refusal serves keys and buttons, and says so: both are
@@ -639,6 +716,22 @@ fn an_unknown_pointer_button_is_refused() {
         }
     );
     assert!(error.to_string().contains("other:<index>"), "{error}");
+}
+
+/// Button names, probed the same way as key names — including
+/// `otherwise`, which begins with the native-index prefix without being
+/// it.
+#[test]
+fn a_button_name_one_character_from_a_known_one_is_unknown() {
+    for name in ["leftmost", "lef", "middles", "otherwise"] {
+        assert_eq!(
+            refuse_event(&format!("e 0 button {name} down")).kind(),
+            &TraceErrorKind::UnknownButton {
+                name: name.to_string()
+            },
+            "{name} was read as a known button"
+        );
+    }
 }
 
 #[test]

--- a/crates/trace/tests/rejects.rs
+++ b/crates/trace/tests/rejects.rs
@@ -1,0 +1,721 @@
+//! Every way a trace can be refused, one test per way.
+//!
+//! A parser of untrusted input is mostly its refusals, so they are tested
+//! the way the accepting paths are: separately, by what they *say*, not by
+//! the fact that something went wrong. Each test here pins one line of one
+//! malformed file to one refusal and one line number. A single test that
+//! asserted "these twenty files are all rejected" would still pass if
+//! nineteen of them started being rejected for the twentieth's reason.
+
+use renew_trace::{TraceError, TraceErrorKind, parse};
+
+const HEADER: &str = "renew-trace 0 sample=input_echo ticks=30 timestep_ns=16666667 budget=5";
+
+/// The refusal a text produces. Every test goes through here, so a text
+/// that is unexpectedly *accepted* fails loudly rather than quietly
+/// passing some later assertion.
+// A test helper, called only from `#[test]` fns: the tests-only panic
+// allowance covers those, not their helpers, and this extends it in the
+// same spirit — an accepted file in a file of refusals is a test failure
+// and has to be reported as one.
+#[allow(clippy::panic)]
+fn refuse(text: &str) -> TraceError {
+    match parse(text) {
+        Ok(trace) => panic!("expected a refusal, read {} events", trace.events().len()),
+        Err(error) => error,
+    }
+}
+
+/// The refusal produced by one event line under the standard header.
+fn refuse_event(line: &str) -> TraceError {
+    refuse(&format!("{HEADER}\n{line}\n"))
+}
+
+#[test]
+fn an_empty_file_is_not_a_trace() {
+    let error = refuse("");
+    assert_eq!(error.line(), 1);
+    assert_eq!(error.kind(), &TraceErrorKind::Empty);
+    assert_eq!(
+        error.to_string(),
+        "line 1: the file is empty; a trace is a header line followed by one line per event"
+    );
+}
+
+/// The byte order mark is named rather than described, because it is
+/// invisible: the file looks correct on screen, and any other message
+/// would send a reader looking at the wrong thing.
+#[test]
+fn a_byte_order_mark_is_refused_by_name() {
+    let error = refuse(&format!("\u{feff}{HEADER}\n"));
+    assert_eq!(error.line(), 1);
+    assert_eq!(error.kind(), &TraceErrorKind::ByteOrderMark);
+    assert!(error.to_string().contains("byte order mark"), "{error}");
+}
+
+#[test]
+fn a_file_that_is_only_a_byte_order_mark_still_names_it() {
+    assert_eq!(refuse("\u{feff}").kind(), &TraceErrorKind::ByteOrderMark);
+}
+
+#[test]
+fn a_first_line_that_is_not_a_header_is_refused() {
+    let error = refuse("hello 0 sample=x\n");
+    assert_eq!(error.line(), 1);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::NotATrace {
+            found: "hello".to_string()
+        }
+    );
+}
+
+#[test]
+fn a_file_of_one_blank_line_is_a_missing_header() {
+    assert_eq!(
+        refuse("\n").kind(),
+        &TraceErrorKind::NotATrace {
+            found: String::new()
+        }
+    );
+}
+
+#[test]
+fn a_version_newer_than_this_reader_is_refused() {
+    let error = refuse("renew-trace 1 sample=x ticks=1 timestep_ns=1 budget=1\n");
+    assert_eq!(error.line(), 1);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnsupportedVersion {
+            found: 1,
+            supported: 0
+        }
+    );
+}
+
+#[test]
+fn a_version_that_is_not_a_number_is_refused() {
+    assert_eq!(
+        refuse("renew-trace v0 sample=x ticks=1 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "the format version",
+            text: "v0".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_header_that_stops_before_its_version_is_refused() {
+    assert_eq!(
+        refuse("renew-trace\n").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the format version"
+        }
+    );
+}
+
+#[test]
+fn a_header_that_stops_before_a_field_names_the_field() {
+    assert_eq!(
+        refuse("renew-trace 0\n").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "`sample=<name>`"
+        }
+    );
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=1 timestep_ns=1\n").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "`budget=<u32>`"
+        }
+    );
+}
+
+/// The four fields the codec owns are positional, so a reader never has
+/// to guess which one it is holding.
+#[test]
+fn a_header_field_in_the_wrong_place_is_refused() {
+    let error = refuse("renew-trace 0 sample=x timestep_ns=1 ticks=1 budget=1\n");
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::HeaderFieldOutOfOrder {
+            expected: "`ticks=<u64>`",
+            found: "timestep_ns=1".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_header_field_that_is_not_a_pair_is_refused() {
+    assert_eq!(
+        refuse("renew-trace 0 sample ticks=1 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::NotAKeyValuePair {
+            field: "sample".to_string()
+        }
+    );
+}
+
+#[test]
+fn a_caller_key_without_a_value_is_refused() {
+    assert_eq!(
+        refuse(&format!("{HEADER} seed\n")).kind(),
+        &TraceErrorKind::NotAKeyValuePair {
+            field: "seed".to_string()
+        }
+    );
+}
+
+#[test]
+fn the_same_caller_key_twice_is_refused() {
+    let error = refuse(&format!("{HEADER} seed=1 seed=2\n"));
+    assert_eq!(error.line(), 1);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::DuplicateHeaderKey {
+            key: "seed".to_string()
+        }
+    );
+}
+
+/// A caller key may not shadow one of the codec's own, which would leave
+/// two answers to one question in one file.
+#[test]
+fn a_caller_key_repeating_one_the_codec_owns_is_refused() {
+    assert_eq!(
+        refuse(&format!("{HEADER} ticks=9\n")).kind(),
+        &TraceErrorKind::DuplicateHeaderKey {
+            key: "ticks".to_string()
+        }
+    );
+}
+
+#[test]
+fn a_caller_key_with_an_empty_value_is_refused() {
+    assert_eq!(
+        refuse(&format!("{HEADER} seed=\n")).kind(),
+        &TraceErrorKind::UnwritableText {
+            text: "seed=".to_string(),
+            reason: "a header key and a header value are each at least one character",
+        }
+    );
+}
+
+#[test]
+fn a_header_value_carrying_a_control_character_is_refused() {
+    assert_eq!(
+        refuse("renew-trace 0 sample=in\u{7}put ticks=1 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::UnwritableText {
+            text: "sample=in\u{7}put".to_string(),
+            reason: "a control character is invisible in a diff and in a log",
+        }
+    );
+}
+
+/// A tab is whitespace that survives a split on spaces, so it is the one
+/// way whitespace can reach a field, and it is refused there.
+#[test]
+fn a_header_value_carrying_a_tab_is_refused() {
+    assert_eq!(
+        refuse(&format!("{HEADER} extent=640\tx480\n")).kind(),
+        &TraceErrorKind::UnwritableText {
+            text: "extent=640\tx480".to_string(),
+            reason: "whitespace would split it into two fields",
+        }
+    );
+}
+
+#[test]
+fn two_spaces_in_the_header_are_refused() {
+    assert_eq!(
+        refuse("renew-trace 0  sample=x ticks=1 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::BlankField
+    );
+}
+
+#[test]
+fn a_trailing_space_on_the_header_is_refused() {
+    assert_eq!(
+        refuse(&format!("{HEADER} \n")).kind(),
+        &TraceErrorKind::BlankField
+    );
+}
+
+#[test]
+fn a_header_number_that_is_not_digits_is_refused() {
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=1_000 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "`ticks=<u64>`",
+            text: "1_000".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=1 timestep_ns=+1 budget=1\n").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "`timestep_ns=<u64>`",
+            text: "+1".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_header_number_too_large_for_its_width_is_refused() {
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=99999999999999999999 timestep_ns=1 budget=1\n").kind(),
+        &TraceErrorKind::IntegerTooLarge {
+            field: "`ticks=<u64>`",
+            text: "99999999999999999999".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=1 timestep_ns=1 budget=4294967296\n").kind(),
+        &TraceErrorKind::IntegerTooLarge {
+            field: "`budget=<u32>`",
+            text: "4294967296".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse("renew-trace 0 sample=x ticks=1 timestep_ns=1 budget=five\n").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "`budget=<u32>`",
+            text: "five".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_second_header_is_refused_where_it_stands() {
+    let error = refuse(&format!("{HEADER}\n{HEADER}\n"));
+    assert_eq!(error.line(), 2);
+    assert_eq!(error.kind(), &TraceErrorKind::HeaderAfterEvents);
+}
+
+#[test]
+fn an_unknown_line_keyword_is_refused_rather_than_skipped() {
+    let error = refuse_event("x 0 close");
+    assert_eq!(error.line(), 2);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnknownKeyword {
+            keyword: "x".to_string()
+        }
+    );
+    assert!(
+        error.to_string().contains("refused rather than skipped"),
+        "{error}"
+    );
+}
+
+/// A blank line is not nothing; it is a line this reader cannot read.
+#[test]
+fn a_blank_line_between_events_is_refused() {
+    let error = refuse(&format!("{HEADER}\n\ne 0 close\n"));
+    assert_eq!(error.line(), 2);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnknownKeyword {
+            keyword: String::new()
+        }
+    );
+}
+
+#[test]
+fn an_unknown_event_kind_is_refused_rather_than_skipped() {
+    let error = refuse_event("e 0 gamepad left down");
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnknownEventKind {
+            kind: "gamepad".to_string()
+        }
+    );
+    assert!(
+        error.to_string().contains("refused rather than skipped"),
+        "{error}"
+    );
+}
+
+#[test]
+fn an_event_line_that_stops_before_its_tick_is_refused() {
+    assert_eq!(
+        refuse_event("e").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the tick"
+        }
+    );
+}
+
+#[test]
+fn an_event_line_that_stops_before_its_kind_is_refused() {
+    assert_eq!(
+        refuse_event("e 0").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the kind of event"
+        }
+    );
+}
+
+#[test]
+fn a_tick_that_is_not_digits_is_refused() {
+    assert_eq!(
+        refuse_event("e -1 close").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "the tick",
+            text: "-1".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_tick_too_large_for_its_width_is_refused() {
+    assert_eq!(
+        refuse_event("e 99999999999999999999 close").kind(),
+        &TraceErrorKind::IntegerTooLarge {
+            field: "the tick",
+            text: "99999999999999999999".to_string(),
+        }
+    );
+}
+
+/// Ticks never decrease. Equal ones are legal, so only a genuine
+/// decrease is refused, and it is refused against its own line.
+#[test]
+fn a_tick_earlier_than_the_one_before_it_is_refused() {
+    let error = refuse(&format!("{HEADER}\ne 7 redraw\ne 7 redraw\ne 3 close\n"));
+    assert_eq!(error.line(), 4);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::TickWentBackwards {
+            tick: 3,
+            previous: 7
+        }
+    );
+}
+
+/// One past the end is refused; the end itself is not, and the message
+/// says so rather than leaving someone to discover it.
+#[test]
+fn a_tick_past_the_end_of_the_run_is_refused() {
+    let error = refuse_event("e 31 close");
+    assert_eq!(error.line(), 2);
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::TickBeyondHeader {
+            tick: 31,
+            ticks: 30
+        }
+    );
+    assert!(
+        error.to_string().contains("the last legal tick is 30"),
+        "{error}"
+    );
+}
+
+#[test]
+fn an_unknown_key_name_is_refused() {
+    let error = refuse_event("e 0 key meta down");
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnknownKey {
+            name: "meta".to_string()
+        }
+    );
+    assert!(error.to_string().contains("arrow-right"), "{error}");
+}
+
+/// The same refusal serves keys and buttons, and says so: both are
+/// `down` or `up`, and a message naming only keys would be wrong on half
+/// the lines that can produce it.
+#[test]
+fn a_state_that_is_neither_down_nor_up_is_refused() {
+    let key = refuse_event("e 0 key space pressed");
+    assert_eq!(
+        key.kind(),
+        &TraceErrorKind::NotAPressedState {
+            text: "pressed".to_string()
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 button left sideways").kind(),
+        &TraceErrorKind::NotAPressedState {
+            text: "sideways".to_string()
+        }
+    );
+    assert!(key.to_string().contains("a key or a button"), "{key}");
+}
+
+#[test]
+fn a_line_that_stops_before_its_state_is_refused() {
+    for line in ["e 0 key space", "e 0 button left"] {
+        assert_eq!(
+            refuse_event(line).kind(),
+            &TraceErrorKind::LineEndsEarly {
+                expected: "`down` or `up`"
+            }
+        );
+    }
+}
+
+#[test]
+fn a_key_line_that_stops_before_its_name_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 key").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the key name"
+        }
+    );
+}
+
+#[test]
+fn a_wheel_line_that_stops_before_a_delta_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 wheel").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the wheel's horizontal delta"
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 wheel 0x00000000").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the wheel's vertical delta"
+        }
+    );
+}
+
+/// The repeat flag is present or absent. A word meaning "no" would be a
+/// second spelling of an absent flag.
+#[test]
+fn anything_but_the_repeat_flag_after_a_key_state_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 key space down norepeat").kind(),
+        &TraceErrorKind::NotTheRepeatFlag {
+            text: "norepeat".to_string()
+        }
+    );
+}
+
+#[test]
+fn a_doubled_space_on_a_key_line_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 key space down  repeat").kind(),
+        &TraceErrorKind::BlankField
+    );
+}
+
+#[test]
+fn text_after_a_complete_line_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 close now").kind(),
+        &TraceErrorKind::TrailingText {
+            text: "now".to_string()
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 key space down repeat twice").kind(),
+        &TraceErrorKind::TrailingText {
+            text: "twice".to_string()
+        }
+    );
+}
+
+#[test]
+fn a_trailing_space_on_an_event_line_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 close ").kind(),
+        &TraceErrorKind::BlankField
+    );
+}
+
+#[test]
+fn a_doubled_space_before_an_event_kind_is_refused() {
+    assert_eq!(
+        refuse_event("e 0  close").kind(),
+        &TraceErrorKind::BlankField
+    );
+}
+
+/// One spelling per file: an uppercase digit, or an uppercase prefix, is
+/// a second way to write a number that already has one.
+#[test]
+fn an_uppercase_bit_pattern_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 scale 0x400000000000000A").kind(),
+        &TraceErrorKind::NotAHexPattern {
+            field: "the scale factor",
+            text: "0x400000000000000A".to_string(),
+            digits: 16,
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 scale 0X4000000000000000").kind(),
+        &TraceErrorKind::NotAHexPattern {
+            field: "the scale factor",
+            text: "0X4000000000000000".to_string(),
+            digits: 16,
+        }
+    );
+}
+
+#[test]
+fn a_bit_pattern_of_the_wrong_width_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 scale 0x4").kind(),
+        &TraceErrorKind::NotAHexPattern {
+            field: "the scale factor",
+            text: "0x4".to_string(),
+            digits: 16,
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 wheel 0x000000000 0x00000000").kind(),
+        &TraceErrorKind::NotAHexPattern {
+            field: "the wheel's horizontal delta",
+            text: "0x000000000".to_string(),
+            digits: 8,
+        }
+    );
+}
+
+#[test]
+fn a_bit_pattern_without_its_prefix_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 pointer 4000000000000000 0x0000000000000000").kind(),
+        &TraceErrorKind::NotAHexPattern {
+            field: "the pointer's x coordinate",
+            text: "4000000000000000".to_string(),
+            digits: 16,
+        }
+    );
+}
+
+#[test]
+fn a_pointer_line_that_stops_before_its_second_coordinate_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 pointer 0x0000000000000000").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the pointer's y coordinate"
+        }
+    );
+}
+
+/// A trace carries finite values only, in both widths.
+#[test]
+fn a_non_finite_bit_pattern_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 scale 0x7ff0000000000000").kind(),
+        &TraceErrorKind::NonFinite {
+            field: "the scale factor",
+            text: "0x7ff0000000000000".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 pointer 0x0000000000000000 0xfff8000000000000").kind(),
+        &TraceErrorKind::NonFinite {
+            field: "the pointer's y coordinate",
+            text: "0xfff8000000000000".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 wheel 0xff800000 0x00000000").kind(),
+        &TraceErrorKind::NonFinite {
+            field: "the wheel's horizontal delta",
+            text: "0xff800000".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 wheel 0x00000000 0x7f800001").kind(),
+        &TraceErrorKind::NonFinite {
+            field: "the wheel's vertical delta",
+            text: "0x7f800001".to_string(),
+        }
+    );
+}
+
+#[test]
+fn an_unknown_pointer_button_is_refused() {
+    let error = refuse_event("e 0 button thumb down");
+    assert_eq!(
+        error.kind(),
+        &TraceErrorKind::UnknownButton {
+            name: "thumb".to_string()
+        }
+    );
+    assert!(error.to_string().contains("other:<index>"), "{error}");
+}
+
+#[test]
+fn a_native_button_index_that_is_not_digits_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 button other:x down").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "the native button index (u16)",
+            text: "x".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 button other: down").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "the native button index (u16)",
+            text: String::new(),
+        }
+    );
+}
+
+#[test]
+fn a_native_button_index_too_large_for_its_width_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 button other:65536 down").kind(),
+        &TraceErrorKind::IntegerTooLarge {
+            field: "the native button index (u16)",
+            text: "65536".to_string(),
+        }
+    );
+}
+
+#[test]
+fn a_button_line_that_stops_before_its_button_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 button").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the pointer button"
+        }
+    );
+}
+
+#[test]
+fn a_focus_state_that_is_neither_in_nor_out_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 focus yes").kind(),
+        &TraceErrorKind::NotAFocusState {
+            text: "yes".to_string()
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 focus").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "`in` or `out`"
+        }
+    );
+}
+
+#[test]
+fn a_resize_that_is_not_two_numbers_is_refused() {
+    assert_eq!(
+        refuse_event("e 0 resize wide 720").kind(),
+        &TraceErrorKind::NotADecimalInteger {
+            field: "the width (u32)",
+            text: "wide".to_string(),
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 resize 1280").kind(),
+        &TraceErrorKind::LineEndsEarly {
+            expected: "the height (u32)"
+        }
+    );
+    assert_eq!(
+        refuse_event("e 0 resize 4294967296 720").kind(),
+        &TraceErrorKind::IntegerTooLarge {
+            field: "the width (u32)",
+            text: "4294967296".to_string(),
+        }
+    );
+}


### PR DESCRIPTION
Input was the one part of a reproducible run the engine could not write down. The build is pinned and the seed is a flag; traces were compiled-in constants, which proves the loop is deterministic but does not let anyone reproduce a bug from the input that caused it.

**The codec owns its own event vocabulary and depends on nothing.** Naming the window seam's vocabulary would mean depending on a crate whose windowing module is default-on, putting a windowing stack into every configuration including the headless ones — and it would make the file format hostage to the growth of an enum in another crate. Owning the vocabulary means a new window event changes what a sample's conversion must handle, not what a file on disk means.

**It does no I/O at all**, which is what makes it fuzzable and testable without a filesystem. A size limit could not live in a parser anyway: by the time a parser can count bytes they are already allocated, so the bound belongs at the read.

Floats are carried as bit patterns in newtypes that refuse non-finite values at construction, which is what makes writing infallible and the round trip total rather than conditional. The tick rules live in the constructor rather than the parser, so a recorder cannot build something its own reader would refuse.

## What review changed, and it was not small

Two adversarial passes found two blockers and a class of blindness that survived the first fix:

- A caller header key containing `=` broke the documented round trip — silently in one case, and in another the **writer emitted a file its own reader refused**, the exact property the design claimed impossible.
- **The property suite could not see it.** A one-token reader mutation passed all 105 tests at 100% region coverage, because the generator's alphabet contained no `=`. Widening it kills both mutants without the hand-written case.
- Then the same blindness turned up in a different rule: every negative word in the refusal suite was unrelated to the legal vocabulary, so nothing distinguished exact-match from prefix-match. Five keyword tables, five surviving mutations — one accepted a header whose magic word merely *began* with the format name. The new negatives are near misses in both directions.
- The memory fix had no regression test, so reinstating the defect passed everything. It has one now, in its own process with a counting allocator, comparing a peak rather than totals because the defect's allocation is freed as the refusal propagates.

## Verified locally

- `cargo test -p renew-trace` — **118 tests, 0 failures**
- `cargo llvm-cov` — **100% on regions, lines and functions** (1853 / 1327 / 131, none missed)
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- `renew check` healthy
- Every mutation described above was re-run after its fix and now fails

The removability cell lands with it: the crate is optional, so CI proves the tree still builds and tests without it. That exclude list is upward-closed only while nothing depends on the crate — the comment says so, and names what has to join it the day a sample records a trace.
