### PR TITLE
Add the content-addressed asset pack format and its two subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "renew-asset"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
 name = "renew-bench"
 version = "0.1.0"
 dependencies = [
@@ -1404,6 +1411,9 @@ dependencies = [
 [[package]]
 name = "renew-cli"
 version = "0.1.0"
+dependencies = [
+ "renew-asset",
+]
 
 [[package]]
 name = "renew-diag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bench/suite", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -69,3 +69,8 @@ file = "samples/input_echo/src/convert.rs"
 lines = [82, 113, 133]
 reason = "The wildcard arms that a non-exhaustive vocabulary forces a downstream crate to write, and the refusal one of them feeds. Every variant that exists today has its own arm above, so these are unreachable until the vocabulary grows - which is exactly when they must already be there, because the compiler will not report the new variant as unhandled in this crate. They refuse rather than folding an unknown event into a neighbouring one, so a recording can never quietly claim something that did not happen."
 
+
+[[exempt]]
+file = "crates/asset/src/write.rs"
+lines = [94, 95, 100, 101, 105, 106, 129, 130, 133, 134]
+reason = "The width guards on the pack's own header fields. Reaching one needs more than four billion entries, or more than four gibibytes of names or of payload in a single pack; the per-entry pair is narrower still, since a name is already bounded to 1024 bytes and a blob length is a usize widening to u64. They are checked conversions rather than casts because a silently wrapped length is a reader pointed at arbitrary bytes, and because the count field is the kind that gets widened later. Unreachable on a 64-bit target and retained for the 32-bit one the platform list does not exclude."

--- a/crates/asset/Cargo.toml
+++ b/crates/asset/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "renew-asset"
+description = "The runtime asset pack: a content-addressed container with a deterministic writer and a reader that validates every field before it is used"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The runtime asset pack format: a content-addressed container, a writer whose output is byte-identical for the same inputs, and a reader that trusts nothing the header claims."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+# Deliberately empty, for the same reason the trace codec's is. This
+# crate turns bytes into a pack and a pack into bytes; it never opens a
+# file and never accepts a path. That keeps the whole untrusted-input
+# surface to one function, makes the crate fuzzable with no filesystem,
+# and puts the size bound on a whole-file read at the seam that can
+# actually enforce it — the caller doing the reading.
+[dependencies]
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/asset/README.md
+++ b/crates/asset/README.md
@@ -1,0 +1,107 @@
+# renew-asset
+
+The runtime asset pack: a single file holding many named blobs, each with
+a digest of its own contents. A writer that is deterministic, and a
+reader that trusts nothing the file tells it.
+
+## Contract
+
+- **The same inputs produce byte-identical output.** Entries are sorted by
+  name before writing, so the order they were added in — and therefore the
+  order a directory happened to be walked in — never reaches the bytes.
+  Nothing here reads a clock, a path, or the environment, and the crate's
+  [clippy.toml](clippy.toml) rejects all three at lint time rather than by
+  review.
+- **Names are unique and sorted.** Enforced when writing and re-checked
+  when reading, because a reader must not assume the file in front of it
+  came from this writer.
+- **A pack is read, never trusted.** Every length is validated against the
+  bytes actually present before it is used to slice anything; all
+  arithmetic is checked; and the four regions must account for the file
+  *exactly*, so a truncated download and an appended payload are refused
+  alike. A malformed pack costs no allocation — everything the reader
+  returns borrows the caller's buffer.
+- **The crate never touches the filesystem.** It takes bytes and returns
+  bytes. The size bound on reading an untrusted file belongs at the seam
+  that can refuse an oversized one, which is the caller.
+
+## The format
+
+Little-endian, four regions:
+
+```
+header    magic "RENEWPK\0" (8) | format u32 | count u32 | names_len u32 | data_len u32
+entries   count × { hash u64 | name_off u32 | name_len u32 | data_off u64 | data_len u64 }
+names     names_len bytes of UTF-8
+data      data_len bytes
+```
+
+Entries are fixed width, so the table can be bounds-checked as a whole
+before any of it is read and an entry can be found by index without
+parsing the ones before it. Names live in one blob rather than inline,
+which is what keeps the table fixed width. `format` is a version, and a
+reader refuses one it does not know rather than guessing — reading an
+unknown layout means treating attacker-chosen bytes as offsets.
+
+## Public API
+
+`PackBuilder::insert` and `finish` to write; `Pack::read` to validate and
+borrow; `entries`, `get` (a binary search, which the sort order exists to
+allow), and `mismatched` to verify payloads against their digests.
+
+Verification is separate from reading on purpose: reading is what every
+consumer does and stays proportional to the table, while verifying touches
+every byte. `renew asset-inspect --verify` asks for it; a runtime load
+would not.
+
+## Thread safety and ownership
+
+No shared state, no interior mutability, no globals. `Pack<'a>` borrows
+the buffer it was read from and cannot outlive it, which is what makes a
+malformed file free of allocation. Both types are `Send` and `Sync` when
+their contents are; nothing here synchronises because nothing here is
+shared.
+
+## Testing
+
+Round-trip and ordering properties over generated packs (seeded), a
+hostile-input property that hands the reader arbitrary bytes and
+pack-shaped bytes and requires an answer rather than a panic, and a golden
+test asserting the exact byte layout by hand.
+
+That last one earns its place: the properties prove the writer and reader
+agree with *each other*, which two halves of the same mistake also do. The
+golden test is the only one that proves they agree with the format as
+documented.
+
+**Real fuzzing is required before this module is called stable, and is
+not here yet.** The hostile-input property is a small fuzzer with a fixed
+budget standing in for it, and the gap is tracked rather than left
+implicit.
+
+## Status
+
+`bootstrap`. The container is settled enough to build on; what is stored
+in it is not. The `[package.metadata.renew]` table in
+[Cargo.toml](Cargo.toml) is authoritative for maturity and manifest
+metadata.
+
+## Key decisions
+
+- **No importer, and no codecs.** A real importer needs an image or audio
+  decoder, which is a dependency the owner has not approved — and a
+  subcommand that only copied bytes would be worse than its absence. v0 is
+  the container, which is the part that has to be right before anything is
+  stored in it.
+- **FNV-1a-64 for the digest.** No dependency, a dozen lines, and **not
+  collision-resistant**. This is content *addressing* — telling whether
+  two blobs are the same one, for change detection and deduplication — not
+  integrity against someone choosing the bytes. A pack from an untrusted
+  source is safe because the reader validates its structure, not because
+  its hashes could not be forged.
+- **Sorting is the determinism mechanism**, rather than recording an
+  explicit order. It is cheap, it is directly testable, and it makes
+  lookup a binary search instead of a scan.
+- **Duplicates are refused, not resolved.** A pack with two `mesh/hero`
+  entries has no correct reading, and silently keeping one is discovered
+  years later by someone whose asset did not change when they changed it.

--- a/crates/asset/clippy.toml
+++ b/crates/asset/clippy.toml
@@ -1,0 +1,51 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# Same shape and same reasoning as the trace codec's, and for the same
+# reason: this crate is a container format and nothing else. It takes
+# bytes and returns a pack, or takes a pack and returns bytes. It never
+# opens a file and never accepts a path.
+#
+# That is not tidiness. A pack is read from a file the engine did not
+# write, so the size bound on that read has to live at the seam that can
+# refuse an oversized file before a byte reaches a parser. One
+# `fs::read` added here for convenience would move an untrusted-input
+# bound into a crate with no way to enforce it — and would make the
+# reader unfuzzable without a filesystem, which is the one thing it most
+# needs to be.
+#
+# The types are banned as well as the calls. Banning `File::open` alone
+# is not enough: `OpenOptions::new().read(true).open(…)` plus
+# `Read::read_to_end` is the same unbounded read of the same untrusted
+# file, spelled in two lines.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::fs::read", reason = "this crate never touches the filesystem: it parses bytes a caller already holds" },
+    { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the I/O seam, which can refuse an oversized file; this crate never does I/O" },
+    { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },
+    { path = "std::io::Read::read_to_end", reason = "the same unbounded read by the other road" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem: it returns bytes for a caller to write" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem, and asking about a file is one line away from opening it" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "a container format is a pure function of its argument; a value from the environment would make one run differ from the next with nothing in the input to explain it" },
+    { path = "std::time::Instant::now", reason = "packing reads no clock: a pack built twice from the same inputs must be byte-identical, and a timestamp in the output would destroy that" },
+    { path = "std::time::SystemTime::now", reason = "packing reads no clock: a timestamp is the classic reason two builds of identical inputs differ" },
+    { path = "std::thread::spawn", reason = "the crate spawns nothing; it is a pure function of its input" },
+]
+
+disallowed-types = [
+    { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle, which banning `File::open` alone does not" },
+    { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on `File::open` misses" },
+    { path = "std::path::Path", reason = "the crate takes bytes and names, never a path: a function that can name a file will eventually open one" },
+    { path = "std::path::PathBuf", reason = "the crate takes bytes and names, never a path" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs; a pack's entry order is part of its bytes and must not depend on a hash seed" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/asset/src/error.rs
+++ b/crates/asset/src/error.rs
@@ -1,0 +1,284 @@
+//! Every way a pack can be refused, and why each is its own variant.
+//!
+//! A reader of untrusted input is judged by its refusals, not by its
+//! successes. Each variant below names one specific thing that was wrong
+//! and carries the numbers a person needs to see it — because the reader
+//! of this message is usually someone holding a file they did not build
+//! and cannot inspect by eye.
+//!
+//! There is deliberately no `Other` and no string-typed catch-all: a
+//! parser that can say "malformed" without saying how has stopped being
+//! able to distinguish a truncated download from an attack.
+
+use core::fmt;
+
+/// Why a pack was refused.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PackError {
+    /// The first eight bytes are not the container's magic.
+    NotAPack,
+    /// A pack, but a version this build does not implement.
+    UnknownFormat { found: u32 },
+    /// The file is shorter than the fixed header.
+    NoHeader { len: usize },
+    /// The four regions do not account for exactly the bytes present.
+    ///
+    /// Checked as equality rather than "at least", so trailing bytes are
+    /// refused as firmly as missing ones. Something appended to a pack is
+    /// as much a sign of trouble as something cut off it.
+    SizeMismatch { declared: u64, actual: usize },
+    /// A count or length that cannot be represented on this target.
+    TooLarge { field: &'static str, value: u64 },
+    /// An entry's name lies outside the names region.
+    NameOutOfRange { index: usize, offset: u32, len: u32 },
+    /// An entry's payload lies outside the data region.
+    DataOutOfRange { index: usize, offset: u64, len: u64 },
+    /// An entry's name is not UTF-8.
+    NameNotUtf8 { index: usize },
+    /// An entry's name is empty, which no lookup could ever match.
+    EmptyName { index: usize },
+    /// A name longer than the format admits.
+    NameTooLong { index: usize, len: usize },
+    /// Entries are not in ascending name order.
+    ///
+    /// Order is part of the format, not a convenience: it is what makes
+    /// lookup a binary search, and what makes a pack byte-identical
+    /// whatever order its inputs arrived in.
+    Unsorted { index: usize },
+    /// Two entries share a name, so a lookup has no correct answer.
+    DuplicateName { index: usize },
+}
+
+impl fmt::Display for PackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAPack => write!(f, "not an asset pack: the magic does not match"),
+            Self::UnknownFormat { found } => write!(
+                f,
+                "asset pack format {found} is not one this build reads (expects {})",
+                crate::layout::FORMAT
+            ),
+            Self::NoHeader { len } => write!(
+                f,
+                "too short to be a pack: {len} bytes, header needs {}",
+                crate::layout::HEADER_BYTES
+            ),
+            Self::SizeMismatch { declared, actual } => write!(
+                f,
+                "the header describes {declared} bytes but the file holds {actual}"
+            ),
+            Self::TooLarge { field, value } => {
+                write!(f, "`{field}` is {value}, too large for this target")
+            }
+            Self::NameOutOfRange { index, offset, len } => write!(
+                f,
+                "entry {index} names bytes {offset}..+{len}, which is outside the names region"
+            ),
+            Self::DataOutOfRange { index, offset, len } => write!(
+                f,
+                "entry {index} claims data {offset}..+{len}, which is outside the data region"
+            ),
+            Self::NameNotUtf8 { index } => write!(f, "entry {index} has a name that is not UTF-8"),
+            Self::EmptyName { index } => write!(f, "entry {index} has an empty name"),
+            Self::NameTooLong { index, len } => write!(
+                f,
+                "entry {index} has a {len}-byte name; the limit is {}",
+                crate::layout::MAX_NAME_BYTES
+            ),
+            Self::Unsorted { index } => write!(
+                f,
+                "entry {index} sorts before the one before it; a pack's entries are ordered"
+            ),
+            Self::DuplicateName { index } => write!(
+                f,
+                "entry {index} repeats the previous name; a pack cannot hold two of one name"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for PackError {}
+
+/// Why a pack could not be built.
+///
+/// Separate from [`PackError`] because the two have different audiences.
+/// A build failure is a mistake by whoever is packing, in their own
+/// inputs, and it can name them. A read failure is a statement about a
+/// file of unknown origin.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BuildError {
+    /// Two inputs share a name.
+    DuplicateName { name: String },
+    /// A name no reader would accept.
+    EmptyName,
+    /// A name longer than the format admits.
+    NameTooLong { name: String, len: usize },
+    /// The pack would not fit the format's own width limits.
+    TooLarge { field: &'static str, value: u64 },
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateName { name } => {
+                write!(f, "two entries are named `{name}`")
+            }
+            Self::EmptyName => write!(f, "an entry has an empty name"),
+            Self::NameTooLong { name, len } => write!(
+                f,
+                "`{}` is a {len}-byte name; the limit is {}",
+                truncated(name),
+                crate::layout::MAX_NAME_BYTES
+            ),
+            Self::TooLarge { field, value } => {
+                write!(f, "`{field}` would be {value}, too large for the format")
+            }
+        }
+    }
+}
+
+impl core::error::Error for BuildError {}
+
+/// The front of an over-long name, so a diagnostic about a 4 MiB string
+/// does not print one.
+fn truncated(name: &str) -> &str {
+    const SHOWN: usize = 48;
+    if name.len() <= SHOWN {
+        return name;
+    }
+    // Back off to a character boundary so the message never panics on a
+    // multi-byte name.
+    let mut end = SHOWN;
+    while end > 0 && !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    &name[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every refusal says what was wrong, with its numbers.
+    #[test]
+    fn every_refusal_carries_the_detail_a_reader_needs() {
+        let cases: Vec<(PackError, &[&str])> = vec![
+            (PackError::NotAPack, &["magic"]),
+            (PackError::UnknownFormat { found: 9 }, &["9", "1"]),
+            (PackError::NoHeader { len: 3 }, &["3", "24"]),
+            (
+                PackError::SizeMismatch {
+                    declared: 100,
+                    actual: 40,
+                },
+                &["100", "40"],
+            ),
+            (
+                PackError::NameOutOfRange {
+                    index: 2,
+                    offset: 7,
+                    len: 9,
+                },
+                &["2", "7", "9"],
+            ),
+            (
+                PackError::DataOutOfRange {
+                    index: 1,
+                    offset: 5,
+                    len: 6,
+                },
+                &["1", "5", "6"],
+            ),
+            (PackError::NameNotUtf8 { index: 4 }, &["4", "UTF-8"]),
+            (PackError::EmptyName { index: 0 }, &["0", "empty"]),
+            (PackError::NameTooLong { index: 3, len: 99 }, &["3", "99"]),
+            (PackError::Unsorted { index: 6 }, &["6"]),
+            (PackError::DuplicateName { index: 8 }, &["8"]),
+        ];
+        for (error, expected) in cases {
+            let shown = error.to_string();
+            for needle in expected {
+                assert!(
+                    shown.contains(needle),
+                    "`{shown}` does not mention `{needle}`"
+                );
+            }
+        }
+    }
+
+    /// The two variants no malformed file reaches: one is a width limit
+    /// the format reserves against, the other is every way a caller can
+    /// hand the builder something it cannot store.
+    #[test]
+    fn the_remaining_variants_say_what_they_are() {
+        let shown = PackError::TooLarge {
+            field: "count",
+            value: 1 << 40,
+        }
+        .to_string();
+        assert!(shown.contains("count"), "{shown}");
+        assert!(shown.contains(&(1u64 << 40).to_string()), "{shown}");
+
+        let cases: Vec<(BuildError, &str)> = vec![
+            (
+                BuildError::DuplicateName {
+                    name: "mesh/hero".to_string(),
+                },
+                "mesh/hero",
+            ),
+            (BuildError::EmptyName, "empty"),
+            (
+                BuildError::NameTooLong {
+                    name: "short".to_string(),
+                    len: 7,
+                },
+                "short",
+            ),
+            (
+                BuildError::TooLarge {
+                    field: "names_len",
+                    value: 99,
+                },
+                "names_len",
+            ),
+        ];
+        for (error, needle) in cases {
+            let shown = error.to_string();
+            assert!(shown.contains(needle), "`{shown}` omits `{needle}`");
+        }
+    }
+
+    /// A build failure quotes only the front of an enormous name.
+    #[test]
+    fn a_build_refusal_quotes_only_the_front_of_a_huge_name() {
+        let name = "n".repeat(10_000);
+        let shown = BuildError::NameTooLong {
+            len: name.len(),
+            name,
+        }
+        .to_string();
+        assert!(shown.len() < 200, "message was {} bytes", shown.len());
+        assert!(shown.contains("10000"));
+    }
+
+    /// Truncation lands on a character boundary rather than splitting one.
+    ///
+    /// The leading `x` is load-bearing. A string of two- or three-byte
+    /// characters alone puts a boundary exactly at 48, so the back-off
+    /// loop never runs and the test passes without exercising the thing
+    /// it is named for — which is how it was written the first time, and
+    /// the coverage report is what noticed. Offsetting by one byte makes
+    /// 48 land mid-character.
+    #[test]
+    fn truncation_never_splits_a_character() {
+        let name = format!("x{}", "\u{3042}".repeat(200));
+        assert!(!name.is_char_boundary(48), "the fixture must straddle 48");
+        let shown = truncated(&name);
+        assert!(name.starts_with(shown));
+        assert!(shown.len() < 48, "the back-off must have moved it");
+        assert!(name.is_char_boundary(shown.len()));
+
+        // And a short name comes back whole.
+        assert_eq!(truncated("short"), "short");
+    }
+}

--- a/crates/asset/src/hash.rs
+++ b/crates/asset/src/hash.rs
@@ -1,0 +1,65 @@
+//! The content digest.
+//!
+//! FNV-1a, 64-bit. Chosen because it needs no dependency, is a dozen
+//! lines, and is the same function three other places in this tree
+//! already use — a duplication that is written down elsewhere rather
+//! than pretended away.
+//!
+//! **It is not collision-resistant, and the distinction matters.** This
+//! is content *addressing*: telling whether two blobs are the same one,
+//! for change detection and deduplication. It is not integrity against
+//! someone who gets to choose the bytes. A pack from an untrusted source
+//! is validated structurally by the reader; its hashes say what the
+//! writer believed, not what an adversary could not forge.
+
+/// FNV-1a offset basis and prime, 64-bit.
+const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// The 64-bit FNV-1a digest of a byte string.
+#[must_use]
+pub fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Published FNV-1a-64 vectors. Frozen constants rather than a
+    /// property, because a hash that changes silently changes every
+    /// pack's bytes, and a reimplementation that is merely
+    /// self-consistent would pass any property test written against it.
+    #[test]
+    fn it_matches_the_published_vectors() {
+        assert_eq!(fnv1a64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a64(b"foobar"), 0x8594_4171_f739_67e8);
+    }
+
+    /// The empty digest is the basis, which is what makes a zero-length
+    /// entry hash to something rather than to nothing.
+    #[test]
+    fn the_empty_digest_is_the_offset_basis() {
+        assert_eq!(fnv1a64(b""), OFFSET_BASIS);
+    }
+
+    /// Order matters — the classic way a folded hash goes wrong is by
+    /// accidentally becoming commutative.
+    #[test]
+    fn it_is_not_commutative() {
+        assert_ne!(fnv1a64(b"ab"), fnv1a64(b"ba"));
+    }
+
+    /// A one-bit change moves the digest. Not a strength claim; a
+    /// smoke test that the input reaches the output at all.
+    #[test]
+    fn one_flipped_bit_changes_the_digest() {
+        assert_ne!(fnv1a64(&[0b0000_0001]), fnv1a64(&[0b0000_0011]));
+    }
+}

--- a/crates/asset/src/layout.rs
+++ b/crates/asset/src/layout.rs
@@ -1,0 +1,74 @@
+//! The on-disk shape, in one place.
+//!
+//! Every constant a reader and a writer must agree on lives here so they
+//! cannot drift: the reader's bounds checks and the writer's offsets are
+//! derived from the same numbers, and a test asserts the arithmetic
+//! rather than trusting that two files were edited together.
+
+/// Identifies the container before anything else is believed.
+///
+/// Eight bytes, NUL-terminated, so the file is recognisable in a hex dump
+/// and cannot be confused with text. A reader that checks this first can
+/// refuse a JPEG, a text file, or a truncated download without ever
+/// looking at a length field.
+pub const MAGIC: [u8; 8] = *b"RENEWPK\0";
+
+/// The format version a reader understands.
+///
+/// **A reader refuses anything else rather than guessing.** Forward
+/// compatibility is not attempted here: reading an unknown layout means
+/// interpreting attacker-chosen bytes as offsets, and "probably still
+/// works" is not a property a parser of untrusted input may assume.
+pub const FORMAT: u32 = 1;
+
+/// `MAGIC` + `format` + `count` + `names_len` + `data_len`.
+pub const HEADER_BYTES: usize = 8 + 4 + 4 + 4 + 4;
+
+/// One entry: `hash` + `name_off` + `name_len` + `data_off` + `data_len`.
+///
+/// Fixed width on purpose. The table can then be bounds-checked as a
+/// whole before a single entry is read, and an entry can be located by
+/// index without parsing the ones before it — neither of which is true
+/// of a format with inline variable-length names.
+pub const ENTRY_BYTES: usize = 8 + 4 + 4 + 8 + 8;
+
+/// The longest name the format admits.
+///
+/// A bound exists so a malformed length cannot ask a reader to slice
+/// four gigabytes, and so a writer refuses a name it could not later
+/// read back. The value is arbitrary and generous; what matters is that
+/// there is one.
+pub const MAX_NAME_BYTES: usize = 1024;
+
+/// Offsets within the header.
+pub const OFF_FORMAT: usize = 8;
+pub const OFF_COUNT: usize = 12;
+pub const OFF_NAMES_LEN: usize = 16;
+pub const OFF_DATA_LEN: usize = 20;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The header offsets are the running sum of the field widths.
+    ///
+    /// Written as arithmetic rather than as repeated literals: the
+    /// constants above are the kind that get edited one at a time.
+    #[test]
+    fn the_header_offsets_follow_the_field_widths() {
+        assert_eq!(OFF_FORMAT, MAGIC.len());
+        assert_eq!(OFF_COUNT, OFF_FORMAT + 4);
+        assert_eq!(OFF_NAMES_LEN, OFF_COUNT + 4);
+        assert_eq!(OFF_DATA_LEN, OFF_NAMES_LEN + 4);
+        assert_eq!(HEADER_BYTES, OFF_DATA_LEN + 4);
+    }
+
+    /// The magic is eight bytes and ends in NUL, so it cannot be mistaken
+    /// for the start of a text file.
+    #[test]
+    fn the_magic_is_eight_bytes_and_not_text() {
+        assert_eq!(MAGIC.len(), 8);
+        assert_eq!(MAGIC[7], 0);
+        assert!(MAGIC[..7].iter().all(u8::is_ascii_graphic));
+    }
+}

--- a/crates/asset/src/lib.rs
+++ b/crates/asset/src/lib.rs
@@ -1,0 +1,67 @@
+//! The runtime asset pack: a content-addressed container.
+//!
+//! A pack is a single file holding many named blobs, each with a digest
+//! of its own contents. [`PackBuilder`] writes one; [`Pack`] reads one.
+//!
+//! # Contract
+//!
+//! - **The same inputs produce byte-identical output.** Entries are
+//!   sorted by name before writing, so the order they were added in — and
+//!   therefore the order a directory happened to be walked in — never
+//!   reaches the bytes. Nothing here reads a clock, a path, or the
+//!   environment.
+//! - **Names are unique and sorted.** Both are enforced when writing and
+//!   re-checked when reading, because a reader must not trust that the
+//!   file in front of it was produced by this writer.
+//! - **A pack is read, never trusted.** Every length is validated against
+//!   the bytes actually present before it is used; the four regions must
+//!   account for the file exactly, so both truncation and appended bytes
+//!   are refused. A malformed pack costs no allocation: everything
+//!   [`Pack`] returns borrows the caller's buffer.
+//! - **The crate never touches the filesystem.** It takes bytes and
+//!   returns bytes. The size bound on reading an untrusted file belongs
+//!   at the seam that can refuse an oversized one, which is the caller.
+//!
+//! # What this is not
+//!
+//! Not compression, not encryption, not streaming, and **not an
+//! importer**. There is no PNG decoder here and no audio decoder: those
+//! need dependencies that are the owner's to approve, and a subcommand
+//! that only copied bytes would be worse than its absence. v0 is the
+//! container, which is the part that has to be right before anything is
+//! stored in it.
+//!
+//! The digest is FNV-1a-64 — fast, dependency-free, and **not
+//! collision-resistant**. It answers "are these the same bytes", which is
+//! what change detection and deduplication need. It is not integrity
+//! against someone choosing the bytes.
+//!
+//! # Example
+//!
+//! ```
+//! use renew_asset::{Pack, PackBuilder};
+//!
+//! let mut builder = PackBuilder::new();
+//! builder.insert("shader/triangle", b"spv...")?;
+//! builder.insert("mesh/hero", b"verts...")?;
+//! let bytes = builder.finish()?;
+//!
+//! let pack = Pack::read(&bytes)?;
+//! assert_eq!(pack.len(), 2);
+//! // Sorted, whatever order they went in.
+//! assert_eq!(pack.entries().next().map(|e| e.name), Some("mesh/hero"));
+//! assert!(pack.mismatched().is_empty());
+//! # Ok::<(), Box<dyn core::error::Error>>(())
+//! ```
+
+mod error;
+mod hash;
+mod layout;
+mod read;
+mod write;
+
+pub use error::{BuildError, PackError};
+pub use hash::fnv1a64;
+pub use layout::{FORMAT, MAX_NAME_BYTES};
+pub use read::{EntryRef, Pack};
+pub use write::PackBuilder;

--- a/crates/asset/src/read.rs
+++ b/crates/asset/src/read.rs
@@ -1,0 +1,249 @@
+//! Reading a pack the engine did not write.
+//!
+//! This is the crate's whole untrusted-input surface, and it is one
+//! function. Everything it returns borrows the caller's bytes, so a
+//! malformed file cannot cost an allocation, and a caller that has
+//! already bounded the read has bounded the parse too.
+//!
+//! **The header is the least trustworthy part of a hostile file.** Every
+//! length in it is checked against the bytes actually present before it
+//! is used to slice anything, all arithmetic is checked, and the four
+//! regions must account for the file exactly — not "at least", so a
+//! truncated download and an appended payload are both refused.
+
+use crate::error::PackError;
+use crate::hash::fnv1a64;
+use crate::layout::{
+    ENTRY_BYTES, FORMAT, HEADER_BYTES, MAGIC, MAX_NAME_BYTES, OFF_COUNT, OFF_DATA_LEN, OFF_FORMAT,
+    OFF_NAMES_LEN,
+};
+
+/// One entry, borrowed from the pack's bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EntryRef<'a> {
+    /// The entry's name. Unique within a pack, and sorted.
+    pub name: &'a str,
+    /// The digest the writer recorded for `bytes`.
+    ///
+    /// Not verified on read: see [`Pack::mismatched`], which is a
+    /// separate and deliberately explicit step.
+    pub hash: u64,
+    /// The payload.
+    pub bytes: &'a [u8],
+}
+
+/// A validated pack, borrowing the bytes it was read from.
+#[derive(Clone, Debug)]
+pub struct Pack<'a> {
+    entries: Vec<EntryRef<'a>>,
+}
+
+/// Read a little-endian `u32` at `offset`, or `None` past the end.
+fn u32_at(bytes: &[u8], offset: usize) -> Option<u32> {
+    let end = offset.checked_add(4)?;
+    let slice = bytes.get(offset..end)?;
+    let array: [u8; 4] = slice.try_into().ok()?;
+    Some(u32::from_le_bytes(array))
+}
+
+/// Read a little-endian `u64` at `offset`, or `None` past the end.
+fn u64_at(bytes: &[u8], offset: usize) -> Option<u64> {
+    let end = offset.checked_add(8)?;
+    let slice = bytes.get(offset..end)?;
+    let array: [u8; 8] = slice.try_into().ok()?;
+    Some(u64::from_le_bytes(array))
+}
+
+/// Narrow a `u64` to a `usize`, naming the field if it will not fit.
+fn fit(value: u64, field: &'static str) -> Result<usize, PackError> {
+    usize::try_from(value).map_err(|_| PackError::TooLarge { field, value })
+}
+
+impl<'a> Pack<'a> {
+    /// Validate `bytes` and borrow them as a pack.
+    ///
+    /// # Errors
+    ///
+    /// A [`PackError`] naming exactly what was wrong. Every field is
+    /// checked before use; nothing is trusted because the header said so.
+    pub fn read(bytes: &'a [u8]) -> Result<Self, PackError> {
+        if bytes.len() < HEADER_BYTES {
+            return Err(PackError::NoHeader { len: bytes.len() });
+        }
+        if bytes.get(..MAGIC.len()) != Some(&MAGIC[..]) {
+            return Err(PackError::NotAPack);
+        }
+        let format = u32_at(bytes, OFF_FORMAT).ok_or(PackError::NoHeader { len: bytes.len() })?;
+        if format != FORMAT {
+            return Err(PackError::UnknownFormat { found: format });
+        }
+
+        let count = u32_at(bytes, OFF_COUNT).ok_or(PackError::NoHeader { len: bytes.len() })?;
+        let names_len =
+            u32_at(bytes, OFF_NAMES_LEN).ok_or(PackError::NoHeader { len: bytes.len() })?;
+        let data_len =
+            u32_at(bytes, OFF_DATA_LEN).ok_or(PackError::NoHeader { len: bytes.len() })?;
+
+        // The regions must account for the file exactly. Computed in u64
+        // so a hostile count cannot wrap the sum on a 32-bit target and
+        // land back inside the file.
+        let table_bytes =
+            u64::from(count)
+                .checked_mul(ENTRY_BYTES as u64)
+                .ok_or(PackError::TooLarge {
+                    field: "count",
+                    value: u64::from(count),
+                })?;
+        let declared = (HEADER_BYTES as u64)
+            .checked_add(table_bytes)
+            .and_then(|sum| sum.checked_add(u64::from(names_len)))
+            .and_then(|sum| sum.checked_add(u64::from(data_len)))
+            .ok_or(PackError::TooLarge {
+                field: "declared size",
+                value: u64::MAX,
+            })?;
+        if declared != bytes.len() as u64 {
+            return Err(PackError::SizeMismatch {
+                declared,
+                actual: bytes.len(),
+            });
+        }
+
+        let table_bytes = fit(table_bytes, "count")?;
+        let names_start = HEADER_BYTES
+            .checked_add(table_bytes)
+            .ok_or(PackError::TooLarge {
+                field: "count",
+                value: u64::from(count),
+            })?;
+        let names_end = names_start
+            .checked_add(names_len as usize)
+            .ok_or(PackError::TooLarge {
+                field: "names_len",
+                value: u64::from(names_len),
+            })?;
+        // Both slices are in range: `declared` equalled the length above.
+        let names = bytes
+            .get(names_start..names_end)
+            .ok_or(PackError::NoHeader { len: bytes.len() })?;
+        let data = bytes
+            .get(names_end..)
+            .ok_or(PackError::NoHeader { len: bytes.len() })?;
+
+        let mut entries: Vec<EntryRef<'a>> = Vec::with_capacity(count as usize);
+        for index in 0..count as usize {
+            let entry = parse_entry(bytes, index, names, data)?;
+            if let Some(previous) = entries.last() {
+                match entry.name.cmp(previous.name) {
+                    core::cmp::Ordering::Less => return Err(PackError::Unsorted { index }),
+                    core::cmp::Ordering::Equal => return Err(PackError::DuplicateName { index }),
+                    core::cmp::Ordering::Greater => {}
+                }
+            }
+            entries.push(entry);
+        }
+
+        Ok(Self { entries })
+    }
+
+    /// How many entries the pack holds.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the pack holds nothing. An empty pack is legal.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Every entry, in name order.
+    pub fn entries(&self) -> impl Iterator<Item = &EntryRef<'a>> {
+        self.entries.iter()
+    }
+
+    /// Look one entry up by name.
+    ///
+    /// A binary search, which the sort order in the format exists to
+    /// make possible.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&EntryRef<'a>> {
+        let found = self
+            .entries
+            .binary_search_by(|entry| entry.name.cmp(name))
+            .ok()?;
+        self.entries.get(found)
+    }
+
+    /// The entries whose payload does not hash to the recorded digest.
+    ///
+    /// Separate from [`Pack::read`] on purpose. Reading is what every
+    /// consumer does and must stay proportional to the table; verifying
+    /// touches every byte, so it is a step a caller asks for — `inspect`
+    /// does, a runtime load would not.
+    #[must_use]
+    pub fn mismatched(&self) -> Vec<&EntryRef<'a>> {
+        self.entries
+            .iter()
+            .filter(|entry| fnv1a64(entry.bytes) != entry.hash)
+            .collect()
+    }
+}
+
+/// Validate one fixed-width table entry and borrow what it points at.
+///
+/// Split out of [`Pack::read`] so the header arithmetic and the per-entry
+/// bounds checks can each be read on their own. Every field is checked
+/// against the region it claims to live in; nothing is sliced on a length
+/// the file supplied without first proving that length fits.
+fn parse_entry<'a>(
+    bytes: &'a [u8],
+    index: usize,
+    names: &'a [u8],
+    data: &'a [u8],
+) -> Result<EntryRef<'a>, PackError> {
+    let short = || PackError::NoHeader { len: bytes.len() };
+    let base = HEADER_BYTES + index * ENTRY_BYTES;
+    let hash = u64_at(bytes, base).ok_or_else(short)?;
+    let name_at = u32_at(bytes, base + 8).ok_or_else(short)?;
+    let name_size = u32_at(bytes, base + 12).ok_or_else(short)?;
+    let blob_at = u64_at(bytes, base + 16).ok_or_else(short)?;
+    let blob_size = u64_at(bytes, base + 24).ok_or_else(short)?;
+
+    if name_size == 0 {
+        return Err(PackError::EmptyName { index });
+    }
+    if name_size as usize > MAX_NAME_BYTES {
+        return Err(PackError::NameTooLong {
+            index,
+            len: name_size as usize,
+        });
+    }
+    let out_of_names = || PackError::NameOutOfRange {
+        index,
+        offset: name_at,
+        len: name_size,
+    };
+    let name_end = name_at.checked_add(name_size).ok_or_else(out_of_names)?;
+    let raw = names
+        .get(name_at as usize..name_end as usize)
+        .ok_or_else(out_of_names)?;
+    let name = core::str::from_utf8(raw).map_err(|_| PackError::NameNotUtf8 { index })?;
+
+    let out_of_data = || PackError::DataOutOfRange {
+        index,
+        offset: blob_at,
+        len: blob_size,
+    };
+    let blob_end = blob_at.checked_add(blob_size).ok_or_else(out_of_data)?;
+    let from = fit(blob_at, "data_off")?;
+    let to = fit(blob_end, "data_off + data_len")?;
+    let payload = data.get(from..to).ok_or_else(out_of_data)?;
+
+    Ok(EntryRef {
+        name,
+        hash,
+        bytes: payload,
+    })
+}

--- a/crates/asset/src/write.rs
+++ b/crates/asset/src/write.rs
@@ -1,0 +1,249 @@
+//! Building a pack, deterministically.
+//!
+//! The one property this file exists to guarantee: **the same set of
+//! named blobs produces byte-identical output, whatever order they were
+//! added in, on any platform.** Directory iteration order is not stable
+//! across filesystems, so a pack built from the same tree on two machines
+//! would otherwise differ — and a content-addressed format whose bytes
+//! depend on the order someone happened to walk a directory is not
+//! content-addressed at all.
+//!
+//! Sorting by name is the whole mechanism. It is cheap, it is testable
+//! directly, and it is what makes lookup a binary search on the reading
+//! side.
+
+use crate::error::BuildError;
+use crate::hash::fnv1a64;
+use crate::layout::{
+    ENTRY_BYTES, FORMAT, HEADER_BYTES, MAGIC, MAX_NAME_BYTES, OFF_COUNT, OFF_DATA_LEN, OFF_FORMAT,
+    OFF_NAMES_LEN,
+};
+
+/// Collects named blobs and writes them out as a pack.
+#[derive(Debug, Default)]
+pub struct PackBuilder {
+    items: Vec<(String, Vec<u8>)>,
+}
+
+impl PackBuilder {
+    /// An empty builder. An empty pack is legal and round-trips.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// How many entries have been added.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Whether nothing has been added yet.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Add one named blob.
+    ///
+    /// # Errors
+    ///
+    /// [`BuildError::EmptyName`] or [`BuildError::NameTooLong`] for a name
+    /// no reader would accept, and [`BuildError::DuplicateName`] when the
+    /// name is already present.
+    ///
+    /// Duplicates are refused here rather than resolved. A pack holding
+    /// two `mesh/hero` entries has no correct reading, and silently
+    /// keeping the last one is the kind of decision that is discovered
+    /// years later by someone whose asset did not change when they
+    /// changed it.
+    pub fn insert(&mut self, name: &str, bytes: &[u8]) -> Result<(), BuildError> {
+        if name.is_empty() {
+            return Err(BuildError::EmptyName);
+        }
+        if name.len() > MAX_NAME_BYTES {
+            return Err(BuildError::NameTooLong {
+                name: name.to_string(),
+                len: name.len(),
+            });
+        }
+        if self.items.iter().any(|(existing, _)| existing == name) {
+            return Err(BuildError::DuplicateName {
+                name: name.to_string(),
+            });
+        }
+        self.items.push((name.to_string(), bytes.to_vec()));
+        Ok(())
+    }
+
+    /// Serialise the pack.
+    ///
+    /// # Errors
+    ///
+    /// [`BuildError::TooLarge`] when the entry count or a region would
+    /// exceed the widths the format reserves for them. Checked rather
+    /// than truncated: a silently wrapped length is a reader pointed at
+    /// arbitrary bytes.
+    pub fn finish(mut self) -> Result<Vec<u8>, BuildError> {
+        // The whole determinism guarantee, in one line. Sorting by name
+        // makes insertion order irrelevant to the output bytes.
+        self.items.sort_by(|left, right| left.0.cmp(&right.0));
+
+        let count = u32::try_from(self.items.len()).map_err(|_| BuildError::TooLarge {
+            field: "count",
+            value: self.items.len() as u64,
+        })?;
+
+        let names_len: usize = self.items.iter().map(|(name, _)| name.len()).sum();
+        let names_len = u32::try_from(names_len).map_err(|_| BuildError::TooLarge {
+            field: "names_len",
+            value: names_len as u64,
+        })?;
+        let data_len: usize = self.items.iter().map(|(_, bytes)| bytes.len()).sum();
+        let data_len = u32::try_from(data_len).map_err(|_| BuildError::TooLarge {
+            field: "data_len",
+            value: data_len as u64,
+        })?;
+
+        let mut out = Vec::with_capacity(
+            HEADER_BYTES + self.items.len() * ENTRY_BYTES + names_len as usize + data_len as usize,
+        );
+        out.extend_from_slice(&MAGIC);
+        out.extend_from_slice(&FORMAT.to_le_bytes());
+        out.extend_from_slice(&count.to_le_bytes());
+        out.extend_from_slice(&names_len.to_le_bytes());
+        out.extend_from_slice(&data_len.to_le_bytes());
+        debug_assert_eq!(out.len(), HEADER_BYTES);
+        debug_assert_eq!(OFF_FORMAT + 4, OFF_COUNT);
+        debug_assert_eq!(OFF_NAMES_LEN + 4, OFF_DATA_LEN);
+
+        let mut name_off: u32 = 0;
+        let mut data_off: u64 = 0;
+        for (name, bytes) in &self.items {
+            // Each length was bounded above by the region totals, so
+            // these conversions cannot fail; they are written as checked
+            // arithmetic anyway because an unchecked cast here is a
+            // reader pointed somewhere it should not be.
+            let this_name = u32::try_from(name.len()).map_err(|_| BuildError::TooLarge {
+                field: "name_len",
+                value: name.len() as u64,
+            })?;
+            let this_data = u64::try_from(bytes.len()).map_err(|_| BuildError::TooLarge {
+                field: "data_len",
+                value: bytes.len() as u64,
+            })?;
+            out.extend_from_slice(&fnv1a64(bytes).to_le_bytes());
+            out.extend_from_slice(&name_off.to_le_bytes());
+            out.extend_from_slice(&this_name.to_le_bytes());
+            out.extend_from_slice(&data_off.to_le_bytes());
+            out.extend_from_slice(&this_data.to_le_bytes());
+            name_off = name_off.saturating_add(this_name);
+            data_off = data_off.saturating_add(this_data);
+        }
+
+        for (name, _) in &self.items {
+            out.extend_from_slice(name.as_bytes());
+        }
+        for (_, bytes) in &self.items {
+            out.extend_from_slice(bytes);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the whole file exists for: insertion order does not
+    /// reach the output.
+    #[test]
+    fn insertion_order_does_not_change_the_bytes() {
+        let mut forward = PackBuilder::new();
+        forward.insert("b/two", b"second").expect("insert");
+        forward.insert("a/one", b"first").expect("insert");
+        forward.insert("c/three", b"third").expect("insert");
+
+        let mut backward = PackBuilder::new();
+        backward.insert("c/three", b"third").expect("insert");
+        backward.insert("b/two", b"second").expect("insert");
+        backward.insert("a/one", b"first").expect("insert");
+
+        assert_eq!(
+            forward.finish().expect("pack"),
+            backward.finish().expect("pack"),
+            "the same entries in a different order produced different bytes"
+        );
+    }
+
+    /// And the same builder twice, which catches anything that leaks in
+    /// from outside the inputs — a clock, an address, a hash seed.
+    #[test]
+    fn the_same_inputs_pack_identically_twice() {
+        let build = || {
+            let mut b = PackBuilder::new();
+            b.insert("x", b"one").expect("insert");
+            b.insert("y", b"two").expect("insert");
+            b.finish().expect("pack")
+        };
+        assert_eq!(build(), build());
+    }
+
+    /// The accessor pair, which a caller uses to decide whether to write
+    /// anything at all.
+    #[test]
+    fn the_builder_reports_what_it_holds() {
+        let mut builder = PackBuilder::new();
+        assert!(builder.is_empty());
+        assert_eq!(builder.len(), 0);
+        builder.insert("one", b"x").expect("insert");
+        assert!(!builder.is_empty());
+        assert_eq!(builder.len(), 1);
+    }
+
+    #[test]
+    fn an_empty_pack_is_just_a_header() {
+        let bytes = PackBuilder::new().finish().expect("pack");
+        assert_eq!(bytes.len(), HEADER_BYTES);
+        assert!(bytes.starts_with(&MAGIC));
+    }
+
+    #[test]
+    fn a_duplicate_name_is_refused_rather_than_resolved() {
+        let mut b = PackBuilder::new();
+        b.insert("same", b"first").expect("insert");
+        let error = b.insert("same", b"second").expect_err("must refuse");
+        assert_eq!(
+            error,
+            BuildError::DuplicateName {
+                name: "same".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_name_is_refused() {
+        let mut b = PackBuilder::new();
+        assert_eq!(
+            b.insert("", b"x").expect_err("must refuse"),
+            BuildError::EmptyName
+        );
+    }
+
+    #[test]
+    fn an_over_long_name_is_refused() {
+        let mut b = PackBuilder::new();
+        let name = "n".repeat(MAX_NAME_BYTES + 1);
+        let error = b.insert(&name, b"x").expect_err("must refuse");
+        assert!(matches!(error, BuildError::NameTooLong { .. }));
+    }
+
+    /// A zero-length blob is a real entry, not an absence.
+    #[test]
+    fn an_entry_may_hold_no_bytes() {
+        let mut b = PackBuilder::new();
+        b.insert("empty", b"").expect("insert");
+        let bytes = b.finish().expect("pack");
+        assert_eq!(bytes.len(), HEADER_BYTES + ENTRY_BYTES + "empty".len());
+    }
+}

--- a/crates/asset/tests/roundtrip.rs
+++ b/crates/asset/tests/roundtrip.rs
@@ -1,0 +1,373 @@
+//! Properties over generated packs, and the hostile-input claim.
+//!
+//! Two claims, different in kind. The first is that writing and reading
+//! are inverses over packs nobody thought to write by hand. On its own
+//! that is weak — a writer and a reader making the *same* mistake are
+//! still inverses — so the golden test beside it anchors the format with
+//! bytes asserted by hand.
+//!
+//! The second is about hostile input: the reader answers, one way or the
+//! other, for every byte string it can be handed. It never panics and
+//! never hangs. That is a small fuzzer with a fixed budget, standing in
+//! until real fuzzing infrastructure exists — which this module needs
+//! before it can be called stable, and not before now.
+
+use proptest::prelude::*;
+use proptest::test_runner::RngSeed;
+use renew_asset::{Pack, PackBuilder, fnv1a64};
+
+/// Names that exercise the sort: shared prefixes, path separators, and
+/// characters either side of `/` in byte order.
+fn name() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        proptest::sample::select(vec!["a", "b", "z", "-", ".", "0", "A", "/"]),
+        1..6,
+    )
+    .prop_map(|parts| parts.concat())
+}
+
+fn blob() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 0..64)
+}
+
+/// A set of uniquely-named entries, in arbitrary order.
+fn entries() -> impl Strategy<Value = Vec<(String, Vec<u8>)>> {
+    proptest::collection::vec((name(), blob()), 0..12).prop_map(|mut items| {
+        items.sort_by(|left, right| left.0.cmp(&right.0));
+        items.dedup_by(|left, right| left.0 == right.0);
+        items
+    })
+}
+
+/// Returns `Result` rather than unwrapping: the lint that forbids
+/// `expect` outside tests reaches helpers in a test file too, because the
+/// exemption follows `#[test]` rather than the file.
+fn pack_of(items: &[(String, Vec<u8>)]) -> Result<Vec<u8>, renew_asset::BuildError> {
+    let mut builder = PackBuilder::new();
+    for (name, bytes) in items {
+        builder.insert(name, bytes)?;
+    }
+    builder.finish()
+}
+
+proptest! {
+    // Seeded: a property suite that picks a fresh seed each run reports a
+    // different question every time and cannot be re-run against a
+    // failure.
+    #![proptest_config(ProptestConfig {
+        rng_seed: RngSeed::Fixed(0x8ea1_2b47_5cd3_9061),
+        cases: 256,
+        ..ProptestConfig::default()
+    })]
+
+    /// Writing then reading gives back what went in.
+    #[test]
+    fn writing_then_reading_returns_every_entry(items in entries()) {
+        let bytes = pack_of(&items).expect("unique names, and it fits");
+        let pack = Pack::read(&bytes).expect("our own writer's output must read");
+        prop_assert_eq!(pack.len(), items.len());
+        for (name, blob) in &items {
+            let found = pack.get(name).expect("every inserted name is present");
+            prop_assert_eq!(found.bytes, &blob[..]);
+            prop_assert_eq!(found.hash, fnv1a64(blob));
+        }
+        prop_assert!(pack.mismatched().is_empty());
+    }
+
+    /// Entries come back in name order however they went in.
+    #[test]
+    fn entries_are_always_in_name_order(items in entries()) {
+        let mut shuffled = items.clone();
+        shuffled.reverse();
+        let bytes = pack_of(&shuffled).expect("packs");
+        let pack = Pack::read(&bytes).expect("reads");
+        let names: Vec<&str> = pack.entries().map(|entry| entry.name).collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        prop_assert_eq!(names, sorted);
+    }
+
+    /// Insertion order never reaches the bytes.
+    #[test]
+    fn the_bytes_do_not_depend_on_insertion_order(items in entries()) {
+        let forward = pack_of(&items).expect("packs");
+        let mut backward_items = items.clone();
+        backward_items.reverse();
+        let backward = pack_of(&backward_items).expect("packs");
+        prop_assert_eq!(forward, backward);
+    }
+
+    /// **Any** byte string gets an answer rather than a panic.
+    #[test]
+    fn arbitrary_bytes_get_an_answer(raw in proptest::collection::vec(any::<u8>(), 0..512)) {
+        let _ = Pack::read(&raw);
+    }
+
+    /// And so does anything shaped like a pack, which reaches far deeper
+    /// into the reader than random bytes ever do: random input dies at
+    /// the magic, so without this the bounds checks below it would be
+    /// exercised by nothing.
+    #[test]
+    fn bytes_shaped_like_a_pack_get_an_answer(
+        items in entries(),
+        cut in 0usize..256,
+        noise in proptest::collection::vec(any::<u8>(), 0..24),
+    ) {
+        let mut bytes = pack_of(&items).expect("packs");
+        // Truncate somewhere, then append something. Both are refusals
+        // the format promises to make.
+        bytes.truncate(cut.min(bytes.len()));
+        bytes.extend_from_slice(&noise);
+        let _ = Pack::read(&bytes);
+    }
+
+    /// Corrupting a payload is caught by verification and not by reading,
+    /// which is the split the API makes on purpose.
+    #[test]
+    fn a_flipped_payload_byte_is_found_only_by_verifying(
+        items in entries().prop_filter("needs a payload", |i| i.iter().any(|(_, b)| !b.is_empty())),
+    ) {
+        let mut bytes = pack_of(&items).expect("packs");
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        let pack = Pack::read(&bytes).expect("structure is untouched, so it still reads");
+        prop_assert!(!pack.mismatched().is_empty(), "verification missed a flipped byte");
+    }
+}
+
+/// The format, asserted by hand.
+///
+/// The property tests above prove the writer and reader agree with each
+/// other. This one proves they agree with the format as documented — the
+/// one thing a round-trip can never show, because two halves of the same
+/// mistake round-trip perfectly.
+#[test]
+fn the_bytes_are_exactly_what_the_format_says() {
+    let mut builder = PackBuilder::new();
+    builder.insert("b", b"\x01\x02").expect("insert");
+    builder.insert("a", b"\xff").expect("insert");
+    let bytes = builder.finish().expect("pack");
+
+    // header(24) + 2 entries(64) + names(2) + data(3)
+    assert_eq!(bytes.len(), 24 + 64 + 2 + 3);
+    assert_eq!(&bytes[0..8], b"RENEWPK\0");
+    assert_eq!(&bytes[8..12], &1u32.to_le_bytes(), "format");
+    assert_eq!(&bytes[12..16], &2u32.to_le_bytes(), "count");
+    assert_eq!(&bytes[16..20], &2u32.to_le_bytes(), "names_len");
+    assert_eq!(&bytes[20..24], &3u32.to_le_bytes(), "data_len");
+
+    // Entry 0 is "a", because entries are sorted and "a" was added second.
+    assert_eq!(&bytes[24..32], &fnv1a64(b"\xff").to_le_bytes(), "hash of a");
+    assert_eq!(&bytes[32..36], &0u32.to_le_bytes(), "a name_off");
+    assert_eq!(&bytes[36..40], &1u32.to_le_bytes(), "a name_len");
+    assert_eq!(&bytes[40..48], &0u64.to_le_bytes(), "a data_off");
+    assert_eq!(&bytes[48..56], &1u64.to_le_bytes(), "a data_len");
+
+    // Names then data, each contiguous and in entry order.
+    assert_eq!(&bytes[88..90], b"ab");
+    assert_eq!(&bytes[90..93], b"\xff\x01\x02");
+}
+
+/// A pack whose entries are out of order is refused, even though every
+/// offset in it is valid. Built by hand, because our writer cannot
+/// produce one.
+#[test]
+fn an_unsorted_table_is_refused() {
+    let mut builder = PackBuilder::new();
+    builder.insert("a", b"1").expect("insert");
+    builder.insert("b", b"2").expect("insert");
+    let mut bytes = builder.finish().expect("pack");
+
+    // Swap the two 32-byte entries, leaving the names blob alone: the
+    // table now reads "b" then "a".
+    let (left, right) = (24usize, 56usize);
+    for offset in 0..32 {
+        bytes.swap(left + offset, right + offset);
+    }
+    let error = Pack::read(&bytes).expect_err("an unsorted table must be refused");
+    assert!(error.to_string().contains("ordered"), "{error}");
+}
+
+/// Truncation is refused rather than partially read.
+#[test]
+fn a_truncated_pack_is_refused() {
+    let mut builder = PackBuilder::new();
+    builder.insert("only", b"payload").expect("insert");
+    let bytes = builder.finish().expect("pack");
+    for cut in 0..bytes.len() {
+        let error = Pack::read(&bytes[..cut]).expect_err("a short pack must be refused");
+        // Every refusal names something; none of them panics, which is
+        // the claim that matters on this path.
+        assert!(!error.to_string().is_empty());
+    }
+    assert!(Pack::read(&bytes).is_ok(), "the whole thing still reads");
+}
+
+/// Appending to a valid pack is refused as firmly as cutting it short.
+#[test]
+fn trailing_bytes_are_refused() {
+    let mut builder = PackBuilder::new();
+    builder.insert("only", b"payload").expect("insert");
+    let mut bytes = builder.finish().expect("pack");
+    bytes.push(0);
+    let error = Pack::read(&bytes).expect_err("trailing bytes must be refused");
+    assert!(error.to_string().contains("holds"), "{error}");
+}
+
+/// An empty pack round-trips, because "no assets" is a real answer.
+#[test]
+fn an_empty_pack_round_trips() {
+    let bytes = PackBuilder::new().finish().expect("pack");
+    let pack = Pack::read(&bytes).expect("an empty pack reads");
+    assert!(pack.is_empty());
+    assert_eq!(pack.len(), 0);
+    assert!(pack.get("anything").is_none());
+    assert!(pack.mismatched().is_empty());
+}
+
+/// A file that is not a pack is refused at the magic, before any length
+/// in it is believed.
+#[test]
+fn a_file_that_is_not_a_pack_is_refused_at_the_magic() {
+    let error = Pack::read(b"\x89PNG\r\n\x1a\n and then some more bytes").expect_err("not a pack");
+    assert!(error.to_string().contains("magic"), "{error}");
+}
+
+/// A two-entry pack, and the offsets of the fields a test wants to bend.
+///
+/// Built by our own writer and then corrupted in place: every refusal
+/// below is reachable only through a file this writer cannot produce,
+/// which is exactly the input the reader exists to survive.
+fn two_entry_pack() -> Result<Vec<u8>, renew_asset::BuildError> {
+    let mut builder = PackBuilder::new();
+    builder.insert("a", b"1")?;
+    builder.insert("b", b"22")?;
+    builder.finish()
+}
+
+/// Overwrite a little-endian `u32` at `offset`.
+fn put_u32(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Overwrite a little-endian `u64` at `offset`.
+fn put_u64(bytes: &mut [u8], offset: usize, value: u64) {
+    bytes[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+/// A name that points outside the names region is refused.
+#[test]
+fn a_name_reaching_past_its_region_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    // Entry 0's name_off sits at header(24) + hash(8).
+    put_u32(&mut bytes, 24 + 8, 9999);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("names region"), "{error}");
+}
+
+/// So is a name whose offset plus length overflows rather than merely
+/// exceeding the region.
+#[test]
+fn a_name_whose_length_overflows_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u32(&mut bytes, 24 + 8, u32::MAX);
+    put_u32(&mut bytes, 24 + 12, 2);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("names region"), "{error}");
+}
+
+/// A zero-length name is refused: no lookup could ever match it.
+#[test]
+fn a_zero_length_name_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u32(&mut bytes, 24 + 12, 0);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("empty name"), "{error}");
+}
+
+/// A name longer than the format admits is refused before it is sliced.
+#[test]
+fn an_over_long_name_is_refused_by_the_reader() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u32(&mut bytes, 24 + 12, 5000);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("5000"), "{error}");
+}
+
+/// A payload reaching past the data region is refused.
+#[test]
+fn a_payload_reaching_past_its_region_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    // Entry 0's data_len sits at header(24) + hash(8) + name(8) + off(8).
+    put_u64(&mut bytes, 24 + 24, 9999);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("data region"), "{error}");
+}
+
+/// And a payload whose offset plus length overflows.
+#[test]
+fn a_payload_whose_length_overflows_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u64(&mut bytes, 24 + 16, u64::MAX);
+    put_u64(&mut bytes, 24 + 24, 2);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("data region"), "{error}");
+}
+
+/// A name that is not UTF-8 is refused.
+#[test]
+fn a_name_that_is_not_utf8_is_refused() {
+    let mut builder = PackBuilder::new();
+    builder.insert("ab", b"1").expect("insert");
+    let mut bytes = builder.finish().expect("pack");
+    // The names blob is the last two bytes before the data.
+    let names_at = bytes.len() - 2 - 1;
+    bytes[names_at] = 0xFF;
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("UTF-8"), "{error}");
+}
+
+/// Two entries with one name have no defined lookup, so the reader
+/// refuses even though every offset is valid.
+#[test]
+fn a_duplicated_name_is_refused_by_the_reader() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    // Point entry 1's name at entry 0's, so the table reads "a" twice.
+    put_u32(&mut bytes, 24 + 32 + 8, 0);
+    put_u32(&mut bytes, 24 + 32 + 12, 1);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains("two of one name"), "{error}");
+}
+
+/// A pack claiming a version this build does not implement is refused
+/// rather than read on the assumption it is close enough.
+#[test]
+fn an_unknown_format_version_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u32(&mut bytes, 8, 9);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(error.to_string().contains('9'), "{error}");
+}
+
+/// A count so large the table could not fit is refused on the size check
+/// rather than by attempting the allocation.
+#[test]
+fn an_impossible_entry_count_is_refused() {
+    let mut bytes = two_entry_pack().expect("the fixture packs");
+    put_u32(&mut bytes, 12, u32::MAX);
+    let error = Pack::read(&bytes).expect_err("must refuse");
+    assert!(!error.to_string().is_empty());
+}
+
+/// Lookup misses answer `None` rather than the neighbouring entry, which
+/// is the way a binary search goes wrong when its comparator is off.
+#[test]
+fn a_lookup_miss_returns_nothing() {
+    let bytes = two_entry_pack().expect("the fixture packs");
+    let pack = Pack::read(&bytes).expect("reads");
+    assert!(pack.get("a").is_some());
+    assert!(pack.get("b").is_some());
+    for miss in ["", "aa", "c", "A", "ab"] {
+        assert!(pack.get(miss).is_none(), "`{miss}` matched something");
+    }
+}

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -15,6 +15,14 @@ core = false
 extension_points = []
 simulation = false
 
+# The CLI's first dependency, and a workspace one: every engine
+# capability gets a command-line face, and the pack format lives in the
+# crate that defines it rather than being reimplemented here. A
+# within-workspace edge carries no supply-chain or licence question; the
+# hand-rolled JSON parser stays hand-rolled.
+[dependencies]
+renew-asset = { path = "../../crates/asset" }
+
 [features]
 # Enabled by instrumented (sanitizer) test runs. Five integration tests
 # replace PATH with a single directory so the test decides what the

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -18,6 +18,8 @@ commands:
   check      verify workspace crate manifests and dependencies
   coverage   hold a coverage report against the exemption manifest
   modules    list every module with its maturity, from the manifests
+  asset-pack     build an asset pack from a directory of files
+  asset-inspect  list an asset pack's entries, optionally verifying them
   doctor     check the development environment
 
 options:
@@ -79,6 +81,31 @@ caller knows what it invoked, and the envelope shape stays uniform.
 A failing sample follows the same contract as any other failing child:
 the `renew` process exits `1`, and the sample's raw exit code survives in
 the envelope's `exit_code`.
+
+## Asset packs
+
+A pack is one file holding many named blobs, each with a digest of its own
+contents. `asset-pack` builds one from a directory; `asset-inspect` reads
+one back.
+
+```
+renew asset-pack --from assets/ --pack game.rpk
+renew asset-inspect --pack game.rpk --verify
+```
+
+Entries are named by their forward-slashed path relative to `--from`, on
+every platform, and the pack is sorted by name before it is written. Those
+two together are what make the output **byte-identical for the same
+inputs**: neither the order a directory happened to be walked in nor the
+separator a filesystem happens to use reaches the bytes.
+
+`--verify` re-hashes every payload and exits non-zero if any disagrees with
+its recorded digest. It is off by default because listing reads only the
+table while verifying reads every byte — a distinction that matters once a
+pack is large.
+
+There is no `import` subcommand. A real importer needs an image or audio
+decoder, and one that only copied bytes would be worse than its absence.
 
 ## The module inventory
 

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -14,6 +14,8 @@ pub enum Command {
     Check,
     Coverage,
     Modules,
+    AssetPack,
+    AssetInspect,
     Doctor,
     Record,
     Replay,
@@ -21,7 +23,7 @@ pub enum Command {
 
 impl Command {
     /// Every subcommand, in the order `usage` lists them.
-    pub const ALL: [Self; 12] = [
+    pub const ALL: [Self; 14] = [
         Self::Configure,
         Self::Build,
         Self::Test,
@@ -33,6 +35,8 @@ impl Command {
         Self::Check,
         Self::Coverage,
         Self::Modules,
+        Self::AssetPack,
+        Self::AssetInspect,
         Self::Doctor,
     ];
 
@@ -49,6 +53,8 @@ impl Command {
             Self::Check => "check",
             Self::Coverage => "coverage",
             Self::Modules => "modules",
+            Self::AssetPack => "asset-pack",
+            Self::AssetInspect => "asset-inspect",
             Self::Doctor => "doctor",
             Self::Record => "record",
             Self::Replay => "replay",
@@ -91,6 +97,8 @@ impl Command {
             Self::Check => "verify workspace crate manifests and dependencies",
             Self::Coverage => "hold a coverage report against the exemption manifest",
             Self::Modules => "list every module with its maturity, from the manifests",
+            Self::AssetPack => "build an asset pack from a directory of files",
+            Self::AssetInspect => "list an asset pack's entries, optionally verifying them",
             Self::Doctor => "check the development environment",
             Self::Record => "run a sample, writing the input it saw to a file",
             Self::Replay => "run a sample from a recorded input file",
@@ -125,6 +133,16 @@ pub struct Invocation {
     /// subcommand can be in play, and two would let a caller construct an
     /// invocation naming both.
     pub trace: Option<String>,
+    /// Both asset subcommands (parse enforces, and requires): the pack
+    /// file to write, or to read.
+    pub pack: Option<String>,
+    /// `asset-pack` only (parse enforces, and requires): the directory
+    /// whose files become the pack's entries.
+    pub from: Option<String>,
+    /// `asset-inspect` only (parse enforces): also check every payload
+    /// against its recorded digest. Off by default because it reads every
+    /// byte, where listing reads only the table.
+    pub verify: bool,
 }
 
 /// What parsing decided: run a subcommand, or show usage on request.
@@ -205,6 +223,9 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     let mut help = false;
     let mut report = None;
     let mut trace: Option<(&'static str, String)> = None;
+    let mut pack: Option<String> = None;
+    let mut from: Option<String> = None;
+    let mut verify = false;
     let mut sample: Option<String> = None;
     let mut sample_args: Vec<String> = Vec::new();
     // The separator, if it comes at all, comes immediately after the
@@ -243,6 +264,17 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
                 let path = rest.next().ok_or(ParseError::MissingValue("--input"))?;
                 trace = Some(("--input", path.clone()));
             }
+            // Same reason as `--report`: the value is consumed here so a
+            // path can never be mistaken for a subcommand.
+            "--pack" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--pack"))?;
+                pack = Some(path.clone());
+            }
+            "--from" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--from"))?;
+                from = Some(path.clone());
+            }
+            "--verify" => verify = true,
             "help" | "--help" | "-h" => help = true,
             other => {
                 if help {
@@ -276,6 +308,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
         trace.as_ref().map(|(flag, _)| *flag),
         sample.as_deref(),
     )?;
+    check_asset_combination(command, pack.as_deref(), from.as_deref(), verify)?;
     match command {
         Some(command) => Ok(Parsed::Run(Invocation {
             command,
@@ -285,9 +318,60 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             sample,
             sample_args,
             trace: trace.map(|(_, path)| path),
+            pack,
+            from,
+            verify,
         })),
         None => Err(ParseError::NoCommand),
     }
+}
+
+/// The asset subcommands' own flag rules.
+///
+/// Separate from [`check_combination`] rather than three more parameters
+/// on it: that function already carries five, and a sixth and seventh
+/// would make the one thing it is good at — reading as a list of rules —
+/// stop being true.
+fn check_asset_combination(
+    command: Option<Command>,
+    pack: Option<&str>,
+    from: Option<&str>,
+    verify: bool,
+) -> Result<(), ParseError> {
+    let is_pack = command == Some(Command::AssetPack);
+    let is_inspect = command == Some(Command::AssetInspect);
+
+    // Stray flags first, matching the order the other rules use: a flag
+    // on the wrong subcommand is as unexpected as any other argument.
+    if pack.is_some() && !(is_pack || is_inspect) {
+        return Err(ParseError::UnexpectedArgument("--pack".to_string()));
+    }
+    if from.is_some() && !is_pack {
+        return Err(ParseError::UnexpectedArgument("--from".to_string()));
+    }
+    if verify && !is_inspect {
+        return Err(ParseError::UnexpectedArgument("--verify".to_string()));
+    }
+
+    // Then what each subcommand cannot work without. Both paths are the
+    // whole input: guessing one would be worse than refusing.
+    if (is_pack || is_inspect) && pack.is_none() {
+        return Err(ParseError::MissingOption {
+            command: if is_pack {
+                "asset-pack"
+            } else {
+                "asset-inspect"
+            },
+            option: "--pack",
+        });
+    }
+    if is_pack && from.is_none() {
+        return Err(ParseError::MissingOption {
+            command: "asset-pack",
+            option: "--from",
+        });
+    }
+    Ok(())
 }
 
 /// The rules that can only be decided once the whole line has been read:
@@ -412,6 +496,9 @@ mod tests {
             sample: None,
             sample_args: Vec::new(),
             trace: None,
+            pack: None,
+            from: None,
+            verify: false,
         }
     }
 
@@ -443,6 +530,21 @@ mod tests {
                     vec![name, "--report", "cov.json"],
                     Invocation {
                         report: Some("cov.json".to_string()),
+                        ..plain(command)
+                    },
+                ),
+                Command::AssetPack => (
+                    vec![name, "--from", "assets", "--pack", "out.rpk"],
+                    Invocation {
+                        from: Some("assets".to_string()),
+                        pack: Some("out.rpk".to_string()),
+                        ..plain(command)
+                    },
+                ),
+                Command::AssetInspect => (
+                    vec![name, "--pack", "out.rpk"],
+                    Invocation {
+                        pack: Some("out.rpk".to_string()),
                         ..plain(command)
                     },
                 ),

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -47,6 +47,17 @@ fn run(invocation: &Invocation) -> ExitCode {
         Command::Doctor => run_doctor(invocation.json),
         Command::Check => run_check(invocation.json),
         Command::Modules => run_modules(invocation.json),
+        // Parsing guarantees both paths for pack and the one for inspect.
+        Command::AssetPack => run_asset_pack(
+            invocation.from.as_deref().unwrap_or_default(),
+            invocation.pack.as_deref().unwrap_or_default(),
+            invocation.json,
+        ),
+        Command::AssetInspect => run_asset_inspect(
+            invocation.pack.as_deref().unwrap_or_default(),
+            invocation.verify,
+            invocation.json,
+        ),
         // Parsing guarantees the path; an empty one would simply fail to
         // open, which is the same answer by a shorter road.
         Command::Coverage => run_coverage(
@@ -184,6 +195,221 @@ fn parsed_metadata(text: &str) -> Result<Value, String> {
 fn findings_from_metadata(text: &str) -> Result<Vec<structure::Finding>, String> {
     let shapes = structure::shapes_from_metadata(&parsed_metadata(text)?)?;
     Ok(structure::evaluate(&shapes))
+}
+
+/// Every file under `root`, with the forward-slashed relative path each
+/// will be named by in the pack.
+///
+/// Forward slashes on every platform, deliberately: a pack built on
+/// Windows and one built on Linux from the same tree must be byte
+/// identical, and a backslash in a name would make them differ. Order
+/// does not matter here because the builder sorts, which is the point of
+/// doing it there.
+fn asset_files(
+    root: &Path,
+    prefix: &str,
+    found: &mut Vec<(String, PathBuf)>,
+) -> Result<(), String> {
+    let entries = std::fs::read_dir(root)
+        .map_err(|error| format!("cannot read {}: {error}", root.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("cannot read {}: {error}", root.display()))?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let path = entry.path();
+        let joined = if prefix.is_empty() {
+            name.to_string()
+        } else {
+            format!("{prefix}/{name}")
+        };
+        if path.is_dir() {
+            asset_files(&path, &joined, found)?;
+        } else {
+            found.push((joined, path));
+        }
+    }
+    Ok(())
+}
+
+/// `renew asset-pack` -- build a pack from a directory.
+fn run_asset_pack(from: &str, pack_path: &str, json_mode: bool) -> ExitCode {
+    let started = Instant::now();
+    match build_pack(Path::new(from), Path::new(pack_path)) {
+        Ok(count) => {
+            if json_mode {
+                let document = Value::Object(vec![
+                    ("schema_version".to_string(), Value::Number(1)),
+                    (
+                        "command".to_string(),
+                        Value::String("asset-pack".to_string()),
+                    ),
+                    ("status".to_string(), Value::String("ok".to_string())),
+                    ("exit_code".to_string(), Value::Number(0)),
+                    (
+                        "duration_ms".to_string(),
+                        Value::Number(duration_ms(started)),
+                    ),
+                    ("stdout".to_string(), Value::String(String::new())),
+                    ("stderr".to_string(), Value::String(String::new())),
+                    ("entries".to_string(), Value::Number(count)),
+                    ("pack".to_string(), Value::String(pack_path.to_string())),
+                ]);
+                emit_stdout_line(&document.render());
+            } else {
+                emit_stdout(&format!("packed {count} entries into {pack_path}\n"));
+            }
+            ExitCode::SUCCESS
+        }
+        Err(message) => asset_failure("asset-pack", &message, json_mode, started),
+    }
+}
+
+/// Read the directory, build the pack, write it. Split from the reporting
+/// so the whole fallible part has one exit.
+fn build_pack(from: &Path, pack_path: &Path) -> Result<i64, String> {
+    if !from.is_dir() {
+        return Err(format!("{} is not a directory", from.display()));
+    }
+    let mut found = Vec::new();
+    asset_files(from, "", &mut found)?;
+
+    let mut builder = renew_asset::PackBuilder::new();
+    for (name, path) in &found {
+        let bytes = std::fs::read(path)
+            .map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+        builder
+            .insert(name, &bytes)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+    }
+    let count = i64::try_from(builder.len()).unwrap_or(i64::MAX);
+    let bytes = builder.finish().map_err(|error| error.to_string())?;
+    std::fs::write(pack_path, &bytes)
+        .map_err(|error| format!("cannot write {}: {error}", pack_path.display()))?;
+    Ok(count)
+}
+
+/// `renew asset-inspect` -- list a pack, optionally verifying payloads.
+fn run_asset_inspect(pack_path: &str, verify: bool, json_mode: bool) -> ExitCode {
+    let started = Instant::now();
+    let bytes = match std::fs::read(pack_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return asset_failure(
+                "asset-inspect",
+                &format!("cannot read {pack_path}: {error}"),
+                json_mode,
+                started,
+            );
+        }
+    };
+    let pack = match renew_asset::Pack::read(&bytes) {
+        Ok(pack) => pack,
+        Err(error) => {
+            return asset_failure("asset-inspect", &error.to_string(), json_mode, started);
+        }
+    };
+    // Computed before reporting either way, so the two output modes
+    // cannot disagree about what was checked.
+    let bad: Vec<String> = if verify {
+        pack.mismatched()
+            .iter()
+            .map(|entry| entry.name.to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let ok = bad.is_empty();
+
+    if json_mode {
+        let items: Vec<Value> = pack
+            .entries()
+            .map(|entry| {
+                Value::Object(vec![
+                    ("name".to_string(), Value::String(entry.name.to_string())),
+                    (
+                        "hash".to_string(),
+                        Value::String(format!("{:016x}", entry.hash)),
+                    ),
+                    (
+                        "bytes".to_string(),
+                        Value::Number(i64::try_from(entry.bytes.len()).unwrap_or(i64::MAX)),
+                    ),
+                ])
+            })
+            .collect();
+        let document = Value::Object(vec![
+            ("schema_version".to_string(), Value::Number(1)),
+            (
+                "command".to_string(),
+                Value::String("asset-inspect".to_string()),
+            ),
+            (
+                "status".to_string(),
+                Value::String(if ok { "ok" } else { "failed" }.to_string()),
+            ),
+            ("exit_code".to_string(), Value::Number(i64::from(!ok))),
+            (
+                "duration_ms".to_string(),
+                Value::Number(duration_ms(started)),
+            ),
+            ("stdout".to_string(), Value::String(String::new())),
+            ("stderr".to_string(), Value::String(String::new())),
+            ("verified".to_string(), Value::Bool(verify)),
+            (
+                "mismatched".to_string(),
+                Value::Array(bad.iter().map(|n| Value::String(n.clone())).collect()),
+            ),
+            ("entries".to_string(), Value::Array(items)),
+        ]);
+        emit_stdout_line(&document.render());
+    } else {
+        let widest = pack.entries().map(|e| e.name.len()).max().unwrap_or(0);
+        let mut report = String::new();
+        for entry in pack.entries() {
+            let _ = writeln!(
+                report,
+                "{:<width$}  {:>10}  {:016x}",
+                entry.name,
+                entry.bytes.len(),
+                entry.hash,
+                width = widest
+            );
+        }
+        for name in &bad {
+            let _ = writeln!(report, "MISMATCH {name}");
+        }
+        let checked = if verify { ", verified" } else { "" };
+        let _ = writeln!(report, "{} entries{checked}", pack.len());
+        emit_stdout(&report);
+    }
+    if ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+/// One refusal shape for both asset subcommands.
+fn asset_failure(command: &str, message: &str, json_mode: bool, started: Instant) -> ExitCode {
+    if json_mode {
+        let document = Value::Object(vec![
+            ("schema_version".to_string(), Value::Number(1)),
+            ("command".to_string(), Value::String(command.to_string())),
+            ("status".to_string(), Value::String("error".to_string())),
+            ("exit_code".to_string(), Value::Number(1)),
+            (
+                "duration_ms".to_string(),
+                Value::Number(duration_ms(started)),
+            ),
+            ("stdout".to_string(), Value::String(String::new())),
+            ("stderr".to_string(), Value::String(message.to_string())),
+            ("entries".to_string(), Value::Array(Vec::new())),
+        ]);
+        emit_stdout_line(&document.render());
+    } else {
+        eprintln!("error: {message}");
+    }
+    ExitCode::FAILURE
 }
 
 /// Read the runnable samples out of `cargo metadata` output.

--- a/tools/cli/src/plan.rs
+++ b/tools/cli/src/plan.rs
@@ -72,6 +72,8 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
         Command::Check
         | Command::Coverage
         | Command::Modules
+        | Command::AssetPack
+        | Command::AssetInspect
         | Command::Doctor
         | Command::Run
         | Command::Record
@@ -181,6 +183,8 @@ mod tests {
         assert!(steps(Command::Check, false).is_empty());
         assert!(steps(Command::Coverage, false).is_empty());
         assert!(steps(Command::Modules, false).is_empty());
+        assert!(steps(Command::AssetPack, false).is_empty());
+        assert!(steps(Command::AssetInspect, false).is_empty());
         assert!(steps(Command::Run, false).is_empty());
         assert!(steps(Command::Record, false).is_empty());
         assert!(steps(Command::Replay, false).is_empty());

--- a/tools/cli/tests/asset.rs
+++ b/tools/cli/tests/asset.rs
@@ -1,0 +1,335 @@
+//! `renew asset-pack` and `renew asset-inspect`, end to end.
+//!
+//! Exercised through the real binary against real directories, because
+//! the parts most worth testing here are the ones the crate deliberately
+//! does not have: walking a tree, naming entries by their relative path,
+//! and refusing the paths that do not exist.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use renew_cli::json::{self, Value};
+
+// Fallible on purpose, matching the sibling suite: the expect() lives
+// inside each #[test], where the lint configuration scopes it. A helper
+// in a test file is not test code as far as the lint is concerned.
+fn run(arguments: &[&str]) -> std::io::Result<Output> {
+    Command::new(env!("CARGO_BIN_EXE_renew"))
+        .args(arguments)
+        .output()
+}
+
+/// A scratch directory unique to this test binary's process.
+fn scratch(tag: &str) -> std::io::Result<PathBuf> {
+    let dir = std::env::temp_dir().join(format!("renew-asset-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, bytes)
+}
+
+/// The parsed envelope, having checked the two fields every one carries.
+fn envelope(text: &str, command: &str) -> Result<Value, String> {
+    let document = json::parse(text.trim()).map_err(|error| error.to_string())?;
+    if document.get("command").and_then(Value::as_str) != Some(command) {
+        return Err(format!("envelope is not `{command}`: {text}"));
+    }
+    if document.get("schema_version") != Some(&Value::Number(1)) {
+        return Err(format!("envelope carries no schema_version: {text}"));
+    }
+    Ok(document)
+}
+
+/// Packing a tree, then reading it back through the tool.
+#[test]
+fn a_directory_packs_and_inspects() {
+    let dir = scratch("roundtrip").expect("scratch dir");
+    let src = dir.join("src");
+    write(&src.join("notes.txt"), b"hello pack").expect("scratch file");
+    write(&src.join("shader/tri.spv"), &[1, 2, 3, 4]).expect("scratch file");
+    write(&src.join("nothing.bin"), b"").expect("scratch file");
+    let pack = dir.join("out.rpk");
+
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &src.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains('3'), "stdout was: {stdout}");
+    assert!(pack.is_file(), "the pack was not written");
+
+    let output =
+        run(&["asset-inspect", "--pack", &pack.to_string_lossy()]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Nested files are named by their forward-slashed relative path on
+    // every platform, which is what makes a pack built on Windows equal
+    // to one built on Linux.
+    assert!(stdout.contains("shader/tri.spv"), "stdout was: {stdout}");
+    assert!(stdout.contains("notes.txt"), "stdout was: {stdout}");
+    assert!(
+        !stdout.contains('\\'),
+        "a backslash reached a name: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The JSON envelopes carry what a script needs, with unconditional keys.
+#[test]
+fn both_subcommands_emit_the_typed_envelope() {
+    let dir = scratch("json").expect("scratch dir");
+    let src = dir.join("src");
+    write(&src.join("one"), b"a").expect("scratch file");
+    write(&src.join("two"), b"bb").expect("scratch file");
+    let pack = dir.join("out.rpk");
+
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &src.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+        "--json",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let document =
+        envelope(&String::from_utf8_lossy(&output.stdout), "asset-pack").expect("a typed envelope");
+    assert_eq!(document.get("entries"), Some(&Value::Number(2)));
+    assert_eq!(document.get("status").and_then(Value::as_str), Some("ok"));
+
+    let output = run(&[
+        "asset-inspect",
+        "--pack",
+        &pack.to_string_lossy(),
+        "--verify",
+        "--json",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let document = envelope(&String::from_utf8_lossy(&output.stdout), "asset-inspect")
+        .expect("a typed envelope");
+    assert_eq!(document.get("verified"), Some(&Value::Bool(true)));
+    assert_eq!(document.get("mismatched"), Some(&Value::Array(Vec::new())));
+    let entries = document
+        .get("entries")
+        .and_then(Value::as_array)
+        .expect("an entries array");
+    assert_eq!(entries.len(), 2);
+    for entry in entries {
+        for key in ["name", "hash", "bytes"] {
+            assert!(entry.get(key).is_some(), "an entry is missing `{key}`");
+        }
+    }
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The same tree packs to the same bytes twice. The tool's half of the
+/// determinism claim: the crate sorts, but the walk happens here.
+#[test]
+fn the_same_tree_packs_to_the_same_bytes() {
+    let dir = scratch("determinism").expect("scratch dir");
+    let src = dir.join("src");
+    write(&src.join("b/second"), b"two").expect("scratch file");
+    write(&src.join("a/first"), b"one").expect("scratch file");
+    write(&src.join("c"), b"three").expect("scratch file");
+
+    let mut built = Vec::new();
+    for name in ["one.rpk", "two.rpk"] {
+        let pack = dir.join(name);
+        let output = run(&[
+            "asset-pack",
+            "--from",
+            &src.to_string_lossy(),
+            "--pack",
+            &pack.to_string_lossy(),
+        ])
+        .expect("binary should spawn");
+        assert_eq!(output.status.code(), Some(0));
+        built.push(fs::read(&pack).expect("the pack is readable"));
+    }
+    assert_eq!(built[0], built[1], "two packs of one tree differ");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Verification finds a payload someone changed under the pack.
+#[test]
+fn a_corrupted_payload_fails_verification_and_only_verification() {
+    let dir = scratch("corrupt").expect("scratch dir");
+    let src = dir.join("src");
+    write(&src.join("payload"), b"original bytes").expect("scratch file");
+    let pack = dir.join("out.rpk");
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &src.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+
+    // Flip the last byte: the structure is untouched, so the pack still
+    // reads and only verification can tell.
+    let mut bytes = fs::read(&pack).expect("read");
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0xFF;
+    fs::write(&pack, &bytes).expect("write");
+
+    let listed =
+        run(&["asset-inspect", "--pack", &pack.to_string_lossy()]).expect("binary should spawn");
+    assert_eq!(listed.status.code(), Some(0), "listing does not verify");
+
+    let checked = run(&[
+        "asset-inspect",
+        "--pack",
+        &pack.to_string_lossy(),
+        "--verify",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(checked.status.code(), Some(1), "verification must fail");
+    let stdout = String::from_utf8_lossy(&checked.stdout);
+    assert!(stdout.contains("MISMATCH"), "stdout was: {stdout}");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Every refusal names what was wrong, on both output paths.
+#[test]
+fn the_refusals_say_what_was_wrong() {
+    let dir = scratch("refusals").expect("scratch dir");
+    let missing = dir.join("nope");
+    let pack = dir.join("out.rpk");
+
+    // A source that is not a directory.
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &missing.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not a directory"), "stderr was: {stderr}");
+
+    // The same, in JSON: the envelope carries the reason and the keys are
+    // present even on the failure path.
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &missing.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+        "--json",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let document =
+        envelope(&String::from_utf8_lossy(&output.stdout), "asset-pack").expect("a typed envelope");
+    assert_eq!(
+        document.get("status").and_then(Value::as_str),
+        Some("error")
+    );
+    assert_eq!(document.get("entries"), Some(&Value::Array(Vec::new())));
+
+    // A pack file that does not exist.
+    let output =
+        run(&["asset-inspect", "--pack", &missing.to_string_lossy()]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!output.stderr.is_empty());
+
+    // A file that exists and is not a pack, refused at the magic.
+    let bogus = dir.join("bogus.rpk");
+    write(&bogus, b"\x89PNG\r\n\x1a\n not a pack at all").expect("scratch file");
+    let output = run(&[
+        "asset-inspect",
+        "--pack",
+        &bogus.to_string_lossy(),
+        "--json",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let document = envelope(&String::from_utf8_lossy(&output.stdout), "asset-inspect")
+        .expect("a typed envelope");
+    let stderr = document
+        .get("stderr")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(stderr.contains("magic"), "stderr was: {stderr}");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// An empty directory is a real answer, not an error.
+#[test]
+fn an_empty_directory_packs_to_an_empty_pack() {
+    let dir = scratch("empty").expect("scratch dir");
+    let src = dir.join("src");
+    fs::create_dir_all(&src).expect("scratch dir");
+    let pack = dir.join("out.rpk");
+
+    let output = run(&[
+        "asset-pack",
+        "--from",
+        &src.to_string_lossy(),
+        "--pack",
+        &pack.to_string_lossy(),
+    ])
+    .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+
+    let output = run(&["asset-inspect", "--pack", &pack.to_string_lossy(), "--json"])
+        .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(0));
+    let document = envelope(&String::from_utf8_lossy(&output.stdout), "asset-inspect")
+        .expect("a typed envelope");
+    assert_eq!(document.get("entries"), Some(&Value::Array(Vec::new())));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// The flags belong to their own subcommands, and each is required.
+#[test]
+fn the_asset_flags_are_checked_against_their_subcommands() {
+    // A flag on the wrong subcommand.
+    let output = run(&["build", "--pack", "x.rpk"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--pack"));
+
+    let output =
+        run(&["asset-inspect", "--pack", "x.rpk", "--from", "d"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--from"));
+
+    let output = run(&["asset-pack", "--from", "d", "--pack", "x.rpk", "--verify"])
+        .expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--verify"));
+
+    // And each subcommand's required input.
+    for line in [
+        vec!["asset-pack", "--from", "d"],
+        vec!["asset-pack", "--pack", "x.rpk"],
+        vec!["asset-inspect"],
+    ] {
+        let output = run(&line).expect("binary should spawn");
+        assert_eq!(output.status.code(), Some(2), "line was {line:?}");
+    }
+}


### PR DESCRIPTION
A pack is one file holding many named blobs, each with a digest of its own contents. `renew asset-pack` builds one from a directory; `renew asset-inspect` reads one back and can re-check every payload against its recorded hash.

```
$ renew asset-pack --from assets/ --pack game.rpk
packed 3 entries into game.rpk
$ renew asset-inspect --pack game.rpk --verify
empty.bin                0  cbf29ce484222325
notes.txt               10  db336841216b200c
shader/tri.spv           4  be7a5e775165785d
3 entries, verified
```

**The property the format is built around: the same inputs produce byte-identical output.** Entries are sorted by name before writing and named by their forward-slashed path relative to the source, so neither the order a filesystem enumerated a tree in nor the separator it uses reaches the bytes. Nothing in the crate reads a clock, a path, or the environment — and its lint file rejects all three rather than leaving it to review.

**The reader treats the header as the least trustworthy part of the file.** Every length is validated against the bytes actually present before it is used to slice anything; all arithmetic is checked; and the four regions must account for the file *exactly*, so a truncated download and an appended payload are refused alike. A malformed pack costs no allocation — everything the reader returns borrows the caller's buffer. The crate never opens a file, which keeps that surface to one function and leaves the size bound where it can be enforced.

**There is no `import` subcommand.** A real importer needs an image or audio decoder, which is a dependency nobody has approved, and one that only copied bytes would be worse than its absence. v0 is the container — the part that has to be right before anything is stored in it.

The digest is FNV-1a-64: no dependency, and deliberately documented as **not collision-resistant**. Content addressing for change detection and deduplication, not integrity against someone choosing the bytes.

**Tested** with round-trip and ordering properties over generated packs, a hostile-input property requiring an answer rather than a panic for arbitrary and pack-shaped bytes, hand-built malformed packs for every bounds refusal the format makes, a golden test asserting the exact byte layout, and end-to-end tests through the real binary covering both output modes and every refusal.

The golden test earns its place: the properties prove the writer and reader agree with *each other*, which two halves of one mistake also do.

Verified: 73 suites / 796 tests, fmt and clippy clean, structure check green, and a directory packed twice produces identical bytes.