### PR TITLE
Repair a mangled source file, and guard the two things that rotted silently

### DIFF
--- a/samples/input_echo/src/trace.rs
+++ b/samples/input_echo/src/trace.rs
@@ -1,7 +1,7 @@
-﻿//! The scripted event traces headless mode replays.
+//! The scripted event traces headless mode replays.
 //!
 //! No runner supplies keystrokes, so a windowing sample that could only
-//! be driven by hand would be a sample CI can never execute â€” and an
+//! be driven by hand would be a sample CI can never execute — and an
 //! unexecuted binary is an untested one. These traces are the same
 //! events the OS would deliver, on a schedule the sample chooses, fed to
 //! the same state machine a window feeds.
@@ -10,7 +10,7 @@
 //!
 //! They used to be a table in this file, written in `WindowEvent`
 //! literals. That made the same fact exist twice: once as Rust, once as
-//! the text format the codec speaks â€” and a scripted run exercised only
+//! the text format the codec speaks — and a scripted run exercised only
 //! the first, so the format a recording is *stored* in was never on the
 //! default path. The traces are now committed files, read by the same
 //! parser that reads a recording and converted by the same translation a
@@ -24,8 +24,8 @@
 //!
 //! # The header is provenance, not configuration
 //!
-//! A trace file carries a header â€” `seed`, `ticks`, `budget`,
-//! `timestep_ns` â€” and on the `--replay-trace` path the header **owns**
+//! A trace file carries a header — `seed`, `ticks`, `budget`,
+//! `timestep_ns` — and on the `--replay-trace` path the header **owns**
 //! the run: it says how long the run was and how it was configured.
 //!
 //! On this path it does not. `--input-trace walk --seed 7` has to honour
@@ -35,14 +35,14 @@
 //! are read. The same bytes therefore mean two compatible things: a
 //! complete run to `replay`, and a reusable script to `--input-trace`.
 //! Keeping one format for both is worth the sentence it takes to say so
-//! â€” a second, headerless format would have cost a second parser.
+//! — a second, headerless format would have cost a second parser.
 //!
 //! # Frames here, ticks in the file
 //!
 //! The file indexes events by **tick**, counted from zero, because that
 //! is what the format means. The scripted driver indexes them by
 //! **frame**, counted from one. They differ by exactly one, and the
-//! conversion happens once, here, at load â€” see [`FIRST_FRAME`].
+//! conversion happens once, here, at load — see [`FIRST_FRAME`].
 
 use renew_platform::window::WindowEvent;
 
@@ -55,7 +55,7 @@ use crate::error::SampleError;
 /// before the frame whose index matches, while the format says tick *k*
 /// is delivered before the step whose tick is *k*, counted from zero. A
 /// headless run executes exactly one step per frame, so the two indexes
-/// describe the same instant offset by one â€” which is why the recorder
+/// describe the same instant offset by one — which is why the recorder
 /// writes `frame - 1`. Named rather than spelled as a bare `+ 1` so the
 /// inverse in `scripted.rs` has something to point at.
 const FIRST_FRAME: u64 = 1;
@@ -80,13 +80,13 @@ const SCRIPTED: &[Scripted] = &[
     },
     Scripted {
         name: "idle",
-        summary: "no input at all â€” the loop running on its own",
+        summary: "no input at all — the loop running on its own",
         text: include_str!("../traces/idle.trace"),
     },
 ];
 
 /// A loaded trace: a named sequence of events, each scheduled at a frame
-/// index counted from one â€” the same index the synthetic clock uses, so
+/// index counted from one — the same index the synthetic clock uses, so
 /// "frame 4" is the frame the event lands in.
 #[derive(Debug)]
 pub struct Trace {
@@ -99,7 +99,7 @@ pub struct Trace {
 ///
 /// # Errors
 ///
-/// [`SampleError::Usage`] naming every trace that does exist â€” a sample
+/// [`SampleError::Usage`] naming every trace that does exist — a sample
 /// that answers "no such trace" and stops is a sample nobody runs twice.
 ///
 /// [`SampleError::Failed`] if a committed trace file does not parse.

--- a/tools/cli/tests/source_hygiene.rs
+++ b/tools/cli/tests/source_hygiene.rs
@@ -1,0 +1,129 @@
+//! Every text file in the tree is plain UTF-8, without a byte-order mark
+//! and without the signatures of a botched encoding round-trip.
+//!
+//! This exists because it happened. A source file was read as Windows-1252
+//! and written back as UTF-8, which turned every em dash into three
+//! characters and prefixed the file with a BOM. Nothing noticed: the code
+//! compiled, the tests passed, clippy was happy, and the damage reached a
+//! merged commit. One of the mangled strings was a sample's own help text,
+//! so the first person to see it would have been a user.
+//!
+//! Tooling on Windows makes this easy to do by accident — PowerShell's
+//! `Get-Content`/`Set-Content` pair will do it without a word — so the
+//! guard is worth more here than the check itself suggests.
+//!
+//! Helpers return `Result` rather than unwrapping: the lint that forbids
+//! `expect` and `panic` outside tests reaches helpers in a test file too,
+//! because the exemption follows `#[test]` rather than the file.
+
+use std::path::{Path, PathBuf};
+
+/// Extensions worth checking. Deliberately a list of text formats rather
+/// than "everything that is not binary": a guess about which unknown file
+/// is text is how a guard starts failing on a PNG.
+const TEXT_EXTENSIONS: &[&str] = &["rs", "toml", "yml", "yaml", "md", "trace", "txt", "json"];
+
+/// Directories never descended into. `target` is build output and
+/// enormous; `.git` is not source.
+const SKIPPED: &[&str] = &["target", ".git"];
+
+/// U+FEFF at the start of a file. Legal UTF-8, and a nuisance in every
+/// format here: it is why a YAML key stops matching and why a golden
+/// comparison fails on one platform only.
+const BOM: &str = "\u{feff}";
+
+/// U+00E2 followed by U+20AC: the signature of UTF-8 bytes read as
+/// Windows-1252 and written back out as UTF-8. It is the first two
+/// characters of every mangled em dash, quote and ellipsis, and it occurs
+/// in no real text.
+///
+/// Written as escapes, never as the characters themselves — including in
+/// this comment. The first draft spelled the pair out here and the test
+/// failed on its own source, which is funny once and an obstacle
+/// thereafter.
+const CP1252_DOUBLE_ENCODED: &str = "\u{e2}\u{20ac}";
+
+/// The replacement character: something already gave up decoding this.
+const REPLACEMENT: char = '\u{fffd}';
+
+fn workspace_root() -> PathBuf {
+    let guess = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    guess.canonicalize().unwrap_or(guess)
+}
+
+/// Every text file under `dir`, recursively.
+fn text_files(dir: &Path, found: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|error| format!("{} unreadable: {error}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("{} unreadable: {error}", dir.display()))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if !SKIPPED.contains(&name.as_ref()) {
+                text_files(&path, found)?;
+            }
+            continue;
+        }
+        let is_text = path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| TEXT_EXTENSIONS.contains(&ext));
+        if is_text {
+            found.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn no_text_file_carries_a_byte_order_mark_or_a_mangled_encoding() {
+    let root = workspace_root();
+    let mut files = Vec::new();
+    text_files(&root, &mut files).expect("the workspace should be walkable");
+    assert!(
+        files.len() > 50,
+        "found only {} text files — the walk is not reaching the tree, and this would pass \
+         vacuously",
+        files.len()
+    );
+
+    let mut faults: Vec<String> = Vec::new();
+    for path in &files {
+        let shown = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        let Ok(text) = std::fs::read_to_string(path) else {
+            // Not valid UTF-8 at all. Reported rather than skipped: a
+            // `.rs` file that is not UTF-8 will not compile, and a `.md`
+            // one renders as garbage.
+            faults.push(format!("{shown}: not valid UTF-8"));
+            continue;
+        };
+        if text.starts_with(BOM) {
+            faults.push(format!("{shown}: starts with a byte-order mark"));
+        }
+        if text.contains(CP1252_DOUBLE_ENCODED) {
+            faults.push(format!(
+                "{shown}: contains `\u{e2}\u{20ac}`, the signature of UTF-8 read as Windows-1252 \
+                 and written back as UTF-8"
+            ));
+        }
+        if text.contains(REPLACEMENT) {
+            faults.push(format!(
+                "{shown}: contains U+FFFD, so something already lost characters"
+            ));
+        }
+    }
+
+    assert!(
+        faults.is_empty(),
+        "{} file(s) have encoding damage:\n  {}\n\nOn Windows this is usually a \
+         `Get-Content`/`Set-Content` round-trip. Rewrite the file as UTF-8 without a BOM.",
+        faults.len(),
+        faults.join("\n  ")
+    );
+}

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -1,0 +1,180 @@
+//! Guards for lists that are maintained by hand in one file while the
+//! facts they track live in another.
+//!
+//! The check here exists because its list has actually rotted, in this
+//! repository, twice — and both times silently, because nothing compared
+//! the two halves. The failure mode is the bad one: a test that keeps
+//! passing while measuring nothing.
+//!
+//! This is a test rather than a `renew check` rule on purpose. A rule
+//! would change what gates `main`, which is a heavier change than the
+//! problem needs; a test rides the suite that already runs on every push
+//! and fails in the same place as everything else.
+//!
+//! Helpers return `Result` rather than unwrapping: the lint that forbids
+//! `expect` and `panic` outside tests reaches helpers in a test file too,
+//! because the exemption follows `#[test]` rather than the file.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use renew_cli::json::{self, Value};
+
+/// The workspace root, from this crate's manifest directory.
+fn workspace_root() -> PathBuf {
+    let guess = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    guess.canonicalize().unwrap_or(guess)
+}
+
+/// Crates whose manifest declares a `sanitized` feature.
+///
+/// Read from cargo rather than by scraping TOML: the feature table is
+/// exactly what cargo already computes, and a hand-rolled parser here
+/// would be a third copy of a fact, in a test whose whole subject is
+/// duplicated facts.
+fn crates_declaring_sanitized(root: &Path) -> Result<Vec<String>, String> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(root)
+        .output()
+        .map_err(|error| format!("cargo metadata could not run: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    let document = json::parse(&text).map_err(|error| format!("metadata is not JSON: {error}"))?;
+    let packages = document
+        .get("packages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "cargo metadata carried no packages array".to_string())?;
+
+    let mut found: Vec<String> = packages
+        .iter()
+        .filter(|package| {
+            package
+                .get("features")
+                .and_then(Value::as_object)
+                .is_some_and(|features| features.iter().any(|(name, _)| name == "sanitized"))
+        })
+        .filter_map(|package| {
+            package
+                .get("name")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .collect();
+    found.sort();
+    Ok(found)
+}
+
+/// Every `<crate>/sanitized` token in the sanitizer workflow, and
+/// separately the ones on its workspace-wide test step.
+///
+/// The file carries more than one `--features`: the workspace step that
+/// runs everything, and a targeted step that reruns the job system's
+/// stress tier alone. Only the first can be checked for *completeness* —
+/// the targeted one legitimately names a single crate. Every token in
+/// either is still checked for *existence*, because a typo anywhere fails
+/// the whole job on an unknown feature.
+///
+/// That distinction is not hypothetical tidiness: the first draft of this
+/// test assumed one `--features` in the file, and said so as an
+/// assertion. It failed on its first run, which is the only reason it
+/// does not now silently check the wrong line.
+fn workflow_features(root: &Path) -> Result<(Vec<String>, Vec<String>), String> {
+    let path = root.join(".github/workflows/nightly-checks.yml");
+    let text = std::fs::read_to_string(&path)
+        .map_err(|error| format!("{} is unreadable: {error}", path.display()))?;
+
+    let mut all = Vec::new();
+    let mut workspace_wide: Option<Vec<String>> = None;
+    for line in text.lines() {
+        let Some((_, after)) = line.split_once("--features ") else {
+            continue;
+        };
+        let Some(argument) = after.split_whitespace().next() else {
+            return Err(format!(
+                "`--features` with no argument in {}",
+                path.display()
+            ));
+        };
+        let named: Vec<String> = argument
+            .split(',')
+            .filter_map(|entry| entry.strip_suffix("/sanitized"))
+            .map(ToString::to_string)
+            .collect();
+        all.extend(named.iter().cloned());
+        if line.contains("--workspace") {
+            if workspace_wide.is_some() {
+                return Err(format!(
+                    "two workspace-wide `--features` lines in {}; this test would check only one",
+                    path.display()
+                ));
+            }
+            workspace_wide = Some(named);
+        }
+    }
+    let mut wide = workspace_wide.ok_or_else(|| {
+        format!(
+            "no workspace-wide `--features` line in {} — the completeness check would have \
+             nothing to read, and would pass vacuously",
+            path.display()
+        )
+    })?;
+    all.sort();
+    all.dedup();
+    wide.sort();
+    Ok((all, wide))
+}
+
+/// The sanitizer workflow must enable `sanitized` for every crate that
+/// declares it.
+///
+/// **This has gone wrong twice.** Once `renew-frame` was missing, and its
+/// allocation-counting test ran under instrumented allocators — passing,
+/// while asserting on counts that meant nothing. Once the
+/// `hello_triangle` sample was missing, and that one surfaced only
+/// because a person went looking on purpose. Both times the list was
+/// correct when written and rotted when a crate was added somewhere else.
+///
+/// The correspondence is *declares the feature*, not *has an
+/// allocation-counting test*: `renew-memory` declares it and has no such
+/// test, so a check written the other way round would report it as a
+/// false positive forever.
+#[test]
+fn the_sanitizer_workflow_names_every_crate_that_declares_the_feature() {
+    let root = workspace_root();
+    let declared = crates_declaring_sanitized(&root).expect("the workspace should describe itself");
+    let (every_token, workspace_step) =
+        workflow_features(&root).expect("the sanitizer workflow should be readable");
+
+    assert!(
+        !declared.is_empty(),
+        "no crate declares a `sanitized` feature — this test would pass vacuously"
+    );
+
+    let missing: Vec<&String> = declared
+        .iter()
+        .filter(|crate_name| !workspace_step.contains(crate_name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "these crates declare a `sanitized` feature but the workspace-wide sanitizer step does \
+         not enable it, so their allocation-counting tests run under instrumented allocators and \
+         assert on counts that mean nothing: {missing:?}. Add `<crate>/sanitized` to the \
+         `--features` list in .github/workflows/nightly-checks.yml."
+    );
+
+    let unknown: Vec<&String> = every_token
+        .iter()
+        .filter(|crate_name| !declared.contains(crate_name))
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "the sanitizer workflow enables `sanitized` for crates that do not declare it: \
+         {unknown:?}. cargo fails on an unknown feature, so this is a job that cannot start."
+    );
+}


### PR DESCRIPTION
Two commits: a defect already on `main`, and guards so neither of its kind recurs.

### The defect

`samples/input_echo/src/trace.rs` reached `main` with a **UTF-8 byte-order mark** and every em dash turned into three characters — a tool read it as Windows-1252 and wrote it back as UTF-8. Nothing caught it, because nothing in the toolchain reads the text: it compiled, the tests passed, clippy was clean.

One of the mangled strings is the `idle` trace's summary, printed when someone names a trace that does not exist. **A user asking what traces are available would have been the first to see it.**

### The guards

**Encoding.** Every text file is now checked for a byte-order mark, for the two-character signature of that round-trip, and for U+FFFD. The signature appears only as escapes, including in comments — the first draft spelled it out and the test failed on its own source, which is funny once.

**The sanitizer feature list.** A per-crate feature list, hand-maintained against manifests it cannot see, which has fallen out of step twice; the first time cost the frame crate's allocation-counting test, which ran under instrumented allocators and passed while asserting on counts that meant nothing. Every crate whose manifest declares the feature must now appear on the workspace-wide step, and every crate named anywhere must declare it — an unknown feature fails the whole job before it starts.

Both are tests rather than workspace-check rules: a rule changes what gates `main`, heavier than these need. The feature table comes from cargo rather than from parsing TOML, so the guard does not become another copy of the fact it protects.

**The list guard caught something on its first run:** the workflow has *two* `--features` lines, because the job system's stress tier is rerun on its own. Only the workspace-wide one can be checked for completeness. The draft that assumed otherwise would have checked whichever came first and silently ignored the other — exactly the defect it exists to prevent.

Both guards are bite-tested against the real damage: dropping a crate from the list fails naming it, adding an undeclared one fails, and a file given a BOM plus a mangled dash is reported for both.

Verified: 69 suites / 735 tests, fmt and clippy clean.