### PR TITLE
docs(ecs): bound the stale-handle guarantee to what it actually covers

### DIFF
--- a/crates/ecs/README.md
+++ b/crates/ecs/README.md
@@ -11,10 +11,19 @@ consequence of the layout.
   removed in. That is the point of the whole design: it makes the
   determinism invariant structural, rather than a rule every future
   contributor has to remember and every reviewer has to catch.
-- **A stale handle is dead, not dangerous.** An entity is a slot plus a
-  generation. Reusing a slot bumps its generation, so a handle to a
-  despawned entity reports as not alive instead of quietly naming whoever
-  took its place.
+- **A stale handle is dead, not dangerous — within two stated limits.** An
+  entity is a slot plus a generation. Reusing a slot bumps its generation,
+  so a handle to a despawned entity reports as not alive instead of
+  quietly naming whoever took its place. Two cases it does not cover, both
+  deliberate:
+  - **A handle from a different `Entities` cannot be detected.** Same
+    slot, same generation, different world: it reports alive. There is a
+    test asserting exactly that, so the limit is pinned rather than
+    latent.
+  - **A generation wraps after 2^32 reuses of one slot**, at which point a
+    handle from the first pass could alias. Wrapping is the honest choice
+    — a saturating counter would silently stop detecting staleness at the
+    same point while looking safe.
 - **Ordered iteration costs the gaps.** It walks slots, so it is
   proportional to the highest occupied slot rather than to the number of
   components. The allocator reuses low slots first to keep that range

--- a/crates/ecs/src/entity.rs
+++ b/crates/ecs/src/entity.rs
@@ -145,9 +145,12 @@ impl Entities {
         if let Some(generation) = self.generations.get_mut(slot) {
             // Wrapping is the honest choice: at four billion reuses of one
             // slot a handle from the first pass could alias, and there is
-            // no cheaper fix that does not leak slots forever. Recorded
-            // rather than hidden behind a saturating counter that would
-            // silently stop detecting staleness at the same point.
+            // no cheaper fix that does not leak slots forever. A
+            // saturating counter would stop detecting staleness at the
+            // same point while looking safe, which is worse. The bound is
+            // stated in the crate README beside the property it limits;
+            // it cannot be tested, because reaching it needs 2^32
+            // despawns of one slot.
             *generation = generation.wrapping_add(1);
         }
         self.free.push(entity.index());


### PR DESCRIPTION
The entity crate's README promised its central safety property without qualification: *"a handle to a despawned entity reports as not alive instead of quietly naming whoever took its place."* Two cases it does not cover, both found while bug-hunting the least-exercised crates.

**A handle from a different `Entities` reports alive.** Same slot, same generation, different world — the generation cannot distinguish them. There is already a test asserting exactly this, captioned *"documented limit, not a promise"*, while the README made it a promise.

**A generation wraps after 2^32 reuses of one slot**, after which a handle from the first pass can alias. Wrapping is the deliberate choice and stays: a saturating counter stops detecting staleness at exactly the same point while looking safe, and never reusing slots leaks them forever.

Both are now stated where a consumer reads the guarantee, rather than one being in a test caption and the other in a source comment.

The comment itself ended *"Recorded rather than hidden behind a saturating counter"* — and nothing recorded it; the comment was true only of itself. It now points at the README line that exists.

No behaviour change. The wrap is deliberately untested: reaching it needs 2^32 despawns of one slot, and the fields that would let a test fabricate the state are private, correctly. The sibling limit is tested, because it is reachable in three lines.