### PR TITLE
Report an oversized file as oversized, not as bad text

### DIFF
--- a/crates/core/platform/src/fs.rs
+++ b/crates/core/platform/src/fs.rs
@@ -120,18 +120,30 @@ pub fn read_to_string_bounded(path: &Path, limit: usize) -> Result<String, FsErr
     let file = std::fs::File::open(path).map_err(|error| classify(path, &error))?;
     // One byte past the limit is enough to tell "at the limit" from
     // "over it" without reading a byte more than that.
-    let mut text = String::new();
+    //
+    // Bytes first, decoding second, and the order is load-bearing.
+    // Decoding the truncated read would report a character the cut
+    // happened to split as invalid text — true about the bytes read, and
+    // misleading about the file, whose only fault is its size. Checking
+    // the length before anything is decoded makes size win, which is the
+    // right precedence: an oversized file is oversized whatever its
+    // contents turn out to be.
+    let mut bytes = Vec::new();
     let read = file
         .take(limit as u64 + 1)
-        .read_to_string(&mut text)
-        .map_err(|error| classify_text(path, &error))?;
+        .read_to_end(&mut bytes)
+        .map_err(|error| classify(path, &error))?;
     if read > limit {
         return Err(FsError::TooLarge {
             path: path.to_path_buf(),
             limit,
         });
     }
-    Ok(text)
+    // Takes the buffer rather than copying it, so this costs no more
+    // than reading into a `String` did.
+    String::from_utf8(bytes).map_err(|_| FsError::InvalidUtf8 {
+        path: path.to_path_buf(),
+    })
 }
 
 /// Write a whole file, replacing any existing content.

--- a/crates/core/platform/tests/fs_roundtrip.rs
+++ b/crates/core/platform/tests/fs_roundtrip.rs
@@ -132,6 +132,28 @@ fn a_zero_limit_admits_only_an_empty_file() {
     ));
 }
 
+/// An oversized file is reported as oversized even when the limit cuts a
+/// character in half.
+///
+/// The bound reads one byte past the limit and then decodes, so a cut
+/// landing inside a multi-byte character makes the decode fail before the
+/// size check is reached. The file is refused either way — nothing unsafe
+/// — but "this file is not valid text" sends a reader hunting for an
+/// encoding problem in a file whose only fault is being too big. Size is
+/// the more fundamental fact, so it has to win.
+#[test]
+fn an_oversized_file_is_too_large_even_when_the_cut_splits_a_character() {
+    let file = scratch("bounded-split-char.txt");
+    // Four ASCII bytes, then a two-byte character, then more: with a
+    // limit of four, the byte read one past the limit is the first half
+    // of that character.
+    fs::write(&file.0, "aaaa\u{e9}bbbb".as_bytes()).expect("write succeeds");
+    match fs::read_to_string_bounded(&file.0, 4) {
+        Err(fs::FsError::TooLarge { limit, .. }) => assert_eq!(limit, 4),
+        other => panic!("expected TooLarge, got {other:?}"),
+    }
+}
+
 /// Bounding does not weaken the other classifications: a missing file
 /// and non-UTF-8 content report what they always did.
 #[test]


### PR DESCRIPTION
A bounded read takes **one byte past the limit** so it can tell "at the limit" from "over it" without trusting the size the filesystem reports — a good design, and the reason this was subtle. It then decoded that truncated read into a string.

When the extra byte landed **inside a multi-byte character**, the decode failed before the size check was reached, and the caller was told the file was not valid text.

That is a true statement about the bytes read and a misleading one about the file, whose only fault is its size. It sends whoever reads the error hunting for an encoding problem that is not there. **Nothing unsafe** — the file was refused either way.

The fix is an ordering change: read bytes, check the length, *then* decode. Size is the more fundamental fact and now wins whatever the contents turn out to be. `String::from_utf8` takes the buffer rather than copying it, so this costs no more than reading into a string did.

**The regression test was written before the fix and observed failing** — `expected TooLarge, got InvalidUtf8`. The neighbouring classifications are unchanged and still covered: a file exactly at the limit, a zero limit, a missing file, and content that is genuinely not UTF-8 while inside the limit.

This sits on the path that reads a trace file — content the engine did not write — so the quality of its refusal is worth more than it looks.

Verified: 69 suites / 746 tests, fmt and clippy clean, every line of the changed file covered.