### PR TITLE
fix(lints): ban self-seeding entropy in every crate that claims determinism

### DIFF
--- a/crates/ecs/clippy.toml
+++ b/crates/ecs/clippy.toml
@@ -36,6 +36,8 @@ disallowed-methods = [
 ]
 
 disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs — unseeded randomness, which simulation code may not contain" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState, and stable Rust ships no other self-seeding source that needs no dependency" },
     { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle" },
     { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on `File::open` misses" },
     { path = "std::path::Path", reason = "the crate takes entity slots and components, never a path" },

--- a/crates/frame/clippy.toml
+++ b/crates/frame/clippy.toml
@@ -23,6 +23,8 @@ disallowed-methods = [
 ]
 
 disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs — unseeded randomness, which simulation code may not contain" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState, and stable Rust ships no other self-seeding source that needs no dependency" },
     { path = "std::collections::HashMap", reason = "the default RandomState hasher is seeded per instance, so iteration order varies between runs of the same binary" },
     { path = "std::collections::HashSet", reason = "the default RandomState hasher is seeded per instance, so iteration order varies between runs of the same binary" },
 ]

--- a/crates/input/clippy.toml
+++ b/crates/input/clippy.toml
@@ -35,6 +35,8 @@ disallowed-methods = [
 ]
 
 disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs — unseeded randomness, which simulation code may not contain" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState, and stable Rust ships no other self-seeding source that needs no dependency" },
     { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle" },
     { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on `File::open` misses" },
     { path = "std::path::Path", reason = "the crate takes entity slots and components, never a path" },

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -362,9 +362,22 @@ fn the_unsafe_surface_is_exactly_what_is_recorded() {
 /// **That is the argument for adding it now**: a list that costs nothing
 /// to satisfy today costs a rewrite once a crate forgets.
 ///
-/// The randomness clause stays unlisted deliberately: `std` ships no
-/// generator, so reaching one means taking a dependency, and that is
-/// caught at the `docs/deps/` gate rather than by a lint.
+/// The randomness clause stays unlisted deliberately — but **the reason
+/// recorded here until 2026-08-01 was wrong, and the correction is worth
+/// keeping.** It said `std` ships no generator, so reaching one means
+/// taking a dependency caught at the `docs/deps/` gate. The premise is
+/// true and the inference is not: what is banned is *unseeded
+/// randomness*, not generators, and `RandomState::new` /
+/// `DefaultHasher::new` are stable Rust's dependency-free road to
+/// operating-system entropy.
+///
+/// It stays unlisted because adding it here is **not** the zero-cost
+/// lock-in the collections were. Every declaring crate must already
+/// satisfy every entry, and until 2026-08-01 only `renew-rng` banned
+/// those two types — the other three carried the marker with no
+/// randomness guard at all. That gap is now closed crate-by-crate, which
+/// is the prerequisite for listing it here rather than an alternative to
+/// it. Add it once a fifth crate would not be surprised by it.
 const BANNED_IN_SIMULATION: &[&str] = &[
     "std::time::Instant::now",
     "std::time::SystemTime::now",


### PR DESCRIPTION
Four crates declare themselves simulation code, and their contract is that output is a function of build, seed and input alone. **Only one of them banned `RandomState` and `DefaultHasher`.** The other three banned the unordered collections and stopped there, and the workspace lint file declares no disallowed types at all — so there was no fallback.

`RandomState::new` and `DefaultHasher::new` seed themselves from the operating system. They are stable Rust's dependency-free road to entropy, which is exactly the road a crate promising reproducibility must not have open.

### Why now

Nothing uses them today, so this **locks in a convention rather than demanding a change**. That is the argument for doing it before a crate reaches for one, not after: the same reasoning that put the unordered collections on the list.

### A rationale that was wrong

The comment beside the shared banned-list argued the randomness clause could stay unlisted because `std` ships no generator, so reaching one means taking a dependency caught at review. **The premise is true and the inference is not** — what is banned is unseeded randomness, not generators, and these two types need no dependency at all. Corrected in place.

The shared list still does not carry these two entries, deliberately, and the comment now says why: every declaring crate must already satisfy every entry, so adding them there was not the zero-cost lock-in the collections were until this change closed the gap crate-by-crate. That is the prerequisite for listing them, not an alternative to it.

### Verification

Introduced `std::hash::RandomState::new()` into one of the newly-guarded crates and watched clippy reject it (`error: use of a disallowed type`), then reverted and confirmed the revert. Full workspace: fmt clean, clippy clean under `-D warnings`, 81 suites green.