### PR TITLE
Record the bench crate's platform dev-dependency in the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "renew-jobs",
  "renew-math",
  "renew-memory",
+ "renew-platform",
  "renew-rng",
 ]
 


### PR DESCRIPTION
The clock benchmark added `renew-platform` as a dev-dependency of the bench crate. The manifest carried the edge; the lockfile did not, because the commit named its paths explicitly and the lockfile was not among them.

One line. A clean clone would otherwise resolve to a lockfile differing from the committed one, which is the property the pinning exists to prevent.