### PR TITLE
Read the scripted traces from committed files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Trace files are golden fixtures: tests compare what the recorder writes
+# against these bytes exactly. The writer emits LF on every platform, so a
+# checkout that converted them to CRLF would fail those comparisons on
+# Windows only — the least useful place to discover it. The reader itself
+# tolerates CRLF; byte equality does not.
+*.trace text eol=lf

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -47,7 +47,7 @@ pub use app::{EchoApp, describe};
 pub use cli::{DEFAULT_FRAMES, DEFAULT_TRACE, Options, Report, SAMPLE, USAGE, parse_args};
 pub use error::SampleError;
 pub use scripted::replay;
-pub use trace::{TRACES, Trace, by_name, names};
+pub use trace::{Trace, by_name, names};
 pub use world::EchoWorld;
 
 /// Setting this to `1` turns a skip into a failure: on a lane that

--- a/samples/input_echo/src/scripted.rs
+++ b/samples/input_echo/src/scripted.rs
@@ -31,11 +31,11 @@ const FRAME_INTERVAL_NS: u64 = Timestep::HZ_60.nanos().get();
 pub fn run(options: &Options) -> Result<Report, SampleError> {
     let trace = trace::by_name(&options.trace)?;
     let Some(path) = &options.record_trace else {
-        return Ok(replay(trace, options.seed, options.frames));
+        return Ok(replay(&trace, options.seed, options.frames));
     };
 
     let mut recorder = Recorder::default();
-    let report = replay_recording(trace, options.seed, options.frames, Some(&mut recorder));
+    let report = replay_recording(&trace, options.seed, options.frames, Some(&mut recorder));
     // The header is written after the run, not before it, because two of
     // its fields are facts about what happened: how many ticks the run
     // actually reached, which the trace's own close request decides.
@@ -92,7 +92,7 @@ pub fn replay_recording(
     );
     let mut stats = FrameStats::new();
     for index in 1..=frames {
-        for (at, event) in trace.events {
+        for (at, event) in &trace.events {
             if *at == index {
                 // `index - 1` is the tick the next step will carry, which
                 // is what the format means by an event's tick: delivered
@@ -203,7 +203,7 @@ mod tests {
     use crate::trace;
 
     fn walk(frames: u64) -> crate::cli::Report {
-        replay(trace::by_name("walk").expect("the walk trace"), 0, frames)
+        replay(&trace::by_name("walk").expect("the walk trace"), 0, frames)
     }
 
     /// The whole sample in one assertion: the key held from frame two to
@@ -241,13 +241,13 @@ mod tests {
 
     #[test]
     fn an_empty_trace_runs_the_loop_and_nothing_else() {
-        let idle = replay(trace::by_name("idle").expect("the idle trace"), 0, 30);
+        let idle = replay(&trace::by_name("idle").expect("the idle trace"), 0, 30);
         assert_eq!(idle.stats.frames(), 30);
         assert_eq!(idle.stats.ticks(), 30);
         assert_eq!(idle.world.events(), 0);
         assert_eq!(idle.world.position(), (0, 0));
         // A frameless run is legal and reports an empty schedule.
-        let nothing = replay(trace::by_name("idle").expect("the idle trace"), 0, 0);
+        let nothing = replay(&trace::by_name("idle").expect("the idle trace"), 0, 0);
         assert_eq!(nothing.stats.frames(), 0);
     }
 
@@ -255,7 +255,7 @@ mod tests {
     fn two_replays_of_one_trace_agree_to_the_last_bit() {
         assert_eq!(walk(600).digest_line(), walk(600).digest_line());
         // The seed is an input like any other, and it shows.
-        let seeded = replay(trace::by_name("walk").expect("the walk trace"), 3, 600);
+        let seeded = replay(&trace::by_name("walk").expect("the walk trace"), 3, 600);
         assert_ne!(seeded.digest_line(), walk(600).digest_line());
         assert_eq!(seeded.world.position(), (48, 16), "speed four");
     }

--- a/samples/input_echo/src/trace.rs
+++ b/samples/input_echo/src/trace.rs
@@ -1,163 +1,226 @@
-//! The scripted event traces headless mode replays.
+﻿//! The scripted event traces headless mode replays.
 //!
 //! No runner supplies keystrokes, so a windowing sample that could only
-//! be driven by hand would be a sample CI can never execute — and an
+//! be driven by hand would be a sample CI can never execute â€” and an
 //! unexecuted binary is an untested one. These traces are the same
 //! events the OS would deliver, on a schedule the sample chooses, fed to
 //! the same state machine a window feeds.
+//!
+//! # Why they are files
+//!
+//! They used to be a table in this file, written in `WindowEvent`
+//! literals. That made the same fact exist twice: once as Rust, once as
+//! the text format the codec speaks â€” and a scripted run exercised only
+//! the first, so the format a recording is *stored* in was never on the
+//! default path. The traces are now committed files, read by the same
+//! parser that reads a recording and converted by the same translation a
+//! replay uses. One representation, one reader.
+//!
+//! Each file is also its own golden: it is exactly what `record`
+//! produces from the trace it holds, so re-recording a loaded trace
+//! reproduces the file byte for byte. That is the assertion which
+//! catches the indexing mistake this migration could most plausibly
+//! make, and it lives in `tests/recording.rs` where the recorder is.
+//!
+//! # The header is provenance, not configuration
+//!
+//! A trace file carries a header â€” `seed`, `ticks`, `budget`,
+//! `timestep_ns` â€” and on the `--replay-trace` path the header **owns**
+//! the run: it says how long the run was and how it was configured.
+//!
+//! On this path it does not. `--input-trace walk --seed 7` has to honour
+//! the command line, because that is how the determinism matrix drives
+//! one trace across many seeds. So a header here records *the run the
+//! file was captured from* and nothing more, and only the event lines
+//! are read. The same bytes therefore mean two compatible things: a
+//! complete run to `replay`, and a reusable script to `--input-trace`.
+//! Keeping one format for both is worth the sentence it takes to say so
+//! â€” a second, headerless format would have cost a second parser.
+//!
+//! # Frames here, ticks in the file
+//!
+//! The file indexes events by **tick**, counted from zero, because that
+//! is what the format means. The scripted driver indexes them by
+//! **frame**, counted from one. They differ by exactly one, and the
+//! conversion happens once, here, at load â€” see [`FIRST_FRAME`].
 
-use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+use renew_platform::window::WindowEvent;
 
+use crate::convert;
 use crate::error::SampleError;
 
-/// A named sequence of events, each scheduled at a frame index counted
-/// from one — the same index the synthetic clock uses, so "frame 4" in
-/// the table is the frame the event lands in.
+/// The frame a tick-zero event is delivered before.
+///
+/// The driver runs frames `1..=frames` and delivers a scripted event
+/// before the frame whose index matches, while the format says tick *k*
+/// is delivered before the step whose tick is *k*, counted from zero. A
+/// headless run executes exactly one step per frame, so the two indexes
+/// describe the same instant offset by one â€” which is why the recorder
+/// writes `frame - 1`. Named rather than spelled as a bare `+ 1` so the
+/// inverse in `scripted.rs` has something to point at.
+const FIRST_FRAME: u64 = 1;
+
+/// A scripted trace as it is stored: its identity, and the committed file
+/// that holds its events.
+struct Scripted {
+    name: &'static str,
+    summary: &'static str,
+    /// Embedded at compile time, not read at run time. A sample that had
+    /// to find its traces on disk would be a sample whose behaviour
+    /// depended on the directory it was started from.
+    text: &'static str,
+}
+
+/// Every trace this sample can replay.
+const SCRIPTED: &[Scripted] = &[
+    Scripted {
+        name: "walk",
+        summary: "keys, pointer, wheel, focus and resize, ending in a close request",
+        text: include_str!("../traces/walk.trace"),
+    },
+    Scripted {
+        name: "idle",
+        summary: "no input at all â€” the loop running on its own",
+        text: include_str!("../traces/idle.trace"),
+    },
+];
+
+/// A loaded trace: a named sequence of events, each scheduled at a frame
+/// index counted from one â€” the same index the synthetic clock uses, so
+/// "frame 4" is the frame the event lands in.
 #[derive(Debug)]
 pub struct Trace {
     pub name: &'static str,
     pub summary: &'static str,
-    pub events: &'static [(u64, WindowEvent)],
+    pub events: Vec<(u64, WindowEvent)>,
 }
 
-const fn press(code: KeyCode) -> WindowEvent {
-    WindowEvent::Key {
-        code,
-        pressed: true,
-        repeat: false,
-    }
-}
-
-const fn release(code: KeyCode) -> WindowEvent {
-    WindowEvent::Key {
-        code,
-        pressed: false,
-        repeat: false,
-    }
-}
-
-/// A short walk: right for twelve ticks, down for four of them, with
-/// every other kind of event the window seam can deliver mixed in, and a
-/// close request at the end.
-const WALK: Trace = Trace {
-    name: "walk",
-    summary: "keys, pointer, wheel, focus and resize, ending in a close request",
-    events: &[
-        (2, press(KeyCode::ArrowRight)),
-        (2, WindowEvent::PointerMoved { x: 12.5, y: 34.5 }),
-        (4, press(KeyCode::ArrowDown)),
-        (
-            6,
-            WindowEvent::PointerButton {
-                button: PointerButton::Left,
-                pressed: true,
-            },
-        ),
-        (
-            6,
-            WindowEvent::PointerButton {
-                button: PointerButton::Left,
-                pressed: false,
-            },
-        ),
-        (8, release(KeyCode::ArrowDown)),
-        (9, WindowEvent::Wheel { dx: 0.0, dy: 16.0 }),
-        (10, WindowEvent::Focused(true)),
-        (
-            11,
-            WindowEvent::Resized {
-                width: 640,
-                height: 360,
-            },
-        ),
-        // A repaint request this sample has nothing to paint for, and a
-        // key repeat it deliberately ignores: both are counted, neither
-        // moves anything.
-        (12, WindowEvent::RedrawRequested),
-        (
-            13,
-            WindowEvent::Key {
-                code: KeyCode::ArrowRight,
-                pressed: true,
-                repeat: true,
-            },
-        ),
-        (14, release(KeyCode::ArrowRight)),
-        (16, WindowEvent::ScaleFactorChanged { scale: 2.0 }),
-        (20, WindowEvent::CloseRequested),
-    ],
-};
-
-/// No input at all: the loop running on its own, which is the shape a
-/// dedicated server or a determinism harness has.
-const IDLE: Trace = Trace {
-    name: "idle",
-    summary: "no input at all — the loop running on its own",
-    events: &[],
-};
-
-/// Every trace this sample can replay.
-pub const TRACES: &[Trace] = &[WALK, IDLE];
-
-/// The trace by that name.
+/// The trace by that name, read from the file that holds it.
 ///
 /// # Errors
 ///
-/// [`SampleError::Usage`] naming every trace that does exist — a sample
+/// [`SampleError::Usage`] naming every trace that does exist â€” a sample
 /// that answers "no such trace" and stops is a sample nobody runs twice.
-pub fn by_name(name: &str) -> Result<&'static Trace, SampleError> {
-    TRACES
+///
+/// [`SampleError::Failed`] if a committed trace file does not parse.
+/// That is a defect in this repository rather than in the caller's
+/// command line and is reported as one, though the unit test below is
+/// what should catch it first.
+pub fn by_name(name: &str) -> Result<Trace, SampleError> {
+    let found = SCRIPTED
         .iter()
-        .find(|trace| trace.name == name)
-        .ok_or_else(|| SampleError::Usage(format!("no trace named `{name}`; {}", names())))
+        .find(|scripted| scripted.name == name)
+        .ok_or_else(|| SampleError::Usage(format!("no trace named `{name}`; {}", names())))?;
+    load(found)
+}
+
+fn load(scripted: &Scripted) -> Result<Trace, SampleError> {
+    let parsed = renew_trace::parse(scripted.text).map_err(|error| {
+        SampleError::failed(
+            &format!("reading the built-in `{}` trace", scripted.name),
+            &error,
+        )
+    })?;
+    let events = parsed
+        .events()
+        .iter()
+        .map(|(tick, event)| {
+            (
+                tick.saturating_add(FIRST_FRAME),
+                convert::from_trace(*event),
+            )
+        })
+        .collect();
+    Ok(Trace {
+        name: scripted.name,
+        summary: scripted.summary,
+        events,
+    })
 }
 
 /// The traces, named and summarized, for a usage message.
 #[must_use]
 pub fn names() -> String {
-    let listed: Vec<String> = TRACES
+    let listed: Vec<String> = SCRIPTED
         .iter()
-        .map(|trace| format!("{} ({})", trace.name, trace.summary))
+        .map(|scripted| format!("{} ({})", scripted.name, scripted.summary))
         .collect();
     format!("available traces: {}", listed.join(", "))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{TRACES, by_name, names, press, release};
+    use super::{FIRST_FRAME, SCRIPTED, Scripted, Trace, by_name, load, names};
     use crate::error::SampleError;
-    use renew_platform::window::{KeyCode, WindowEvent};
 
-    /// The two shorthands the tables above are written with. They are
-    /// const-evaluated into those tables, so nothing else ever executes
-    /// them — and a shorthand that meant the opposite of its name would
-    /// silently invert a whole trace.
+    fn every_trace() -> Vec<Trace> {
+        SCRIPTED
+            .iter()
+            .map(|scripted| load(scripted).expect("a committed trace must parse"))
+            .collect()
+    }
+
+    /// Whether the committed file behind a named trace writes an event on
+    /// the given tick. Reads the stored text, so an assertion built on it
+    /// is anchored to the file rather than to the load path under test.
+    fn file_has_event_at_tick(name: &str, tick: u64) -> bool {
+        SCRIPTED
+            .iter()
+            .find(|scripted| scripted.name == name)
+            .is_some_and(|scripted| {
+                let marker = format!("e {tick} ");
+                scripted.text.lines().any(|line| line.starts_with(&marker))
+            })
+    }
+
+    /// The refusal path, which no committed file can reach while they all
+    /// parse — and which would therefore go untested if it were left to
+    /// them. Reached by handing `load` a deliberately broken entry, so
+    /// the arm is exercised rather than exempted.
+    ///
+    /// What it must get right is the blame: a codec error surfacing on
+    /// its own says a trace is malformed without saying which, or whose
+    /// fault it is. The caller typed a name; the defect is in this
+    /// repository, and the message has to say so.
     #[test]
-    fn the_key_shorthands_mean_what_they_say() {
-        assert_eq!(
-            press(KeyCode::Space),
-            WindowEvent::Key {
-                code: KeyCode::Space,
-                pressed: true,
-                repeat: false
-            }
+    fn a_trace_file_that_does_not_parse_says_which_one_and_whose_fault() {
+        let broken = Scripted {
+            name: "broken",
+            summary: "not a trace at all",
+            text: "this is not a trace
+",
+        };
+        let error = load(&broken).expect_err("a non-trace must be refused");
+        assert!(matches!(error, SampleError::Failed(_)), "{error:?}");
+        let message = error.to_string();
+        assert!(message.contains("broken"), "must name the trace: {message}");
+        assert!(
+            message.contains("built-in"),
+            "must say the file is this repository's, not the caller's: {message}"
         );
-        assert_eq!(
-            release(KeyCode::Space),
-            WindowEvent::Key {
-                code: KeyCode::Space,
-                pressed: false,
-                repeat: false
-            }
-        );
+    }
+
+    /// A committed file that did not parse would otherwise fail at run
+    /// time, inside a sample, with a message about this repository rather
+    /// than about the caller's command line.
+    #[test]
+    fn every_committed_trace_file_parses() {
+        for scripted in SCRIPTED {
+            load(scripted)
+                .unwrap_or_else(|error| panic!("`{}` does not parse: {error}", scripted.name));
+        }
     }
 
     #[test]
     fn every_trace_is_findable_by_the_name_it_carries() {
-        for trace in TRACES {
-            let found = by_name(trace.name).expect("a listed trace");
-            assert_eq!(found.name, trace.name);
-            assert!(!found.summary.is_empty(), "{} has no summary", trace.name);
+        for scripted in SCRIPTED {
+            let found = by_name(scripted.name).expect("a listed trace");
+            assert_eq!(found.name, scripted.name);
+            assert!(
+                !found.summary.is_empty(),
+                "{} has no summary",
+                scripted.name
+            );
         }
     }
 
@@ -167,20 +230,51 @@ mod tests {
         assert!(matches!(error, SampleError::Usage(_)), "{error:?}");
         let message = error.to_string();
         assert!(message.contains("moonwalk"), "{message}");
-        for trace in TRACES {
-            assert!(message.contains(trace.name), "{message}");
+        for scripted in SCRIPTED {
+            assert!(message.contains(scripted.name), "{message}");
         }
     }
 
     #[test]
     fn the_scripted_events_are_ordered_and_land_inside_a_short_run() {
-        for trace in TRACES {
+        for trace in every_trace() {
             let mut previous = 0;
-            for (frame, _) in trace.events {
+            for (frame, _) in &trace.events {
                 assert!(*frame >= previous, "{} is out of order", trace.name);
                 previous = *frame;
             }
         }
         assert!(names().contains("walk"));
+    }
+
+    /// The load-bearing property of the migration: the file counts ticks
+    /// from zero, the driver counts frames from one, and every loaded
+    /// event must have moved by exactly that.
+    ///
+    /// Anchored to the file's own text, because two readings of one table
+    /// agree however wrong the reading is. The walk's first event is on
+    /// the file's tick 1 and must arrive on frame 2; nothing may arrive
+    /// on frame 0, which the driver never runs and where a missing shift
+    /// would put every tick-zero event.
+    #[test]
+    fn a_files_tick_becomes_the_next_frame() {
+        assert_eq!(FIRST_FRAME, 1);
+        assert!(
+            file_has_event_at_tick("walk", 1),
+            "the fixture must carry a tick-1 event or this proves nothing"
+        );
+        let walk = by_name("walk").expect("the walk trace");
+        assert_eq!(
+            walk.events.first().map(|(frame, _)| *frame),
+            Some(2),
+            "tick 1 in the file is frame 2 in the driver"
+        );
+        for trace in every_trace() {
+            assert!(
+                trace.events.iter().all(|(frame, _)| *frame >= FIRST_FRAME),
+                "{} put an event on a frame the driver never runs",
+                trace.name
+            );
+        }
     }
 }

--- a/samples/input_echo/tests/recording.rs
+++ b/samples/input_echo/tests/recording.rs
@@ -178,3 +178,49 @@ fn the_recorded_file_reads_back_and_rewrites_identically() {
     // trace ends by asking to close, and that arrives after the last step.
     assert_eq!(parsed.header().ticks(), 20);
 }
+
+/// Each committed trace file is the fixed point of its own round trip:
+/// loading it, running it, and recording the result reproduces the file
+/// byte for byte.
+///
+/// **This is a guard, not an anchor, and the difference matters.** The
+/// loader shifts a file's tick to a frame and the recorder shifts it
+/// back, so a pair of shifts wrong in the same direction would satisfy
+/// this test perfectly. What it does catch is the committed file drifting
+/// away from what the code produces — a hand edit, a reordered event, a
+/// header nobody meant to change — which is the realistic failure for a
+/// checked-in fixture. The assertion that the shift itself is correct is
+/// the hand-typed expectation above, and the one anchored to the file's
+/// own text in `trace.rs`.
+#[test]
+fn every_committed_trace_is_the_fixed_point_of_its_own_recording() {
+    for (name, committed) in [
+        ("walk", include_str!("../traces/walk.trace")),
+        ("idle", include_str!("../traces/idle.trace")),
+    ] {
+        let path = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+            .join(format!("{name}-fixed-point.trace"));
+        let _ = std::fs::remove_file(&path);
+        // No `--seed` and no `--frames`: the committed files were
+        // captured from the defaults, and naming them here would let the
+        // fixture and the test drift apart while both looked deliberate.
+        let code = renew_sample_input_echo::run_cli(
+            [
+                "--headless",
+                "--input-trace",
+                name,
+                "--record-trace",
+                &path.to_string_lossy(),
+            ]
+            .into_iter()
+            .map(str::to_string),
+        );
+        assert_eq!(code, 0, "`{name}` should run");
+
+        let recorded = std::fs::read_to_string(&path).expect("the recorded trace");
+        assert_eq!(
+            recorded, committed,
+            "`{name}.trace` is no longer what recording it produces"
+        );
+    }
+}

--- a/samples/input_echo/traces/idle.trace
+++ b/samples/input_echo/traces/idle.trace
@@ -1,0 +1,1 @@
+renew-trace 0 sample=input_echo ticks=600 timestep_ns=16666667 budget=5 seed=0

--- a/samples/input_echo/traces/walk.trace
+++ b/samples/input_echo/traces/walk.trace
@@ -1,0 +1,15 @@
+renew-trace 0 sample=input_echo ticks=20 timestep_ns=16666667 budget=5 seed=0
+e 1 key arrow-right down
+e 1 pointer 0x4029000000000000 0x4041400000000000
+e 3 key arrow-down down
+e 5 button left down
+e 5 button left up
+e 7 key arrow-down up
+e 8 wheel 0x00000000 0x41800000
+e 9 focus in
+e 10 resize 640 360
+e 11 redraw
+e 12 key arrow-right down repeat
+e 13 key arrow-right up
+e 15 scale 0x4000000000000000
+e 19 close


### PR DESCRIPTION
The scripted traces existed twice — as a table of `WindowEvent` literals in the sample, and as the text format the codec speaks. One fact in two representations, and a scripted run exercised only the first, so **the format a recording is stored in was never on the default path**.

They are now committed files, read by the same parser that reads a recording and converted by the same translation a replay uses. Embedded with `include_str!` rather than found on disk: a sample that had to locate its traces would be a sample whose behaviour depended on the directory it was started from.

**The indexing is the risk.** The file counts ticks from zero; the driver counts frames from one. The conversion happens once, at load, behind a named constant so the recorder's inverse has something to point at. Setting it wrong is caught by **eight tests across four files** — verified by mutation, not assumed — including a hand-typed expected recording that no round trip could satisfy by accident, and a new unit test anchored to the file's own text rather than to another reading of it.

**A header means two things now, and that is deliberate.** On `--replay-trace` the header owns the run. On `--input-trace` it cannot, because `--seed` from the command line is how the determinism matrix drives one trace across many seeds — so here it is provenance only. Said plainly where a reader will meet it; a second, headerless format would have cost a second parser.

Also adds a fixed-point guard: recording a loaded trace reproduces its file byte for byte. Its doc comment says what it is *not* — two shifts wrong in the same direction would satisfy it, so it guards the fixture against drift rather than anchoring the shift.

`.gitattributes` pins `*.trace` to LF. The reader tolerates CRLF; byte-for-byte comparison does not, and a converting checkout would have failed on Windows only — the least useful place to find out.

Verified: 67 suites / 732 tests, fmt and clippy clean, `trace.rs` at 100% coverage with no new exemptions (the parse-failure arm is exercised by a deliberately broken entry rather than exempted).