### PR TITLE
Measure a skewed parallel_for workload

### DIFF
--- a/bench/suite/benches/jobs.rs
+++ b/bench/suite/benches/jobs.rs
@@ -1,8 +1,59 @@
-//! Job-pool timings: raw dispatch overhead, and the flagship parallel
+//! Job-pool timings: raw dispatch overhead, the flagship parallel
 //! transform measured against the serial `math_mat4_transform_4096`
-//! baseline in the math group. Worker counts are fixed (not detected)
-//! so numbers are comparable across machines with the configuration
-//! stated in the name.
+//! baseline in the math group, and a deliberately skewed workload.
+//! Worker counts are fixed (not detected) so numbers are comparable
+//! across machines with the configuration stated in the name.
+//!
+//! # The skew group, and how to read it
+//!
+//! The uniform transform above is the case where a scheduler cannot
+//! distinguish itself: every chunk costs the same, so any assignment is
+//! as good as any other. The skew group exists to measure the case that
+//! is actually claimed to be a problem — one chunk far more expensive
+//! than its neighbours — and it is arranged so the *policy*, not the
+//! arithmetic, decides the answer.
+//!
+//! There are 4096 elements in 16 coarse chunks. One chunk’s worth of
+//! them (256) costs [`HEAVY_FACTOR`] times what the others do.
+//!
+//! **The pool is three configured workers plus the calling thread, which
+//! participates in its own dispatch — so the effective width is four.**
+//! The names below say `3_workers` because that is the configuration,
+//! matching the group above; every ratio here is against four. Getting
+//! this wrong is not cosmetic: it moves perfect speedup by a third.
+//!
+//! With `C` chunks, `W` participating threads, one heavy chunk of cost
+//! `H = k·L` and `C-1` light chunks of cost `L`, no schedule can finish
+//! before `max(H, total/W)`. For the heavy chunk not to be the
+//! bottleneck all by itself — which would make every policy look
+//! identical and measure nothing — we need `k < (C-1)/(W-1)`. At
+//! `C = 16` and `W = 4` that is `k < 5`, which is why the factor below is
+//! 4 and not a rounder, larger number.
+//!
+//! Read the four benchmarks together:
+//!
+//! * `jobs_skew_serial` is the total work. **Perfect speedup is that
+//!   divided by four**, and that is the number the parallel runs are
+//!   really being compared against — not against each other.
+//! * `heavy_first` should land near perfect: the expensive chunk is
+//!   claimed immediately, and the fifteen cheap ones absorb the rest.
+//!   Expect about `5L` against an ideal of `4.75L`.
+//! * `heavy_last` is the tail case. The cheap chunks are consumed first,
+//!   the expensive one is claimed last, and it runs alone while three
+//!   threads idle. Expect about `15L/4 + 4L = 7.75L` against the same
+//!   `4.75L` ideal — around two thirds longer.
+//! * `heavy_last_fine_grain` is the same arrangement with the grain cut
+//!   to a quarter, which splits the expensive region across four chunks
+//!   and should land back near the ideal.
+//!
+//! The comparison the last two make is the one worth having. **A shared
+//! claim cursor is already dynamic load balancing** — a worker that
+//! finishes early takes the next chunk immediately, which is most of
+//! what stealing is usually credited with. What it cannot do is split a
+//! chunk that has already been claimed, and *neither can work stealing*:
+//! stealing moves whole tasks. If `heavy_last_fine_grain` closes the gap
+//! that `heavy_last` opens, then the lever on tail latency is grain
+//! size, which this pool already exposes to every caller.
 
 use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -52,5 +103,116 @@ fn jobs_benches(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, jobs_benches);
+// --- Skewed workload ----------------------------------------------------
+//
+// See the module docs for the arithmetic these constants satisfy and for
+// how the four measurements below are meant to be read together.
+
+/// Elements in the skew group. A quarter of the flagship transform's
+/// count, because each element here does far more work per element.
+const SKEW_COUNT: usize = 4096;
+
+/// Elements in the expensive region: exactly one coarse chunk, so the
+/// skew is a property of one chunk rather than smeared across several.
+const HEAVY_SPAN: usize = 256;
+
+/// How much more an expensive element costs. Bounded above by
+/// `(chunks - 1) / (threads - 1)` = 5 — sixteen chunks over four
+/// participating threads — or the heavy chunk alone would set the
+/// makespan and no scheduling policy could show a difference.
+const HEAVY_FACTOR: u32 = 4;
+
+/// Rounds of mixing one ordinary element does. Large enough that the
+/// per-element call is not measuring call overhead, small enough that
+/// the whole sweep stays in the sub-millisecond range criterion likes.
+const BASE_ROUNDS: u32 = 64;
+
+/// One element's work: `rounds` rounds of an integer mix.
+///
+/// `#[inline(never)]` and a returned value the caller stores, because
+/// the entire measurement is the *time* this takes — an optimiser that
+/// hoisted, unrolled against a constant, or elided it would leave four
+/// benchmarks that all measure dispatch overhead and agree beautifully.
+/// `rounds` arrives from a runtime table for the same reason.
+#[inline(never)]
+fn burn(seed: u64, rounds: u32) -> u64 {
+    let mut state = seed;
+    for _ in 0..rounds {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        state ^= state >> 33;
+    }
+    state
+}
+
+/// Per-element round counts with the expensive region at one end.
+///
+/// Both arrangements carry identical total work by construction, so the
+/// serial baseline describes either one and the two parallel runs differ
+/// only in *where* the expensive region sits.
+fn skew_profile(heavy_at_end: bool) -> Vec<u32> {
+    (0..SKEW_COUNT)
+        .map(|index| {
+            let heavy = if heavy_at_end {
+                index >= SKEW_COUNT - HEAVY_SPAN
+            } else {
+                index < HEAVY_SPAN
+            };
+            if heavy {
+                BASE_ROUNDS * HEAVY_FACTOR
+            } else {
+                BASE_ROUNDS
+            }
+        })
+        .collect()
+}
+
+fn skew_benches(c: &mut Criterion) {
+    let Ok(mut pool) = JobPool::new(&PoolConfig::new(3)) else {
+        return;
+    };
+    let coarse = NonZeroUsize::MIN.saturating_add(HEAVY_SPAN - 1);
+    let fine = NonZeroUsize::MIN.saturating_add(HEAVY_SPAN / 4 - 1);
+    let at_end = skew_profile(true);
+    let at_start = skew_profile(false);
+    let mut output = vec![0_u64; SKEW_COUNT];
+
+    // The total work, and so the perfect-speedup bound: this divided by
+    // the worker count is what the three parallel runs are measured
+    // against. Without it they can only be compared to each other, which
+    // says which is faster but never how much is left on the table.
+    c.bench_function("jobs_skew_serial_4096", |b| {
+        b.iter(|| {
+            for (index, slot) in output.iter_mut().enumerate() {
+                *slot = burn(index as u64, at_end[index]);
+            }
+            black_box(output[SKEW_COUNT - 1]);
+        });
+    });
+
+    for (name, profile, grain) in [
+        (
+            "jobs_skew_heavy_first_grain256_3_workers",
+            &at_start,
+            coarse,
+        ),
+        ("jobs_skew_heavy_last_grain256_3_workers", &at_end, coarse),
+        ("jobs_skew_heavy_last_grain64_3_workers", &at_end, fine),
+    ] {
+        c.bench_function(name, |b| {
+            b.iter(|| {
+                pool.parallel_for_slice_mut(black_box(&mut output), grain, |offset, chunk| {
+                    for (index, slot) in chunk.iter_mut().enumerate() {
+                        let at = offset + index;
+                        *slot = burn(at as u64, profile[at]);
+                    }
+                });
+                black_box(output[SKEW_COUNT - 1]);
+            });
+        });
+    }
+}
+
+criterion_group!(benches, jobs_benches, skew_benches);
 criterion_main!(benches);


### PR DESCRIPTION
The job benchmarks measured dispatch overhead and a **uniform** parallel transform — precisely the case where scheduling policy cannot distinguish itself, since every chunk costs the same and any assignment is as good as any other. The case that is actually claimed to be a problem, one chunk far more expensive than its neighbours, had no benchmark.

Four measurements meant to be read together: the serial total, the expensive chunk claimed first, claimed last, and claimed last at a quarter of the grain.

**Perfect speedup is serial / 4, not / 3.** `PoolConfig::new(3)` spawns three workers and the calling thread participates in its own dispatch. Getting that wrong moves the reference by a third — my first run did, which put the skew factor over its bound and quietly measured a floor instead of a policy.

The skew factor is bounded by `(chunks-1)/(threads-1)`. Above that the expensive chunk alone sets the makespan and every policy measures the same number. The bound is in the module docs beside the list-scheduling arithmetic each case is predicted from, so a reader can check the design rather than trust it.

Results on one machine, with the predictions written before the run:

| benchmark | time | vs ideal (89.1 us) | predicted |
|---|---|---|---|
| serial | 356.39 us | — | — |
| heavy first, grain 256 | 98.15 us | 1.10x | 1.05x |
| heavy last, grain 256 | 147.84 us | 1.66x | 1.63x |
| heavy last, grain 64 | 92.15 us | 1.03x | ~1x |

Worst-case placement really does cost 66% over ideal. The cause is that an already-claimed chunk cannot be subdivided — and quartering the grain closes the gap to 3% with no new machinery.

The work body is deliberately awkward for an optimiser: never inlined, returning a value the caller stores, iteration count from a runtime table. Hoisted or elided, all four benchmarks would measure dispatch overhead and agree beautifully.

Verified: `cargo bench --bench jobs -- --test` (CI's smoke mode) passes, clippy clean, fmt clean.