### PR TITLE
test(input): make the binding-order property test what its name claims

### DIFF
--- a/crates/input/tests/properties.proptest-regressions
+++ b/crates/input/tests/properties.proptest-regressions
@@ -5,11 +5,19 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 #
-# Provenance, so nobody reads this as a released defect: the case below
-# was found while deliberately mutating `any_down_for` to consider only
-# the FIRST binding of an action instead of all of them. It has never
-# failed against unmutated code. It is kept because it is the minimal
-# input that distinguishes the two -- six keys all bound to one action,
-# with a press on a key that is not the first. Anything less cannot tell
-# an OR from a lookup of the first match.
+# Provenance, so nobody reads these as released defects. Neither has ever
+# failed against unmutated code; both were found by deliberately breaking
+# the crate to check that a property could fail at all.
+#
+# 1. `table = [0,...], script = [(1, true)]` -- found by making
+#    `any_down_for` consider only the FIRST binding of an action instead
+#    of all of them. It is the minimal input that tells an OR from a
+#    lookup of the first match: six keys on one action, pressing a key
+#    that is not the first.
+# 2. `... order = [...], swaps = [...]` -- found by making `bind` append
+#    instead of inserting in sorted position, so the binary search over
+#    the binding table went wrong in a way that depended on registration
+#    order. It is the case that distinguishes "order does not matter"
+#    from "the table happened to be built in a helpful order".
 cc 158dca2c03bfabcff073fb5f7a261dca695ec2f15d46050fd1fadef0d361b0d8 # shrinks to table = [0, 0, 0, 0, 0, 0], script = [(1, true)]
+cc 5a82d16fac466b38f576b013da395d737a1ca93f133c17e4e475c374a0b6698a # shrinks to table = [0, 0, 0, 0, 0, 0], script = [(2, true)], order = [0, 1, 2, 3, 4, 5], swaps = [(4, 1)]

--- a/crates/input/tests/properties.rs
+++ b/crates/input/tests/properties.rs
@@ -88,21 +88,36 @@ proptest! {
 
     /// The claim the sorted binding table exists to make: which order the
     /// bindings were registered in never reaches the resulting state.
+    ///
+    /// **An arbitrary permutation, not a rotation.** The first version
+    /// rotated the registration order, which is six orderings out of 720
+    /// and leaves every key's neighbours intact — so it could not
+    /// distinguish "order does not matter" from "only adjacency matters".
+    /// The name said *never*; the body checked a sixth of a percent of
+    /// the space.
     #[test]
-    fn binding_order_never_reaches_state(table in table(), script in script(), rotate in 0usize..6) {
+    fn binding_order_never_reaches_state(
+        table in table(),
+        script in script(),
+        order in proptest::sample::subsequence((0..KEYS.len()).collect::<Vec<_>>(), KEYS.len()),
+        swaps in proptest::collection::vec((0usize..6, 0usize..6), 0..12),
+    ) {
+        let mut permuted: Vec<usize> = order;
+        for (a, b) in swaps {
+            permuted.swap(a, b);
+        }
+
         let mut forward = build(&table);
-        // The same table, registered starting from a different key.
-        let mut rotated = InputMap::new();
-        for offset in 0..KEYS.len() {
-            let index = (offset + rotate) % KEYS.len();
-            rotated.bind(Binding::key(KEYS[index]), ACTIONS[table[index]]);
+        let mut shuffled = InputMap::new();
+        for index in &permuted {
+            shuffled.bind(Binding::key(KEYS[*index]), ACTIONS[table[*index]]);
         }
 
         for (index, pressed) in &script {
             forward.handle(key_event(*index, *pressed));
-            rotated.handle(key_event(*index, *pressed));
+            shuffled.handle(key_event(*index, *pressed));
         }
-        prop_assert_eq!(states(&forward), states(&rotated));
+        prop_assert_eq!(states(&forward), states(&shuffled), "order {:?}", permuted);
     }
 
     /// An action is held exactly when at least one key bound to it is


### PR DESCRIPTION
The property is that registration order never reaches state. The test rotated the order — six of 720 possible orderings, every key keeping its neighbours — so it could not distinguish *"order does not matter"* from *"only adjacency matters"*. **The name said never; the body checked a sixth of a percent of the space.**

Now an arbitrary permutation: a generated ordering with generated swaps applied on top.

Confirmed by breaking the sorted-table invariant — making `bind` append instead of inserting in place, so the binary search goes wrong in a way that depends on registration order — and watching the property fail.

Found by reading the names of the tests I wrote today against what they actually assert. This was the only one that promised more than it checked.

The committed regression seed carries provenance, and the existing comment was extended to cover both seeds rather than left describing one — it said "the case below" and there are now two, from two different mutations.