### PR TITLE
fix(lints): close two holes in the no-threads and no-filesystem contracts

### DIFF
--- a/.github/workflows/bench-baselines.yml
+++ b/.github/workflows/bench-baselines.yml
@@ -100,10 +100,10 @@ jobs:
       - name: Install the pinned software Vulkan stack
         if: runner.os == 'Linux'
         uses: ./.github/actions/software-vulkan
-      # The exit criterion's actual number: the sample's own frame time,
-      # measured end to end through the command the roadmap names rather
-      # than through a harness built for this workflow. What CI runs and
-      # what a human runs stay the same thing.
+      # The target's actual number: the sample's own frame time, measured
+      # end to end through the command the project defines rather than
+      # through a harness built for this workflow. What CI runs and what a
+      # human runs stay the same thing.
       #
       # These are dev-profile numbers. Starting a sample through the
       # workspace runner is the canonical path and it has no release

--- a/crates/asset/clippy.toml
+++ b/crates/asset/clippy.toml
@@ -36,6 +36,7 @@ disallowed-methods = [
     { path = "std::time::Instant::now", reason = "packing reads no clock: a pack built twice from the same inputs must be byte-identical, and a timestamp in the output would destroy that" },
     { path = "std::time::SystemTime::now", reason = "packing reads no clock: a timestamp is the classic reason two builds of identical inputs differ" },
     { path = "std::thread::spawn", reason = "the crate spawns nothing; it is a pure function of its input" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; the crate spawns nothing; it is a pure function of its input" },
 ]
 
 disallowed-types = [

--- a/crates/ecs/clippy.toml
+++ b/crates/ecs/clippy.toml
@@ -32,6 +32,7 @@ disallowed-methods = [
     { path = "std::time::Instant::now", reason = "simulation state reads no clock: the same inputs must produce the same state, and a timestamp would destroy that" },
     { path = "std::time::SystemTime::now", reason = "simulation state reads no clock" },
     { path = "std::thread::spawn", reason = "storage spawns nothing; parallelism over components belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; storage spawns nothing; parallelism over components belongs to the job system" },
 ]
 
 disallowed-types = [

--- a/crates/ecs/src/store.rs
+++ b/crates/ecs/src/store.rs
@@ -9,8 +9,8 @@
 //! two iterators rather than one. After any churn the dense array is in
 //! no useful order at all, so a query that walked it would visit entities
 //! in an order decided by their removal history — reproducible only if
-//! every prior operation was. The engine defines an order instead
-//! (ADR-0010), and [`Store::iter`] provides it by walking `sparse`.
+//! every prior operation was. The engine defines an order instead —
+//! ascending slot — and [`Store::iter`] provides it by walking `sparse`.
 
 /// Components of one type, addressed by entity slot.
 #[derive(Debug)]

--- a/crates/frame/clippy.toml
+++ b/crates/frame/clippy.toml
@@ -14,7 +14,8 @@ allow-panic-in-tests = true
 disallowed-methods = [
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
-    { path = "std::thread::spawn", reason = "simulation is single-threaded until the deterministic parallel-scheduling ADR exists" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },
     { path = "std::fs::write", reason = "this crate never touches the filesystem" },
     { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },

--- a/crates/input/clippy.toml
+++ b/crates/input/clippy.toml
@@ -31,6 +31,7 @@ disallowed-methods = [
     { path = "std::time::Instant::now", reason = "simulation state reads no clock: the same inputs must produce the same state, and a timestamp would destroy that" },
     { path = "std::time::SystemTime::now", reason = "simulation state reads no clock" },
     { path = "std::thread::spawn", reason = "storage spawns nothing; parallelism over components belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; storage spawns nothing; parallelism over components belongs to the job system" },
 ]
 
 disallowed-types = [

--- a/crates/jobs/clippy.toml
+++ b/crates/jobs/clippy.toml
@@ -9,6 +9,7 @@ allow-panic-in-tests = true
 
 disallowed-methods = [
     { path = "std::thread::spawn", reason = "workers come from renew_platform::thread::spawn_named — the only thread-spawn seam" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; workers come from renew_platform::thread::spawn_named — the only thread-spawn seam" },
     { path = "std::time::Instant::now", reason = "this crate never reads a clock; timing belongs to callers via renew-platform" },
     { path = "std::time::SystemTime::now", reason = "this crate never reads a clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },

--- a/crates/rhi/clippy.toml
+++ b/crates/rhi/clippy.toml
@@ -9,10 +9,18 @@ allow-panic-in-tests = true
 
 disallowed-methods = [
     { path = "std::thread::spawn", reason = "the RHI is single-threaded by contract; parallelism belongs to the job pool" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; the RHI is single-threaded by contract; parallelism belongs to the job pool" },
     { path = "std::time::Instant::now", reason = "this crate never reads a clock; timing belongs to callers via renew-platform" },
     { path = "std::time::SystemTime::now", reason = "this crate never reads a clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem; shader bytes arrive embedded or from callers" },
     { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    # The three below were missing while the README claimed filesystem
+    # access was rejected outright. `read` and `write` are the convenience
+    # wrappers; opening a handle is the way a real shader-from-disk would
+    # actually get written, and it was the one route left open.
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
 ]
 
 # The SAFETY-comment lint accepts the comment above an attribute or

--- a/crates/rng/clippy.toml
+++ b/crates/rng/clippy.toml
@@ -20,6 +20,7 @@ disallowed-methods = [
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until the deterministic parallel-scheduling decision exists" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; simulation is single-threaded until the deterministic parallel-scheduling decision exists" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },
     { path = "std::fs::write", reason = "this crate never touches the filesystem" },
     { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },

--- a/crates/trace/clippy.toml
+++ b/crates/trace/clippy.toml
@@ -40,6 +40,7 @@ disallowed-methods = [
     { path = "std::time::Instant::now", reason = "a codec reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::time::SystemTime::now", reason = "a codec reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::thread::spawn", reason = "a codec spawns nothing; it is a pure function of its input" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; a codec spawns nothing; it is a pure function of its input" },
 ]
 
 disallowed-types = [


### PR DESCRIPTION
Two documented contracts had holes wide enough to walk through. Both found by sweeping READMEs for claims and asking what actually enforces each; both confirmed by adding a call and watching the lint fire, then reverting.

**Filesystem.** `renew-rhi`'s README says *"thread spawning, clock reads, and filesystem access are rejected at lint time"*, and its `clippy.toml` header says the crate *"never [talks] to the clock, the filesystem, or raw threads"*. Only `std::fs::read` and `std::fs::write` were banned — `File::open`, `File::create` and `read_to_string` were all reachable. Every peer crate (`diag`, `math`, `memory`, `jobs`) already bans them, so this crate was the outlier, and opening a handle is how a shader-loaded-from-disk would realistically get written.

**Threads.** Eight crates ban `std::thread::spawn`. None banned `std::thread::Builder::spawn` — the same act with a name attached, and the obvious spelling to reach for. Only `renew-platform` legitimately spawns, via `Builder` inside its `spawn_named` seam, and it is not one of the eight; nothing else in the tree uses `Builder` at all, so this breaks nothing.

Also rewords three comments that named internal working documents rather than the fact they were describing — one of them in `crates/frame/clippy.toml`, which is where the sweep started.

Verified: workspace clippy clean, 79 suites / 854 tests green.