### PR TITLE
ci(golden): verify every refreshed golden, not one by name

### DIFF
--- a/.github/workflows/golden-refresh.yml
+++ b/.github/workflows/golden-refresh.yml
@@ -21,8 +21,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/software-vulkan
+      # Record what is being deleted so the verification below can be
+      # derived from it. The delete is a wildcard and the check used to
+      # be one hardcoded name, so a second golden would have been
+      # removed and never checked for regeneration -- the ritual would
+      # have passed while silently losing it.
       - name: Remove the committed goldens
-        run: rm -f crates/rhi/tests/goldens/*.rgba
+        run: |
+          ls crates/rhi/tests/goldens/*.rgba             | xargs -n1 basename             | sed 's/\.rgba$//' > "$RUNNER_TEMP/goldens.txt"
+          test -s "$RUNNER_TEMP/goldens.txt"
+          echo "refreshing:"; cat "$RUNNER_TEMP/goldens.txt"
+          rm -f crates/rhi/tests/goldens/*.rgba
       # Expected to fail: the bootstrap path writes the candidate and
       # panics so the refresh is never silent.
       - name: Render fresh candidates (fails by design)
@@ -31,12 +40,21 @@ jobs:
         env:
           RENEW_GOLDEN: "1"
         run: cargo test --package renew-rhi --test golden
-      - name: Verify the ritual behaved (test failed, candidate exists)
+      - name: Verify the ritual behaved (test failed, every candidate exists)
         run: |
           test "${{ steps.render.outcome }}" = "failure"
           ls -l crates/rhi/tests/goldens/
-          test -f crates/rhi/tests/goldens/triangle-256x256.candidate.rgba
-          test -f crates/rhi/tests/goldens/triangle-256x256.provenance.txt
+          missing=0
+          while read -r name; do
+            for suffix in candidate.rgba provenance.txt; do
+              path="crates/rhi/tests/goldens/$name.$suffix"
+              if [ ! -f "$path" ]; then
+                echo "::error::$path was deleted but no replacement was produced"
+                missing=1
+              fi
+            done
+          done < "$RUNNER_TEMP/goldens.txt"
+          test "$missing" -eq 0
       - name: Upload candidates for inspection
         uses: actions/upload-artifact@v4
         with:

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -348,7 +348,29 @@ fn the_unsafe_surface_is_exactly_what_is_recorded() {
 /// calling a clock is the crate's own lint file. Nothing compared the
 /// two, so the declaration bought nothing on its own — a crate could
 /// claim the property and permit the calls that break it.
-const BANNED_IN_SIMULATION: &[&str] = &["std::time::Instant::now", "std::time::SystemTime::now"];
+/// What a `simulation = true` crate's lint file must forbid.
+///
+/// **Two of I3's three applicable clauses, and it used to be one.** I3
+/// bans wall-clock reads, unseeded randomness, and iteration-order
+/// dependent state (fast-math has no stable-Rust equivalent). Until
+/// 2026-08-01 this list held only the clocks, so a crate could declare
+/// itself simulation code and iterate a `HashMap` freely — which is
+/// precisely the non-determinism the third clause exists to prevent.
+///
+/// All four declaring crates already banned the collections when this
+/// grew, so it locks in a convention rather than demanding a change.
+/// **That is the argument for adding it now**: a list that costs nothing
+/// to satisfy today costs a rewrite once a crate forgets.
+///
+/// The randomness clause stays unlisted deliberately: `std` ships no
+/// generator, so reaching one means taking a dependency, and that is
+/// caught at the `docs/deps/` gate rather than by a lint.
+const BANNED_IN_SIMULATION: &[&str] = &[
+    "std::time::Instant::now",
+    "std::time::SystemTime::now",
+    "std::collections::HashMap",
+    "std::collections::HashSet",
+];
 
 /// Crates whose manifest sets `simulation = true`, with the text of the
 /// lint file sitting beside it.
@@ -384,7 +406,7 @@ fn simulation_crates(root: &Path) -> Result<Vec<(String, String)>, String> {
 /// This does not prove such a crate is reproducible — no test here
 /// could. It proves the one mechanical guard it relies on is present.
 #[test]
-fn every_simulation_crate_forbids_reading_a_clock() {
+fn every_simulation_crate_forbids_the_nondeterminism_i3_names() {
     let root = workspace_root();
     let crates = simulation_crates(&root).expect("manifests and lint files should be readable");
 
@@ -404,7 +426,7 @@ fn every_simulation_crate_forbids_reading_a_clock() {
     assert!(
         faults.is_empty(),
         "these crates declare themselves simulation code but their lint files permit \
-         reading a clock, so the declaration is enforced by nothing: {faults:?}"
+         a source of non-determinism, so the declaration is enforced by nothing: {faults:?}"
     );
 }
 


### PR DESCRIPTION
The refresh step deletes goldens by wildcard and the verification
checked a single hardcoded filename, so a second golden would have been
removed and never checked for regeneration — the ritual would pass
while silently losing it. Harmless with one golden, and a trap the
moment there are two, which the resource-model work would create.

The verification now derives its list from what the delete step
actually removed, and names any missing file in an error annotation
rather than failing on a bare `test -f`.

Verified by dispatching the workflow on this branch rather than by
reading it, and the loop was bite-tested locally against a simulated
two-golden tree where only one regenerates.