### PR TITLE
docs(rhi): narrow two README claims to what the suite actually tests

### DIFF
--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -36,12 +36,18 @@ the bytes.
   swapchain — recoverable results. Mixing objects across devices or a
   wrong-sized readback buffer — contract violations (the readback
   length check is retained in release builds; it guards memory safety).
-- **Validation is evidence.** The test suites bring devices up with
-  `Validation::Required` and mechanically assert zero validation
-  errors at teardown; golden tests pin exact bytes on the CI-pinned
-  software rasterizer.
+- **Validation is evidence, and the lanes are uneven.** The device
+  suite brings devices up with `Validation::Required` and mechanically
+  asserts zero validation errors at teardown; the fault suite runs
+  `IfAvailable` with one `Required` scenario, and the golden and
+  present suites run `IfAvailable`. **No `Required` lane constructs a
+  window target**, so the strict validation oracle covers the offscreen
+  path only. Golden tests pin exact bytes on the CI-pinned software
+  rasterizer.
 - **Steady-state frames allocate nothing** on the engine side — pinned
-  by an allocation-counting integration test. Driver host allocations
+  by an allocation-counting integration test **that builds an offscreen
+  target only**. The window render path has no allocation gate; the
+  contract covers it, the test does not. Driver host allocations
   are instrumented separately through `VkAllocationCallbacks` into a
   per-device ledger (`host_allocation_stats`), diagnostics only.
 


### PR DESCRIPTION
Two claims in the rendering crate's README were true of the offscreen path and written as if they covered everything. Found while reading the crate closely; both verified against the suites rather than recalled.

**Validation.** The README said *"The test suites bring devices up with `Validation::Required`"*. Actually: `device.rs` runs `Required` (plus two deliberate `Off` cases), `fault.rs` runs `IfAvailable` with one `Required` scenario, and `golden.rs`, `present_smoke.rs` run `IfAvailable` while `zero_alloc.rs` runs `Off`. **No `Required` lane constructs a window target**, so the strict validation oracle — the thing that makes the barriers trustworthy — covers the offscreen path only.

**Allocation.** The README said steady-state frames allocate nothing, *"pinned by an allocation-counting integration test"*. That test builds an offscreen target and nothing else; the window render path has no allocation gate anywhere. The contract still covers it — the test does not, and the README implied otherwise.

Neither is a code change. Both narrow a claim to what is actually enforced, which matters here because the next work in this crate will lean on exactly these guarantees.