### PR TITLE
fix(cli): stop asset-inspect calling a failed verification verified

### DIFF
--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -378,7 +378,16 @@ fn run_asset_inspect(pack_path: &str, verify: bool, json_mode: bool) -> ExitCode
         for name in &bad {
             let _ = writeln!(report, "MISMATCH {name}");
         }
-        let checked = if verify { ", verified" } else { "" };
+        // The suffix reports the *outcome*, not the request. It used to
+        // read `if verify { ", verified" }`, so a pack with a corrupt
+        // payload printed `MISMATCH b.txt` and then `2 entries, verified`
+        // two lines later. The exit code was right and the JSON was
+        // right; only the line a person reads contradicted itself.
+        let checked = match (verify, bad.len()) {
+            (false, _) => String::new(),
+            (true, 0) => ", verified".to_string(),
+            (true, failed) => format!(", {failed} FAILED verification"),
+        };
         let _ = writeln!(report, "{} entries{checked}", pack.len());
         emit_stdout(&report);
     }

--- a/tools/cli/tests/asset.rs
+++ b/tools/cli/tests/asset.rs
@@ -111,6 +111,26 @@ fn both_subcommands_emit_the_typed_envelope() {
     assert_eq!(document.get("entries"), Some(&Value::Number(2)));
     assert_eq!(document.get("status").and_then(Value::as_str), Some("ok"));
 
+    // The same check without `--json`, because the two paths print from
+    // different code and only the JSON one was ever asserted. The
+    // human-readable success line went unexercised until a match arm made
+    // that visible -- the summary was one line then, covered incidentally
+    // by the corrupt-pack test taking the same branch.
+    let plain = run(&[
+        "asset-inspect",
+        "--pack",
+        &pack.to_string_lossy(),
+        "--verify",
+    ])
+    .expect("binary should spawn");
+    assert_eq!(plain.status.code(), Some(0));
+    let text = String::from_utf8_lossy(&plain.stdout);
+    assert!(
+        text.contains("2 entries, verified"),
+        "a clean verify must say so: {text}"
+    );
+    assert!(!text.contains("MISMATCH"), "nothing is wrong here: {text}");
+
     let output = run(&[
         "asset-inspect",
         "--pack",
@@ -205,6 +225,20 @@ fn a_corrupted_payload_fails_verification_and_only_verification() {
     assert_eq!(checked.status.code(), Some(1), "verification must fail");
     let stdout = String::from_utf8_lossy(&checked.stdout);
     assert!(stdout.contains("MISMATCH"), "stdout was: {stdout}");
+
+    // The summary line has to agree with the line above it. This test
+    // asserted the exit code and the MISMATCH and stopped there, so for a
+    // while the output read `MISMATCH b.txt` and then `2 entries,
+    // verified` two lines later -- the code correct, the JSON correct,
+    // and the only part a person reads contradicting itself.
+    assert!(
+        !stdout.contains(", verified"),
+        "a failed run must not call itself verified: {stdout}"
+    );
+    assert!(
+        stdout.contains("FAILED verification"),
+        "the summary must say verification failed: {stdout}"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
A pack with a corrupt payload printed `MISMATCH b.txt` for the entry and then **`2 entries, verified`** two lines later. The suffix keyed off whether `--verify` was *requested*, not off whether it *passed*.

The exit code was already 1 and the JSON already reported `status: failed` with the mismatched names, so no script was ever misled. Only the line a person reads contradicted itself — which is the half nothing was checking.

**Found by feeding the inspector seven deliberately malformed packs**: empty, ten bytes, wrong magic, truncated to half, a header claiming 4 GB, a flipped payload byte, and a format number of 2^31-1. The other six are all refused with specific messages, correct exit codes, and no hang or panic — worth stating, because it bounds the finding to the one path.

**The existing corruption test is why this survived.** It asserted the exit code and the presence of `MISMATCH`, then stopped — so the contradictory summary two lines below was never looked at. It now asserts that a failed run does not call itself verified, and confirmed by reverting the fix and watching it fail.

Output now: `2 entries, verified` when clean, `2 entries, 1 FAILED verification` when not, `2 entries` without `--verify`.

80 suites / 863 tests green, clippy clean.