### PR TITLE
Stop naming a maturity level that will change

### DIFF
--- a/crates/trace/README.md
+++ b/crates/trace/README.md
@@ -281,7 +281,8 @@ writing the call and watching the lint fire.
 - **No fuzz target.** The property suite hands the reader generated
   garbage with a fixed budget, which is a small fuzzer and not a
   substitute for one. A real target needs tooling this tree does not have
-  yet; the maturity level says `bootstrap` for reasons including this one.
+  yet, and one is required before this crate could be considered stable —
+  which is among the reasons it has not been promoted.
 - **Nothing here records or replays.** This crate is the codec: the
   recorder that produces a trace from a live session, the driver that
   feeds one back into a run, and the command-line face of both are


### PR DESCRIPTION
The trace README explained a missing fuzz target by citing the crate's current maturity level in prose. `Cargo.toml` is the authoritative place for that field and the README already says so a few sections up — so naming it again gave one fact two homes, and the prose copy goes wrong the day the crate is promoted, which is precisely when nobody is rereading that paragraph.

Now says the thing that is true and stays true: a fuzz target is a prerequisite for calling the crate stable, and its absence is among the reasons it has not been promoted.

Found while checking all nine engine crates for manifest/README maturity agreement. **The other eight were already correct**, and so was this one's declaration — this was the only sentence that restated rather than linked.