### PR TITLE
Separate a dispatch's wakeup from its bookkeeping

### DIFF
--- a/bench/suite/benches/jobs.rs
+++ b/bench/suite/benches/jobs.rs
@@ -255,6 +255,36 @@ fn batching_benches(c: &mut Criterion) {
     let grain = NonZeroUsize::MIN.saturating_add(BATCH_GRAIN - 1);
     let mut output = vec![0_u64; BATCH_ELEMENTS];
 
+    // The same sweep on a zero-worker pool, which the pool documents as
+    // running every dispatch inline on the caller: no threads woken, no
+    // waiting, one uncontended poison check. Identical work, identical
+    // chunking, identical call count -- **the only thing removed is the
+    // wakeup**.
+    //
+    // Subtracting one curve from the other therefore splits a dispatch's
+    // cost into the part a better wakeup protocol could reclaim and the
+    // part that is dispatch bookkeeping regardless. That distinction is
+    // the whole question facing anyone who would optimise this, and it
+    // is not answerable from the three-worker numbers alone.
+    if let Ok(mut inline) = JobPool::new(&PoolConfig::new(0)) {
+        for dispatches in [1_usize, 4, 16, 64] {
+            let span = BATCH_ELEMENTS / dispatches;
+            let name = format!("jobs_batching_{dispatches}_dispatches_inline_pool");
+            c.bench_function(&name, |b| {
+                b.iter(|| {
+                    for slice in output.chunks_mut(span) {
+                        inline.parallel_for_slice_mut(black_box(slice), grain, |offset, chunk| {
+                            for (index, slot) in chunk.iter_mut().enumerate() {
+                                *slot = burn((offset + index) as u64, BATCH_ROUNDS);
+                            }
+                        });
+                    }
+                    black_box(output[BATCH_ELEMENTS - 1]);
+                });
+            });
+        }
+    }
+
     for dispatches in [1_usize, 4, 16, 64] {
         let span = BATCH_ELEMENTS / dispatches;
         let name = format!("jobs_batching_{dispatches}_dispatches_3_workers");


### PR DESCRIPTION
Knowing a dispatch costs ~1.2 us does not say **whether that is waking workers or the dispatch machinery** — and those have different remedies. The first is a protocol anyone could improve; the second is inherent.

The pool documents a zero-worker configuration that runs every dispatch inline on the caller, no threads woken, no waiting. Running the identical sweep on it holds work, chunking and call count fixed and removes exactly one thing.

| dispatches | inline pool | 3 workers |
|---|---|---|
| 1 | 17.42 us | 6.32 us |
| 4 | 17.51 us | 10.10 us |
| 16 | 17.69 us | 24.69 us |
| 64 | 18.15 us | 18.28 us |

**Per additional dispatch: 12 ns inline, 1.215 us with workers. The wakeup is 1.204 us — 99.0% of the cost.** The dispatch machinery is effectively free; everything measurable is waking and re-parking threads.

**The two curves are also each other's control.** At 64 dispatches every dispatch covers a single chunk, which the pool runs inline whatever its worker count — so both curves *must* converge there. They agree to within **0.69%**, which is the reason to trust the separation rather than just the arithmetic.

For anyone sizing a future improvement: a cheaper wakeup (spin-then-park, persistent tasks, signalling without a broadcast) is aimed at 99% of the per-dispatch cost. Reducing the bookkeeping is aimed at 12 ns.

Verified: `--test` smoke mode runs all fourteen benchmarks, clippy and fmt clean.