### PR TITLE
Add `renew modules`, the workspace maturity inventory

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -17,6 +17,7 @@ commands:
   lint       check formatting, then run clippy with warnings denied
   check      verify workspace crate manifests and dependencies
   coverage   hold a coverage report against the exemption manifest
+  modules    list every module with its maturity, from the manifests
   doctor     check the development environment
 
 options:
@@ -78,6 +79,33 @@ caller knows what it invoked, and the envelope shape stays uniform.
 A failing sample follows the same contract as any other failing child:
 the `renew` process exits `1`, and the sample's raw exit code survives in
 the envelope's `exit_code`.
+
+## The module inventory
+
+`modules` prints every workspace crate with the maturity it declares, read
+from that crate's own manifest:
+
+```
+renew modules
+renew modules --json
+```
+
+Each crate states its maturity in `[package.metadata.renew]`, and that is
+the only place it is written down. Anything that needs the list — a
+release note recording what a version promises, a document naming the
+optional crates — reads it from here rather than restating it, because a
+retyped table is a second copy of a fact that goes stale without saying
+so. Rows are ordered by maturity rather than alphabetically, and the
+summary line counts how many crates are `stable`, since that is the set a
+version's compatibility promise can cover.
+
+A crate whose metadata does not parse still gets a row, carrying the
+reason in place of its fields. Dropping it would make the inventory
+quietly shorter than the workspace, and an inventory that silently omits
+what it could not read is the kind that gets believed.
+
+It reports; it does not gate. `check` is what fails on a malformed
+manifest.
 
 ## The coverage gate
 

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -13,6 +13,7 @@ pub enum Command {
     Lint,
     Check,
     Coverage,
+    Modules,
     Doctor,
     Record,
     Replay,
@@ -20,7 +21,7 @@ pub enum Command {
 
 impl Command {
     /// Every subcommand, in the order `usage` lists them.
-    pub const ALL: [Self; 11] = [
+    pub const ALL: [Self; 12] = [
         Self::Configure,
         Self::Build,
         Self::Test,
@@ -31,6 +32,7 @@ impl Command {
         Self::Lint,
         Self::Check,
         Self::Coverage,
+        Self::Modules,
         Self::Doctor,
     ];
 
@@ -46,6 +48,7 @@ impl Command {
             Self::Lint => "lint",
             Self::Check => "check",
             Self::Coverage => "coverage",
+            Self::Modules => "modules",
             Self::Doctor => "doctor",
             Self::Record => "record",
             Self::Replay => "replay",
@@ -87,6 +90,7 @@ impl Command {
             Self::Lint => "check formatting, then run clippy with warnings denied",
             Self::Check => "verify workspace crate manifests and dependencies",
             Self::Coverage => "hold a coverage report against the exemption manifest",
+            Self::Modules => "list every module with its maturity, from the manifests",
             Self::Doctor => "check the development environment",
             Self::Record => "run a sample, writing the input it saw to a file",
             Self::Replay => "run a sample from a recorded input file",

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -46,6 +46,7 @@ fn run(invocation: &Invocation) -> ExitCode {
     match invocation.command {
         Command::Doctor => run_doctor(invocation.json),
         Command::Check => run_check(invocation.json),
+        Command::Modules => run_modules(invocation.json),
         // Parsing guarantees the path; an empty one would simply fail to
         // open, which is the same answer by a shorter road.
         Command::Coverage => run_coverage(
@@ -188,6 +189,168 @@ fn findings_from_metadata(text: &str) -> Result<Vec<structure::Finding>, String>
 /// Read the runnable samples out of `cargo metadata` output.
 fn samples_from_metadata(text: &str) -> Result<Vec<samples::Sample>, String> {
     samples::from_metadata(&parsed_metadata(text)?)
+}
+
+/// One row of the module table, already reduced to what is printed.
+///
+/// A crate whose metadata does not parse still gets a row, carrying the
+/// reason instead of its fields. Dropping it would make an inventory
+/// quietly shorter than the workspace, and an inventory that omits what
+/// it could not read is the kind that gets believed.
+struct ModuleRow {
+    name: String,
+    maturity: String,
+    core: Option<bool>,
+    problem: Option<String>,
+}
+
+/// Every workspace crate with its declared maturity, from the manifests.
+///
+/// Sorted by maturity then name rather than alphabetically: the question
+/// this answers is "what does this release promise", and that is read off
+/// the maturity groups, not the alphabet.
+fn module_rows(text: &str) -> Result<Vec<ModuleRow>, String> {
+    let shapes = structure::shapes_from_metadata(&parsed_metadata(text)?)?;
+    let mut rows: Vec<ModuleRow> = shapes
+        .iter()
+        .map(|shape| match &shape.meta {
+            Ok(meta) => ModuleRow {
+                name: shape.name.clone(),
+                maturity: meta.maturity.clone(),
+                core: Some(meta.core),
+                problem: None,
+            },
+            Err(problems) => ModuleRow {
+                name: shape.name.clone(),
+                maturity: "unreadable".to_string(),
+                core: None,
+                problem: Some(problems.join("; ")),
+            },
+        })
+        .collect();
+    let rank = |maturity: &str| match maturity {
+        "stable" => 0,
+        "internal" => 1,
+        "bootstrap" => 2,
+        _ => 3,
+    };
+    rows.sort_by(|a, b| {
+        rank(&a.maturity)
+            .cmp(&rank(&b.maturity))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(rows)
+}
+
+/// `renew modules` — the module inventory, for people and for releases.
+///
+/// This exists because the maturity of a module is declared in exactly one
+/// place, its manifest, and until now nothing could read that place out
+/// loud. Anyone needing the table — a release note stating what a version
+/// promises, a document listing the optional crates — had to retype it,
+/// and a retyped table is a second home for a fact that goes stale without
+/// telling anyone.
+///
+/// It reports rather than gates: no finding, no failure, exit zero unless
+/// the workspace cannot be read at all.
+fn run_modules(json_mode: bool) -> ExitCode {
+    let started = Instant::now();
+    let outcome = workspace_root()
+        .ok_or_else(|| "no workspace root found above the current directory".to_string())
+        .and_then(|root| cargo_metadata(&root))
+        .and_then(|text| module_rows(&text));
+
+    let rows = match outcome {
+        Ok(rows) => rows,
+        Err(message) => {
+            if json_mode {
+                let document = Value::Object(vec![
+                    ("schema_version".to_string(), Value::Number(1)),
+                    ("command".to_string(), Value::String("modules".to_string())),
+                    ("status".to_string(), Value::String("error".to_string())),
+                    ("exit_code".to_string(), Value::Number(1)),
+                    (
+                        "duration_ms".to_string(),
+                        Value::Number(duration_ms(started)),
+                    ),
+                    ("stdout".to_string(), Value::String(String::new())),
+                    ("stderr".to_string(), Value::String(message)),
+                    // Always present, never conditional: a consumer that
+                    // reads `modules` must not have to test for the key.
+                    ("modules".to_string(), Value::Array(Vec::new())),
+                ]);
+                emit_stdout_line(&document.render());
+            } else {
+                eprintln!("error: {message}");
+            }
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if json_mode {
+        let items: Vec<Value> = rows
+            .iter()
+            .map(|row| {
+                let mut fields = vec![
+                    ("name".to_string(), Value::String(row.name.clone())),
+                    ("maturity".to_string(), Value::String(row.maturity.clone())),
+                ];
+                fields.push((
+                    "core".to_string(),
+                    row.core.map_or(Value::Null, Value::Bool),
+                ));
+                fields.push((
+                    "problem".to_string(),
+                    row.problem
+                        .as_ref()
+                        .map_or(Value::Null, |text| Value::String(text.clone())),
+                ));
+                Value::Object(fields)
+            })
+            .collect();
+        let document = Value::Object(vec![
+            ("schema_version".to_string(), Value::Number(1)),
+            ("command".to_string(), Value::String("modules".to_string())),
+            ("status".to_string(), Value::String("ok".to_string())),
+            ("exit_code".to_string(), Value::Number(0)),
+            (
+                "duration_ms".to_string(),
+                Value::Number(duration_ms(started)),
+            ),
+            ("stdout".to_string(), Value::String(String::new())),
+            ("stderr".to_string(), Value::String(String::new())),
+            ("modules".to_string(), Value::Array(items)),
+        ]);
+        emit_stdout_line(&document.render());
+        return ExitCode::SUCCESS;
+    }
+
+    let widest = rows.iter().map(|row| row.name.len()).max().unwrap_or(0);
+    let mut report = String::new();
+    for row in &rows {
+        let core = match row.core {
+            Some(true) => "core",
+            Some(false) => "optional",
+            None => "?",
+        };
+        let _ = writeln!(
+            report,
+            "{:<width$}  {:<10}  {core}",
+            row.name,
+            row.maturity,
+            width = widest
+        );
+        if let Some(problem) = &row.problem {
+            let _ = writeln!(report, "{:<width$}  {problem}", "", width = widest);
+        }
+    }
+    let stable = rows.iter().filter(|row| row.maturity == "stable").count();
+    // The count is the point, not decoration: a version's compatibility
+    // promise covers `stable` modules, so a reader needs to see at a
+    // glance how much of the tree that is.
+    let _ = writeln!(report, "{} module(s), {stable} stable", rows.len());
+    emit_stdout(&report);
+    ExitCode::SUCCESS
 }
 
 fn run_coverage(report_path: &str, json_mode: bool) -> ExitCode {

--- a/tools/cli/src/plan.rs
+++ b/tools/cli/src/plan.rs
@@ -71,6 +71,7 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
         // of the command line.
         Command::Check
         | Command::Coverage
+        | Command::Modules
         | Command::Doctor
         | Command::Run
         | Command::Record
@@ -179,6 +180,7 @@ mod tests {
         assert!(steps(Command::Doctor, false).is_empty());
         assert!(steps(Command::Check, false).is_empty());
         assert!(steps(Command::Coverage, false).is_empty());
+        assert!(steps(Command::Modules, false).is_empty());
         assert!(steps(Command::Run, false).is_empty());
         assert!(steps(Command::Record, false).is_empty());
         assert!(steps(Command::Replay, false).is_empty());

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -421,6 +421,205 @@ fn check_json_reports_an_empty_findings_array_here() {
     assert!(document.contains("\"findings\":[]"), "stdout was: {stdout}");
 }
 
+/// The inventory names every workspace crate, and says how many are
+/// `stable` — the number a release's compatibility promise is scoped to.
+#[test]
+fn modules_lists_the_whole_workspace_with_its_maturities() {
+    let output = run(&["modules"]).expect("binary should spawn");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(0), "stdout was: {stdout}");
+
+    // Named crates rather than a count: a count would keep passing while
+    // the walk silently stopped finding half the tree.
+    for crate_name in [
+        "renew-diag",
+        "renew-platform",
+        "renew-jobs",
+        "renew-trace",
+        "renew-cli",
+        "vk-fault-layer",
+    ] {
+        assert!(
+            stdout.contains(crate_name),
+            "`{crate_name}` is missing from the inventory; stdout was: {stdout}"
+        );
+    }
+    assert!(stdout.contains("stable"), "stdout was: {stdout}");
+}
+
+/// The JSON carries one row per crate with the fields a release note
+/// needs, and the keys are unconditional.
+#[test]
+fn modules_json_carries_every_crate_with_unconditional_keys() {
+    let output = run(&["modules", "--json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let document = stdout.trim();
+    let envelope = validated_envelope(document, "modules").expect("modules --json envelope");
+
+    let rows = envelope
+        .get("modules")
+        .and_then(Value::as_array)
+        .expect("a modules array");
+    assert!(rows.len() > 10, "only {} module(s) listed", rows.len());
+    for row in rows {
+        for key in ["name", "maturity", "core", "problem"] {
+            assert!(
+                row.get(key).is_some(),
+                "a module row is missing `{key}`; a consumer must never test for a key"
+            );
+        }
+    }
+    // Ordering is part of the contract: maturity first, so a reader sees
+    // what a release promises before what it does not.
+    let first = rows[0]
+        .get("maturity")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        first == "stable" || first == "internal",
+        "rows must be ordered by maturity; the first was `{first}`"
+    );
+}
+
+/// A crate whose metadata will not parse still appears, carrying the
+/// reason. An inventory that silently drops what it could not read is
+/// shorter than the workspace and gets believed anyway.
+#[test]
+fn modules_lists_a_crate_whose_metadata_is_unreadable() {
+    let directory = std::env::temp_dir().join(format!("renew-cli-modules-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&directory);
+    // Two members, not one: with a single row `sort_by` never calls the
+    // comparator, so a one-crate fixture cannot show where an unreadable
+    // row sorts — and would leave the ordering rule untested.
+    let member = directory.join("bad");
+    let sound = directory.join("sound");
+    fs::create_dir_all(member.join("src")).expect("scratch dirs");
+    fs::create_dir_all(sound.join("src")).expect("scratch dirs");
+    fs::write(
+        directory.join("Cargo.toml"),
+        "[workspace]
+resolver = \"3\"
+members = [\"bad\", \"sound\"]
+",
+    )
+    .expect("scratch root manifest");
+    fs::write(
+        member.join("Cargo.toml"),
+        concat!(
+            "[package]
+name = \"bad\"
+version = \"0.1.0\"
+edition = \"2021\"
+
+",
+            "[package.metadata.renew]
+purpose = \"x\"
+maturity = \"wrong\"
+",
+            "core = false
+extension_points = []
+simulation = false
+",
+        ),
+    )
+    .expect("scratch member manifest");
+    fs::write(
+        sound.join("Cargo.toml"),
+        concat!(
+            "[package]
+name = \"sound\"
+version = \"0.1.0\"
+edition = \"2021\"
+
+",
+            "[package.metadata.renew]
+purpose = \"x\"
+maturity = \"internal\"
+",
+            "core = false
+extension_points = []
+simulation = false
+",
+        ),
+    )
+    .expect("scratch member manifest");
+    fs::write(member.join("src").join("lib.rs"), "").expect("scratch lib");
+    fs::write(sound.join("src").join("lib.rs"), "").expect("scratch lib");
+
+    // Reporting, not gating: the inventory succeeds and says what is
+    // wrong. `check` is the one that fails on this workspace.
+    let output = run_in(&directory, &["modules"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("bad"), "stdout was: {stdout}");
+    assert!(stdout.contains("unreadable"), "stdout was: {stdout}");
+    assert!(stdout.contains("maturity"), "stdout was: {stdout}");
+    assert!(stdout.contains("0 stable"), "stdout was: {stdout}");
+
+    let output = run_in(&directory, &["modules", "--json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope = validated_envelope(stdout.trim(), "modules").expect("modules --json envelope");
+    let rows = envelope
+        .get("modules")
+        .and_then(Value::as_array)
+        .expect("a modules array");
+    assert_eq!(rows.len(), 2, "two members, two rows");
+    // The readable crate sorts first and the unreadable one last, which is
+    // the ordering rule: a reader sees what is known before what is not.
+    assert_eq!(rows[0].get("name").and_then(Value::as_str), Some("sound"));
+    let broken = &rows[1];
+    assert_eq!(broken.get("name").and_then(Value::as_str), Some("bad"));
+    assert_eq!(broken.get("core"), Some(&Value::Null), "core is unknown");
+    let problem = broken.get("problem").and_then(Value::as_str);
+    assert!(
+        problem.is_some_and(|text| text.contains("maturity")),
+        "the row must carry the reason; got {problem:?}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
+/// Outside a workspace the inventory refuses, on both paths, rather than
+/// reporting an empty tree — the failure mode this whole tool exists to
+/// avoid.
+#[test]
+fn modules_outside_a_workspace_refuses_rather_than_reporting_nothing() {
+    let directory = std::env::temp_dir().join(format!("renew-cli-nomods-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).expect("scratch dir");
+
+    let output = run_in(&directory, &["modules"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty(), "the plain path reports on stderr");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no workspace root"), "stderr was: {stderr}");
+
+    let output = run_in(&directory, &["modules", "--json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let envelope = validated_envelope(stdout.trim(), "modules")
+        .unwrap_or_else(|reason| panic!("modules --json: {reason}"));
+    assert_eq!(
+        envelope.get("status").and_then(Value::as_str),
+        Some("error")
+    );
+    // The array is present and empty rather than absent, so a consumer
+    // never has to test for the key on the failure path.
+    assert_eq!(
+        envelope.get("modules"),
+        Some(&Value::Array(Vec::new())),
+        "the modules key must survive the error path"
+    );
+    assert!(
+        envelope_stderr(&envelope).contains("no workspace root"),
+        "stdout was: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
 #[test]
 fn check_flags_a_workspace_with_broken_metadata() {
     let directory = std::env::temp_dir().join(format!("renew-cli-check-{}", std::process::id()));
@@ -537,7 +736,7 @@ fn every_cheap_subcommand_emits_the_full_typed_envelope() {
     // The expensive subcommands (build/test/bench/lint) share the same
     // envelope emitter, covered by unit tests; spawning them here would
     // recurse the whole workspace build inside the test suite.
-    for command in ["help", "configure", "doctor", "check"] {
+    for command in ["help", "configure", "doctor", "check", "modules"] {
         let output = run(&[command, "--json"]).expect("binary should spawn");
         let stdout = String::from_utf8_lossy(&output.stdout);
         let envelope = validated_envelope(stdout.trim(), command)
@@ -554,6 +753,13 @@ fn every_cheap_subcommand_emits_the_full_typed_envelope() {
                 assert!(
                     envelope.get("findings").and_then(Value::as_array).is_some(),
                     "check must carry a findings array"
+                );
+            }
+            "modules" => {
+                let modules = envelope.get("modules").and_then(Value::as_array);
+                assert!(
+                    modules.is_some_and(|items| !items.is_empty()),
+                    "modules must carry a non-empty modules array"
                 );
             }
             _ => {}


### PR DESCRIPTION
A crate declares its maturity in exactly one place — its own manifest — and until now **nothing could read that place out loud**. Anything needing the list had to retype it, and a retyped table is a second copy of a fact that goes stale without saying so.

```
$ renew modules
renew-diag                   internal    core
renew-math                   internal    core
...
15 module(s), 0 stable
```

`--json` carries the same rows in the standard envelope. Rows are ordered by maturity rather than alphabetically, because the question this answers is what a release can promise, and that is read off the maturity groups. The summary counts how many crates are `stable`, since that is the set such a promise can cover.

**A crate whose metadata will not parse still gets a row**, carrying the reason in place of its fields. Dropping it would make the inventory quietly shorter than the workspace, and an inventory that omits what it could not read is the kind that gets believed. It reports rather than gates — `check` is what fails on a malformed manifest.

**The command found three errors in a hand-written table the first time it ran:** a `[[bin]]` target counted as a crate, and two crates missed because their names do not start with the same prefix as the rest. That is the argument for it in one line.

Tests cover the inventory, the envelope's unconditional keys, the ordering rule, the unreadable-crate row, and the refusal outside a workspace. **The broken-metadata fixture carries two members deliberately:** with one row `sort_by` never calls the comparator, so a single-member fixture cannot exercise the ordering it claims to test — found by measuring coverage, which left that one line unreached.

Verified: 69 suites / 745 tests, fmt and clippy clean, and every new line covered — checked with llvm-cov **before** pushing rather than after CI said so.