### PR TITLE
Map raw window events to named actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,6 +1435,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-input"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-platform",
+]
+
+[[package]]
 name = "renew-jobs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -56,12 +56,12 @@ reason = "A release-mode refusal guarded by a debug assertion on the same condit
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [482, 483]
+lines = [487, 488]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [800]
+lines = [805]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -74,7 +74,12 @@ pub enum WindowEvent {
 /// Physical keys, the subset current consumers need — grows additively.
 /// Unmapped keys arrive as [`KeyCode::Unidentified`]; nothing is lost
 /// silently, nothing panics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// `Ord` so a consumer can keep these in a sorted table and binary
+// search it. The order is declaration order, which is arbitrary but
+// stable within a build — which is all a lookup key needs, and is
+// what a hash map cannot offer, since its iteration order varies
+// between runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum KeyCode {
     Escape,
@@ -92,7 +97,7 @@ pub enum KeyCode {
     Unidentified,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[non_exhaustive]
 pub enum PointerButton {
     Left,

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "renew-input"
+description = "Raw window events to named actions: bindings, per-tick edges, and no clock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Maps physical keys and pointer buttons to caller-named actions, with press and release edges that live on the tick rather than on the event."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+# The one dependency is the event vocabulary this crate translates from.
+# Taking a copy of it instead would mean every caller converting at the
+# seam, and two enums that must be kept in step by hand.
+[dependencies]
+renew-platform = { path = "../core/platform" }
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/input/README.md
+++ b/crates/input/README.md
@@ -1,0 +1,86 @@
+# renew-input
+
+Raw window events to named actions. A game asks "is the player jumping",
+not "is the space bar down"; this is the layer between.
+
+## Contract
+
+- **Edges live on the tick, not on the event.** `just_pressed` is true for
+  the whole tick in which an action became active and false in the next,
+  whatever order events arrived in or how many there were. **A key pressed
+  and released inside one tick still reports both edges** — a game that
+  misses a fast tap is worse than one that sees it a tick late.
+- **Nothing here reads a clock.** `advance` is called by the caller's
+  fixed-timestep loop. The crate cannot know whether a frame was slow and
+  so cannot behave differently on one.
+- **Binding order does not reach behaviour.** The binding table is a
+  sorted vector, searched rather than hashed, so two runs of the same
+  events always agree.
+- **Unbound input is ignored, not refused.** A keyboard has far more keys
+  than any game binds.
+
+## Architecture
+
+Three sorted vectors: bindings by physical input, one state per distinct
+action, and the set of inputs currently down. Lookup is a binary search;
+at the size a binding table actually reaches, that beats a map and cannot
+surprise anyone with its iteration order.
+
+`HashMap` is banned by the crate's [clippy.toml](clippy.toml), and here it
+is a real temptation rather than a theoretical one — a binding table is
+the textbook use for one. Its hasher is seeded per process, so resolving
+which action an input drives could differ between runs.
+
+## Public API
+
+`Binding::key` and `Binding::pointer` to name a physical input; `bind` to
+attach it to an action; `handle` to feed a window event; `advance` to end
+a tick; `held`, `just_pressed`, `just_released`, and `state` to read.
+
+`release_all` exists for focus loss: the OS stops delivering key-up for
+keys released while another window has focus, so without it a player who
+alt-tabs mid-jump comes back still jumping. It reports the releases as
+edges, so a system watching for them sees them.
+
+Actions are a caller-defined type, not strings — a typo is a compile
+error rather than an action that silently never fires. The bound is
+`Copy + Eq`, deliberately not `Hash`.
+
+## Thread safety and ownership
+
+No shared state, no interior mutability, no globals. `InputMap<A>` owns
+its tables and is `Send` and `Sync` when `A` is. Nothing synchronises,
+because nothing is shared.
+
+## Testing
+
+The state machine's edges, including the cases that justify the layer: a
+tap inside one tick, a key repeat that must not re-fire the press, two
+bindings OR-ing into one action, rebinding, focus loss, and redundant
+events that a real event stream produces.
+
+Two of them are about the absence of hidden inputs rather than about the
+machine — the same events produce the same state twice over, and binding
+order does not change behaviour.
+
+## Status
+
+`bootstrap`. Bindings and edges are settled; anything above them — axes,
+chords, gamepads, runtime rebinding UI, serialised binding sets — is not,
+and none of it has a consumer asking yet.
+
+## Key decisions
+
+- **Edges on the tick, not the event.** The alternative is to report a
+  press the instant it arrives, which loses a tap that completes inside
+  one tick and makes behaviour depend on how many events a frame happened
+  to deliver.
+- **Repeats ignored.** A repeat is the OS restating that a key is still
+  down, which the map already knows.
+- **Rebinding replaces.** One physical input means one thing at a time;
+  keeping both would make the result depend on binding order.
+- **Sorted vectors, not maps.** Determinism first, and faster at this
+  size anyway.
+- **No axes yet.** A stick or a mouse delta is a different shape from a
+  button and deserves its own design, not a bool with a magnitude bolted
+  on.

--- a/crates/input/clippy.toml
+++ b/crates/input/clippy.toml
@@ -1,0 +1,46 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate turns events into action state and does nothing else. The
+# clock bans are the ones that matter: input edges live on the tick, and
+# the tick is the caller's. A crate that could read a clock could make a
+# tap register differently on a slow frame, which is exactly the class of
+# bug a fixed-timestep loop exists to prevent.
+#
+# `HashMap` is banned for the determinism reason, and here it is a real
+# temptation rather than a theoretical one: a binding table is the
+# textbook use for a map. Its hasher is seeded per process, so iterating
+# one to resolve which action an input drives would give a different
+# answer between runs whenever two bindings collide. Sorted vectors
+# instead, which are also faster at this size.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::fs::read", reason = "this crate is data structures; it never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
+    { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },
+    { path = "std::io::Read::read_to_end", reason = "the same unbounded read by the other road" },
+    { path = "std::fs::write", reason = "this crate is data structures; it never touches the filesystem" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem, and asking about a file is one line away from opening it" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "a value from the environment would make one run differ from the next with nothing in the inputs to explain it" },
+    { path = "std::time::Instant::now", reason = "simulation state reads no clock: the same inputs must produce the same state, and a timestamp would destroy that" },
+    { path = "std::time::SystemTime::now", reason = "simulation state reads no clock" },
+    { path = "std::thread::spawn", reason = "storage spawns nothing; parallelism over components belongs to the job system" },
+]
+
+disallowed-types = [
+    { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle" },
+    { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on `File::open` misses" },
+    { path = "std::path::Path", reason = "the crate takes entity slots and components, never a path" },
+    { path = "std::path::PathBuf", reason = "the crate takes entity slots and components, never a path" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per process, so iteration order differs every run; a query that iterated one would break the defined order the storage exists to provide" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per process, so iteration order differs every run" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -1,0 +1,288 @@
+//! Raw input events to named actions, deterministically.
+//!
+//! A game asks "is the player jumping", not "is the space bar down". This
+//! crate is the layer between: a caller declares which physical inputs
+//! mean which action, feeds it window events, and reads action state once
+//! per tick.
+//!
+//! # Contract
+//!
+//! - **Edges are per tick, not per event.** `just_pressed` is true for the
+//!   whole tick in which an action became active and false in the next
+//!   one, whatever order the events arrived in or how many of them there
+//!   were. A key pressed and released inside one tick still reports both
+//!   edges, because a game that misses a fast tap is worse than one that
+//!   sees it late.
+//! - **Nothing here reads a clock.** [`InputMap::advance`] is called by
+//!   the caller's fixed-timestep loop; the crate has no idea what time it
+//!   is and cannot behave differently on a slow frame.
+//! - **Binding order does not affect state.** Two inputs bound to one
+//!   action are an OR, and the action is held while any of them is.
+//! - **Unbound input is ignored, not an error.** A keyboard has more keys
+//!   than any game binds, and refusing the others would make the common
+//!   case noisy.
+//!
+//! # Example
+//!
+//! ```
+//! use renew_input::{Binding, InputMap};
+//! use renew_platform::window::{KeyCode, WindowEvent};
+//!
+//! #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+//! enum Action { Jump, Left }
+//!
+//! let mut input = InputMap::new();
+//! input.bind(Binding::key(KeyCode::Space), Action::Jump);
+//! input.bind(Binding::key(KeyCode::ArrowLeft), Action::Left);
+//!
+//! input.handle(WindowEvent::Key { code: KeyCode::Space, pressed: true, repeat: false });
+//! assert!(input.just_pressed(Action::Jump));
+//! assert!(input.held(Action::Jump));
+//!
+//! // A new tick: the edge is gone, the hold remains.
+//! input.advance();
+//! assert!(!input.just_pressed(Action::Jump));
+//! assert!(input.held(Action::Jump));
+//! ```
+
+use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+
+/// One physical input that can be bound to an action.
+///
+/// A small closed enum rather than a general "any event" matcher: the
+/// inputs a game binds are keys and buttons, and admitting resize or
+/// focus events here would invite bindings that make no sense and then
+/// need rules about what they mean.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Binding {
+    /// A physical key, identified by position rather than by label.
+    Key(KeyCode),
+    /// A pointer button.
+    Pointer(PointerButton),
+}
+
+impl Binding {
+    /// Bind a key.
+    #[must_use]
+    pub const fn key(code: KeyCode) -> Self {
+        Self::Key(code)
+    }
+
+    /// Bind a pointer button.
+    #[must_use]
+    pub const fn pointer(button: PointerButton) -> Self {
+        Self::Pointer(button)
+    }
+}
+
+/// What an action is doing this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ActionState {
+    /// Held down as of now.
+    pub held: bool,
+    /// Became held during this tick.
+    pub just_pressed: bool,
+    /// Stopped being held during this tick.
+    pub just_released: bool,
+}
+
+/// Bindings and the state they produce.
+///
+/// Generic over the action type so a game names its own actions and the
+/// compiler catches a typo, rather than passing strings that fail at
+/// runtime. `A` need only be `Copy + Eq`: no hashing, because a hash map
+/// would order iteration by a per-process seed and this crate promises
+/// its behaviour does not vary between runs.
+#[derive(Debug)]
+pub struct InputMap<A> {
+    /// Sorted by binding, so lookup is a binary search and iteration is
+    /// stable. A `Vec` beats a map at this size and cannot surprise
+    /// anyone with its order.
+    bindings: Vec<(Binding, A)>,
+    /// One entry per distinct action, in first-bound order.
+    actions: Vec<(A, ActionState)>,
+    /// Bindings currently physically down, sorted.
+    down: Vec<Binding>,
+}
+
+impl<A: Copy + Eq> Default for InputMap<A> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A: Copy + Eq> InputMap<A> {
+    /// A map with no bindings.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            bindings: Vec::new(),
+            actions: Vec::new(),
+            down: Vec::new(),
+        }
+    }
+
+    /// Bind an input to an action.
+    ///
+    /// Binding the same input twice replaces the earlier action: a
+    /// physical key means one thing at a time, and keeping both would
+    /// make the result depend on binding order.
+    ///
+    /// Binding several inputs to one action is an OR — the action is held
+    /// while any of them is.
+    pub fn bind(&mut self, binding: Binding, action: A) {
+        match self.bindings.binary_search_by(|(b, _)| b.cmp(&binding)) {
+            Ok(at) => {
+                if let Some(entry) = self.bindings.get_mut(at) {
+                    entry.1 = action;
+                }
+            }
+            Err(at) => self.bindings.insert(at, (binding, action)),
+        }
+        if !self.actions.iter().any(|(known, _)| *known == action) {
+            self.actions.push((action, ActionState::default()));
+        }
+    }
+
+    /// How many bindings are registered.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Whether nothing is bound.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+
+    /// The action a physical input is bound to, if any.
+    #[must_use]
+    pub fn action_for(&self, binding: Binding) -> Option<A> {
+        let at = self
+            .bindings
+            .binary_search_by(|(b, _)| b.cmp(&binding))
+            .ok()?;
+        self.bindings.get(at).map(|(_, action)| *action)
+    }
+
+    /// Feed one window event.
+    ///
+    /// Events that are not bound input — resize, focus, redraw — are
+    /// ignored. Key repeats are ignored too: a repeat is the OS saying
+    /// the key is still down, which this crate already knows, and letting
+    /// one through would fire `just_pressed` again mid-hold.
+    pub fn handle(&mut self, event: WindowEvent) {
+        let (binding, pressed) = match event {
+            WindowEvent::Key {
+                code,
+                pressed,
+                repeat: false,
+            } => (Binding::Key(code), pressed),
+            WindowEvent::PointerButton { button, pressed } => (Binding::Pointer(button), pressed),
+            _ => return,
+        };
+        self.set(binding, pressed);
+    }
+
+    /// Record a binding's physical state and update the action it drives.
+    fn set(&mut self, binding: Binding, pressed: bool) {
+        let known = self.down.binary_search(&binding);
+        match (pressed, known) {
+            (true, Err(at)) => self.down.insert(at, binding),
+            (false, Ok(at)) => {
+                self.down.remove(at);
+            }
+            // Already in the state being set: a duplicate press or a
+            // release of something that was never down. Neither is an
+            // error and neither changes anything.
+            _ => return,
+        }
+        let Some(action) = self.action_for(binding) else {
+            return;
+        };
+        let now_held = self.any_down_for(action);
+        // `bind` adds every action it binds, so the entry is always
+        // there. `for` over the matching entries rather than `if let`:
+        // the absent case is then an empty iteration rather than a branch
+        // with a body, so nothing unreachable needs claiming or exempting.
+        for (_, state) in self
+            .actions
+            .iter_mut()
+            .filter(|(known, _)| *known == action)
+        {
+            if now_held && !state.held {
+                state.just_pressed = true;
+            }
+            if !now_held && state.held {
+                state.just_released = true;
+            }
+            state.held = now_held;
+        }
+    }
+
+    /// Whether any binding for this action is physically down.
+    fn any_down_for(&self, action: A) -> bool {
+        self.bindings
+            .iter()
+            .filter(|(_, bound)| *bound == action)
+            .any(|(binding, _)| self.down.binary_search(binding).is_ok())
+    }
+
+    /// End the tick: edges are cleared, holds are kept.
+    ///
+    /// **A tap that pressed and released within one tick keeps both edges
+    /// until this is called**, so a fast input is seen late rather than
+    /// missed. That is the reason edges live on the tick rather than on
+    /// the event.
+    pub fn advance(&mut self) {
+        for (_, state) in &mut self.actions {
+            state.just_pressed = false;
+            state.just_released = false;
+        }
+    }
+
+    /// This action's full state.
+    #[must_use]
+    pub fn state(&self, action: A) -> ActionState {
+        self.actions
+            .iter()
+            .find(|(known, _)| *known == action)
+            .map(|(_, state)| *state)
+            .unwrap_or_default()
+    }
+
+    /// Whether the action is held.
+    #[must_use]
+    pub fn held(&self, action: A) -> bool {
+        self.state(action).held
+    }
+
+    /// Whether the action became held this tick.
+    #[must_use]
+    pub fn just_pressed(&self, action: A) -> bool {
+        self.state(action).just_pressed
+    }
+
+    /// Whether the action stopped being held this tick.
+    #[must_use]
+    pub fn just_released(&self, action: A) -> bool {
+        self.state(action).just_released
+    }
+
+    /// Forget all physical state, keeping bindings.
+    ///
+    /// For focus loss: the OS stops delivering key-up for keys released
+    /// while another window has focus, so without this a player who
+    /// alt-tabs mid-jump comes back still jumping. Releases are reported
+    /// as edges, so a system watching `just_released` sees them.
+    pub fn release_all(&mut self) {
+        self.down.clear();
+        for (_, state) in &mut self.actions {
+            if state.held {
+                state.just_released = true;
+            }
+            state.held = false;
+        }
+    }
+}

--- a/crates/input/tests/actions.rs
+++ b/crates/input/tests/actions.rs
@@ -1,0 +1,301 @@
+//! The action state machine, including the cases that make it worth
+//! having a layer here at all rather than reading keys directly.
+
+use renew_input::{ActionState, Binding, InputMap};
+use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Action {
+    Jump,
+    Fire,
+    Left,
+}
+
+fn key(code: KeyCode, pressed: bool) -> WindowEvent {
+    WindowEvent::Key {
+        code,
+        pressed,
+        repeat: false,
+    }
+}
+
+fn mapped() -> InputMap<Action> {
+    let mut input = InputMap::new();
+    input.bind(Binding::key(KeyCode::Space), Action::Jump);
+    input.bind(Binding::key(KeyCode::ArrowLeft), Action::Left);
+    input.bind(Binding::pointer(PointerButton::Left), Action::Fire);
+    input
+}
+
+#[test]
+fn an_unbound_map_reports_nothing() {
+    let input: InputMap<Action> = InputMap::new();
+    assert!(input.is_empty());
+    assert_eq!(input.len(), 0);
+    assert_eq!(input.state(Action::Jump), ActionState::default());
+    assert!(!input.held(Action::Jump));
+    assert!(input.action_for(Binding::key(KeyCode::Space)).is_none());
+}
+
+#[test]
+fn a_press_sets_the_edge_and_the_hold() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    assert_eq!(
+        input.state(Action::Jump),
+        ActionState {
+            held: true,
+            just_pressed: true,
+            just_released: false
+        }
+    );
+    // Unrelated actions are untouched.
+    assert_eq!(input.state(Action::Left), ActionState::default());
+}
+
+#[test]
+fn advancing_clears_the_edge_and_keeps_the_hold() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.advance();
+    assert!(input.held(Action::Jump));
+    assert!(!input.just_pressed(Action::Jump));
+
+    input.handle(key(KeyCode::Space, false));
+    assert!(!input.held(Action::Jump));
+    assert!(input.just_released(Action::Jump));
+    input.advance();
+    assert!(!input.just_released(Action::Jump));
+}
+
+/// The case the whole per-tick design exists for: a tap inside one tick
+/// must not be lost. A game that misses a fast input is worse than one
+/// that sees it a tick late.
+#[test]
+fn a_tap_within_one_tick_reports_both_edges() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.handle(key(KeyCode::Space, false));
+    let state = input.state(Action::Jump);
+    assert!(state.just_pressed, "the press must survive the release");
+    assert!(state.just_released);
+    assert!(!state.held, "and it must not still be held");
+}
+
+/// A repeat is the OS restating what is already known. Letting one
+/// through would fire `just_pressed` again in the middle of a hold.
+#[test]
+fn a_key_repeat_does_not_re_fire_the_press_edge() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.advance();
+    input.handle(WindowEvent::Key {
+        code: KeyCode::Space,
+        pressed: true,
+        repeat: true,
+    });
+    assert!(input.held(Action::Jump));
+    assert!(!input.just_pressed(Action::Jump), "a repeat is not a press");
+}
+
+/// Two bindings for one action are an OR: it stays held while either is
+/// down, and only releases when the last one goes.
+#[test]
+fn two_bindings_for_one_action_or_together() {
+    let mut input = InputMap::new();
+    input.bind(Binding::key(KeyCode::Space), Action::Jump);
+    input.bind(Binding::key(KeyCode::ArrowUp), Action::Jump);
+    assert_eq!(input.len(), 2);
+
+    input.handle(key(KeyCode::Space, true));
+    input.advance();
+    input.handle(key(KeyCode::ArrowUp, true));
+    assert!(input.held(Action::Jump));
+    assert!(
+        !input.just_pressed(Action::Jump),
+        "already held; the second binding is not a new press"
+    );
+
+    input.advance();
+    input.handle(key(KeyCode::Space, false));
+    assert!(input.held(Action::Jump), "the other binding is still down");
+    assert!(!input.just_released(Action::Jump));
+
+    input.handle(key(KeyCode::ArrowUp, false));
+    assert!(!input.held(Action::Jump));
+    assert!(input.just_released(Action::Jump));
+}
+
+#[test]
+fn rebinding_an_input_replaces_the_action_it_drives() {
+    let mut input = mapped();
+    let before = input.len();
+    input.bind(Binding::key(KeyCode::Space), Action::Fire);
+    assert_eq!(input.len(), before, "rebinding must not add a binding");
+    assert_eq!(
+        input.action_for(Binding::key(KeyCode::Space)),
+        Some(Action::Fire)
+    );
+
+    input.handle(key(KeyCode::Space, true));
+    assert!(input.held(Action::Fire));
+    assert!(!input.held(Action::Jump));
+}
+
+#[test]
+fn pointer_buttons_bind_like_keys() {
+    let mut input = mapped();
+    input.handle(WindowEvent::PointerButton {
+        button: PointerButton::Left,
+        pressed: true,
+    });
+    assert!(input.just_pressed(Action::Fire));
+    input.handle(WindowEvent::PointerButton {
+        button: PointerButton::Right,
+        pressed: true,
+    });
+    assert!(
+        input.held(Action::Fire),
+        "an unbound button changes nothing"
+    );
+}
+
+#[test]
+fn events_that_are_not_input_are_ignored() {
+    let mut input = mapped();
+    for event in [
+        WindowEvent::CloseRequested,
+        WindowEvent::RedrawRequested,
+        WindowEvent::Focused(true),
+        WindowEvent::Resized {
+            width: 1,
+            height: 1,
+        },
+        WindowEvent::ScaleFactorChanged { scale: 2.0 },
+        WindowEvent::PointerMoved { x: 1.0, y: 2.0 },
+        WindowEvent::Wheel { dx: 0.0, dy: 1.0 },
+    ] {
+        input.handle(event);
+    }
+    assert_eq!(input.state(Action::Jump), ActionState::default());
+    assert_eq!(input.state(Action::Fire), ActionState::default());
+}
+
+/// A duplicate press, and a release of something never pressed. Both are
+/// things a real event stream produces and neither is an error.
+#[test]
+fn redundant_events_change_nothing() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.advance();
+    input.handle(key(KeyCode::Space, true));
+    assert!(!input.just_pressed(Action::Jump), "already down");
+
+    input.handle(key(KeyCode::ArrowLeft, false));
+    assert_eq!(input.state(Action::Left), ActionState::default());
+}
+
+/// Focus loss: the OS stops delivering key-up, so a player who alt-tabs
+/// mid-jump would come back still jumping.
+#[test]
+fn releasing_everything_reports_edges_and_clears_holds() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.handle(key(KeyCode::ArrowLeft, true));
+    input.advance();
+
+    input.release_all();
+    assert!(!input.held(Action::Jump));
+    assert!(!input.held(Action::Left));
+    assert!(
+        input.just_released(Action::Jump),
+        "a system watching releases must see it"
+    );
+    assert!(input.just_released(Action::Left));
+
+    // And it is idempotent: nothing was held, so nothing is released.
+    input.advance();
+    input.release_all();
+    assert!(!input.just_released(Action::Jump));
+}
+
+/// After a release-all, the physical state is genuinely forgotten — a
+/// later release of a key the map thought was down must not resurrect an
+/// edge.
+#[test]
+fn a_release_after_release_all_is_a_no_op() {
+    let mut input = mapped();
+    input.handle(key(KeyCode::Space, true));
+    input.release_all();
+    input.advance();
+    input.handle(key(KeyCode::Space, false));
+    assert_eq!(input.state(Action::Jump), ActionState::default());
+}
+
+/// The same event sequence produces the same state, every time. The
+/// crate has no clock and no hashing, so this is a statement about the
+/// absence of hidden inputs rather than about the state machine.
+#[test]
+fn the_same_events_produce_the_same_state() {
+    let script = [
+        key(KeyCode::Space, true),
+        key(KeyCode::ArrowLeft, true),
+        key(KeyCode::Space, false),
+        key(KeyCode::ArrowLeft, false),
+        key(KeyCode::Space, true),
+    ];
+    let run = || {
+        let mut input = mapped();
+        let mut seen = Vec::new();
+        for (index, event) in script.iter().enumerate() {
+            input.handle(*event);
+            if index % 2 == 1 {
+                input.advance();
+            }
+            seen.push((
+                input.state(Action::Jump),
+                input.state(Action::Left),
+                input.state(Action::Fire),
+            ));
+        }
+        seen
+    };
+    assert_eq!(run(), run());
+}
+
+/// Binding order does not reach the state, which is what the sorted
+/// table exists to guarantee.
+#[test]
+fn binding_order_does_not_change_behaviour() {
+    let build = |reverse: bool| {
+        let mut input = InputMap::new();
+        let pairs = [
+            (Binding::key(KeyCode::Space), Action::Jump),
+            (Binding::key(KeyCode::ArrowUp), Action::Jump),
+            (Binding::key(KeyCode::ArrowLeft), Action::Left),
+        ];
+        if reverse {
+            for (binding, action) in pairs.iter().rev() {
+                input.bind(*binding, *action);
+            }
+        } else {
+            for (binding, action) in &pairs {
+                input.bind(*binding, *action);
+            }
+        }
+        input.handle(key(KeyCode::ArrowUp, true));
+        input.handle(key(KeyCode::ArrowLeft, true));
+        (input.state(Action::Jump), input.state(Action::Left))
+    };
+    assert_eq!(build(false), build(true));
+}
+
+/// `Default` is what a struct holding a map will use, so it must agree
+/// with `new` rather than merely compile.
+#[test]
+fn default_and_new_agree() {
+    let made: InputMap<Action> = InputMap::default();
+    assert!(made.is_empty());
+    assert_eq!(made.len(), InputMap::<Action>::new().len());
+    assert_eq!(made.state(Action::Jump), ActionState::default());
+}


### PR DESCRIPTION
A game asks whether the player is jumping, not whether the space bar is down. This is the layer between.

**Edges live on the tick, not on the event, and that is the design rather than a detail.** A key pressed *and released* inside one tick still reports both edges — a game that misses a fast tap is worse than one that sees it a tick late. Nothing here reads a clock: the tick belongs to the caller's fixed-timestep loop, so the layer cannot behave differently on a slow frame.

**Three sorted vectors, searched rather than hashed.** A binding table is the textbook use for a hash map, and a hash map is exactly what this must not be — its hasher is seeded per process, so resolving which action an input drives could differ between runs. The crate's lint file rejects one, along with clocks and the filesystem.

Actions are a caller-defined type, so a typo is a compile error rather than an action that silently never fires.

`release_all` exists for focus loss: the OS stops delivering key-up for keys released while another window has focus, so without it a player who alt-tabs mid-jump comes back still jumping. The releases are reported as edges, so a system watching for them sees them.

Also derives a total order on the platform crate's two input enums, which is what lets a consumer keep them in a sorted table. Additive; the ordering is declaration order — arbitrary but stable within a build, which is all a lookup key needs and is what a hash map cannot offer.

**Tested against the cases that justify the layer:** a tap inside one tick, a repeat that must not re-fire the press, two bindings OR-ing into one action, rebinding, focus loss, and the redundant events a real stream produces. Two tests are about the absence of hidden inputs rather than the state machine — the same events produce the same state twice over, and binding order does not change behaviour.

Verified: 79 suites / 840 tests, fmt and clippy clean, structure check green.