### PR TITLE
fix(cli): document the flags the help text never mentioned

### DIFF
--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -465,6 +465,10 @@ pub fn usage() -> String {
         "  --smoke           (bench only) run each benchmark once, without statistics\n",
         "  --output <path>   (record only, required) the trace file to write\n",
         "  --input <path>    (replay only, required) the trace file to read\n",
+        "  --pack <path>     (asset-pack, asset-inspect; required) the pack file\n",
+        "  --from <dir>      (asset-pack only, required) the directory to pack\n",
+        "  --verify          (asset-inspect only) check each entry against its digest\n",
+        "  --help, -h        print this text; `renew help` does the same\n",
         "\nEverything after `run <sample>` goes to the sample untouched, including\n",
         "flags renew itself knows: `renew run hello_triangle --json` gives the sample\n",
         "`--json`, while `renew --json run hello_triangle` gives it to renew. One `--`\n",
@@ -997,8 +1001,17 @@ mod tests {
         }
     }
 
+    /// The command half is derived from `Command::ALL`, so it cannot rot.
+    ///
+    /// **The option half used to be three hardcoded strings under a name
+    /// promising every option**, and five flags went undocumented while
+    /// this passed. The flags are now checked against the parser's own
+    /// match arms by `the_usage_text_documents_every_flag_the_parser_
+    /// accepts` in `tests/workspace_lists.rs`; the three kept here are a
+    /// cheap smoke test in the same file as the text, not the guarantee.
+    /// The name says what is actually checked.
     #[test]
-    fn usage_lists_every_command_and_every_option() {
+    fn usage_lists_every_command_and_explains_the_pass_through() {
         let text = usage();
         for command in Command::ALL {
             let name = command.name();

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -592,3 +592,68 @@ fn every_engine_crate_denies_printing_at_its_root() {
          cannot supply because the CLI and the samples print by design: {faults:?}"
     );
 }
+
+/// Every flag the parser accepts appears in the usage text.
+///
+/// **There was already a test called `usage_lists_every_command_and_every
+/// _option`, and five flags were undocumented anyway.** It derived the
+/// command half from `Command::ALL`, so that half could not rot — and
+/// hardcoded the option half as three strings. The name made a claim
+/// about twelve flags while the body checked a quarter of them, which is
+/// the failure mode this file exists for: a test that keeps passing while
+/// measuring less than it says.
+///
+/// `--pack`, `--from` and `--verify` were the casualties, all three
+/// belonging to the two most recently added subcommands, and `--pack` is
+/// *required* by both — so the tool told a user it needed a flag that its
+/// own help never mentioned.
+///
+/// Derived from the parser's own match arms rather than a list kept
+/// beside them. A source scan is cruder than a shared constant, but it
+/// cannot be updated in one place and forgotten in the other, which is
+/// exactly what happened.
+#[test]
+fn the_usage_text_documents_every_flag_the_parser_accepts() {
+    let root = workspace_root();
+    let source = std::fs::read_to_string(root.join("tools/cli/src/cli.rs"))
+        .expect("the parser source is readable");
+    // Only the parser, never its test module: test fixtures name sample
+    // flags like `--frames` that renew passes through and does not own.
+    let parser = source
+        .split_once(
+            "
+mod tests",
+        )
+        .map_or(source.as_str(), |(before, _)| before);
+
+    let mut flags: Vec<String> = Vec::new();
+    let mut rest = parser;
+    while let Some(at) = rest.find("\"--") {
+        rest = &rest[at + 1..];
+        if let Some(end) = rest.find('"') {
+            let flag = &rest[..end];
+            if flag.len() > 2
+                && flag[2..]
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c == '-')
+                && !flags.iter().any(|seen| seen == flag)
+            {
+                flags.push(flag.to_string());
+            }
+        }
+    }
+    assert!(
+        flags.len() >= 8,
+        "the scan found only {flags:?}, which means it stopped matching the source"
+    );
+
+    let text = renew_cli::cli::usage();
+    let missing: Vec<&String> = flags
+        .iter()
+        .filter(|f| !text.contains(f.as_str()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "the parser accepts {missing:?} and the usage text never mentions them;          a flag a user cannot discover may as well not exist"
+    );
+}


### PR DESCRIPTION
`asset-pack` and `asset-inspect` both require `--pack`, `asset-pack`
also requires `--from`, and neither appeared in `renew --help`. The
tool refused a command line by naming a flag its own help did not
list. `--verify` and `--help` were undocumented too.

A test named `usage_lists_every_command_and_every_option` passed
throughout. It derived the command half from `Command::ALL`, which
cannot rot, and hardcoded the option half as three strings: the name
claimed twelve flags, the body checked three.

The flags are now derived from the parser's own match arms, so a flag
added without a help entry fails the suite. The old test keeps its
three as a smoke check and is renamed to what it verifies.