### PR TITLE
ci: give the thread sanitizer a Vulkan runtime and retire the loader suppression

### DIFF
--- a/.github/tsan-suppressions.txt
+++ b/.github/tsan-suppressions.txt
@@ -1,42 +1,41 @@
 # ThreadSanitizer suppressions.
 #
-# One entry. Adding a second is a decision, not a maintenance step: every
-# line here is a place the only tool in the matrix that can see a data
-# race has been told not to look.
+# NO ENTRIES. Adding one is a decision, not a maintenance step: every line
+# here is a place the only tool in the matrix that can see a data race has
+# been told not to look. The file is kept, empty, because the job points
+# TSAN_OPTIONS at it and because the history below is worth more than the
+# entry it used to hold.
 #
-# --- libvulkan loader teardown -------------------------------------------
+# --- retired: called_from_lib:libvulkan.so -------------------------------
 #
-# What is reported: a write to a pthread mutex during pthread_mutex_destroy
-# inside libvulkan.so.1, reached from `<libloading::Library as Drop>::drop`
-# -> drop glue for `ash::entry::Entry`. Two warnings, at process exit,
-# from renew-rhi's device tests.
+# What it suppressed: a write to a pthread mutex during
+# pthread_mutex_destroy inside libvulkan.so.1, reached from
+# `<libloading::Library as Drop>::drop` -> drop glue for
+# `ash::entry::Entry`. Two warnings at process exit, from renew-rhi's
+# device tests.
 #
-# Why it happens here and not in the rendering lane: this job has no Vulkan
-# runtime installed, so every one of those tests calls `Device::new`, which
-# dlopens the loader, fails to find a device, and drops the Entry on the
-# way out -- dlclose. The tests then skip and pass. Nine of them run on
-# parallel harness threads, so the binary opens and closes libvulkan nine
-# times over, concurrently. On the success path the Entry is moved into
-# `DeviceShared` and lives as long as the device, so none of this happens
-# where a device actually exists.
+# Why it existed: this job had no Vulkan runtime, so every device test
+# called `Device::new`, dlopened the loader, failed to find a device, and
+# dlclosed on the way out. Nine ran on parallel harness threads, so the
+# binary opened and closed libvulkan nine times over, concurrently.
 #
-# Why suppressing rather than fixing: neither libvulkan nor the dynamic
-# loader is instrumented, so TSan cannot see their internal
-# synchronization and reports the teardown as a race it cannot prove
-# ordered. The engine frames in the stack are the ones *dropping* the
-# library; no engine state is involved on either side of the reported
-# access.
+# Why it is gone: the job now installs the same pinned software rasterizer
+# the rendering lane uses, so those tests do real work instead of skipping,
+# and the pattern the entry described no longer arises the way it did.
+# Keeping a blanket `called_from_lib` pattern over a real driver in a real
+# code path would be strictly worse than the skips it replaced -- it would
+# hide engine-frame races along with driver-internal ones. That trade was
+# named in advance as the one this change must not make.
 #
-# What this suppression does NOT establish, and the reason it is written
-# down: it is not proof the report is a false positive. dlclose of a
-# graphics driver while other threads hold it open is a genuinely
-# questionable pattern, and "third-party" is not a synonym for "harmless".
-# What is established is that no engine data races here, and that the
-# scenario only arises on a skip path in an environment with no driver.
+# What the retired entry's own analysis got wrong, recorded because it was
+# careful reasoning that still missed: it said the dlopen/dlclose churn
+# happens only on the skip path, and that with a device present the Entry
+# lives as long as the device "so none of this happens". The first half is
+# right. The second is not -- `DeviceShared::drop` itself reaches
+# `loader_clear_scanned_icd_list`, so the loader is still torn down at
+# device drop, just later. Installing a driver did not remove that
+# teardown; it moved it.
 #
-# The better fix, when someone has the appetite: install a software Vulkan
-# runtime in this job the way the rendering lane does. Then these tests do
-# real work instead of skipping, the Entry is retained, the churn stops --
-# and the sanitizer would start covering renew-rhi, which today it does
-# not cover at all.
-called_from_lib:libvulkan.so
+# If entries return, each carries its own reasoning at this length, and a
+# driver-internal race gets a pattern scoped to the driver -- never a
+# blanket one.

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -51,6 +51,23 @@ jobs:
         if: runner.os == 'Windows'
       - uses: ./.github/actions/software-vulkan
         if: matrix.vulkan
+      # Set through GITHUB_ENV rather than the step's `env:` map, because
+      # this variable must be ABSENT on the other lanes, not empty. An
+      # `env:` entry whose expression yields '' still sets the variable,
+      # and libtest parses this one as a number -- an empty value panics
+      # in test::helpers::concurrency before a single test runs. That is
+      # not hypothetical: it reddened three previously-green lanes.
+      #
+      # RENEW_GOLDEN below can use the inline form safely because every
+      # one of its readers compares against the literal "1"
+      # (`is_some_and(|v| v == "1")` / `is_none_or(|v| v != "1")`), so
+      # empty means "not strict". The idiom is only safe when the
+      # consumer treats empty as absent, which is a property of the
+      # reader, not of the workflow.
+      - name: Serialise test functions on the lane with a driver
+        if: matrix.vulkan
+        shell: bash
+        run: echo "RUST_TEST_THREADS=1" >> "$GITHUB_ENV"
       - name: Run tests under ${{ matrix.sanitizer }} sanitizer
         env:
           RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
@@ -88,34 +105,6 @@ jobs:
           # It is set on every lane because it names nothing that exists
           # where no rasterizer does.
           LP_NUM_THREADS: "0"
-          # Serialise test FUNCTIONS on the lane that has a driver.
-          #
-          # With a real driver, the one remaining race is between two test
-          # functions on parallel harness threads, both sides inside the
-          # validation layer, on state it allocated -- each thread holding
-          # a read lock on a *different* command-buffer mutex. The tests
-          # share nothing: the helper builds a fresh device per test, so
-          # there is no shared engine state to synchronise.
-          #
-          # The reason this is not a meaningful coverage loss, which is
-          # the part that matters:
-          #   - It does NOT serialise threads *within* a test. The jobs
-          #     stress tier -- the interleaving this whole job exists for
-          #     -- spawns its own threads and is untouched.
-          #   - Global mutable state is banned in engine modules outside
-          #     the sanctioned log and assert sinks, so racing *between*
-          #     tests is close to a null set by construction.
-          #   - The macOS thread lane still runs tests in parallel, so
-          #     cross-test racing keeps a home in the matrix. Only this
-          #     lane trades it, and only for real device coverage it
-          #     could not otherwise have.
-          #
-          # Preferred over suppressing the report. A suppression here
-          # would have to name the validation layer, and every engine
-          # Vulkan call passes through it -- so the pattern would be at
-          # least as blanket as the loader entry retired in this same
-          # change, while looking narrower.
-          RUST_TEST_THREADS: ${{ matrix.vulkan && '1' || '' }}
           # Read only by the thread sanitizer; harmless where the file's
           # contents mean nothing. Every line in it is a place this job
           # has been told not to look, so it is short and each entry

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -88,6 +88,34 @@ jobs:
           # It is set on every lane because it names nothing that exists
           # where no rasterizer does.
           LP_NUM_THREADS: "0"
+          # Serialise test FUNCTIONS on the lane that has a driver.
+          #
+          # With a real driver, the one remaining race is between two test
+          # functions on parallel harness threads, both sides inside the
+          # validation layer, on state it allocated -- each thread holding
+          # a read lock on a *different* command-buffer mutex. The tests
+          # share nothing: the helper builds a fresh device per test, so
+          # there is no shared engine state to synchronise.
+          #
+          # The reason this is not a meaningful coverage loss, which is
+          # the part that matters:
+          #   - It does NOT serialise threads *within* a test. The jobs
+          #     stress tier -- the interleaving this whole job exists for
+          #     -- spawns its own threads and is untouched.
+          #   - Global mutable state is banned in engine modules outside
+          #     the sanctioned log and assert sinks, so racing *between*
+          #     tests is close to a null set by construction.
+          #   - The macOS thread lane still runs tests in parallel, so
+          #     cross-test racing keeps a home in the matrix. Only this
+          #     lane trades it, and only for real device coverage it
+          #     could not otherwise have.
+          #
+          # Preferred over suppressing the report. A suppression here
+          # would have to name the validation layer, and every engine
+          # Vulkan call passes through it -- so the pattern would be at
+          # least as blanket as the loader entry retired in this same
+          # change, while looking narrower.
+          RUST_TEST_THREADS: ${{ matrix.vulkan && '1' || '' }}
           # Read only by the thread sanitizer; harmless where the file's
           # contents mean nothing. Every line in it is a place this job
           # has been told not to look, so it is short and each entry

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -26,6 +26,11 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             sanitizer: thread
+            # The only lane with a Vulkan runtime. Without one, every
+            # device-touching test takes the graceful-skip path and passes
+            # while doing nothing, and a skip prints only on failure — so
+            # a green log is exactly the case that withholds the fact.
+            vulkan: true
           - os: macos-latest
             target: aarch64-apple-darwin
             sanitizer: address
@@ -44,9 +49,45 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+      - uses: ./.github/actions/software-vulkan
+        if: matrix.vulkan
       - name: Run tests under ${{ matrix.sanitizer }} sanitizer
         env:
           RUSTFLAGS: "-Zsanitizer=${{ matrix.sanitizer }}"
+          # On the lane that has a driver, a skipped device test is a
+          # failure: the lane exists to run them, so passing must mean
+          # executed rather than absent. Empty elsewhere, where a skip is
+          # the only honest outcome.
+          RENEW_GOLDEN: ${{ matrix.vulkan && '1' || '' }}
+          # Run the rasterizer single-threaded. This is a DIAGNOSTIC, and
+          # the variable under test.
+          #
+          # A previous attempt added the runtime alone and found three
+          # races: two entirely inside lavapipe's fence lifecycle, and one
+          # with engine frames -- DeviceShared::drop closing the loader
+          # while a driver worker thread was still live. Reading the
+          # teardown afterwards showed the engine's order is the
+          # spec-required one and nothing instance-derived outlives the
+          # instance, which argues against an engine defect and leaves
+          # "lavapipe does not join its workers by vkDestroyDevice" as the
+          # live hypothesis. A reading is not a sanitizer report.
+          #
+          # LP_NUM_THREADS=0 turns llvmpipe's threading off entirely
+          # (Mesa's documented behaviour for zero). Against the recorded
+          # three-race baseline this is a single-variable experiment and
+          # every outcome is informative:
+          #   - all three gone: the other side of each was a driver worker,
+          #     so the engine teardown is exonerated and the remaining
+          #     question is lavapipe's, not ours;
+          #   - the two driver-internal ones gone, the engine-frame one
+          #     left: the other side is NOT a driver worker, which is a
+          #     worse and more interesting finding;
+          #   - all three still there: the variable does not reach lavapipe
+          #     and the hypothesis needs a different lever.
+          #
+          # It is set on every lane because it names nothing that exists
+          # where no rasterizer does.
+          LP_NUM_THREADS: "0"
           # Read only by the thread sanitizer; harmless where the file's
           # contents mean nothing. Every line in it is a place this job
           # has been told not to look, so it is short and each entry


### PR DESCRIPTION
The thread-sanitizer lane has no Vulkan runtime, so twelve device-touching tests take the graceful-skip path and pass without executing. libtest prints captured output only for failing tests, so a skip prints nothing at all: **the green log is precisely the case that withholds the fact.**

This installs the same pinned software rasterizer the rendering lane uses, sets `RENEW_GOLDEN=1` there so a skip is a failure rather than a vacuous pass, and **deletes the blanket loader suppression rather than carrying it forward**.

### How it got here

An earlier attempt was reverted after finding three races. Each step since changed exactly one variable against a recorded baseline:

1. **Runtime alone** — 3 races: two inside the rasterizer's fence lifecycle, one where device teardown closed the loader while a driver worker was still live.
2. **Rasterizer threading off** (`LP_NUM_THREADS=0`) — down to 1. The two fence races *and* the teardown race all vanished, which is only possible if the other side of each was a rasterizer worker. That exonerates the engine's teardown order by evidence rather than by reading.
3. **Test functions serialised on that lane** — down to 0. The last report had both sides inside the validation layer, between two test functions on parallel harness threads, each holding a read lock on a *different* command-buffer mutex. The helper builds a fresh device per test, so they shared no engine state.

### Why serialisation rather than a suppression

The only stable token in that report was the validation layer's library name, and every engine Vulkan call passes through the layer — so a pattern naming it would have been at least as blanket as the loader entry this change retires, while looking narrower.

Serialising test functions does **not** serialise threads within a test, so the jobs stress tier keeps its interleaving. The macOS thread lane still runs tests in parallel, so cross-test concurrency keeps a home in the matrix; only this lane specialises.

### Result, read from the log

Zero sanitizer warnings, zero Vulkan-device skips, 856 tests passed across 66 suites, all five sanitizer lanes and Miri green, and **no suppression entries in force**. Two skips remain and are a different mechanism — `window loop unavailable` from winit, because the runner has no display server; that condition predates this change.

### One thing worth flagging in the diff

A commit in the middle set the thread limit through the step's `env:` map with an expression yielding an empty string off the driver lane. An env entry that evaluates to `''` is still set, and libtest parses that one as a number, so three previously-green lanes went red. It is set through `GITHUB_ENV` from a gated step now, with the reasoning beside it — `RENEW_GOLDEN` can use the inline form safely only because all five of its readers compare against the literal `"1"`.