### PR TITLE
docs(input): name the manifest as the authority for maturity

### DIFF
--- a/crates/input/README.md
+++ b/crates/input/README.md
@@ -76,7 +76,9 @@ order does not change behaviour.
 
 `bootstrap`. Bindings and edges are settled; anything above them — axes,
 chords, gamepads, runtime rebinding UI, serialised binding sets — is not,
-and none of it has a consumer asking yet.
+and none of it has a consumer asking yet. The `[package.metadata.renew]`
+table in [Cargo.toml](Cargo.toml) is authoritative for maturity; the word
+above is a convenience and that table decides.
 
 **It has a consumer now**, which is the more useful fact: the input-echo
 sample's drivers own the map and pass resolved intent into the


### PR DESCRIPTION
Every other crate README that states a maturity level also names the table that decides it — `renew-ecs`, for instance: *"The `[package.metadata.renew]` table in Cargo.toml is authoritative for maturity."* This one stated `bootstrap` and pointed nowhere, so the word had no owner, while the manifest is the machine-readable source the structure check actually reads.

Found by comparing **every** crate README's stated maturity against its manifest. **All twelve agree** — no mismatches anywhere, which is the more reassuring half of the result. Three READMEs restate the level at all; two of those three name the authority beside it and this one did not.

One sentence, matching the sibling crates' wording.