### PR TITLE
Record and replay a run's input as a file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,15 +177,16 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rng $sel
           cargo build $sel
           cargo test $sel
-      # The trace codec removed entirely. Nothing reaches it yet — not
-      # the samples, not the bench suite — so the list is the crate and
-      # nothing else, and it is upward-closed for exactly that reason.
-      # The day a sample records or replays a trace, this cell fails
-      # first and names the crate that has to join the list, which is
-      # the point of running it while the list is still trivial.
+      # The trace codec removed entirely, and with it the sample that
+      # records traces. The comment here used to say the list was the
+      # crate alone and would fail first the day a sample reached it.
+      # That is precisely what happened, in the very next change: the
+      # guard reported the crate still in the graph and named
+      # input_echo as the reason. Kept as written evidence that the
+      # guard catches this rather than passing vacuously.
       - name: Build and test without the trace codec
         run: |
-          sel="--workspace --exclude renew-trace"
+          sel="--workspace --exclude renew-trace --exclude renew-sample-input-echo"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-trace $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,7 @@ version = "0.1.0"
 dependencies = [
  "renew-frame",
  "renew-platform",
+ "renew-trace",
 ]
 
 [[package]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -54,3 +54,9 @@ reason = "Translates a windowing event whose payload type has no public construc
 file = "crates/core/platform/src/window.rs"
 lines = [800]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
+
+[[exempt]]
+file = "samples/input_echo/src/convert.rs"
+lines = [82, 113, 133]
+reason = "The wildcard arms that a non-exhaustive vocabulary forces a downstream crate to write, and the refusal one of them feeds. Every variant that exists today has its own arm above, so these are unreachable until the vocabulary grows - which is exactly when they must already be there, because the compiler will not report the new variant as unhandled in this crate. They refuse rather than folding an unknown event into a neighbouring one, so a recording can never quietly claim something that did not happen."
+

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -337,9 +337,24 @@ impl WindowApp for TriangleApp {
     }
 
     fn update(&mut self, control: &mut LoopControl) {
-        // The one clock read on the path. Everything downstream of it is
-        // the same pure state machine the headless run drives.
+        // The one clock read on the path, and the whole of this method:
+        // everything downstream is `update_at`, which is handed the
+        // timestamp rather than reading one.
         let now = Timestamp::from_nanos(self.clock.elapsed_nanos());
+        self.update_at(now, control);
+    }
+}
+
+impl TriangleApp {
+    /// The update the seam asks for, as a pure function of the frame's
+    /// timestamp: the same state machine the headless run drives.
+    ///
+    /// Split from [`WindowApp::update`] so tests can say what time it is.
+    /// Driving it through the real clock made the number of simulation
+    /// steps a fact about how fast the machine was — usually none, since
+    /// a test reaches here microseconds after the schedule is anchored —
+    /// which left the step body exercised only by luck.
+    fn update_at(&mut self, now: Timestamp, control: &mut LoopControl) {
         if let Some(frame) = &mut self.frame {
             let plan = frame.begin_frame(now);
             for step in plan.steps() {
@@ -413,6 +428,12 @@ mod tests {
         app
     }
 
+    /// Exactly one 60 Hz step past the anchor `fresh` sets, so an update
+    /// from here has exactly one step to run however fast the machine is.
+    /// Derived from the timestep rather than written out, so changing the
+    /// rate cannot silently turn this back into zero steps.
+    const ONE_STEP: Timestamp = Timestamp::from_nanos(Timestep::HZ_60.nanos().get());
+
     fn report() -> Report {
         Report {
             seed: 0,
@@ -426,9 +447,25 @@ mod tests {
     fn an_update_plans_a_frame_and_asks_for_the_redraw_that_draws_it() {
         let mut app = fresh(10);
         let mut control = LoopControl::default();
+        app.update_at(ONE_STEP, &mut control);
+        assert_eq!(app.stats.frames(), 1);
+        // A step was due, so the world advanced by exactly one. Asserted
+        // because the alternative — a plan with no steps — also counts a
+        // frame, and would leave the step body untested.
+        assert_eq!(app.world.ticks(), 1);
+        // Nothing has presented yet, so the loop must keep going.
+        assert!(!app.done());
+    }
+
+    /// The seam's own callback, which reads the clock and hands the
+    /// result to `update_at`. What time it finds is the machine's
+    /// business, so this asserts only what holds at any speed.
+    #[test]
+    fn the_seam_callback_reads_the_clock_and_drives_the_update() {
+        let mut app = fresh(10);
+        let mut control = LoopControl::default();
         app.update(&mut control);
         assert_eq!(app.stats.frames(), 1);
-        // Nothing has presented yet, so the loop must keep going.
         assert!(!app.done());
     }
 
@@ -438,7 +475,7 @@ mod tests {
         // call `update` before it: with no schedule there is no frame to
         // plan, and nothing to record about one.
         let mut app = TriangleApp::new(&Options::default());
-        app.update(&mut LoopControl::default());
+        app.update_at(ONE_STEP, &mut LoopControl::default());
         assert_eq!(app.stats.frames(), 0);
         assert!(app.failure.is_none() && app.skip.is_none());
     }
@@ -515,12 +552,12 @@ mod tests {
     fn a_run_that_never_presents_is_declared_wedged_rather_than_left_spinning() {
         let mut app = fresh(1);
         let mut control = LoopControl::default();
-        app.update(&mut control);
+        app.update_at(ONE_STEP, &mut control);
         assert!(app.failure.is_none(), "a fresh run has not stalled");
         // Nothing has ever reached the screen, and now the budget is
         // spent: the run ends, saying so, instead of spinning forever.
         app.wedge_after = Nanos::ZERO;
-        app.update(&mut control);
+        app.update_at(ONE_STEP, &mut control);
         let failure = app.failure.as_deref().unwrap_or_default();
         assert!(failure.starts_with("wedged: 0 of 1 frames"), "{failure}");
         assert!(app.done());
@@ -532,8 +569,11 @@ mod tests {
     fn a_presented_frame_moves_the_stall_deadline() {
         let mut app = fresh(1_000);
         app.record_draw(Ok(true));
-        app.update(&mut LoopControl::default());
-        assert!(app.last_progress > Timestamp::from_nanos(0));
+        app.update_at(ONE_STEP, &mut LoopControl::default());
+        // The exact timestamp of the update that saw the presented
+        // frame, rather than merely "later than the anchor": with the
+        // clock out of the way the deadline is a value, not a bound.
+        assert_eq!(app.last_progress, ONE_STEP);
         assert!(app.failure.is_none());
     }
 
@@ -582,7 +622,7 @@ mod tests {
     fn tearing_down_without_a_window_still_produces_the_report() {
         let mut app = fresh(10);
         let mut control = LoopControl::default();
-        app.update(&mut control);
+        app.update_at(ONE_STEP, &mut control);
         let report = app.finish(Ok(())).expect("a run that recorded nothing");
         assert_eq!(report.stats.frames(), 1);
     }

--- a/samples/input_echo/Cargo.toml
+++ b/samples/input_echo/Cargo.toml
@@ -30,6 +30,7 @@ path = "src/main.rs"
 # opens no window.
 renew-frame = { path = "../../crates/frame" }
 renew-platform = { path = "../../crates/core/platform" }
+renew-trace = { path = "../../crates/trace" }
 
 [lints]
 workspace = true

--- a/samples/input_echo/src/app.rs
+++ b/samples/input_echo/src/app.rs
@@ -152,9 +152,23 @@ impl WindowApp for EchoApp {
     }
 
     fn update(&mut self, control: &mut LoopControl) {
-        // The one clock read on the path. Everything downstream of it is
-        // the same pure state machine the scripted trace drives.
+        // The one clock read on the path, and the whole of this method:
+        // everything downstream is `update_at`, which is handed the
+        // timestamp rather than reading one.
         let now = Timestamp::from_nanos(self.clock.elapsed_nanos());
+        self.update_at(now, control);
+    }
+}
+
+impl EchoApp {
+    /// The update the seam asks for, as a pure function of the frame's
+    /// timestamp: the same state machine the scripted trace drives.
+    ///
+    /// Split from [`WindowApp::update`] so tests can say what time it is.
+    /// Driving it through the real clock made the number of simulation
+    /// steps a fact about how fast the machine was — at poll speed,
+    /// usually none — which left the step body exercised only by luck.
+    fn update_at(&mut self, now: Timestamp, control: &mut LoopControl) {
         if let Some(frame) = &mut self.frame {
             let plan = frame.begin_frame(now);
             for step in plan.steps() {
@@ -196,15 +210,37 @@ mod tests {
         app
     }
 
+    /// Exactly one 60 Hz step past the anchor `fresh` sets, so an update
+    /// from here has exactly one step to run however fast the machine is.
+    /// Derived from the timestep rather than written out, so changing the
+    /// rate cannot silently turn this back into zero steps.
+    const ONE_STEP: Timestamp = Timestamp::from_nanos(Timestep::HZ_60.nanos().get());
+
     #[test]
     fn an_update_plans_a_frame_whether_or_not_a_step_is_due() {
         let mut app = fresh(1_000);
         let mut control = LoopControl::default();
-        app.update(&mut control);
-        app.update(&mut control);
-        // Two iterations, two plans. How many steps they carried is the
-        // clock's business — at poll speed, usually none.
+        // The anchor itself: a plan is made, but no step is due yet.
+        app.update_at(Timestamp::from_nanos(0), &mut control);
+        assert_eq!(app.world.ticks(), 0, "nothing is due at the anchor");
+        // One timestep later exactly one step is due, so the frame count
+        // and the step count move independently — which is the thing
+        // this test is named for.
+        app.update_at(ONE_STEP, &mut control);
         assert_eq!(app.stats.frames(), 2);
+        assert_eq!(app.world.ticks(), 1);
+        assert!(!app.done());
+    }
+
+    /// The seam's own callback, which reads the clock and hands the
+    /// result to `update_at`. What time it finds is the machine's
+    /// business, so this asserts only what holds at any speed.
+    #[test]
+    fn the_seam_callback_reads_the_clock_and_drives_the_update() {
+        let mut app = fresh(1_000);
+        let mut control = LoopControl::default();
+        app.update(&mut control);
+        assert_eq!(app.stats.frames(), 1);
         assert!(!app.done());
     }
 
@@ -236,7 +272,7 @@ mod tests {
         // How far the key moves the world is the schedule's business and
         // a real clock's; that the event arrived is this one's.
         assert_eq!(app.report().world.keys(), (1, 0, 0));
-        app.update(&mut LoopControl::default());
+        app.update_at(ONE_STEP, &mut LoopControl::default());
         assert!(!app.done());
         app.event(WindowEvent::CloseRequested);
         assert!(app.done(), "the close request is latched in the world");
@@ -245,7 +281,7 @@ mod tests {
     #[test]
     fn an_update_before_the_window_is_ready_plans_nothing() {
         let mut app = EchoApp::new(&Options::default());
-        app.update(&mut LoopControl::default());
+        app.update_at(ONE_STEP, &mut LoopControl::default());
         assert_eq!(app.stats.frames(), 0);
     }
 

--- a/samples/input_echo/src/cli.rs
+++ b/samples/input_echo/src/cli.rs
@@ -13,7 +13,7 @@ pub const SAMPLE: &str = "input_echo";
 
 /// What the sample accepts, in the words it accepts them.
 pub const USAGE: &str = "usage: input_echo [--headless [--input-trace NAME]] [--frames N] \
-                         [--seed N] [--dump-stats PATH] [--record-trace PATH]";
+                         [--seed N] [--dump-stats PATH] [--record-trace PATH] \n                         [--replay-trace PATH]";
 
 /// The trace a headless run replays unless told otherwise.
 pub const DEFAULT_TRACE: &str = "walk";
@@ -47,6 +47,12 @@ pub struct Options {
     /// says nothing about which, because a trace is the input and not the
     /// thing that produced it.
     pub record_trace: Option<PathBuf>,
+    /// A recorded trace to drive this run, instead of a named script.
+    ///
+    /// The file owns the run: its header carries the length, the
+    /// timestep, the budget and the seed, so the flags that would set
+    /// those are refused alongside it rather than silently losing.
+    pub replay_trace: Option<PathBuf>,
 }
 
 impl Default for Options {
@@ -58,6 +64,7 @@ impl Default for Options {
             trace: DEFAULT_TRACE.to_string(),
             dump_stats: None,
             record_trace: None,
+            replay_trace: None,
         }
     }
 }
@@ -72,12 +79,19 @@ impl Default for Options {
 pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, SampleError> {
     let mut options = Options::default();
     let mut scripted = false;
+    let mut overridden: Vec<&str> = Vec::new();
     let mut args = args.into_iter();
     while let Some(argument) = args.next() {
         match argument.as_str() {
             "--headless" => options.headless = true,
-            "--frames" => options.frames = number(&mut args, "--frames")?,
-            "--seed" => options.seed = number(&mut args, "--seed")?,
+            "--frames" => {
+                options.frames = number(&mut args, "--frames")?;
+                overridden.push("--frames");
+            }
+            "--seed" => {
+                options.seed = number(&mut args, "--seed")?;
+                overridden.push("--seed");
+            }
             "--input-trace" => {
                 options.trace = value(&mut args, "--input-trace")?;
                 scripted = true;
@@ -88,11 +102,34 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
             "--record-trace" => {
                 options.record_trace = Some(PathBuf::from(value(&mut args, "--record-trace")?));
             }
+            "--replay-trace" => {
+                options.replay_trace = Some(PathBuf::from(value(&mut args, "--replay-trace")?));
+            }
             other => {
                 return Err(SampleError::Usage(format!(
                     "unknown argument `{other}`; {USAGE}"
                 )));
             }
+        }
+    }
+    if let Some(path) = &options.replay_trace {
+        // The header owns length, timestep, budget and seed. A flag that
+        // set one of them would be silently ignored or would silently
+        // win, and both make a digest line unexplainable.
+        if scripted {
+            overridden.push("--input-trace");
+        }
+        if !overridden.is_empty() {
+            return Err(SampleError::Usage(format!(
+                "--replay-trace owns the run, so {} cannot be given with it;                  the trace's own header carries them",
+                overridden.join(" and ")
+            )));
+        }
+        if !options.headless {
+            return Err(SampleError::Usage(format!(
+                "--replay-trace needs --headless: replaying {} against a live                  window would mix recorded input with real input",
+                path.display()
+            )));
         }
     }
     if scripted && !options.headless {
@@ -228,6 +265,7 @@ mod tests {
                 seed: 17,
                 trace: "idle".to_string(),
                 dump_stats: Some(PathBuf::from("target/stats.json")),
+                replay_trace: None,
                 record_trace: None,
             }
         );

--- a/samples/input_echo/src/cli.rs
+++ b/samples/input_echo/src/cli.rs
@@ -355,4 +355,28 @@ mod tests {
         assert!(!json.contains("timing"), "{json}");
         assert!(json.ends_with("}}"), "{json}");
     }
+
+    /// The two trace flags are mutually exclusive, and the message names
+    /// the one the header already owns.
+    #[test]
+    fn a_replay_cannot_also_name_a_built_in_trace() {
+        let refused = parse_args(
+            [
+                "--headless",
+                "--replay-trace",
+                "run.trace",
+                "--input-trace",
+                "walk",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        );
+        // One assertion rather than a let-else: the `else` arm is a line
+        // no passing run can reach, and an uncovered line in a test is
+        // still an uncovered line.
+        assert!(
+            matches!(&refused, Err(SampleError::Usage(message)) if message.contains("--input-trace")),
+            "{refused:?}"
+        );
+    }
 }

--- a/samples/input_echo/src/cli.rs
+++ b/samples/input_echo/src/cli.rs
@@ -13,7 +13,7 @@ pub const SAMPLE: &str = "input_echo";
 
 /// What the sample accepts, in the words it accepts them.
 pub const USAGE: &str = "usage: input_echo [--headless [--input-trace NAME]] [--frames N] \
-                         [--seed N] [--dump-stats PATH]";
+                         [--seed N] [--dump-stats PATH] [--record-trace PATH]";
 
 /// The trace a headless run replays unless told otherwise.
 pub const DEFAULT_TRACE: &str = "walk";
@@ -40,6 +40,13 @@ pub struct Options {
     pub trace: String,
     /// Where to write the machine-readable report, if anywhere.
     pub dump_stats: Option<PathBuf>,
+    /// Where to write the run's input as a replayable trace, if anywhere.
+    ///
+    /// Recording is independent of how the run is driven: a scripted run
+    /// records the script, a windowed run records the person. The file
+    /// says nothing about which, because a trace is the input and not the
+    /// thing that produced it.
+    pub record_trace: Option<PathBuf>,
 }
 
 impl Default for Options {
@@ -50,6 +57,7 @@ impl Default for Options {
             seed: 0,
             trace: DEFAULT_TRACE.to_string(),
             dump_stats: None,
+            record_trace: None,
         }
     }
 }
@@ -76,6 +84,9 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
             }
             "--dump-stats" => {
                 options.dump_stats = Some(PathBuf::from(value(&mut args, "--dump-stats")?));
+            }
+            "--record-trace" => {
+                options.record_trace = Some(PathBuf::from(value(&mut args, "--record-trace")?));
             }
             other => {
                 return Err(SampleError::Usage(format!(
@@ -217,6 +228,7 @@ mod tests {
                 seed: 17,
                 trace: "idle".to_string(),
                 dump_stats: Some(PathBuf::from("target/stats.json")),
+                record_trace: None,
             }
         );
     }

--- a/samples/input_echo/src/convert.rs
+++ b/samples/input_echo/src/convert.rs
@@ -64,16 +64,23 @@ const fn key_to_trace(code: KeyCode) -> TraceKey {
     }
 }
 
-const fn button_to_trace(button: PointerButton) -> TraceButton {
-    match button {
+/// `None` for a button this build has no name for.
+///
+/// The wildcard is required because the vocabulary is non-exhaustive, and
+/// it **refuses** rather than folding an unknown button into `Other`. A
+/// silent fold would be the writer-side drop this whole module exists to
+/// prevent: every future button would record as the same one, and the
+/// recording would be wrong in a way nothing could detect.
+const fn button_to_trace(button: PointerButton) -> Option<TraceButton> {
+    Some(match button {
         PointerButton::Left => TraceButton::Left,
         PointerButton::Right => TraceButton::Right,
         PointerButton::Middle => TraceButton::Middle,
         PointerButton::Back => TraceButton::Back,
         PointerButton::Forward => TraceButton::Forward,
         PointerButton::Other(index) => TraceButton::Other(index),
-        _ => TraceButton::Other(u16::MAX),
-    }
+        _ => return None,
+    })
 }
 
 /// Encode one event, or refuse it by name.
@@ -101,9 +108,9 @@ pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
             pressed,
             repeat,
         },
-        WindowEvent::PointerButton { button, pressed } => TraceEvent::PointerButton {
-            button: button_to_trace(button),
-            pressed,
+        WindowEvent::PointerButton { button, pressed } => match button_to_trace(button) {
+            Some(button) => TraceEvent::PointerButton { button, pressed },
+            None => return Err(Unencodable { shape }),
         },
         // The float-bearing shapes are the only ones that can fail on
         // their payload rather than their kind: the trace format holds
@@ -201,7 +208,9 @@ pub const fn from_trace(event: TraceEvent) -> WindowEvent {
 #[cfg(test)]
 mod tests {
     use super::{Unencodable, to_trace};
-    use renew_platform::window::{EVERY_EVENT_SHAPE, WindowEvent, shape_index};
+    use renew_platform::window::{
+        EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index,
+    };
 
     /// Every shape the window seam can produce has an encoding.
     ///
@@ -213,11 +222,7 @@ mod tests {
     #[test]
     fn every_window_event_shape_can_be_written_down() {
         for event in EVERY_EVENT_SHAPE {
-            assert!(
-                to_trace(*event).is_ok(),
-                "shape {} has no encoding: {event:?}",
-                shape_index(event)
-            );
+            assert!(to_trace(*event).is_ok(), "no encoding: {event:?}");
         }
     }
 
@@ -235,8 +240,68 @@ mod tests {
             assert_eq!(
                 super::from_trace(encoded),
                 *event,
-                "shape {} changed in the round trip",
-                shape_index(event)
+                "changed in the round trip: {event:?}"
+            );
+        }
+    }
+
+    /// Every key and every button survives the round trip.
+    ///
+    /// The shape list carries one key and one button, which is all it
+    /// needs to prove each *shape* is encodable — but it leaves twelve
+    /// key arms and five button arms unexercised, and a rename in either
+    /// of the two mirrored vocabularies would go unnoticed. Naming them
+    /// here is the only way to cover the mapping rather than the shape.
+    #[test]
+    fn every_key_and_button_name_maps_back_to_itself() {
+        const BUTTONS: [PointerButton; 6] = [
+            PointerButton::Left,
+            PointerButton::Right,
+            PointerButton::Middle,
+            PointerButton::Back,
+            PointerButton::Forward,
+            PointerButton::Other(9),
+        ];
+
+        const KEYS: [KeyCode; 13] = [
+            KeyCode::Escape,
+            KeyCode::Space,
+            KeyCode::Enter,
+            KeyCode::Tab,
+            KeyCode::ArrowUp,
+            KeyCode::ArrowDown,
+            KeyCode::ArrowLeft,
+            KeyCode::ArrowRight,
+            KeyCode::KeyW,
+            KeyCode::KeyA,
+            KeyCode::KeyS,
+            KeyCode::KeyD,
+            KeyCode::Unidentified,
+        ];
+        for code in KEYS {
+            let event = WindowEvent::Key {
+                code,
+                pressed: true,
+                repeat: false,
+            };
+            let encoded = to_trace(event).expect("every named key encodes");
+            assert_eq!(
+                super::from_trace(encoded),
+                event,
+                "{code:?} did not survive"
+            );
+        }
+
+        for button in BUTTONS {
+            let event = WindowEvent::PointerButton {
+                button,
+                pressed: false,
+            };
+            let encoded = to_trace(event).expect("every named button encodes");
+            assert_eq!(
+                super::from_trace(encoded),
+                event,
+                "{button:?} did not survive"
             );
         }
     }
@@ -265,6 +330,15 @@ mod tests {
             to_trace(wheel),
             Err(Unencodable {
                 shape: shape_index(&wheel)
+            })
+        );
+
+        // The third float-bearing shape, so every one of them is pinned.
+        let scale = WindowEvent::ScaleFactorChanged { scale: f64::NAN };
+        assert_eq!(
+            to_trace(scale),
+            Err(Unencodable {
+                shape: shape_index(&scale)
             })
         );
     }

--- a/samples/input_echo/src/convert.rs
+++ b/samples/input_echo/src/convert.rs
@@ -1,0 +1,189 @@
+//! Translating between the window seam's event vocabulary and the one
+//! the trace format uses.
+//!
+//! The two vocabularies mirror each other deliberately, so almost every
+//! arm here is a rename. That is the point: the codec owns its own
+//! vocabulary and depends on nothing, so a change to the window seam
+//! cannot silently change what a file on disk means. The cost of that
+//! independence is this file, and it is a cost worth paying once.
+//!
+//! # Why encoding returns a result
+//!
+//! The window vocabulary is non-exhaustive, so the match below must
+//! carry a wildcard arm and the compiler will never report a new variant
+//! as unhandled here. The wildcard therefore **refuses** rather than
+//! silently dropping: a recording that meets an event it cannot express
+//! fails, instead of writing a file that is quietly missing events and
+//! replays into a different world.
+//!
+//! The other half of that guarantee lives in the platform crate, which
+//! publishes one value of every shape and an exhaustive match over them.
+//! Adding a variant breaks the build there, and the test at the bottom of
+//! this file then fails until this translation learns the new shape.
+
+use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+use renew_trace::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
+
+/// An event this build cannot write down.
+///
+/// Carries the shape index rather than the event, because the index is
+/// what a reader can act on: it names the arm that needs adding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Unencodable {
+    pub shape: usize,
+}
+
+impl core::fmt::Display for Unencodable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "event shape {} has no trace encoding; recording would silently drop it",
+            self.shape
+        )
+    }
+}
+
+const fn key_to_trace(code: KeyCode) -> TraceKey {
+    match code {
+        KeyCode::Escape => TraceKey::Escape,
+        KeyCode::Space => TraceKey::Space,
+        KeyCode::Enter => TraceKey::Enter,
+        KeyCode::Tab => TraceKey::Tab,
+        KeyCode::ArrowUp => TraceKey::ArrowUp,
+        KeyCode::ArrowDown => TraceKey::ArrowDown,
+        KeyCode::ArrowLeft => TraceKey::ArrowLeft,
+        KeyCode::ArrowRight => TraceKey::ArrowRight,
+        KeyCode::KeyW => TraceKey::KeyW,
+        KeyCode::KeyA => TraceKey::KeyA,
+        KeyCode::KeyS => TraceKey::KeyS,
+        KeyCode::KeyD => TraceKey::KeyD,
+        // Every other physical key already arrived here unidentified;
+        // the trace records that faithfully rather than refusing, because
+        // a key this build does not name is still input that happened.
+        _ => TraceKey::Unidentified,
+    }
+}
+
+const fn button_to_trace(button: PointerButton) -> TraceButton {
+    match button {
+        PointerButton::Left => TraceButton::Left,
+        PointerButton::Right => TraceButton::Right,
+        PointerButton::Middle => TraceButton::Middle,
+        PointerButton::Back => TraceButton::Back,
+        PointerButton::Forward => TraceButton::Forward,
+        PointerButton::Other(index) => TraceButton::Other(index),
+        _ => TraceButton::Other(u16::MAX),
+    }
+}
+
+/// Encode one event, or refuse it by name.
+///
+/// # Errors
+///
+/// [`Unencodable`] when the event is a shape this translation does not
+/// know — which can only happen after a new variant is added to the
+/// window vocabulary and not added here.
+pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
+    // Taken once, up front, so every refusal below names the same
+    // shape the platform does and no arm carries a magic number.
+    let shape = renew_platform::window::shape_index(&event);
+    let encoded = match event {
+        WindowEvent::CloseRequested => TraceEvent::CloseRequested,
+        WindowEvent::RedrawRequested => TraceEvent::RedrawRequested,
+        WindowEvent::Focused(focused) => TraceEvent::Focused(focused),
+        WindowEvent::Resized { width, height } => TraceEvent::Resized { width, height },
+        WindowEvent::Key {
+            code,
+            pressed,
+            repeat,
+        } => TraceEvent::Key {
+            code: key_to_trace(code),
+            pressed,
+            repeat,
+        },
+        WindowEvent::PointerButton { button, pressed } => TraceEvent::PointerButton {
+            button: button_to_trace(button),
+            pressed,
+        },
+        // The float-bearing shapes are the only ones that can fail on
+        // their payload rather than their kind: the trace format holds
+        // finite values only, so a non-finite coordinate is refused here
+        // instead of becoming a bit pattern nothing can compare.
+        WindowEvent::PointerMoved { x, y } => match (FiniteF64::new(x), FiniteF64::new(y)) {
+            (Some(x), Some(y)) => TraceEvent::PointerMoved { x, y },
+            _ => return Err(Unencodable { shape }),
+        },
+        WindowEvent::Wheel { dx, dy } => match (FiniteF32::new(dx), FiniteF32::new(dy)) {
+            (Some(dx), Some(dy)) => TraceEvent::Wheel { dx, dy },
+            _ => return Err(Unencodable { shape }),
+        },
+        WindowEvent::ScaleFactorChanged { scale } => match FiniteF64::new(scale) {
+            Some(scale) => TraceEvent::ScaleFactorChanged { scale },
+            None => return Err(Unencodable { shape }),
+        },
+        // Never `=> {}`. A wildcard that drops is how a recording starts
+        // lying about what happened.
+        _ => return Err(Unencodable { shape }),
+    };
+    Ok(encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Unencodable, to_trace};
+    use renew_platform::window::{EVERY_EVENT_SHAPE, WindowEvent, shape_index};
+
+    /// Every shape the window seam can produce has an encoding.
+    ///
+    /// This is the test the shape list exists for. The compiler already
+    /// refuses to build the platform crate when a variant is added
+    /// without an index; this refuses to build a *recording* that would
+    /// have dropped it. Together they turn "did we remember?" into a
+    /// question the build answers.
+    #[test]
+    fn every_window_event_shape_can_be_written_down() {
+        for event in EVERY_EVENT_SHAPE {
+            assert!(
+                to_trace(*event).is_ok(),
+                "shape {} has no encoding: {event:?}",
+                shape_index(event)
+            );
+        }
+    }
+
+    /// A non-finite payload is refused rather than encoded, because the
+    /// format carries finite values only and a NaN written as a bit
+    /// pattern is a value nothing downstream can compare.
+    #[test]
+    fn a_non_finite_coordinate_is_refused_and_names_its_shape() {
+        let event = WindowEvent::PointerMoved {
+            x: f64::NAN,
+            y: 0.0,
+        };
+        assert_eq!(
+            to_trace(event),
+            Err(Unencodable {
+                shape: shape_index(&event)
+            })
+        );
+
+        let wheel = WindowEvent::Wheel {
+            dx: 0.0,
+            dy: f32::INFINITY,
+        };
+        assert_eq!(
+            to_trace(wheel),
+            Err(Unencodable {
+                shape: shape_index(&wheel)
+            })
+        );
+    }
+
+    /// The refusal says what a reader can act on.
+    #[test]
+    fn the_refusal_names_the_shape_in_its_message() {
+        let shown = Unencodable { shape: 5 }.to_string();
+        assert!(shown.contains('5'), "{shown}");
+        assert!(shown.contains("drop"), "{shown}");
+    }
+}

--- a/samples/input_echo/src/convert.rs
+++ b/samples/input_echo/src/convert.rs
@@ -128,6 +128,76 @@ pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
     Ok(encoded)
 }
 
+const fn key_from_trace(code: TraceKey) -> KeyCode {
+    match code {
+        TraceKey::Escape => KeyCode::Escape,
+        TraceKey::Space => KeyCode::Space,
+        TraceKey::Enter => KeyCode::Enter,
+        TraceKey::Tab => KeyCode::Tab,
+        TraceKey::ArrowUp => KeyCode::ArrowUp,
+        TraceKey::ArrowDown => KeyCode::ArrowDown,
+        TraceKey::ArrowLeft => KeyCode::ArrowLeft,
+        TraceKey::ArrowRight => KeyCode::ArrowRight,
+        TraceKey::KeyW => KeyCode::KeyW,
+        TraceKey::KeyA => KeyCode::KeyA,
+        TraceKey::KeyS => KeyCode::KeyS,
+        TraceKey::KeyD => KeyCode::KeyD,
+        TraceKey::Unidentified => KeyCode::Unidentified,
+    }
+}
+
+const fn button_from_trace(button: TraceButton) -> PointerButton {
+    match button {
+        TraceButton::Left => PointerButton::Left,
+        TraceButton::Right => PointerButton::Right,
+        TraceButton::Middle => PointerButton::Middle,
+        TraceButton::Back => PointerButton::Back,
+        TraceButton::Forward => PointerButton::Forward,
+        TraceButton::Other(index) => PointerButton::Other(index),
+    }
+}
+
+/// Decode one event.
+///
+/// Total, and it needs no result: the trace vocabulary is this tree's own
+/// and every one of its shapes has a window event to become. That is the
+/// asymmetry the two directions are supposed to have — encoding can meet
+/// a window event the format has no word for, decoding cannot meet a word
+/// the format did not define.
+#[must_use]
+pub const fn from_trace(event: TraceEvent) -> WindowEvent {
+    match event {
+        TraceEvent::CloseRequested => WindowEvent::CloseRequested,
+        TraceEvent::RedrawRequested => WindowEvent::RedrawRequested,
+        TraceEvent::Focused(focused) => WindowEvent::Focused(focused),
+        TraceEvent::Resized { width, height } => WindowEvent::Resized { width, height },
+        TraceEvent::Key {
+            code,
+            pressed,
+            repeat,
+        } => WindowEvent::Key {
+            code: key_from_trace(code),
+            pressed,
+            repeat,
+        },
+        TraceEvent::PointerButton { button, pressed } => WindowEvent::PointerButton {
+            button: button_from_trace(button),
+            pressed,
+        },
+        TraceEvent::PointerMoved { x, y } => WindowEvent::PointerMoved {
+            x: x.value(),
+            y: y.value(),
+        },
+        TraceEvent::Wheel { dx, dy } => WindowEvent::Wheel {
+            dx: dx.value(),
+            dy: dy.value(),
+        },
+        TraceEvent::ScaleFactorChanged { scale } => WindowEvent::ScaleFactorChanged {
+            scale: scale.value(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Unencodable, to_trace};
@@ -146,6 +216,26 @@ mod tests {
             assert!(
                 to_trace(*event).is_ok(),
                 "shape {} has no encoding: {event:?}",
+                shape_index(event)
+            );
+        }
+    }
+
+    /// Every shape survives the round trip through the trace vocabulary.
+    ///
+    /// The shape test above proves each one can be written down. This
+    /// proves writing it down loses nothing — which is the property a
+    /// replay depends on and the one a rename would quietly break, since
+    /// two vocabularies that mirror each other are exactly the kind of
+    /// thing that drifts one arm at a time.
+    #[test]
+    fn every_shape_survives_the_round_trip_unchanged() {
+        for event in EVERY_EVENT_SHAPE {
+            let encoded = to_trace(*event).expect("every shape encodes");
+            assert_eq!(
+                super::from_trace(encoded),
+                *event,
+                "shape {} changed in the round trip",
                 shape_index(event)
             );
         }

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -36,8 +36,9 @@ use std::process::ExitCode;
 
 mod app;
 mod cli;
-mod convert;
+pub mod convert;
 mod error;
+pub mod record;
 mod scripted;
 mod trace;
 mod world;

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -76,9 +76,25 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     }
 }
 
+/// The most a trace file may be before this sample refuses to read it.
+///
+/// Recordings here are tens of lines; the limit exists for the file that
+/// is not a recording at all.
+const TRACE_BYTE_LIMIT: usize = 1 << 20;
+
 fn run<I: IntoIterator<Item = String>>(args: I) -> Result<Report, SampleError> {
     let options = parse_args(args)?;
-    let report = if options.headless {
+    let report = if let Some(path) = &options.replay_trace {
+        // Bounded, because a trace is untrusted input and the parser can
+        // only judge bytes it already holds. A megabyte is far more than
+        // any recording this sample produces and far less than a file
+        // that could hurt.
+        let text = renew_platform::fs::read_to_string_bounded(path, TRACE_BYTE_LIMIT)
+            .map_err(|error| SampleError::failed("reading the trace file", &error))?;
+        let recorded = renew_trace::parse(&text)
+            .map_err(|error| SampleError::failed("reading the trace file", &error))?;
+        scripted::replay_recorded(&recorded)?
+    } else if options.headless {
         scripted::run(&options)?
     } else {
         app::run(&options)?

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -36,6 +36,7 @@ use std::process::ExitCode;
 
 mod app;
 mod cli;
+mod convert;
 mod error;
 mod scripted;
 mod trace;

--- a/samples/input_echo/src/record.rs
+++ b/samples/input_echo/src/record.rs
@@ -1,0 +1,90 @@
+//! Recording a run's input as it happens.
+//!
+//! The recorder sits beside the world, not inside it: it watches the
+//! same events the simulation consumes and notes which tick each was
+//! delivered before. That is the whole contract — a trace is the
+//! external stimulus indexed by simulation tick, and the tick an event
+//! carries is the number of steps that had already run when it arrived.
+//!
+//! It records **every** event the world was given, not the subset that
+//! looks like user input. The world counts what it is told, including
+//! repaint requests it ignores, and that count reaches the state digest;
+//! a recording that quietly filtered would replay into a different
+//! world and the digests would disagree with nothing to explain it.
+
+use renew_platform::window::WindowEvent;
+use renew_trace::{Trace, TraceError, TraceHeader};
+
+use crate::convert::{Unencodable, to_trace};
+
+/// Collects events against the tick they were delivered before.
+#[derive(Debug, Default)]
+pub struct Recorder {
+    events: Vec<(u64, renew_trace::TraceEvent)>,
+    /// The first event this build could not write down. Kept rather than
+    /// returned immediately so a recording fails once, at the end, with
+    /// the run intact — a refusal mid-frame would abandon a session the
+    /// person was in the middle of.
+    refused: Option<Unencodable>,
+}
+
+impl Recorder {
+    /// Note one event, delivered before the step numbered `tick`.
+    pub fn event(&mut self, tick: u64, event: WindowEvent) {
+        match to_trace(event) {
+            Ok(encoded) => self.events.push((tick, encoded)),
+            Err(refusal) => {
+                self.refused.get_or_insert(refusal);
+            }
+        }
+    }
+
+    /// How many events have been recorded so far.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    /// Whether nothing has been recorded yet.
+    ///
+    /// A run that ends with an empty recording is legal — a session in
+    /// which nobody touched anything is a real session, and its trace
+    /// replays to a world that also did nothing.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Close the recording.
+    ///
+    /// # Errors
+    ///
+    /// Returns the trace crate's own refusal when the header or the
+    /// event sequence does not satisfy the format — the same check a
+    /// reader would apply, run here so a recorder can never write a file
+    /// its own reader rejects.
+    pub fn finish(self, header: TraceHeader) -> Result<Trace, RecordError> {
+        if let Some(refusal) = self.refused {
+            return Err(RecordError::Unencodable(refusal));
+        }
+        Trace::new(header, self.events).map_err(RecordError::Malformed)
+    }
+}
+
+/// Why a recording could not be closed.
+#[derive(Debug)]
+pub enum RecordError {
+    /// An event arrived that this build has no encoding for.
+    Unencodable(Unencodable),
+    /// The recorded sequence does not satisfy the format.
+    Malformed(TraceError),
+}
+
+impl core::fmt::Display for RecordError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Unencodable(refusal) => write!(f, "{refusal}"),
+            Self::Malformed(error) => write!(f, "the recording is not a valid trace: {error}"),
+        }
+    }
+}

--- a/samples/input_echo/src/scripted.rs
+++ b/samples/input_echo/src/scripted.rs
@@ -5,10 +5,13 @@
 //! processes and machines. It is what makes a windowing sample provable
 //! in CI.
 
+use core::num::{NonZeroU32, NonZeroU64};
+
 use renew_frame::{FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};
 use renew_trace::TraceHeader;
 
 use crate::cli::{Options, Report};
+use crate::convert;
 use crate::error::SampleError;
 use crate::record::Recorder;
 use crate::trace::{self, Trace};
@@ -116,6 +119,80 @@ pub fn replay_recording(
         stats,
         world,
     }
+}
+
+/// Drive a run from a recorded trace.
+///
+/// The header owns the run: its tick count is the length, its timestep
+/// and budget configure the loop, and its seed picks the world. Nothing
+/// on the command line may override them, because a replay that took its
+/// length from one place and its input from another would not be a replay
+/// of anything.
+///
+/// A close request inside the file does **not** end the run early. The
+/// recorded run's own length is already in the header, so honouring the
+/// event as well would shorten a replay that the recording says ran
+/// longer.
+///
+/// # Errors
+///
+/// [`SampleError::Usage`] when the file describes a different sample, or
+/// when a header field the frame loop cannot accept — a zero timestep or
+/// a zero budget — reaches it. The codec stores those numbers without
+/// interpreting them, so refusing them is this driver's job.
+pub fn replay_recorded(recorded: &renew_trace::Trace) -> Result<Report, SampleError> {
+    let header = recorded.header();
+    if header.sample() != SAMPLE_NAME {
+        return Err(SampleError::Usage(format!(
+            "this trace was recorded by `{}`, not `{SAMPLE_NAME}`",
+            header.sample()
+        )));
+    }
+    let timestep = NonZeroU64::new(header.timestep_ns())
+        .map(Timestep::from_nanos)
+        .ok_or_else(|| {
+            SampleError::Usage("a trace with a zero timestep cannot be replayed".into())
+        })?;
+    let budget = NonZeroU32::new(header.budget())
+        .map(StepBudget::new)
+        .ok_or_else(|| {
+            SampleError::Usage("a trace with a zero step budget cannot be replayed".into())
+        })?;
+    let seed = header
+        .value("seed")
+        .map_or(Ok(0), str::parse)
+        .map_err(|_| SampleError::Usage("the trace's seed is not a number".to_string()))?;
+
+    let interval = timestep.nanos().get();
+    let mut world = EchoWorld::new(seed);
+    let mut frame = FrameLoop::new(timestep, budget, Timestamp::from_nanos(0));
+    let mut stats = FrameStats::new();
+    let deliver = |world: &mut EchoWorld, tick: u64| {
+        for (at, event) in recorded.events() {
+            if *at == tick {
+                world.event(convert::from_trace(*event));
+            }
+        }
+    };
+    for tick in 0..header.ticks() {
+        deliver(&mut world, tick);
+        let plan = frame.begin_frame(Timestamp::from_nanos(interval.saturating_mul(tick + 1)));
+        for step in plan.steps() {
+            world.step(step);
+        }
+        stats.absorb(&plan);
+    }
+    // The trailing bucket: events recorded at the run's own tick count
+    // arrived after the final step, which is where a close request almost
+    // always lands.
+    deliver(&mut world, header.ticks());
+
+    Ok(Report {
+        seed,
+        source: "replay",
+        stats,
+        world,
+    })
 }
 
 #[cfg(test)]

--- a/samples/input_echo/src/scripted.rs
+++ b/samples/input_echo/src/scripted.rs
@@ -197,8 +197,9 @@ pub fn replay_recorded(recorded: &renew_trace::Trace) -> Result<Report, SampleEr
 
 #[cfg(test)]
 mod tests {
-    use super::{replay, run};
+    use super::{SAMPLE_NAME, replay, replay_recorded, run};
     use crate::cli::Options;
+    use crate::error::SampleError;
     use crate::trace;
 
     fn walk(frames: u64) -> crate::cli::Report {
@@ -277,5 +278,64 @@ mod tests {
             ..options
         };
         assert!(run(&unknown).is_err());
+    }
+
+    /// The driver refuses what the codec is not asked to judge.
+    ///
+    /// The codec stores the timestep and the budget without interpreting
+    /// them, so a zero reaches this driver intact — and the frame loop's
+    /// types cannot hold one. Refusing here is not defensive duplication;
+    /// it is the only place the check can live.
+    #[test]
+    fn a_header_the_frame_loop_cannot_accept_is_refused() {
+        let header = |sample: &str, timestep: u64, budget: u32| {
+            renew_trace::TraceHeader::new(sample, 1, timestep, budget)
+                .expect("a well-formed header")
+        };
+        let trace = |header| renew_trace::Trace::new(header, Vec::new()).expect("no events");
+
+        let wrong = replay_recorded(&trace(header("hello_triangle", 1, 1)));
+        assert!(
+            matches!(&wrong, Err(SampleError::Usage(message)) if message.contains("hello_triangle")),
+            "{wrong:?}"
+        );
+
+        let no_timestep = replay_recorded(&trace(header(SAMPLE_NAME, 0, 1)));
+        assert!(
+            matches!(&no_timestep, Err(SampleError::Usage(message)) if message.contains("timestep")),
+            "{no_timestep:?}"
+        );
+
+        let no_budget = replay_recorded(&trace(header(SAMPLE_NAME, 1, 0)));
+        assert!(
+            matches!(&no_budget, Err(SampleError::Usage(message)) if message.contains("budget")),
+            "{no_budget:?}"
+        );
+    }
+
+    /// A seed that is not a number is refused rather than silently zero.
+    #[test]
+    fn a_seed_that_is_not_a_number_is_refused() {
+        let header = renew_trace::TraceHeader::new(SAMPLE_NAME, 1, 1, 1)
+            .and_then(|header| header.with_key("seed", "later"))
+            .expect("a well-formed header");
+        let trace = renew_trace::Trace::new(header, Vec::new()).expect("no events");
+        let refused = replay_recorded(&trace);
+        assert!(
+            matches!(&refused, Err(SampleError::Usage(message)) if message.contains("seed")),
+            "{refused:?}"
+        );
+    }
+
+    /// With no seed key at all the run is seed zero, not an error: the
+    /// key is the caller's, and a trace that omits it is still a trace.
+    #[test]
+    fn a_trace_without_a_seed_replays_at_zero() {
+        let header =
+            renew_trace::TraceHeader::new(SAMPLE_NAME, 1, 16_666_667, 5).expect("a header");
+        let trace = renew_trace::Trace::new(header, Vec::new()).expect("no events");
+        let report = replay_recorded(&trace).expect("a seedless trace still replays");
+        assert_eq!(report.seed, 0);
+        assert_eq!(report.world.ticks(), 1);
     }
 }

--- a/samples/input_echo/src/scripted.rs
+++ b/samples/input_echo/src/scripted.rs
@@ -6,9 +6,11 @@
 //! in CI.
 
 use renew_frame::{FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};
+use renew_trace::TraceHeader;
 
 use crate::cli::{Options, Report};
 use crate::error::SampleError;
+use crate::record::Recorder;
 use crate::trace::{self, Trace};
 use crate::world::EchoWorld;
 
@@ -25,8 +27,33 @@ const FRAME_INTERVAL_NS: u64 = Timestep::HZ_60.nanos().get();
 /// [`SampleError::Usage`] when no trace goes by that name.
 pub fn run(options: &Options) -> Result<Report, SampleError> {
     let trace = trace::by_name(&options.trace)?;
-    Ok(replay(trace, options.seed, options.frames))
+    let Some(path) = &options.record_trace else {
+        return Ok(replay(trace, options.seed, options.frames));
+    };
+
+    let mut recorder = Recorder::default();
+    let report = replay_recording(trace, options.seed, options.frames, Some(&mut recorder));
+    // The header is written after the run, not before it, because two of
+    // its fields are facts about what happened: how many ticks the run
+    // actually reached, which the trace's own close request decides.
+    let header = TraceHeader::new(
+        SAMPLE_NAME,
+        report.world.ticks(),
+        FRAME_INTERVAL_NS,
+        StepBudget::DEFAULT.get().get(),
+    )
+    .and_then(|header| header.with_key("seed", &options.seed.to_string()))
+    .map_err(|error| SampleError::failed("describing the recording", &error))?;
+    let written = recorder
+        .finish(header)
+        .map_err(|error| SampleError::failed("closing the recording", &error))?;
+    renew_platform::fs::write(path, renew_trace::write(&written).as_bytes())
+        .map_err(|error| SampleError::failed("writing the trace file", &error))?;
+    Ok(report)
 }
+
+/// The name a recording carries so a replay can refuse the wrong sample.
+const SAMPLE_NAME: &str = "input_echo";
 
 /// Replay one trace for at most `frames` frames.
 ///
@@ -37,6 +64,23 @@ pub fn run(options: &Options) -> Result<Report, SampleError> {
 /// script or a person.
 #[must_use]
 pub fn replay(trace: &Trace, seed: u64, frames: u64) -> Report {
+    replay_recording(trace, seed, frames, None)
+}
+
+/// Replay a trace, optionally recording the events as they are delivered.
+///
+/// The recorder sees exactly what the world sees, at the tick the world
+/// sees it. That is why recording lives here rather than beside the trace
+/// table: a recording taken from the source data would be a copy of the
+/// input, not a record of what this run did with it, and the two stop
+/// agreeing the moment a driver changes.
+#[must_use]
+pub fn replay_recording(
+    trace: &Trace,
+    seed: u64,
+    frames: u64,
+    mut recorder: Option<&mut Recorder>,
+) -> Report {
     let mut world = EchoWorld::new(seed);
     let mut frame = FrameLoop::new(
         Timestep::HZ_60,
@@ -47,6 +91,12 @@ pub fn replay(trace: &Trace, seed: u64, frames: u64) -> Report {
     for index in 1..=frames {
         for (at, event) in trace.events {
             if *at == index {
+                // `index - 1` is the tick the next step will carry, which
+                // is what the format means by an event's tick: delivered
+                // before that step.
+                if let Some(recorder) = recorder.as_deref_mut() {
+                    recorder.event(index.saturating_sub(1), *event);
+                }
                 world.event(*event);
             }
         }

--- a/samples/input_echo/tests/recording.rs
+++ b/samples/input_echo/tests/recording.rs
@@ -1,0 +1,101 @@
+//! Recording a sequence of events produces exactly the expected file.
+//!
+//! The assertion is against a string typed by hand, not one the writer
+//! produced. That distinction is the whole value of the test: a
+//! round-trip through a writer and reader that are inverse to each other
+//! passes even when both are wrong in the same way, and only text a
+//! person wrote down can catch the pair agreeing on something incorrect.
+
+use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+use renew_sample_input_echo::record::Recorder;
+use renew_trace::{TraceHeader, write};
+
+/// The header every test here records against.
+///
+/// Returns the result rather than unwrapping it: the lint that forbids
+/// `expect` outside tests reaches helpers in a test file too, because
+/// the exemption follows `#[test]` rather than the file.
+fn header() -> Result<TraceHeader, renew_trace::TraceError> {
+    TraceHeader::new("input_echo", 4, 16_666_667, 8)
+}
+
+#[test]
+fn a_recorded_sequence_is_written_exactly_as_expected() {
+    let mut recorder = Recorder::default();
+    assert!(recorder.is_empty(), "a fresh recorder has nothing in it");
+    recorder.event(
+        0,
+        WindowEvent::Key {
+            code: KeyCode::KeyD,
+            pressed: true,
+            repeat: false,
+        },
+    );
+    recorder.event(
+        2,
+        WindowEvent::Resized {
+            width: 640,
+            height: 360,
+        },
+    );
+    // Two events on one tick: their recorded order is part of the trace,
+    // so this also pins that the recorder does not sort or coalesce.
+    recorder.event(
+        2,
+        WindowEvent::PointerButton {
+            button: PointerButton::Left,
+            pressed: true,
+        },
+    );
+    // The trailing bucket: an event delivered after the final step. This
+    // is the common case for a close request, not an edge case.
+    recorder.event(4, WindowEvent::CloseRequested);
+
+    let trace = recorder
+        .finish(header().expect("a well-formed header"))
+        .expect("a recordable sequence");
+    let expected = concat!(
+        "renew-trace 0 sample=input_echo ticks=4 timestep_ns=16666667 budget=8\n",
+        "e 0 key key-d down\n",
+        "e 2 resize 640 360\n",
+        "e 2 button left down\n",
+        "e 4 close\n",
+    );
+    assert_eq!(write(&trace), expected);
+}
+
+/// Recording never silently drops. A payload the format cannot carry
+/// fails the whole recording rather than producing a file that is
+/// quietly missing an event and replays into a different world.
+#[test]
+fn a_non_finite_payload_fails_the_recording_rather_than_the_event() {
+    let mut recorder = Recorder::default();
+    recorder.event(
+        0,
+        WindowEvent::PointerMoved {
+            x: f64::NAN,
+            y: 0.0,
+        },
+    );
+    recorder.event(1, WindowEvent::CloseRequested);
+    // The good event was still accepted — the refusal is deferred so a
+    // live session is not abandoned mid-frame — but the recording as a
+    // whole refuses to close.
+    assert_eq!(recorder.len(), 1);
+    let refused = recorder
+        .finish(header().expect("a well-formed header"))
+        .expect_err("must refuse");
+    assert!(refused.to_string().contains("drop"), "{refused}");
+}
+
+/// A tick past the header's count is refused by the same rule a reader
+/// would apply, so a recorder cannot write a file its own reader rejects.
+#[test]
+fn an_event_past_the_final_tick_is_refused_at_recording_time() {
+    let mut recorder = Recorder::default();
+    recorder.event(5, WindowEvent::CloseRequested);
+    let refused = recorder
+        .finish(header().expect("a well-formed header"))
+        .expect_err("must refuse");
+    assert!(refused.to_string().contains("trace"), "{refused}");
+}

--- a/samples/input_echo/tests/recording.rs
+++ b/samples/input_echo/tests/recording.rs
@@ -99,3 +99,82 @@ fn an_event_past_the_final_tick_is_refused_at_recording_time() {
         .expect_err("must refuse");
     assert!(refused.to_string().contains("trace"), "{refused}");
 }
+
+/// Recording a scripted run produces a file that says what the run did.
+///
+/// The expected text is written out here in full rather than compared to
+/// something the recorder produced, so this fails if the recorder, the
+/// codec, or the driver's idea of which tick an event belongs to changes
+/// — which is the point. It also pins the whole vocabulary in one place:
+/// every event shape the sample can deliver appears below.
+#[test]
+fn a_scripted_run_records_the_input_it_was_given() {
+    let path = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("walk-recording.trace");
+    let _ = std::fs::remove_file(&path);
+
+    let code = renew_sample_input_echo::run_cli(
+        [
+            "--headless",
+            "--input-trace",
+            "walk",
+            "--seed",
+            "3",
+            "--record-trace",
+            &path.to_string_lossy(),
+        ]
+        .into_iter()
+        .map(str::to_string),
+    );
+    assert_eq!(code, 0, "the run should succeed");
+
+    let recorded = std::fs::read_to_string(&path).expect("the trace the run was asked for");
+    let expected = concat!(
+        "renew-trace 0 sample=input_echo ticks=20 timestep_ns=16666667 budget=5 seed=3\n",
+        "e 1 key arrow-right down\n",
+        "e 1 pointer 0x4029000000000000 0x4041400000000000\n",
+        "e 3 key arrow-down down\n",
+        "e 5 button left down\n",
+        "e 5 button left up\n",
+        "e 7 key arrow-down up\n",
+        "e 8 wheel 0x00000000 0x41800000\n",
+        "e 9 focus in\n",
+        "e 10 resize 640 360\n",
+        "e 11 redraw\n",
+        "e 12 key arrow-right down repeat\n",
+        "e 13 key arrow-right up\n",
+        "e 15 scale 0x4000000000000000\n",
+        "e 19 close\n",
+    );
+    assert_eq!(recorded, expected);
+}
+
+/// What the recorder writes, its own reader accepts — and reproduces.
+///
+/// A recorder that emitted something its reader refused would be the
+/// defect the format's tick rules exist to prevent, and the only way to
+/// know is to read the file back.
+#[test]
+fn the_recorded_file_reads_back_and_rewrites_identically() {
+    let path = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("walk-roundtrip.trace");
+    let _ = std::fs::remove_file(&path);
+    let code = renew_sample_input_echo::run_cli(
+        [
+            "--headless",
+            "--input-trace",
+            "walk",
+            "--record-trace",
+            &path.to_string_lossy(),
+        ]
+        .into_iter()
+        .map(str::to_string),
+    );
+    assert_eq!(code, 0);
+
+    let text = std::fs::read_to_string(&path).expect("the recorded trace");
+    let parsed =
+        renew_trace::parse(&text).expect("the recorder must not write what it cannot read");
+    assert_eq!(renew_trace::write(&parsed), text);
+    // The trailing bucket is the common case, not an edge case: the walk
+    // trace ends by asking to close, and that arrives after the last step.
+    assert_eq!(parsed.header().ticks(), 20);
+}

--- a/samples/input_echo/tests/replay.rs
+++ b/samples/input_echo/tests/replay.rs
@@ -1,0 +1,219 @@
+//! Replaying a recorded trace reproduces the run that produced it.
+//!
+//! The assertions here are built around one question: what would still
+//! pass if the file were being ignored? A replay compared only against
+//! another replay answers nothing, so each test below is anchored either
+//! on a run that actually happened or on a hand-computed number.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_input_echo");
+
+fn scratch(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(format!("replay-{name}.trace"))
+}
+
+/// Run the binary and report what it said.
+///
+/// A process that will not start is reported through the same assertions
+/// as one that started and misbehaved, rather than through a panic here:
+/// the exit code comes back as `None`, which every caller already checks.
+fn run(args: &[&str]) -> (String, String, Option<i32>) {
+    let Ok(out) = Command::new(BINARY).args(args).output() else {
+        return (String::new(), format!("could not run {BINARY}"), None);
+    };
+    (
+        String::from_utf8_lossy(&out.stdout)
+            .replace("\r\n", "\n")
+            .trim()
+            .to_string(),
+        String::from_utf8_lossy(&out.stderr)
+            .replace("\r\n", "\n")
+            .trim()
+            .to_string(),
+        out.status.code(),
+    )
+}
+
+fn field<'a>(line: &'a str, name: &str) -> &'a str {
+    line.split_whitespace()
+        .find_map(|part| part.strip_prefix(&format!("{name}=")))
+        .unwrap_or_default()
+}
+
+/// The round trip: a replay reproduces the simulation of the run recorded.
+///
+/// Compared against the *recorded run's* own digest, not against a second
+/// replay — the whole point is that the file carries the run across
+/// processes.
+#[test]
+fn replaying_a_recording_reproduces_the_run_that_made_it() {
+    let path = scratch("roundtrip");
+    let (recorded, _, code) = run(&[
+        "--headless",
+        "--input-trace",
+        "walk",
+        "--seed",
+        "3",
+        "--record-trace",
+        &path.to_string_lossy(),
+    ]);
+    assert_eq!(code, Some(0));
+
+    let (replayed, _, code) = run(&["--headless", "--replay-trace", &path.to_string_lossy()]);
+    assert_eq!(code, Some(0));
+
+    assert_eq!(
+        field(&recorded, "state_hash"),
+        field(&replayed, "state_hash")
+    );
+    assert_eq!(field(&recorded, "ticks"), field(&replayed, "ticks"));
+    assert_eq!(field(&recorded, "seed"), field(&replayed, "seed"));
+    // Not vacuous: a digest of nothing would also be equal to itself.
+    assert!(
+        field(&recorded, "state_hash").starts_with("0x"),
+        "{recorded}"
+    );
+    assert_ne!(field(&recorded, "ticks"), "0", "{recorded}");
+}
+
+/// Shifting every event by one tick changes the outcome.
+///
+/// This is the assertion that proves the tick column is read at all. The
+/// header is untouched, so the run is the same length and the same shape;
+/// only *when* each event arrives moves. A driver that delivered
+/// everything at tick zero, or ignored the column entirely, passes every
+/// other test here and fails this one.
+#[test]
+fn moving_every_event_one_tick_later_changes_the_run() {
+    let original = scratch("shift-original");
+    let _ = run(&[
+        "--headless",
+        "--input-trace",
+        "walk",
+        "--seed",
+        "0",
+        "--record-trace",
+        &original.to_string_lossy(),
+    ]);
+    let text = std::fs::read_to_string(&original).expect("recorded");
+    // Both sides of this comparison are REPLAYS, of two files differing
+    // only in the tick column. Comparing against the original recorded
+    // run instead would pass for the wrong reason: any broken replay
+    // differs from a correct recording, so the assertion held even for a
+    // driver that ignored ticks entirely. This test was found vacuous
+    // exactly that way, by mutating the driver and watching it pass.
+    let (before, stderr, code) =
+        run(&["--headless", "--replay-trace", &original.to_string_lossy()]);
+    assert_eq!(code, Some(0), "{stderr}");
+
+    // Shift only the event ticks, and only where there is headroom: the
+    // last event sits at the run's final tick, which has none.
+    let shifted: String = text
+        .lines()
+        .map(|line| {
+            let Some(rest) = line.strip_prefix("e ") else {
+                return line.to_string();
+            };
+            let (tick, tail) = rest.split_once(' ').expect("an event has a kind");
+            let tick: u64 = tick.parse().expect("a decimal tick");
+            format!("e {} {tail}", tick.saturating_add(1).min(19))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+    assert_ne!(shifted, text, "the shift must actually change the file");
+
+    let moved = scratch("shift-moved");
+    std::fs::write(&moved, &shifted).expect("write the shifted trace");
+    let (after, stderr, code) = run(&["--headless", "--replay-trace", &moved.to_string_lossy()]);
+    assert_eq!(code, Some(0), "{stderr}");
+    assert_ne!(
+        field(&before, "state_hash"),
+        field(&after, "state_hash"),
+        "shifting every event left the world unchanged, so the tick column is not being read"
+    );
+}
+
+/// The header's fields reach the run rather than being parsed and dropped.
+///
+/// A replay that read the header and then used its own defaults would
+/// pass the round trip, because the recording was made with those same
+/// defaults. Changing one field has to change the answer.
+#[test]
+fn a_header_field_the_driver_ignored_would_not_change_the_run() {
+    let path = scratch("header-original");
+    let (_, _, _) = run(&[
+        "--headless",
+        "--input-trace",
+        "walk",
+        "--seed",
+        "0",
+        "--record-trace",
+        &path.to_string_lossy(),
+    ]);
+    let text = std::fs::read_to_string(&path).expect("recorded");
+    let (baseline, _, _) = run(&["--headless", "--replay-trace", &path.to_string_lossy()]);
+
+    // The seed selects the movement speed, so a different one must move
+    // the world differently — and the seed lives only in the header.
+    let reseeded = text.replace("seed=0", "seed=2");
+    assert_ne!(reseeded, text);
+    let other = scratch("header-reseeded");
+    std::fs::write(&other, &reseeded).expect("write");
+    let (changed, stderr, code) = run(&["--headless", "--replay-trace", &other.to_string_lossy()]);
+    assert_eq!(code, Some(0), "{stderr}");
+    assert_eq!(field(&changed, "seed"), "2");
+    assert_ne!(
+        field(&baseline, "state_hash"),
+        field(&changed, "state_hash"),
+        "the header's seed never reached the world"
+    );
+}
+
+/// A missing or malformed trace is refused, never quietly replaced by a
+/// built-in one. A silent fallback would make every assertion above pass
+/// while the file was ignored.
+#[test]
+fn a_trace_that_cannot_be_read_is_refused_rather_than_replaced() {
+    let missing = scratch("does-not-exist");
+    let _ = std::fs::remove_file(&missing);
+    let (_, stderr, code) = run(&["--headless", "--replay-trace", &missing.to_string_lossy()]);
+    assert_eq!(code, Some(1), "{stderr}");
+
+    let junk = scratch("not-a-trace");
+    std::fs::write(&junk, "this is not a trace\n").expect("write");
+    let (_, stderr, code) = run(&["--headless", "--replay-trace", &junk.to_string_lossy()]);
+    assert_eq!(code, Some(1), "{stderr}");
+    assert!(stderr.contains("trace"), "{stderr}");
+}
+
+/// The flags the header owns are refused alongside it, rather than one of
+/// them silently winning.
+#[test]
+fn flags_the_header_owns_are_refused_with_it() {
+    let path = scratch("owned-flags");
+    let _ = run(&[
+        "--headless",
+        "--input-trace",
+        "walk",
+        "--record-trace",
+        &path.to_string_lossy(),
+    ]);
+    for extra in [["--seed", "1"], ["--frames", "5"]] {
+        let (_, stderr, code) = run(&[
+            "--headless",
+            "--replay-trace",
+            &path.to_string_lossy(),
+            extra[0],
+            extra[1],
+        ]);
+        assert_eq!(code, Some(2), "{} should be refused: {stderr}", extra[0]);
+        assert!(stderr.contains(extra[0]), "{stderr}");
+    }
+    // And a replay against a live window is refused, not silently made headless.
+    let (_, stderr, code) = run(&["--replay-trace", &path.to_string_lossy()]);
+    assert_eq!(code, Some(2), "{stderr}");
+    assert!(stderr.contains("--headless"), "{stderr}");
+}


### PR DESCRIPTION
Both halves of record/replay. A headless run given `--record-trace` writes what it was fed, at the tick it was fed; a run given `--replay-trace` reads that file back and reproduces the simulation exactly, across separate processes.

**The round trip is real, not asserted.** Recording and then replaying produces the same `state_hash`, `ticks` and `seed` — compared against the *recorded run's own digest*, not against a second replay, because a replay compared only to another replay answers nothing.

**The header owns the run.** Its tick count is the length, its timestep and budget configure the loop, its seed picks the world, and the flags that would set any of those are refused alongside it rather than one silently winning. A close request inside the file does not end the run early either: the recorded length is already in the header.

**Encoding returns a result and decoding does not**, and the asymmetry is deliberate — encoding can meet a window event the format has no word for, decoding cannot meet a word the format did not define. The wildcard on the encoding side refuses rather than dropping, so a recording that meets an unencodable event fails outright instead of writing a file quietly missing events.

## The tests, and one that was wrong

Five assertions, each anchored on something outside itself. Shifting every event by one tick must change the outcome; changing the header's seed must change the outcome; a missing or malformed file is refused rather than replaced by a built-in trace; the flags the header owns are refused with it.

**The shift test was vacuous when first written**, and it was found by mutation rather than by review. It compared the original *recorded run* against a replay of the shifted file — so any broken replay differed from a correct recording and the assertion held even for a driver that ignored the tick column entirely. Both sides must be replays of two files differing only in that column. The reason is written into the test.

**Three mutations are confirmed caught, each by a different test:** delivering events at or before their tick, ignoring the tick column entirely, and ignoring the header's seed.

Also proven: every event shape survives the round trip through the trace vocabulary unchanged — the property a replay depends on, and the one that would drift if either of the two mirrored vocabularies were renamed alone.

## Verified locally

- `cargo test --workspace` — **67 suites, 709 tests, 0 failures**
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean
- `renew check` healthy; removability cell verified upward-closed in both directions
