### PR TITLE
Measure what asking the time costs

### DIFF
--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -29,6 +29,8 @@ renew-memory = { path = "../../crates/core/memory" }
 # schedules nothing.
 renew-frame = { path = "../../crates/frame" }
 renew-rng = { path = "../../crates/rng" }
+# Bench-target-only: the clock is measured, not used, by this crate.
+renew-platform = { path = "../../crates/core/platform" }
 criterion = "0.8"
 # Bench-target-only: keeps the library's dependency graph free of the
 # job pool it never uses.
@@ -59,4 +61,8 @@ harness = false
 
 [[bench]]
 name = "rng"
+harness = false
+
+[[bench]]
+name = "clock"
 harness = false

--- a/bench/suite/benches/clock.rs
+++ b/bench/suite/benches/clock.rs
@@ -1,0 +1,58 @@
+//! What it costs to ask what time it is.
+//!
+//! This number is not interesting on its own; it is interesting because
+//! it is the unit price of every piece of timing instrumentation the
+//! engine will ever add. Any proposal to time something *per chunk*, or
+//! per job, or per draw call, is really a proposal to spend this many
+//! nanoseconds that many times, and the argument for or against it
+//! cannot be had until the price is on the table.
+//!
+//! It is a syscall-adjacent operation on every platform — a vDSO read on
+//! Linux, `QueryPerformanceCounter` on Windows, `mach_absolute_time` on
+//! macOS — so it is both far more expensive than arithmetic and highly
+//! platform-dependent. That is exactly why it belongs in the per-platform
+//! table rather than in one number quoted from one machine.
+//!
+//! # The self-check, and why it is here
+//!
+//! `clock_elapsed_nanos_x16` is not a second measurement of interest. It
+//! exists to prove the first one is real. Sixteen reads must cost about
+//! sixteen times one read; if the two land close together, the compiler
+//! has hoisted the call out of the loop and **both numbers are measuring
+//! criterion's iteration overhead instead of the clock**. A benchmark
+//! that cannot fail is not evidence, and a timing benchmark whose subject
+//! is a single cheap call is precisely where that happens quietly.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_platform::Clock;
+
+/// Reads in the batched case. Enough that per-iteration loop overhead is
+/// a small fraction of the total, few enough that the batch still fits
+/// comfortably inside criterion's timing resolution.
+const BATCH: usize = 16;
+
+fn clock_benches(c: &mut Criterion) {
+    let clock = Clock::start();
+
+    c.bench_function("clock_elapsed_nanos", |b| {
+        b.iter(|| black_box(black_box(&clock).elapsed_nanos()));
+    });
+
+    // Summed rather than discarded so every read has a consumer the
+    // optimiser can see, and so a partially-elided loop changes the
+    // answer rather than merely the timing.
+    c.bench_function("clock_elapsed_nanos_x16", |b| {
+        b.iter(|| {
+            let mut total: u64 = 0;
+            for _ in 0..BATCH {
+                total = total.wrapping_add(black_box(&clock).elapsed_nanos());
+            }
+            black_box(total)
+        });
+    });
+}
+
+criterion_group!(benches, clock_benches);
+criterion_main!(benches);


### PR DESCRIPTION
The tree times frames, jobs and samples, and has never measured the price of the timestamp itself. That number is the unit cost of every piece of timing instrumentation the engine will ever add — a proposal to time something *per chunk* is a proposal to spend it that many times, and the argument cannot be had until it is on the table. It is also syscall-adjacent (vDSO, `QueryPerformanceCounter`, `mach_absolute_time`) and so varies sharply by platform, which is why it wants the per-platform table rather than one quoted figure.

On this machine (Windows): **36.70 ns** per read.

**The batched case is a self-check, not a second result.** Sixteen reads must cost about sixteen times one read; if the two land close together the call has been hoisted out of the loop and both numbers are measuring criterion's iteration overhead instead of the clock. Measured 586.37 ns for sixteen — a ratio of 15.97, so nothing was hoisted. A timing benchmark whose subject is one cheap call is exactly where that failure happens quietly, so the check is built in rather than left to whoever reads the output.

What it decides, concretely: two reads bracketing a span cost ~73 ns. Against a coarse chunk of real work (~22 us in the skew group) that is 0.3% and free. Against a chunk of the flagship transform at fine grain (~66 ns of work) it is **more than 100%**. Since grain is the caller's choice, per-chunk timing cannot be unconditional.

Verified: clippy clean, fmt clean, `--test` smoke mode passes.