### PR TITLE
Deny printing in the three new engine crates, and guard the rule

### DIFF
--- a/crates/asset/src/lib.rs
+++ b/crates/asset/src/lib.rs
@@ -54,6 +54,10 @@
 //! # Ok::<(), Box<dyn core::error::Error>>(())
 //! ```
 
+// A container format writes bytes for a caller and returns refusals as
+// values; anything it printed would reach a stream it does not own.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
 mod error;
 mod hash;
 mod layout;

--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -52,6 +52,11 @@
 //! assert_eq!(both, vec![hero.index()]);
 //! ```
 
+// Storage answers questions; it never reports. A print from inside a
+// query would be output no caller asked for, on a path that runs once
+// per entity per frame.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
 mod entity;
 mod store;
 

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -45,6 +45,10 @@
 //! assert!(input.held(Action::Jump));
 //! ```
 
+// This layer resolves state; it never reports. Diagnostics about input
+// belong to whoever is driving the loop.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
 use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
 
 /// One physical input that can be bound to an action.

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -511,3 +511,84 @@ fn the_position_matcher_reads_whole_words_only() {
     assert!(cited("a multi-line refusal").is_none(), "no number follows");
     assert!(cited("the line above").is_none(), "no number follows");
 }
+
+/// The lints every engine crate is expected to carry itself.
+///
+/// Held as a list rather than one string so the message can say which of
+/// them is missing, and so adding a third is a one-line change.
+const ENGINE_CRATE_DENIES: &[&str] = &["clippy::print_stdout", "clippy::print_stderr"];
+
+/// Every crate under the engine module root denies printing, at the crate
+/// root, in its own source.
+///
+/// The workspace lint table cannot carry this: two non-engine crates —
+/// the CLI and the samples — print by design, and a workspace-wide deny
+/// would need an `allow` escape in each of them. So it is per crate, by
+/// hand, which is exactly the arrangement that rots.
+///
+/// **And it did.** The convention held for nine crates and then three
+/// landed on one day without it. Nothing noticed: the structure check
+/// requires each crate's `clippy.toml` to exist but says nothing about
+/// its contents or about crate-root attributes, and clippy cannot warn
+/// about a deny that was never written. This was the predicted failure —
+/// the convention holds until the crate that forgets, and nothing says
+/// so — and it came true three times before this test existed.
+#[test]
+fn every_engine_crate_denies_printing_at_its_root() {
+    let root = workspace_root();
+    let engine = root.join("crates");
+    let mut checked = Vec::new();
+    let mut faults = Vec::new();
+
+    let mut pending = vec![engine];
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.file_name().and_then(|n| n.to_str()) != Some("Cargo.toml") {
+                continue;
+            }
+            let Some(crate_dir) = path.parent() else {
+                continue;
+            };
+            let lib = crate_dir.join("src").join("lib.rs");
+            let shown = crate_dir
+                .strip_prefix(&root)
+                .unwrap_or(crate_dir)
+                .display()
+                .to_string();
+            let Ok(source) = std::fs::read_to_string(&lib) else {
+                // A crate under `crates/` with no lib.rs is a shape this
+                // rule has no opinion about; reported rather than skipped
+                // so a binary-only engine crate is a decision someone
+                // makes rather than a silent exemption.
+                faults.push(format!("{shown} has no src/lib.rs to carry the denies"));
+                continue;
+            };
+            checked.push(shown.clone());
+            for deny in ENGINE_CRATE_DENIES {
+                if !source.contains(deny) {
+                    faults.push(format!("{shown} does not deny `{deny}` at its crate root"));
+                }
+            }
+        }
+    }
+
+    assert!(
+        checked.len() >= 9,
+        "only {} engine crates were found; the walk is not reaching the tree and this would pass \
+         vacuously",
+        checked.len()
+    );
+    assert!(
+        faults.is_empty(),
+        "these engine crates are missing a crate-root print deny, which the workspace lint table \
+         cannot supply because the CLI and the samples print by design: {faults:?}"
+    );
+}


### PR DESCRIPTION
Every engine crate denies `print_stdout` and `print_stderr` at its own crate root. The workspace lint table cannot carry this — the CLI and the samples print by design, so a workspace-wide deny would need an allow escape in each. So it is per crate, by hand.

**Nine crates had it. The three that landed today did not**, and nothing noticed: the structure check requires each crate's lint file to *exist* but says nothing about its contents or about crate-root attributes, and clippy cannot warn about a deny nobody wrote.

This was the predicted failure mode for a hand-maintained convention — it holds until the crate that forgets, and nothing says so. It came true three times in one day.

**So the rule now has a test.** Every crate under the engine module root must carry both denies in its own source. Bite-tested by removing one again, which fails naming the crate and both missing lints.

Two details in the test worth flagging: it asserts it found **at least nine crates**, because a walk that stops finding the tree would otherwise report success; and it *reports* rather than skips an engine crate with no `lib.rs`, so a binary-only one is a decision someone makes rather than a silent exemption.

Verified: 79 suites / 842 tests, fmt and clippy clean.