### PR TITLE
fix(cli): correct two JSON reader defects and add generated-input tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
 name = "renew-cli"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "renew-asset",
 ]
 

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -23,6 +23,14 @@ simulation = false
 [dependencies]
 renew-asset = { path = "../../crates/asset" }
 
+# Test-only, and already approved for exactly this use: the entry covering
+# it scopes it to dev-dependencies in test code, never linked into shipped
+# code. The hand-rolled JSON reader is the third parser of external input
+# in this workspace and the only one whose robustness rested on examples
+# alone; the other two are covered by generated input.
+[dev-dependencies]
+proptest = "1.11"
+
 [features]
 # Enabled by instrumented (sanitizer) test runs. Five integration tests
 # replace PATH with a single directory so the test decides what the

--- a/tools/cli/src/json.rs
+++ b/tools/cli/src/json.rs
@@ -83,7 +83,28 @@ impl Value {
             }
             Self::Null => out.push_str("null"),
             Self::Number(number) => out.push_str(&number.to_string()),
-            Self::Float(number) => out.push_str(&number.to_string()),
+            Self::Float(number) => {
+                let text = number.to_string();
+                out.push_str(&text);
+                // `2.0f64.to_string()` is `"2"`, which the parser reads
+                // back as `Number(2)` because the integer branch takes any
+                // lexeme without `.`/`e`. The value survives that trip but
+                // its type does not, so a parsed float re-emitted once
+                // comes back as an integer. Nothing renders a parsed float
+                // today -- the parser is the only thing that builds one --
+                // which is why this never showed up in output. It still
+                // makes `parse(render(v)) == v` false for a value the
+                // parser itself can produce, so the suffix goes on here
+                // rather than the property being weakened to match.
+                //
+                // Finite only: the parser refuses non-finite numbers (JSON
+                // cannot spell them), so a non-finite `Float` is already
+                // unconstructible from input and `"inf.0"` would be no
+                // more valid than `"inf"`.
+                if number.is_finite() && !text.contains(['.', 'e', 'E']) {
+                    out.push_str(".0");
+                }
+            }
             Self::Bool(value) => out.push_str(if *value { "true" } else { "false" }),
             Self::Array(items) => {
                 out.push('[');

--- a/tools/cli/src/json.rs
+++ b/tools/cli/src/json.rs
@@ -316,8 +316,16 @@ impl<'a> Parser<'a> {
             Some(b't') => self.literal("true", Value::Bool(true)),
             Some(b'f') => self.literal("false", Value::Bool(false)),
             Some(b'n') => self.literal("null", Value::Null),
-            Some(_) => self.number(),
-            None => Err(self.err("a value")),
+            // Only a byte that could begin a number goes to the number
+            // parser. Everything else is not a malformed number — it is
+            // not the start of any value — and reporting "expected a
+            // finite number" for a `]` sends the reader hunting a numeric
+            // typo that was never there. The end-of-input arm below
+            // already had the right word.
+            Some(b'-' | b'0'..=b'9') => self.number(),
+            // A byte that starts nothing, and running out of bytes, are
+            // the same answer: no value begins here.
+            _ => Err(self.err("a value")),
         }
     }
 
@@ -656,6 +664,31 @@ mod tests {
         assert!(value.as_array().is_none());
         assert!(value.as_object().is_none());
         assert_eq!(Value::Bool(true).as_bool(), Some(true));
+    }
+
+    #[test]
+    fn an_error_names_the_right_byte_and_the_right_expectation() {
+        // Both halves, pinned. The test below checks the message mentions
+        // a byte and nothing checked WHICH byte, so a parser that always
+        // reported zero would have passed it — and nothing anywhere
+        // checked the expectation, which was wrong for every non-numeric
+        // byte standing where a value belongs.
+        for (text, at, expected) in [
+            ("[1,]", 3, "a value"),
+            ("{\"a\":}", 5, "a value"),
+            ("[1 2]", 3, "`,` or `]`"),
+            ("{\"a\" 1}", 5, "`:`"),
+            ("  tru", 2, "a literal"),
+            ("1.2.3", 0, "a finite number"),
+            ("", 0, "a value"),
+        ] {
+            let JsonError::Syntax {
+                at: got_at,
+                expected: got_expected,
+            } = parse(text).expect_err("must fail");
+            assert_eq!(got_at, at, "byte position for {text:?}");
+            assert_eq!(got_expected, expected, "expectation for {text:?}");
+        }
     }
 
     #[test]

--- a/tools/cli/tests/properties.proptest-regressions
+++ b/tools/cli/tests/properties.proptest-regressions
@@ -1,0 +1,14 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+#
+# The case below passes today. It is kept because it is the one the
+# round-trip property caught before the writer was fixed: a whole float
+# rendered without a fractional part and read back as an integer.
+# Negative zero is the shrunk form, and it is a better witness than the
+# `2.0` a person would write by hand -- whole, signed, and it prints as
+# `-0`.
+cc 40b2fb1554cb7a0db066302315f7ce93b1ed72f9a5a7f81ac78ba9b8cd58b5cb # shrinks to document = Object([("", Object([("", Float(-0.0))]))])

--- a/tools/cli/tests/properties.rs
+++ b/tools/cli/tests/properties.rs
@@ -1,0 +1,181 @@
+//! Property-based tests for the hand-rolled JSON reader.
+//!
+//! **This is the third parser of external data in the workspace and was
+//! the only one whose robustness rested on examples.** The pack format
+//! and the trace codec each carry a generated-input suite with an
+//! "any input at all gets an answer" property; this reader had sixteen
+//! unit tests and a set of hostile documents written by hand. Sixteen
+//! good examples are sixteen good examples — they cannot say anything
+//! about the inputs nobody thought of, which is the whole reason the
+//! reader has a depth bound in the first place.
+//!
+//! What it consumes is genuinely external: `cargo metadata` output and
+//! coverage reports produced by another program, neither of which this
+//! workspace writes.
+
+use proptest::prelude::*;
+use proptest::test_runner::RngSeed;
+use renew_cli::json::{Value, parse};
+
+/// Strings that exercise the escape writer: quotes, backslashes, the
+/// named control escapes, sub-`0x20` bytes that become `\u00xx`, and
+/// ordinary text. Generated from parts rather than `any::<String>()` so
+/// the interesting characters actually appear instead of turning up once
+/// in a thousand cases.
+fn text() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        proptest::sample::select(vec![
+            "a",
+            "Z",
+            "0",
+            " ",
+            "\"",
+            "\\",
+            "\n",
+            "\r",
+            "\t",
+            "\u{1}",
+            "\u{1f}",
+            "/",
+            "{",
+            "}",
+            "[",
+            "]",
+            ":",
+            ",",
+            "\u{e9}",
+            "\u{1f600}",
+        ]),
+        0..8,
+    )
+    .prop_map(|parts| parts.concat())
+}
+
+/// A whole document. Recursive, because nesting is where a reader that
+/// tracks depth wrongly goes wrong, and shallow-only generation would
+/// never reach the bound-adjacent cases.
+///
+/// **Non-finite floats are excluded deliberately**: JSON cannot spell
+/// them, the reader refuses them on input, and so a `Float` holding one
+/// is unreachable from any document. Generating them would test the
+/// behaviour of a value the parser cannot produce.
+fn value() -> impl Strategy<Value = Value> {
+    let leaf = prop_oneof![
+        Just(Value::Null),
+        any::<bool>().prop_map(Value::Bool),
+        any::<i64>().prop_map(Value::Number),
+        any::<f64>()
+            .prop_filter("JSON has no non-finite numbers", |f| f.is_finite())
+            .prop_map(Value::Float),
+        text().prop_map(Value::String),
+    ];
+    leaf.prop_recursive(6, 48, 6, |inner| {
+        prop_oneof![
+            proptest::collection::vec(inner.clone(), 0..6).prop_map(Value::Array),
+            proptest::collection::vec((text(), inner), 0..6).prop_map(Value::Object),
+        ]
+    })
+}
+
+proptest! {
+    // Fixed seed, matching every other property suite in the tree: the
+    // same inputs are explored on every run and every machine, so a
+    // failure reproduces from the message alone.
+    #![proptest_config(ProptestConfig {
+        rng_seed: RngSeed::Fixed(0x0d5e_7a11),
+        ..ProptestConfig::default()
+    })]
+
+    /// **Any** text at all gets an answer rather than a panic. The
+    /// weakest property here and the one that would have caught the most.
+    #[test]
+    fn any_text_at_all_gets_an_answer(raw in ".{0,400}") {
+        let _ = parse(&raw);
+    }
+
+    /// And so does anything shaped like a document, which reaches far
+    /// deeper than random text ever does: random input dies at the first
+    /// byte, so without this the reader below that point would be
+    /// exercised by nothing.
+    #[test]
+    fn text_shaped_like_json_gets_an_answer(
+        document in value(),
+        cut in 0usize..400,
+        noise in ".{0,16}",
+    ) {
+        let mut rendered = document.render();
+        rendered.truncate(
+            (0..=cut.min(rendered.len()))
+                .rev()
+                .find(|at| rendered.is_char_boundary(*at))
+                .unwrap_or(0),
+        );
+        rendered.push_str(&noise);
+        let _ = parse(&rendered);
+    }
+
+    /// Writing then reading gives back what was written — for every value
+    /// the reader itself can produce.
+    ///
+    /// This is the property that found something. An integral float
+    /// rendered as `2`, which the reader took back as `Number(2)`,
+    /// because the integer branch claims any lexeme without `.` or `e`.
+    /// The value survived the trip; its type did not.
+    #[test]
+    fn rendering_then_parsing_returns_the_same_value(document in value()) {
+        let rendered = document.render();
+        let read = parse(&rendered);
+        prop_assert!(read.is_ok(), "own output rejected: {rendered:?} -> {read:?}");
+        prop_assert_eq!(read.expect("checked above"), document, "via {}", rendered);
+    }
+
+    /// Reading then writing gives back the same text, which is the claim
+    /// the `--json` contract actually needs: a document this tool passes
+    /// through is byte-identical, not merely equivalent.
+    #[test]
+    fn parsing_then_rendering_returns_the_same_text(document in value()) {
+        let once = document.render();
+        let read = parse(&once).expect("own output parses");
+        prop_assert_eq!(read.render(), once);
+    }
+}
+
+/// Nesting past the documented bound is refused, and refusing is not the
+/// same as surviving: the point of the bound is that neither answer is a
+/// stack overflow, so both sides of it are checked here.
+///
+/// A fixed input rather than a generated one — the bound is a specific
+/// number in the reader's documentation, and the cases that matter are
+/// the two either side of it plus one far past.
+#[test]
+fn nesting_is_bounded_rather_than_fatal() {
+    for (depth, expected_ok) in [(120usize, true), (128, true), (129, false), (4096, false)] {
+        let document = format!("{}{}", "[".repeat(depth), "]".repeat(depth));
+        let outcome = parse(&document);
+        assert_eq!(
+            outcome.is_ok(),
+            expected_ok,
+            "depth {depth} should {} — got {outcome:?}",
+            if expected_ok { "parse" } else { "be refused" }
+        );
+    }
+}
+
+/// The integral-float case, written out rather than left to generation.
+///
+/// The property above covers it, but a generated failure names a seed
+/// while this names the rule: a float that happens to be whole still
+/// reads back as a float, because `2` and `2.0` are different values to
+/// this reader even though JSON does not distinguish them.
+#[test]
+fn a_whole_float_stays_a_float_across_a_round_trip() {
+    for text in ["2.0", "-0.0", "1e2", "0.0"] {
+        let once = parse(text).expect("parses");
+        let again = parse(&once.render()).expect("re-parses");
+        assert_eq!(once, again, "{text} did not survive a round trip");
+        assert!(
+            matches!(once, Value::Float(_)),
+            "{text} should read as a float, got {once:?}"
+        );
+    }
+}


### PR DESCRIPTION
The hand-rolled JSON reader is the third parser of external data here
and the only one whose robustness rested on examples: the pack format
and the trace codec each already carry a generated-input suite with an
"any input at all gets an answer" property. Adding the equivalent found
two defects.

Whole floats lost their type across a round trip. `2.0` parsed to
`Float(2.0)`, rendered as `2` because Rust prints a whole f64 without a
fractional part, and read back as `Number(2)`. Nothing constructs a
float for output today, so no emitted document changes shape; the
reader is the only thing that builds one, which is why it never
surfaced. Rendering now appends `.0` when a finite float would
otherwise print with neither a `.` nor an exponent.

The error message named the wrong expectation. Every byte that did not
open an object, array, string or literal fell through to the number
parser, so `[1,]` reported "expected a finite number" and sent the
reader after a numeric typo that was never there. The end-of-input arm
already said "a value". Only a byte that can begin a number now reaches
the number parser.

The suite covers both round trips, checks that arbitrary text and
document-shaped text get an answer rather than a panic, pins the
recursion bound from both sides, and pins the byte position and the
expectation across seven inputs — one test previously asserted only
that the message contains the word "byte", so a reader always reporting
position zero would have passed.

Adds proptest as a dev-dependency of this crate; it is already used
that way by six others.