### PR TITLE
Fail when the unsafe surface changes without being recorded

### DIFF
--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -178,3 +178,162 @@ fn the_sanitizer_workflow_names_every_crate_that_declares_the_feature() {
          {unknown:?}. cargo fails on an unknown feature, so this is a job that cannot start."
     );
 }
+
+// --- The unsafe surface -------------------------------------------------
+
+/// Every file that opts itself out of the workspace's `unsafe_code` denial
+/// with a crate-root allow.
+///
+/// Kept here so that adding one **fails this test** rather than passing
+/// quietly. Carrying unsafe is a reviewed, per-crate decision with a
+/// written grant behind it; the grant records exactly where the unsafe
+/// territory is, and a file that appears here without appearing there
+/// makes that record under-report. Both have happened: one grant was
+/// written naming three of four items, and another naming one of three
+/// test files. Neither was caught by anything mechanical.
+const ALLOWS_UNSAFE: &[&str] = &[
+    "crates/core/diag/tests/zero_alloc.rs",
+    "crates/core/memory/src/lib.rs",
+    "crates/jobs/src/lib.rs",
+    "crates/rhi/src/lib.rs",
+    "crates/rhi/tests/fault.rs",
+    "crates/rhi/tests/fault_present.rs",
+    "crates/rhi/tests/zero_alloc.rs",
+];
+
+/// Crates that do not inherit the workspace lint table, and so are not
+/// subject to its `unsafe_code` denial at all.
+///
+/// The second, quieter route to carrying unsafe: no allow appears
+/// anywhere in the source, because the lint was never in force. A guard
+/// that only looked for allows would miss it entirely.
+const OPTS_OUT_OF_WORKSPACE_LINTS: &[&str] = &["tools/vk-fault-layer"];
+
+/// The attribute this walk searches for, assembled at runtime so that
+/// **this file does not match its own search**. Spelled as one literal it
+/// would, and the test would report itself forever.
+///
+/// Second time today a guard has matched its own source; the encoding
+/// check learned it first. A guard that scans the tree is part of the
+/// tree.
+fn root_allow_needle() -> String {
+    format!("#![{}(unsafe_code)]", "allow")
+}
+
+fn files_with_root_allow(dir: &Path, found: &mut Vec<String>, root: &Path) -> Result<(), String> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|error| format!("{} unreadable: {error}", dir.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("{} unreadable: {error}", dir.display()))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            // `target` is build output and enormous. Nothing else is
+            // skipped by name: the walk is rooted at the workspace's own
+            // members, so it never sees anything that is not source.
+            if name != "target" {
+                files_with_root_allow(&path, found, root)?;
+            }
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)
+            .map_err(|error| format!("{} unreadable: {error}", path.display()))?;
+        if text.contains(&root_allow_needle()) {
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            found.push(
+                rel.to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/"),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Crates whose manifest does not inherit the workspace lint table.
+/// The workspace's member directories, as its own manifest lists them.
+fn workspace_members(root: &Path) -> Result<Vec<String>, String> {
+    let text = std::fs::read_to_string(root.join("Cargo.toml"))
+        .map_err(|error| format!("workspace manifest unreadable: {error}"))?;
+    let list = text
+        .split_once("members = [")
+        .ok_or_else(|| "no members list in the workspace manifest".to_string())?
+        .1
+        .split_once(']')
+        .ok_or_else(|| "unterminated members list".to_string())?
+        .0;
+    let members: Vec<String> = list
+        .split(',')
+        .map(|member| member.trim().trim_matches('"').to_string())
+        .filter(|member| !member.is_empty())
+        .collect();
+    if members.is_empty() {
+        return Err(
+            "the workspace lists no members; every check here would be vacuous".to_string(),
+        );
+    }
+    Ok(members)
+}
+
+fn crates_not_inheriting_lints(root: &Path) -> Result<Vec<String>, String> {
+    let mut found = Vec::new();
+    for member in workspace_members(root)? {
+        let manifest = std::fs::read_to_string(root.join(&member).join("Cargo.toml"))
+            .map_err(|error| format!("{member}/Cargo.toml unreadable: {error}"))?;
+        let inherits = manifest
+            .split_once("[lints]")
+            .is_some_and(|(_, rest)| rest.trim_start().starts_with("workspace = true"));
+        if !inherits {
+            found.push(member.clone());
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+/// The unsafe surface is exactly what is recorded, by both routes.
+///
+/// Unsafe is granted per crate, in writing, and the grant is what a
+/// reader consults to learn where unsafe lives. Nothing mechanical has
+/// ever checked that the grant matches the code, and twice the grant has
+/// been written incomplete. This does not read the grant — it cannot —
+/// but it makes the code side impossible to change silently, which is the
+/// half that moves.
+#[test]
+fn the_unsafe_surface_is_exactly_what_is_recorded() {
+    let root = workspace_root();
+
+    // Rooted at each workspace member rather than at the repository, so
+    // the guard's scope is exactly the crates the workspace builds and it
+    // needs no knowledge of anything else that may sit beside them.
+    let mut allows = Vec::new();
+    for member in workspace_members(&root).expect("the workspace should list its members") {
+        files_with_root_allow(&root.join(&member), &mut allows, &root)
+            .expect("every member directory should be walkable");
+    }
+    allows.sort();
+    let expected: Vec<String> = ALLOWS_UNSAFE.iter().map(ToString::to_string).collect();
+    assert_eq!(
+        allows, expected,
+        "the set of files carrying a crate-root `allow(unsafe_code)` has changed. \
+         Adding one is a reviewed decision: update this list, and update the written \
+         grant that records where the unsafe territory is: a file allowed here but \
+         absent there makes that record under-report, which has happened twice."
+    );
+
+    let opted_out = crates_not_inheriting_lints(&root).expect("manifests should be readable");
+    let expected_out: Vec<String> = OPTS_OUT_OF_WORKSPACE_LINTS
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(
+        opted_out, expected_out,
+        "the set of crates not inheriting the workspace lint table has changed. This \
+         is the quieter way to carry unsafe: no allow appears anywhere, because the \
+         denial was never in force. It needs the same written grant and the same \
+         scrutiny."
+    );
+}


### PR DESCRIPTION
Carrying `unsafe` is a per-crate decision with a written grant behind it, and the grant is what a reader consults to learn where the unsafe territory is. **Nothing mechanical has ever checked that the grant matches the code, and twice a grant has been written incomplete** — once enumerating three of four language items, once naming one of three test files that carry a crate-root allow. Neither was unsound; neither was caught by tooling.

This cannot read the grant, but it makes the code side impossible to change quietly, which is the half that moves.

**Both routes are covered, because checking allows alone would miss the second entirely:**

- files carrying a crate-root `allow(unsafe_code)`;
- crates that do not inherit the workspace lint table at all — where *no allow appears anywhere*, because the denial was never in force.

Bite-tested on each: adding an allow to a crate that has none fails naming the file; switching a crate off the shared lint table fails naming the crate.

Two details worth the reviewer's attention:

- **The attribute is assembled at runtime rather than spelled as one literal**, because otherwise this file matches its own search and the test reports itself forever. Second guard today to need that.
- **The walk is rooted at each workspace member**, not at the repository. The first draft skipped a directory by name, which quietly made the test depend on something outside the workspace; scoping it to the members the manifest lists removes the need to know about anything else.

Verified: 69 suites / 736 tests, fmt and clippy clean.