### PR TITLE
docs(memory): compile-check the allocator installation example

### DIFF
--- a/crates/core/memory/src/counting.rs
+++ b/crates/core/memory/src/counting.rs
@@ -8,7 +8,13 @@ use crate::counters;
 
 /// A counting wrapper over [`System`]. Install in a binary:
 ///
-/// ```ignore
+/// `no_run` rather than `ignore`: the snippet cannot execute, because a
+/// doctest harness has already installed its own global allocator — but
+/// it does compile, so a rename of this type breaks the build instead of
+/// silently leaving the example wrong. `ignore` would not even compile
+/// it.
+///
+/// ```no_run
 /// #[global_allocator]
 /// static ALLOCATOR: renew_memory::CountingAllocator =
 ///     renew_memory::CountingAllocator;


### PR DESCRIPTION
The snippet was fenced `ignore`, so rustdoc never compiled it and a
rename of `CountingAllocator` would have left the example silently
wrong. It cannot run — a doctest harness has already installed its own
global allocator — but `no_run` compiles without running, which is the
whole distinction between the two fences and the reason `ignore` was
the wrong one here.

Found while accounting for a discrepancy between `cargo test` (876
passing) and `cargo test -- --list` (878): the delta was two ignored
tests, and checking both were legitimate turned up one that did not
need to be ignored at all.

Bite-tested by renaming the type inside the example, which now fails
the build.