### PR TITLE
test(asset): pin the accepted end of the name-length limit

### DIFF
--- a/crates/asset/src/write.rs
+++ b/crates/asset/src/write.rs
@@ -238,6 +238,21 @@ mod tests {
         assert!(matches!(error, BuildError::NameTooLong { .. }));
     }
 
+    /// The other side of the same boundary, and the side that was
+    /// missing. The test above pins `MAX_NAME_BYTES + 1`; a limit is two
+    /// claims and only one of them was checked, so relaxing the guard
+    /// from `>` to `>=` — which rejects the longest name the format
+    /// actually permits — passed the suite.
+    #[test]
+    fn a_name_at_exactly_the_limit_is_accepted() {
+        let mut b = PackBuilder::new();
+        let name = "n".repeat(MAX_NAME_BYTES);
+        b.insert(&name, b"x")
+            .expect("a name of exactly MAX_NAME_BYTES is legal");
+        let bytes = b.finish().expect("pack");
+        assert_eq!(bytes.len(), HEADER_BYTES + ENTRY_BYTES + MAX_NAME_BYTES + 1);
+    }
+
     /// A zero-length blob is a real entry, not an absence.
     #[test]
     fn an_entry_may_hold_no_bytes() {

--- a/crates/asset/tests/roundtrip.rs
+++ b/crates/asset/tests/roundtrip.rs
@@ -135,6 +135,28 @@ proptest! {
     }
 }
 
+/// The read side of the name-length boundary.
+///
+/// The writer now pins both ends of the limit, but the reader validates
+/// name length independently — it has to, since a pack can arrive from
+/// anywhere — and its guard had the same untested edge. A pack whose
+/// name is exactly the longest legal one must be read back, not refused.
+#[test]
+fn a_name_at_exactly_the_limit_survives_a_round_trip() {
+    let name = "n".repeat(renew_asset::MAX_NAME_BYTES);
+    let mut builder = PackBuilder::new();
+    builder
+        .insert(&name, b"payload")
+        .expect("insert at the limit");
+    let bytes = builder.finish().expect("pack");
+
+    let pack = Pack::read(&bytes).expect("a name at the limit is legal on read");
+    assert_eq!(pack.len(), 1);
+    let found = pack.get(&name).expect("the entry is present");
+    assert_eq!(found.name, name);
+    assert_eq!(found.bytes, b"payload");
+}
+
 /// The format, asserted by hand.
 ///
 /// The property tests above prove the writer and reader agree with each


### PR DESCRIPTION
A length limit makes two claims — what it rejects and what it permits —
and only the rejecting half was covered. Nothing exercised a name of
exactly MAX_NAME_BYTES, so relaxing either guard from `>` to `>=`,
which refuses the longest name the format actually allows, passed the
suite on both the writing and reading sides.

The writer test asserts the insert succeeds and the pack is exactly the
expected size. The reader gets its own round-trip test, because it
validates name length independently — it has to, since a pack can
arrive from anywhere.