### PR TITLE
Add record and replay subcommands

### DIFF
--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -14,16 +14,20 @@ pub enum Command {
     Check,
     Coverage,
     Doctor,
+    Record,
+    Replay,
 }
 
 impl Command {
     /// Every subcommand, in the order `usage` lists them.
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 11] = [
         Self::Configure,
         Self::Build,
         Self::Test,
         Self::Bench,
         Self::Run,
+        Self::Record,
+        Self::Replay,
         Self::Lint,
         Self::Check,
         Self::Coverage,
@@ -43,6 +47,31 @@ impl Command {
             Self::Check => "check",
             Self::Coverage => "coverage",
             Self::Doctor => "doctor",
+            Self::Record => "record",
+            Self::Replay => "replay",
+        }
+    }
+
+    /// Whether the subcommand names a sample and forwards the rest of
+    /// the line to it. These are the subcommands whose flags must come
+    /// *before* the sample name.
+    #[must_use]
+    pub const fn takes_sample(self) -> bool {
+        matches!(self, Self::Run | Self::Record | Self::Replay)
+    }
+
+    /// The sample-side flag this subcommand translates to, and the
+    /// `renew` flag whose value fills it.
+    ///
+    /// The pairing is a convention the tool cannot verify — a sample is
+    /// free not to honour it — which is why a rejection from the child
+    /// is rewritten to name the flag the caller actually typed.
+    #[must_use]
+    pub const fn trace_flags(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            Self::Record => Some(("--output", "--record-trace")),
+            Self::Replay => Some(("--input", "--replay-trace")),
+            _ => None,
         }
     }
 
@@ -59,6 +88,8 @@ impl Command {
             Self::Check => "verify workspace crate manifests and dependencies",
             Self::Coverage => "hold a coverage report against the exemption manifest",
             Self::Doctor => "check the development environment",
+            Self::Record => "run a sample, writing the input it saw to a file",
+            Self::Replay => "run a sample from a recorded input file",
         }
     }
 
@@ -80,11 +111,16 @@ pub struct Invocation {
     /// Coverage only (parse enforces, and requires): the `llvm-cov` JSON
     /// export to read.
     pub report: Option<String>,
-    /// Run only (parse enforces, and requires): the sample to start,
-    /// named by its binary.
+    /// Run, record and replay (parse enforces, and requires): the sample
+    /// to start, named by its binary.
     pub sample: Option<String>,
-    /// Run only: the sample's own command line, taken verbatim.
+    /// Run, record and replay: the sample's own command line, verbatim.
     pub sample_args: Vec<String>,
+    /// Record and replay only (parse enforces, and requires): the trace
+    /// file to write, or to read. One field for both because exactly one
+    /// subcommand can be in play, and two would let a caller construct an
+    /// invocation naming both.
+    pub trace: Option<String>,
 }
 
 /// What parsing decided: run a subcommand, or show usage on request.
@@ -108,8 +144,10 @@ pub enum ParseError {
         command: &'static str,
         option: &'static str,
     },
-    /// `run` was given without naming a sample.
-    MissingSample,
+    /// A sample-taking subcommand was given without naming a sample.
+    /// Carries the subcommand, so the message names what the caller
+    /// typed rather than the first subcommand that ever needed one.
+    MissingSample(&'static str),
 }
 
 impl fmt::Display for ParseError {
@@ -124,7 +162,9 @@ impl fmt::Display for ParseError {
             Self::MissingOption { command, option } => {
                 write!(f, "`{command}` needs `{option} <path>`")
             }
-            Self::MissingSample => write!(f, "`run` needs a sample to run"),
+            Self::MissingSample(command) => {
+                write!(f, "`{command}` needs a sample to run")
+            }
         }
     }
 }
@@ -133,10 +173,13 @@ impl std::error::Error for ParseError {}
 
 /// Parse command-line arguments (excluding the program name).
 ///
-/// Everything after `run <sample>` is the sample's own command line and
-/// is taken verbatim, so a flag this binary also understands still
-/// reaches the sample. Flags meant for `renew` itself therefore go
-/// *before* the sample name. A single `--` may stand between the two
+/// Everything after `run <sample>` — or `record`'s or `replay`'s — is
+/// the sample's own command line and is taken verbatim, so a flag this
+/// binary also understands still reaches the sample. Flags meant for
+/// `renew` itself therefore go *before* the sample name; putting
+/// `--output` after it would forward the flag and produce an error
+/// naming something the caller never typed. A single `--` may stand
+/// between the two
 /// halves for readers; it is the marker, not an argument, so only the
 /// first one is dropped and a sample that wants a literal `--` gets it
 /// by writing two.
@@ -147,13 +190,17 @@ impl std::error::Error for ParseError {}
 /// unknown, or an argument other than the known flags is present —
 /// including `--smoke` with any subcommand other than `bench`, `--report`
 /// with any subcommand other than `coverage`, `--report` without a path,
-/// `coverage` without `--report`, and `run` without a sample.
+/// `coverage` without `--report`, a trace flag given to a subcommand that
+/// does not answer to it (including `record --input` and `replay
+/// --output`, each of which names the other's flag), `record` or `replay`
+/// without one, and any sample-taking subcommand without a sample.
 pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     let mut command = None;
     let mut json = false;
     let mut smoke = false;
     let mut help = false;
     let mut report = None;
+    let mut trace: Option<(&'static str, String)> = None;
     let mut sample: Option<String> = None;
     let mut sample_args: Vec<String> = Vec::new();
     // The separator, if it comes at all, comes immediately after the
@@ -182,15 +229,25 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
                 let path = rest.next().ok_or(ParseError::MissingValue("--report"))?;
                 report = Some(path.clone());
             }
+            // Same reason as `--report`: the value is consumed here so a
+            // path can never be mistaken for a subcommand or a sample.
+            "--output" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--output"))?;
+                trace = Some(("--output", path.clone()));
+            }
+            "--input" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--input"))?;
+                trace = Some(("--input", path.clone()));
+            }
             "help" | "--help" | "-h" => help = true,
             other => {
                 if help {
                     // Help short-circuits; ignore anything after it.
                     continue;
                 }
-                if command == Some(Command::Run) {
-                    // `run`'s first free argument names the sample; the
-                    // rest of the line is the sample's, taken above.
+                if command.is_some_and(Command::takes_sample) {
+                    // The first free argument names the sample; the rest
+                    // of the line is the sample's, taken above.
                     sample = Some(other.to_string());
                     separator_due = true;
                     continue;
@@ -208,6 +265,45 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     if help {
         return Ok(Parsed::Help { json });
     }
+    check_combination(
+        command,
+        smoke,
+        report.as_deref(),
+        trace.as_ref().map(|(flag, _)| *flag),
+        sample.as_deref(),
+    )?;
+    match command {
+        Some(command) => Ok(Parsed::Run(Invocation {
+            command,
+            json,
+            smoke,
+            report,
+            sample,
+            sample_args,
+            trace: trace.map(|(_, path)| path),
+        })),
+        None => Err(ParseError::NoCommand),
+    }
+}
+
+/// The rules that can only be decided once the whole line has been read:
+/// which subcommand a flag belongs to, and which subcommands require one.
+///
+/// Split out of [`parse`] so the scan and the cross-argument rules can
+/// each be read on their own — the scan says what was typed, this says
+/// whether the combination means anything.
+///
+/// Order matters and is deliberate. Every "this flag is not yours" rule
+/// comes before every "you are missing a flag" rule, so a caller who
+/// typed a flag hears about the flag they typed rather than about a
+/// different one they did not. `coverage --smoke` set that precedent.
+fn check_combination(
+    command: Option<Command>,
+    smoke: bool,
+    report: Option<&str>,
+    trace: Option<&'static str>,
+    sample: Option<&str>,
+) -> Result<(), ParseError> {
     if smoke && command != Some(Command::Bench) {
         // The flag belongs to exactly one subcommand; anywhere else it is
         // as unexpected as any stray argument.
@@ -215,6 +311,17 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     }
     if report.is_some() && command != Some(Command::Coverage) {
         return Err(ParseError::UnexpectedArgument("--report".to_string()));
+    }
+    // A trace flag the subcommand does not answer to, which covers three
+    // cases at once: any subcommand that takes neither, no subcommand at
+    // all, and each of record and replay handed the other's flag —
+    // `record --input` names a real flag, but reading it as `--output`
+    // would write over the file the caller meant to read.
+    if let Some(given) = trace {
+        let answers_to = command.and_then(Command::trace_flags);
+        if answers_to.map(|(flag, _)| flag) != Some(given) {
+            return Err(ParseError::UnexpectedArgument(given.to_string()));
+        }
     }
     if command == Some(Command::Coverage) && report.is_none() {
         // The report is the whole input: coverage has nothing to read
@@ -224,22 +331,26 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             option: "--report",
         });
     }
-    if command == Some(Command::Run) && sample.is_none() {
+    // The path is the whole input for these two, exactly as `--report`
+    // is for coverage: there is nothing to record to, or replay from.
+    if let Some(named) = command
+        && let Some((expected, _)) = named.trace_flags()
+        && trace.is_none()
+    {
+        return Err(ParseError::MissingOption {
+            command: named.name(),
+            option: expected,
+        });
+    }
+    if let Some(named) = command
+        && named.takes_sample()
+        && sample.is_none()
+    {
         // Guessing a sample would be worse than refusing: which one runs
         // is the entire content of the command.
-        return Err(ParseError::MissingSample);
+        return Err(ParseError::MissingSample(named.name()));
     }
-    match command {
-        Some(command) => Ok(Parsed::Run(Invocation {
-            command,
-            json,
-            smoke,
-            report,
-            sample,
-            sample_args,
-        })),
-        None => Err(ParseError::NoCommand),
-    }
+    Ok(())
 }
 
 /// The usage text printed for `help` and for usage errors.
@@ -250,6 +361,8 @@ pub fn usage() -> String {
     let mut text = String::from(concat!(
         "usage: renew <command> [options]\n",
         "       renew [options] run <sample> [--] [sample arguments...]\n",
+        "       renew record --output <path> <sample> [--] [sample arguments...]\n",
+        "       renew replay --input <path> <sample> [--] [sample arguments...]\n",
         "\ncommands:\n",
     ));
     for command in Command::ALL {
@@ -262,10 +375,17 @@ pub fn usage() -> String {
         "  --json            emit one machine-readable JSON document on stdout\n",
         "  --report <path>   (coverage only, required) the llvm-cov JSON export to read\n",
         "  --smoke           (bench only) run each benchmark once, without statistics\n",
+        "  --output <path>   (record only, required) the trace file to write\n",
+        "  --input <path>    (replay only, required) the trace file to read\n",
         "\nEverything after `run <sample>` goes to the sample untouched, including\n",
         "flags renew itself knows: `renew run hello_triangle --json` gives the sample\n",
         "`--json`, while `renew --json run hello_triangle` gives it to renew. One `--`\n",
         "after the sample name is an optional separator and is not passed on.\n",
+        "\n`record` and `replay` are `run` with a trace file: their flag goes before\n",
+        "the sample name for the same reason, and reaches the sample as\n",
+        "`--record-trace <path>` or `--replay-trace <path>` at the front of its line.\n",
+        "Replaying is a headless run — pass `--headless` to the sample; it is not\n",
+        "assumed, because a windowed replay is a live run wearing a replay's name.\n",
     ));
     text
 }
@@ -287,7 +407,15 @@ mod tests {
             report: None,
             sample: None,
             sample_args: Vec::new(),
+            trace: None,
         }
+    }
+
+    /// Every subcommand except the one a flag belongs to. Derived from
+    /// `Command::ALL` rather than written out, so a subcommand added
+    /// later cannot quietly escape the rejection tests below.
+    fn all_except(owner: Command) -> impl Iterator<Item = Command> {
+        Command::ALL.into_iter().filter(move |c| *c != owner)
     }
 
     /// What `run <sample>` with a given tail must parse to.
@@ -303,9 +431,9 @@ mod tests {
     fn every_command_parses_by_name() {
         for command in Command::ALL {
             let name = command.name();
-            // Two subcommands need more than their name: coverage takes a
-            // required option, run takes the sample. Both still have to
-            // round-trip by name.
+            // Four subcommands need more than their name: coverage takes
+            // a required option, run takes the sample, and record and
+            // replay take both. All still have to round-trip by name.
             let (line, expected) = match command {
                 Command::Coverage => (
                     vec![name, "--report", "cov.json"],
@@ -321,6 +449,21 @@ mod tests {
                         ..plain(command)
                     },
                 ),
+                Command::Record | Command::Replay => {
+                    // Whichever flag this one owns, taken from the same
+                    // table the parser consults, so the two cannot drift.
+                    let (flag, _) = command
+                        .trace_flags()
+                        .expect("record and replay carry flags");
+                    (
+                        vec![name, flag, "walk.trace", "input_echo"],
+                        Invocation {
+                            sample: Some("input_echo".to_string()),
+                            trace: Some("walk.trace".to_string()),
+                            ..plain(command)
+                        },
+                    )
+                }
                 _ => (vec![name], plain(command)),
             };
             assert_eq!(
@@ -363,15 +506,8 @@ mod tests {
 
     #[test]
     fn smoke_with_any_other_subcommand_is_rejected() {
-        for name in [
-            "configure",
-            "build",
-            "test",
-            "run",
-            "lint",
-            "check",
-            "doctor",
-        ] {
+        for command in all_except(Command::Bench) {
+            let name = command.name();
             assert_eq!(
                 parse(&arguments(&[name, "--smoke"])),
                 Err(ParseError::UnexpectedArgument("--smoke".to_string())),
@@ -410,15 +546,8 @@ mod tests {
 
     #[test]
     fn report_with_any_other_subcommand_is_rejected() {
-        for name in [
-            "configure",
-            "build",
-            "test",
-            "bench",
-            "run",
-            "lint",
-            "check",
-        ] {
+        for command in all_except(Command::Coverage) {
+            let name = command.name();
             assert_eq!(
                 parse(&arguments(&[name, "--report", "cov.json"])),
                 Err(ParseError::UnexpectedArgument("--report".to_string())),
@@ -463,13 +592,143 @@ mod tests {
         );
     }
 
+    /// Each of the two owns exactly one flag, and each must refuse the
+    /// other's: they differ only in direction, so a swap that parsed
+    /// would read the file the caller asked to write.
     #[test]
-    fn run_without_a_sample_is_rejected() {
-        assert_eq!(parse(&arguments(&["run"])), Err(ParseError::MissingSample));
+    fn record_and_replay_take_their_own_flag_and_refuse_the_others() {
+        for command in [Command::Record, Command::Replay] {
+            let name = command.name();
+            let (mine, _) = command.trace_flags().expect("both carry a flag");
+            assert_eq!(
+                parse(&arguments(&[name, mine, "walk.trace", "input_echo"])),
+                Ok(Parsed::Run(Invocation {
+                    sample: Some("input_echo".to_string()),
+                    trace: Some("walk.trace".to_string()),
+                    ..plain(command)
+                })),
+                "`{name} {mine}` must parse"
+            );
+            // The flag before the subcommand name, as `--report` allows.
+            assert_eq!(
+                parse(&arguments(&[mine, "walk.trace", name, "input_echo"])),
+                Ok(Parsed::Run(Invocation {
+                    sample: Some("input_echo".to_string()),
+                    trace: Some("walk.trace".to_string()),
+                    ..plain(command)
+                })),
+                "`{mine} … {name}` must parse"
+            );
+            let (theirs, _) = all_except(command)
+                .find_map(Command::trace_flags)
+                .expect("the other subcommand carries the other flag");
+            assert_eq!(
+                parse(&arguments(&[name, theirs, "walk.trace", "input_echo"])),
+                Err(ParseError::UnexpectedArgument(theirs.to_string())),
+                "`{name} {theirs}` must be rejected"
+            );
+        }
+    }
+
+    /// The mirror of the `--smoke` and `--report` rejections: a trace
+    /// flag anywhere it is not owned, derived from `ALL` so a subcommand
+    /// added later cannot escape it.
+    #[test]
+    fn a_trace_flag_with_any_other_subcommand_is_rejected() {
+        for owner in [Command::Record, Command::Replay] {
+            let (flag, _) = owner.trace_flags().expect("both carry a flag");
+            for command in all_except(owner) {
+                let name = command.name();
+                assert_eq!(
+                    parse(&arguments(&[name, flag, "walk.trace"])),
+                    Err(ParseError::UnexpectedArgument(flag.to_string())),
+                    "`{name} {flag}` must be rejected"
+                );
+            }
+            // And with no subcommand at all, rather than `NoCommand`.
+            assert_eq!(
+                parse(&arguments(&[flag, "walk.trace"])),
+                Err(ParseError::UnexpectedArgument(flag.to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn a_trace_subcommand_without_its_flag_is_rejected() {
+        for command in [Command::Record, Command::Replay] {
+            let name = command.name();
+            let (flag, _) = command.trace_flags().expect("both carry a flag");
+            assert_eq!(
+                parse(&arguments(&[name, "input_echo"])),
+                Err(ParseError::MissingOption {
+                    command: name,
+                    option: flag,
+                }),
+                "`{name}` without {flag} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn a_trace_flag_without_a_path_is_rejected() {
+        for command in [Command::Record, Command::Replay] {
+            let (flag, _) = command.trace_flags().expect("both carry a flag");
+            assert_eq!(
+                parse(&arguments(&[command.name(), flag])),
+                Err(ParseError::MissingValue(flag))
+            );
+        }
+    }
+
+    /// The ordering rule these subcommands exist to respect: past the
+    /// sample name, a flag `renew` knows is the sample's. Written out
+    /// because it is the failure the design named — `--output` after the
+    /// sample would be forwarded, and the sample would reject a flag the
+    /// caller did type, blaming the wrong tool.
+    #[test]
+    fn a_trace_flag_after_the_sample_name_belongs_to_the_sample() {
         assert_eq!(
-            parse(&arguments(&["--json", "run"])),
-            Err(ParseError::MissingSample)
+            parse(&arguments(&[
+                "record",
+                "--output",
+                "a.trace",
+                "input_echo",
+                "--output",
+                "b.trace",
+            ])),
+            Ok(Parsed::Run(Invocation {
+                sample: Some("input_echo".to_string()),
+                sample_args: vec!["--output".to_string(), "b.trace".to_string()],
+                trace: Some("a.trace".to_string()),
+                ..plain(Command::Record)
+            }))
         );
+    }
+
+    #[test]
+    fn a_sample_taking_subcommand_without_a_sample_is_rejected() {
+        // Derived from `takes_sample` rather than listed, so a fourth
+        // sample-taking subcommand cannot be added without an answer
+        // here. Record and replay need their flag first, or they fail on
+        // that instead and never reach the question being asked.
+        for command in Command::ALL.into_iter().filter(|c| c.takes_sample()) {
+            let name = command.name();
+            let mut line = vec![name];
+            if let Some((flag, _)) = command.trace_flags() {
+                line.extend_from_slice(&[flag, "walk.trace"]);
+            }
+            assert_eq!(
+                parse(&arguments(&line)),
+                Err(ParseError::MissingSample(name)),
+                "`{name}` without a sample must be rejected, naming itself"
+            );
+            line.insert(0, "--json");
+            assert_eq!(
+                parse(&arguments(&line)),
+                Err(ParseError::MissingSample(name)),
+                "`--json {name}` must be rejected the same way"
+            );
+        }
     }
 
     #[test]
@@ -665,7 +924,7 @@ mod tests {
                 command: "coverage",
                 option: "--report",
             },
-            ParseError::MissingSample,
+            ParseError::MissingSample("record"),
         ] {
             assert!(!error.to_string().is_empty(), "{error:?}");
         }

--- a/tools/cli/src/json.rs
+++ b/tools/cli/src/json.rs
@@ -141,8 +141,9 @@ pub fn result_envelope(
     duration_ms: i64,
     stdout: &str,
     stderr: &str,
+    extra: Vec<(String, Value)>,
 ) -> Value {
-    Value::Object(vec![
+    let mut fields = vec![
         ("schema_version".to_string(), Value::Number(1)),
         ("command".to_string(), Value::String(command.to_string())),
         ("status".to_string(), Value::String(status.to_string())),
@@ -150,7 +151,14 @@ pub fn result_envelope(
         ("duration_ms".to_string(), Value::Number(duration_ms)),
         ("stdout".to_string(), Value::String(stdout.to_string())),
         ("stderr".to_string(), Value::String(stderr.to_string())),
-    ])
+    ];
+    // Appended, never interleaved, so a reader finds the shared keys in
+    // the same place whatever ran. Taken as a parameter rather than
+    // patched into the returned value by the caller, because that needs
+    // a match on `Value::Object` whose other arm can only silently drop
+    // the fields it was asked to add.
+    fields.extend(extra);
+    Value::Object(fields)
 }
 
 /// Why parsing failed.
@@ -503,7 +511,7 @@ mod tests {
 
     #[test]
     fn parse_round_trips_what_the_emitter_writes() {
-        let original = result_envelope("check", "ok", 0, 7, "a\"b\\c\nd", "çağdaş ✔");
+        let original = result_envelope("check", "ok", 0, 7, "a\"b\\c\nd", "çağdaş ✔", Vec::new());
         let parsed = parse(&original.render()).expect("emitter output parses");
         assert_eq!(parsed, original);
     }
@@ -654,7 +662,7 @@ mod tests {
 
     #[test]
     fn envelope_leads_with_schema_version_one() {
-        let document = result_envelope("test", "ok", 0, 42, "out", "err").render();
+        let document = result_envelope("test", "ok", 0, 42, "out", "err", Vec::new()).render();
         assert!(
             document.starts_with("{\"schema_version\":1,\"command\":\"test\""),
             "unexpected prefix: {document}"

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Ok(Parsed::Help { json: true }) => {
-            let document = json::result_envelope("help", "ok", 0, 0, &cli::usage(), "");
+            let document = json::result_envelope("help", "ok", 0, 0, &cli::usage(), "", Vec::new());
             emit_stdout_line(&document.render());
             ExitCode::SUCCESS
         }
@@ -52,7 +52,7 @@ fn run(invocation: &Invocation) -> ExitCode {
             invocation.report.as_deref().unwrap_or_default(),
             invocation.json,
         ),
-        Command::Run => run_sample(invocation),
+        Command::Run | Command::Record | Command::Replay => run_sample(invocation),
         _ => run_steps(invocation),
     }
 }
@@ -452,17 +452,32 @@ impl<'a> Runner<'a> {
 
     /// Every child succeeded.
     fn finish(&self) -> ExitCode {
+        self.finish_with(Vec::new())
+    }
+
+    /// Every child succeeded, with subcommand-specific fields folded into
+    /// the envelope after the shared ones. Ignored outside `--json`,
+    /// where the child's own output already reached the caller.
+    fn finish_with(&self, extra: Vec<(String, Value)>) -> ExitCode {
         if self.json {
-            return finish_json(
+            return finish_json_with(
                 self.name,
                 "ok",
                 0,
                 self.started,
                 &self.stdout_all,
                 &self.stderr_all,
+                extra,
             );
         }
         ExitCode::SUCCESS
+    }
+
+    /// What the children wrote to stdout, as captured. Empty outside
+    /// `--json`, where children inherit this process's stdout and nothing
+    /// passes through here.
+    fn captured_stdout(&self) -> &str {
+        &self.stdout_all
     }
 }
 
@@ -536,8 +551,32 @@ fn run_sample(invocation: &Invocation) -> ExitCode {
         );
         return ExitCode::from(2);
     };
-    let args = plan::sample_step(&sample.package, &sample.name, &invocation.sample_args);
+    // Parsing guarantees the path whenever the subcommand carries a
+    // flag, so the pair is either wholly present or wholly absent.
+    let lead = invocation
+        .command
+        .trace_flags()
+        .zip(invocation.trace.as_deref())
+        .map(|((_, child_flag), path)| (child_flag, path));
+    let args = plan::sample_step(&sample.package, &sample.name, lead, &invocation.sample_args);
     match runner.execute("cargo", &args) {
+        // A replay's whole result is the digest the child printed, and in
+        // JSON mode this process captured the child's stdout rather than
+        // letting it through — so without lifting the line into the
+        // envelope the caller would have to parse it back out of a string
+        // field, or in plain mode would simply have seen it already.
+        Ok(()) if invocation.command == Command::Replay => {
+            runner.finish_with(vec![(
+                "digest".to_string(),
+                match samples::digest_line(runner.captured_stdout()) {
+                    Some(line) => Value::String(line.to_string()),
+                    // Null rather than an empty string: a replay that
+                    // printed no digest did not produce one, which is a
+                    // different fact from producing an empty one.
+                    None => Value::Null,
+                },
+            )])
+        }
         Ok(()) => runner.finish(),
         Err(exit) => exit,
     }
@@ -551,6 +590,28 @@ fn finish_json(
     stdout: &str,
     stderr: &str,
 ) -> ExitCode {
+    finish_json_with(
+        command,
+        status,
+        child_code,
+        started,
+        stdout,
+        stderr,
+        Vec::new(),
+    )
+}
+
+/// The same envelope with subcommand-specific fields appended, so a
+/// reader finds the shared keys in the same order whatever ran.
+fn finish_json_with(
+    command: &str,
+    status: &str,
+    child_code: i32,
+    started: Instant,
+    stdout: &str,
+    stderr: &str,
+    extra: Vec<(String, Value)>,
+) -> ExitCode {
     let document = json::result_envelope(
         command,
         status,
@@ -558,6 +619,7 @@ fn finish_json(
         duration_ms(started),
         stdout,
         stderr,
+        extra,
     );
     emit_stdout_line(&document.render());
     if status == "ok" {

--- a/tools/cli/src/plan.rs
+++ b/tools/cli/src/plan.rs
@@ -66,14 +66,21 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
         ],
         // Subcommands whose child cannot be a fixed table entry: check
         // spawns `cargo metadata` itself, coverage reads the export it is
-        // handed, doctor's probes are gathered separately, and `run`'s
-        // child is built by `sample_step` out of the command line.
-        Command::Check | Command::Coverage | Command::Doctor | Command::Run => &[],
+        // handed, doctor's probes are gathered separately, and run,
+        // record and replay have their child built by `sample_step` out
+        // of the command line.
+        Command::Check
+        | Command::Coverage
+        | Command::Doctor
+        | Command::Run
+        | Command::Record
+        | Command::Replay => &[],
     }
 }
 
-/// The cargo arguments `run` spawns for one sample: build and start that
-/// binary, then hand it the rest of the command line.
+/// The cargo arguments `run`, `record` and `replay` spawn for one
+/// sample: build and start that binary, then hand it the rest of the
+/// command line.
 ///
 /// Owned rather than a table entry, because which sample runs and what it
 /// is told are not knowable until the command line is read — that is the
@@ -82,8 +89,19 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
 ///
 /// The trailing `--` is always present, so a sample argument that looks
 /// like a cargo flag reaches the sample instead of cargo.
+///
+/// `lead` is the flag a subcommand translates to — `--record-trace` or
+/// `--replay-trace` and its path — and goes at the **front** of the
+/// sample's line, ahead of anything the caller wrote. Front rather than
+/// back because the caller's half is verbatim and may end in a flag
+/// still waiting for its value, which would otherwise swallow this one.
 #[must_use]
-pub fn sample_step(package: &str, binary: &str, sample_args: &[String]) -> Vec<String> {
+pub fn sample_step(
+    package: &str,
+    binary: &str,
+    lead: Option<(&str, &str)>,
+    sample_args: &[String],
+) -> Vec<String> {
     let mut args = vec![
         "run".to_string(),
         "--package".to_string(),
@@ -92,6 +110,10 @@ pub fn sample_step(package: &str, binary: &str, sample_args: &[String]) -> Vec<S
         binary.to_string(),
         "--".to_string(),
     ];
+    if let Some((flag, value)) = lead {
+        args.push(flag.to_string());
+        args.push(value.to_string());
+    }
     args.extend(sample_args.iter().cloned());
     args
 }
@@ -158,6 +180,8 @@ mod tests {
         assert!(steps(Command::Check, false).is_empty());
         assert!(steps(Command::Coverage, false).is_empty());
         assert!(steps(Command::Run, false).is_empty());
+        assert!(steps(Command::Record, false).is_empty());
+        assert!(steps(Command::Replay, false).is_empty());
     }
 
     #[test]
@@ -165,6 +189,7 @@ mod tests {
         let args = sample_step(
             "renew-sample-hello-triangle",
             "hello_triangle",
+            None,
             &["--headless".to_string(), "--frames".to_string()],
         );
         assert_eq!(
@@ -186,7 +211,7 @@ mod tests {
     fn a_sample_step_with_nothing_to_hand_over_still_ends_in_the_separator() {
         // Uniform shape: the separator is not conditional, so nothing
         // downstream has to know whether the sample was given arguments.
-        let args = sample_step("renew-sample-input-echo", "input_echo", &[]);
+        let args = sample_step("renew-sample-input-echo", "input_echo", None, &[]);
         assert_eq!(
             args,
             [
@@ -196,6 +221,35 @@ mod tests {
                 "--bin",
                 "input_echo",
                 "--",
+            ]
+        );
+    }
+
+    /// The translated flag leads the sample's line, ahead of everything
+    /// the caller wrote. Ordering is the point: the caller's half is
+    /// verbatim and may end in a flag still waiting for a value, which
+    /// would swallow this one if it came last.
+    #[test]
+    fn a_trace_flag_leads_the_samples_line_ahead_of_the_callers_own() {
+        let args = sample_step(
+            "renew-sample-input-echo",
+            "input_echo",
+            Some(("--replay-trace", "walk.trace")),
+            &["--headless".to_string(), "--seed".to_string()],
+        );
+        assert_eq!(
+            args,
+            [
+                "run",
+                "--package",
+                "renew-sample-input-echo",
+                "--bin",
+                "input_echo",
+                "--",
+                "--replay-trace",
+                "walk.trace",
+                "--headless",
+                "--seed",
             ]
         );
     }

--- a/tools/cli/src/samples.rs
+++ b/tools/cli/src/samples.rs
@@ -111,9 +111,85 @@ pub fn unknown(name: &str, known: &[Sample]) -> String {
     )
 }
 
+/// The marker a sample's digest line begins with. A convention, not a
+/// contract the tool can enforce — the same weakness the trace flags
+/// have, and it resolves the same way, by the manifest eventually
+/// declaring what a sample emits.
+const DIGEST_MARKER: &str = "renew-frame ";
+
+/// The digest line in a sample's output, if it printed one.
+///
+/// The **last** match, not the first: a run that somehow reported twice
+/// is described by where it ended up, and taking the first would report a
+/// digest the sample itself superseded. Trailing whitespace is trimmed
+/// because the line crosses a pipe and a `\r` would otherwise ride into
+/// the envelope.
+#[must_use]
+pub fn digest_line(stdout: &str) -> Option<&str> {
+    stdout
+        .lines()
+        .map(str::trim_end)
+        .rfind(|line| line.starts_with(DIGEST_MARKER))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Realistic shape: the sample prints its own chatter, then the
+    /// digest last. Written out rather than built from the sample’s own
+    /// formatter, because a shared formatter would let both sides drift
+    /// together and still agree.
+    const RUN_OUTPUT: &str = concat!(
+        "started input_echo\n",
+        "renew-frame sample=input_echo seed=3 source=trace frames=20 ticks=20 ",
+        "dropped=0 schedule_hash=0x0000000000000001 state_hash=0x00000000000000ff\n",
+    );
+
+    #[test]
+    fn the_digest_line_is_found_among_the_samples_other_output() {
+        let found = digest_line(RUN_OUTPUT).expect("the run printed a digest");
+        assert!(found.starts_with("renew-frame sample=input_echo seed=3"));
+        assert!(found.ends_with("state_hash=0x00000000000000ff"));
+    }
+
+    #[test]
+    fn output_without_a_digest_has_none() {
+        assert_eq!(digest_line(""), None);
+        assert_eq!(digest_line("started input_echo\nfinished\n"), None);
+        // The marker has to begin the line: a sample quoting it mid-
+        // sentence is talking about a digest, not printing one.
+        assert_eq!(digest_line("about to print renew-frame sample=x"), None);
+    }
+
+    #[test]
+    fn the_last_digest_wins_when_a_run_printed_more_than_one() {
+        let twice = concat!(
+            "renew-frame sample=a state_hash=0x1\n",
+            "renew-frame sample=a state_hash=0x2\n",
+        );
+        assert_eq!(
+            digest_line(twice),
+            Some("renew-frame sample=a state_hash=0x2")
+        );
+    }
+
+    /// The line crosses a pipe, and a child on Windows ends it with a
+    /// carriage return before the newline. That byte must not ride into
+    /// the envelope, where it would make two identical digests compare
+    /// unequal depending on which platform recorded them.
+    #[test]
+    fn a_carriage_return_does_not_reach_the_caller() {
+        let windows = "renew-frame sample=a state_hash=0x1\r\n";
+        assert!(
+            windows.contains('\r'),
+            "the input must carry the byte under test"
+        );
+        assert_eq!(
+            digest_line(windows),
+            Some("renew-frame sample=a state_hash=0x1")
+        );
+    }
 
     /// Two sample packages and one crate that is not one, in the shape
     /// `cargo metadata --format-version 1 --no-deps` emits: a sample

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -272,6 +272,13 @@ fn sample_workspace(tag: &str) -> std::io::Result<PathBuf> {
             "fn main() {\n",
             "    let args: Vec<String> = std::env::args().skip(1).collect();\n",
             "    println!(\"echo_sample saw [{}]\", args.join(\" \"));\n",
+            // A real sample ends a replay by printing its digest. This
+            // one imitates that when it is replaying, so `replay`'s
+            // envelope has a line to lift and `record`'s has none.
+            "    let quiet = args.iter().any(|argument| argument == \"--quiet\");\n",
+            "    if !quiet && args.iter().any(|argument| argument == \"--replay-trace\") {\n",
+            "        println!(\"renew-frame sample=echo_sample state_hash=0x00000000000000ab\");\n",
+            "    }\n",
             "    if args.iter().any(|argument| argument == \"--fail\") {\n",
             "        std::process::exit(3);\n",
             "    }\n",
@@ -1106,6 +1113,170 @@ fn a_run_that_cannot_read_the_sample_list_refuses_instead_of_denying_it() {
 
     let _ = fs::remove_dir_all(&broken);
     let _ = fs::remove_dir_all(&empty);
+}
+
+/// The whole translation chain, end to end: `renew`'s flag becomes the
+/// sample's flag, in front of the caller's own arguments, and only a
+/// replay's envelope grows a digest.
+#[test]
+fn record_and_replay_translate_their_flag_and_lead_the_samples_line() {
+    let directory = sample_workspace("trace").expect("scratch workspace should be creatable");
+
+    for (subcommand, renew_flag, sample_flag) in [
+        ("record", "--output", "--record-trace"),
+        ("replay", "--input", "--replay-trace"),
+    ] {
+        // The caller's own `--output` comes after the sample name and so
+        // is the sample's, while renew's identically-spelled flag before
+        // it is renew's. Both must appear, in that order, with renew's
+        // first — which is the failure the ordering rule exists to stop.
+        let output = run_building_in(
+            &directory,
+            &[
+                subcommand,
+                renew_flag,
+                "renew.trace",
+                "echo_sample",
+                "--output",
+                "callers.txt",
+            ],
+        )
+        .expect("binary should spawn");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "stdout: {stdout}
+stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected = format!("echo_sample saw [{sample_flag} renew.trace --output callers.txt]");
+        assert!(stdout.contains(&expected), "stdout was: {stdout}");
+    }
+
+    // A replay's result is its digest, and in JSON mode the child's
+    // stdout is captured — so the line has to be lifted out as a field
+    // or a caller would have to parse it back out of a string.
+    let output = run_building_in(
+        &directory,
+        &["--json", "replay", "--input", "walk.trace", "echo_sample"],
+    )
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope = validated_envelope(stdout.trim(), "replay")
+        .unwrap_or_else(|reason| panic!("replay --json: {reason}"));
+    assert_eq!(
+        envelope.get("digest").and_then(Value::as_str),
+        Some("renew-frame sample=echo_sample state_hash=0x00000000000000ab"),
+        "stdout was: {stdout}"
+    );
+
+    // Recording produces a file, not a digest, so the field is absent
+    // rather than present and empty.
+    let output = run_building_in(
+        &directory,
+        &["--json", "record", "--output", "walk.trace", "echo_sample"],
+    )
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope = validated_envelope(stdout.trim(), "record")
+        .unwrap_or_else(|reason| panic!("record --json: {reason}"));
+    assert_eq!(envelope.get("digest"), None, "stdout was: {stdout}");
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
+/// A replay whose sample printed no digest. The field is present and
+/// null, not absent: the run happened and produced nothing to report,
+/// which is a different fact from a subcommand that never carries one.
+#[test]
+fn a_replay_that_produced_no_digest_reports_null_rather_than_nothing() {
+    let directory = sample_workspace("nodigest").expect("scratch workspace should be creatable");
+    let output = run_building_in(
+        &directory,
+        &[
+            "--json",
+            "replay",
+            "--input",
+            "walk.trace",
+            "echo_sample",
+            "--quiet",
+        ],
+    )
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope = validated_envelope(stdout.trim(), "replay")
+        .unwrap_or_else(|reason| panic!("quiet replay --json: {reason}"));
+    // The sample really did stay quiet, or this asserts nothing.
+    assert!(
+        envelope
+            .get("stdout")
+            .and_then(Value::as_str)
+            .is_some_and(|captured| !captured.contains("renew-frame")),
+        "the sample must not have printed a digest: {stdout}"
+    );
+    assert_eq!(
+        envelope.get("digest"),
+        Some(&Value::Null),
+        "stdout was: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
+#[test]
+fn the_trace_subcommands_refuse_a_command_line_that_cannot_work() {
+    // Neither of these reaches a workspace or a build: parsing refuses
+    // first, which is why they are cheap enough to drive through the
+    // real binary.
+    for (line, named) in [
+        (vec!["record", "echo_sample"], "--output"),
+        (vec!["replay", "echo_sample"], "--input"),
+        (
+            vec!["record", "--input", "t.trace", "echo_sample"],
+            "--input",
+        ),
+        (
+            vec!["replay", "--output", "t.trace", "echo_sample"],
+            "--output",
+        ),
+        (vec!["record", "--output", "t.trace"], "record"),
+        (vec!["replay", "--input", "t.trace"], "replay"),
+    ] {
+        let output = run(&line).expect("binary should spawn");
+        assert_eq!(output.status.code(), Some(2), "`{line:?}` must be refused");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(named),
+            "`{line:?}` should have named `{named}`; stderr was: {stderr}"
+        );
+        assert!(
+            output.stdout.is_empty(),
+            "usage errors never emit an envelope"
+        );
+    }
+}
+
+#[test]
+fn usage_documents_the_trace_subcommands_and_their_flags() {
+    let output = run(&["help"]).expect("binary should spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "record",
+        "replay",
+        "--output",
+        "--input",
+        "--record-trace",
+        "--replay-trace",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "usage omits {expected}: {stdout}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Gives the trace file a command-line face:

```
renew record --output <path> <sample> [sample arguments...]
renew replay --input  <path> <sample> [sample arguments...]
```

Both translate to the flag the sample already answers to (`--record-trace` / `--replay-trace`).

**Ordering.** The flag goes *before* the sample name, because everything after that name is the sample's own line and is taken verbatim — a trailing `--output` would be forwarded, and the sample would reject a flag naming the wrong tool. The translated flag then *leads* the sample's line rather than trailing it, since the caller's half may end in a flag still waiting for a value.

**Replay's envelope carries a `digest` field.** In `--json` mode this process captures the child's stdout, so without lifting the line out a caller would have to parse it back out of a string field. It is `null` when the run printed none — a different fact from an empty one, and tested as such.

**Replaying stays explicitly headless.** `--headless` is passed by the caller, never assumed: a windowed replay is a live run wearing a replay's name.

**Refusals.** Either flag is rejected anywhere it is not owned, including each subcommand handed the other's — silently reading `--input` as `--output` would write over the file the caller meant to read. The rejection tests now derive their subcommand lists from the canonical table rather than hardcoding them; two subcommands were already missing from those lists.

**Verification.** End to end against a real sample, a recorded run and a replay of its file report identical `schedule_hash` and `state_hash`, with `source` correctly differing (`walk` -> `replay`). Locally: 67 suites / 730 tests, fmt and clippy clean, structure healthy, and the four touched files measure 100% with no new exemptions.