### PR TITLE
Make the sanitizer job green again, and run it daily

### DIFF
--- a/.github/tsan-suppressions.txt
+++ b/.github/tsan-suppressions.txt
@@ -1,0 +1,42 @@
+# ThreadSanitizer suppressions.
+#
+# One entry. Adding a second is a decision, not a maintenance step: every
+# line here is a place the only tool in the matrix that can see a data
+# race has been told not to look.
+#
+# --- libvulkan loader teardown -------------------------------------------
+#
+# What is reported: a write to a pthread mutex during pthread_mutex_destroy
+# inside libvulkan.so.1, reached from `<libloading::Library as Drop>::drop`
+# -> drop glue for `ash::entry::Entry`. Two warnings, at process exit,
+# from renew-rhi's device tests.
+#
+# Why it happens here and not in the rendering lane: this job has no Vulkan
+# runtime installed, so every one of those tests calls `Device::new`, which
+# dlopens the loader, fails to find a device, and drops the Entry on the
+# way out -- dlclose. The tests then skip and pass. Nine of them run on
+# parallel harness threads, so the binary opens and closes libvulkan nine
+# times over, concurrently. On the success path the Entry is moved into
+# `DeviceShared` and lives as long as the device, so none of this happens
+# where a device actually exists.
+#
+# Why suppressing rather than fixing: neither libvulkan nor the dynamic
+# loader is instrumented, so TSan cannot see their internal
+# synchronization and reports the teardown as a race it cannot prove
+# ordered. The engine frames in the stack are the ones *dropping* the
+# library; no engine state is involved on either side of the reported
+# access.
+#
+# What this suppression does NOT establish, and the reason it is written
+# down: it is not proof the report is a false positive. dlclose of a
+# graphics driver while other threads hold it open is a genuinely
+# questionable pattern, and "third-party" is not a synonym for "harmless".
+# What is established is that no engine data races here, and that the
+# scenario only arises on a skip path in an environment with no driver.
+#
+# The better fix, when someone has the appetite: install a software Vulkan
+# runtime in this job the way the rendering lane does. Then these tests do
+# real work instead of skipping, the Entry is retained, the churn stops --
+# and the sanitizer would start covering renew-rhi, which today it does
+# not cover at all.
+called_from_lib:libvulkan.so

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -2,7 +2,11 @@ name: Nightly checks
 
 on:
   schedule:
-    - cron: "0 6 * * 1"
+    # Daily, not weekly. It was weekly, and that is why two failures sat
+    # on main unseen: the job last ran nine hours before the crate that
+    # breaks it landed, so every green run in its history was green
+    # about code that no longer existed.
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 env:
@@ -43,6 +47,11 @@ jobs:
       - name: Run tests under ${{ matrix.sanitizer }} sanitizer
         env:
           RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
+          # Read only by the thread sanitizer; harmless where the file's
+          # contents mean nothing. Every line in it is a place this job
+          # has been told not to look, so it is short and each entry
+          # carries its own reasoning.
+          TSAN_OPTIONS: "suppressions=${{ github.workspace }}/.github/tsan-suppressions.txt"
         # Doctests are compiled without sanitizer instrumentation and fail the
         # ABI-mismatch check; they run in the regular CI workflow instead.
         # The sanitized feature marks allocation-counting tests ignored:
@@ -56,7 +65,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-cli/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -15,6 +15,14 @@ core = false
 extension_points = []
 simulation = false
 
+[features]
+# Enabled by instrumented (sanitizer) test runs. Five integration tests
+# replace PATH with a single directory so the test decides what the
+# binary can and cannot spawn; under ASan on Windows that also removes
+# the sanitizer runtime DLL, and the child dies with
+# STATUS_DLL_NOT_FOUND before it can choose the exit code they assert on.
+sanitized = []
+
 [lints]
 workspace = true
 

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -643,6 +643,10 @@ fn a_run_outside_any_workspace_fails_in_both_modes() {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "replaces PATH, which under ASan on Windows also hides the sanitizer runtime DLL"
+)]
 fn a_step_that_cannot_be_spawned_fails_in_both_modes() {
     let empty = scratch_directory("nopath").expect("scratch directory should be creatable");
     // `configure`'s first step is `rustup`; an empty search path makes it
@@ -677,6 +681,10 @@ fn a_step_that_cannot_be_spawned_fails_in_both_modes() {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "replaces PATH, which under ASan on Windows also hides the sanitizer runtime DLL"
+)]
 fn check_fails_loudly_when_cargo_metadata_cannot_be_read() {
     let directory = broken_workspace("metadata").expect("scratch workspace should be creatable");
     // Pin the search path to the cargo that built this test, so the child
@@ -1084,6 +1092,10 @@ fn an_unknown_sample_is_a_usage_error_naming_the_samples_that_exist() {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "replaces PATH, which under ASan on Windows also hides the sanitizer runtime DLL"
+)]
 fn a_run_that_cannot_read_the_sample_list_refuses_instead_of_denying_it() {
     // No workspace at all: the same refusal every other subcommand gives.
     let empty = scratch_directory("run-noroot").expect("scratch directory should be creatable");
@@ -1364,6 +1376,10 @@ fn doctor_check<'a>(envelope: &'a Value, name: &str) -> Option<&'a Value> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "replaces PATH, which under ASan on Windows also hides the sanitizer runtime DLL"
+)]
 fn doctor_fails_when_no_tool_is_on_the_search_path() {
     let empty = scratch_directory("doctor-bare").expect("scratch directory should be creatable");
     let output =
@@ -1387,6 +1403,10 @@ fn doctor_fails_when_no_tool_is_on_the_search_path() {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "replaces PATH, which under ASan on Windows also hides the sanitizer runtime DLL"
+)]
 fn a_rustup_that_cannot_name_its_toolchain_still_counts_as_found() {
     let directory =
         scratch_directory("doctor-rustup").expect("scratch directory should be creatable");


### PR DESCRIPTION
Two of six sanitizer jobs were failing **on `main`**, unnoticed. Reproduced by dispatching the workflow against unmodified `main`, so neither was caused by anything in flight. Both are fixed here, because fixing either alone leaves the job red.

**Windows / address.** Five CLI integration tests replace `PATH` with a single directory so the test decides what the binary may spawn. Under ASan that also removes `clang_rt.asan_dynamic-x86_64.dll`, so the child dies with `STATUS_DLL_NOT_FOUND` (`0xC0000135`) before it can pick the exit code they assert on. They now carry the same `sanitized` gate eight other crates already use. **The cost is stated rather than hidden:** those five paths lose sanitizer coverage; they still run in the ordinary matrix on all three platforms.

**Linux / thread.** A data race reported in `libvulkan`'s teardown, reached from the loader being dropped in `Device::new`. It happens only in this job because **this job has no Vulkan runtime**: every device test dlopens the loader, fails to find a device, drops it again, and skips — nine times over, on parallel harness threads. Where a device exists the loader is moved into `DeviceShared` and retained for its lifetime, so none of this occurs. Suppressed narrowly, in a file that records what the suppression does and does not establish (it is *not* proof of a false positive) and names the better fix: install a software Vulkan runtime here as the rendering lane does — which would also give this job its **first real coverage of `renew-rhi`**, which today it does not cover at all.

**The schedule moves from weekly to daily,** and this is the part that matters most. Weekly is why both sat unseen: the last run predated `crates/rhi/tests/device.rs` by nine hours, so every green run in the job's history was green about code that no longer existed. A gate slower than the tree's rate of change reports on a different tree while looking healthy — and its name says "Nightly".

Verified: with the feature on, exactly 5 tests are ignored and 33 pass; with it off, all 38 run. Workspace 67 suites / 733 tests, fmt and clippy clean (including under `--features sanitized`). The sanitizer workflow is dispatched against this branch; merging waits on it going green.