### PR TITLE
test(rhi): make the single-threaded contract fail the build when broken

### DIFF
--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -12,6 +12,28 @@
 //!   and everything holding one is `!Send + !Sync` by construction:
 //!   Vulkan's external-synchronization rules are unrepresentable to
 //!   violate. Lifting this is a future, deliberate change.
+//!
+//!   The two examples below are the contract, executed. They must fail
+//!   to compile, and the error code is pinned so they cannot pass
+//!   vacuously on a typo:
+//!
+//!   ```compile_fail,E0277
+//!   fn needs_send<T: Send>() {}
+//!   needs_send::<renew_rhi::Device>();
+//!   ```
+//!
+//!   ```compile_fail,E0277
+//!   fn needs_sync<T: Sync>() {}
+//!   needs_sync::<renew_rhi::Device>();
+//!   ```
+//!
+//!   **What this does and does not catch.** The spine is asserted, not
+//!   every resource, because the resources are `!Send` for one reason —
+//!   each holds an `Rc<DeviceShared>` — and a change that made them
+//!   shareable would have to make that `Rc` shareable first, which these
+//!   two catch. What they do not catch is a hand-written `unsafe impl
+//!   Send` on one resource; that is governed by the crate's `unsafe`
+//!   policy instead, which requires a written safety argument per site.
 //! - **Errors are the environment's; assertions are the caller's.** A
 //!   missing Vulkan runtime, a lost device, an out-of-date swapchain —
 //!   recoverable results. Mixing objects across devices or handing a


### PR DESCRIPTION
The crate's contract says `Device` and everything holding one is `!Send + !Sync` **by construction**, and the threading standard asks for thread affinity to be structural rather than a comment.

It *is* structural — `Rc<DeviceShared>` supplies it — but nothing executed the claim. `unsafe impl Send for Device {}` would have broken no test in the tree, and neither would swapping the `Rc` for an `Arc`. The invariant was true and undefended, which matters more than usual here: it is the premise every category-2 `unsafe` safety argument in `src/vk/` leans on.

Two `compile_fail,E0277` doctests now assert it. The error code is pinned so they cannot pass vacuously if a typo makes the snippet fail to compile for an unrelated reason.

**Confirmed rather than assumed:** appending the two `unsafe impl`s made both doctests fail with *"Test compiled successfully, but it's marked `compile_fail`"*, then the mutation was reverted.

The scope is written into the docs rather than left implied — these catch the spine becoming shareable, which is the realistic regression, and not a hand-written `unsafe impl` on a single resource, which the crate's `unsafe` policy governs instead by requiring a written safety argument per site.

No dependency added; `compile_fail` is a rustdoc feature and the doctests run in the normal suite. Verified locally: 79 suites / 845 tests, clippy clean, and green with `--no-default-features` too.