### PR TITLE
Name every crate declaring the sanitized feature

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -48,7 +48,15 @@ jobs:
         # The sanitized feature marks allocation-counting tests ignored:
         # instrumented runtimes allocate on their own, so those counts are
         # meaningless here (the regular CI workflow measures them).
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-rng/sanitized,renew-frame/sanitized -Zbuild-std --target ${{ matrix.target }}
+        #
+        # THIS LIST MUST NAME EVERY CRATE THAT DECLARES THE FEATURE. It is
+        # hand-maintained against manifests it cannot see, and it has now
+        # gone stale twice: once for renew-frame, whose counting test ran
+        # under instrumented allocators and passed while measuring noise,
+        # and once for the hello_triangle sample. Neither was caught by a
+        # gate. To check it by hand:
+        #   grep -rl '^sanitized = ' --include=Cargo.toml .
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.


### PR DESCRIPTION
The sanitizer job's `--features` list named **seven** crates; **eight** declare the feature. The missing one was the `hello_triangle` sample, whose allocation-counting test is `#[ignore]`d under `sanitized` and would otherwise run against instrumented allocators — where the counts it asserts on are meaningless.

**It had never actually run wrong**, and only by luck of timing: the test landed on 2026-07-31 and the job last ran on 2026-07-30, on a weekly schedule. The next scheduled run would have been the first, and it would have been wrong.

This is the second time this particular list has gone stale — the first cost `renew-frame` a counting test that passed while measuring noise — and the first time it was found deliberately rather than by accident. The comment above the line now states the correspondence it must satisfy and gives the one-line command that checks it:

```
grep -rl '^sanitized = ' --include=Cargo.toml .
```

That is a stopgap. The rule belongs in the workspace checker, which would need to read a workflow file; deliberately not bundled here, since it changes what gates `main`.

One subtlety a future guard must get right: `crates/core/memory` declares the feature and has no `zero_alloc.rs`. The correspondence is *every crate declaring the feature is listed*, not *every crate with a counting test* — checking the latter would report memory as a false positive.

No alternatives to weigh here: the list has no design choice (it must equal the set of crates declaring the feature), and the completeness question a reviewer would ask was answered mechanically against the manifests before the change.