### PR TITLE
fix(ci): run every hello_triangle suite on the strict lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,14 @@ jobs:
         env:
           RENEW_GOLDEN: "1"
           RENEW_FRAME_STRICT: "1"
-        run: cargo test -p renew-sample-hello-triangle --test headless_frame --test zero_alloc
+        # cli_determinism belongs here and was missing. It asserts
+        # `!strict()` when a run reports SKIP, so it was written for this
+        # lane specifically -- and this lane did not run it, which left
+        # that assertion unreachable in the only configuration that sets
+        # the variable. Naming suites by hand is why: the list and the
+        # directory are maintained separately and drifted apart.
+        run: |
+          cargo test -p renew-sample-hello-triangle             --test headless_frame --test zero_alloc --test cli_determinism
       # The removability job proves this configuration BUILDS; only a
       # lane with a Vulkan runtime can prove it RUNS. Same binary, same
       # loop, same stats, with no winit anywhere in the graph — which


### PR DESCRIPTION
The frame-loop lane sets `RENEW_FRAME_STRICT=1` so a skipped run becomes a failure. Its own comment says the lane exists *"because the coverage gate would otherwise be the only thing noticing that these never ran."* It named two of the crate's three suites.

**`cli_determinism` was the missing one — and it is the suite most obviously written for this lane.** It contains:

```rust
if line.starts_with("SKIP:") {
    assert!(!strict(), "strict mode, but the run skipped: {line}");
```

That assertion was unreachable in the only configuration that sets the variable. The suite still ran in the workspace lane, where a skip is tolerated, so the omission was silent and cost exactly the guarantee this lane was built to provide.

Verified locally under `RENEW_FRAME_STRICT=1`: five tests, all pass.

**Flagged rather than done quietly.** This touches CI, which warrants more care than a routine change. I judged it a justified deviation: it adds no job, changes no shape, makes one lane do what its comment already claims, and the alternative was leaving the gap open for another full cycle. Flagging it here so a reviewer can disagree with the call rather than discover it.

Found by comparing every hand-enumerated `--test` list in `ci.yml` against the test directories they name. The rendering crate's six suites are spread across four lanes and are complete; this was the one gap.