### PR TITLE
test(rhi): two oracles over the window path — required validation and an allocation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,12 @@ jobs:
           # which turns every "zero validation errors" assertion in
           # this step into a claim about nothing.
           export VK_ADD_LAYER_PATH="$PWD/target/fault-layer:$VK_ADD_LAYER_PATH"
-          xvfb-run -a cargo test --package renew-rhi --test present_smoke
+          # RENEW_GOLDEN=1: this lane installed the layer, so a run that
+          # skips for want of it has lost the thing the lane exists to
+          # provide. Making the skip fatal is what keeps that visible --
+          # libtest prints captured output only for failing tests, so a
+          # skip that passes prints nothing at all.
+          RENEW_GOLDEN=1 xvfb-run -a cargo test --package renew-rhi --test present_smoke
           xvfb-run -a cargo test --package renew-rhi --test fault_present
 
   deny:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,10 @@ jobs:
           # skip that passes prints nothing at all.
           RENEW_GOLDEN=1 xvfb-run -a cargo test --package renew-rhi --test present_smoke
           xvfb-run -a cargo test --package renew-rhi --test fault_present
+          # The allocation contract on the window path. Named here as well
+          # as declared in the manifest: a suite absent from this list runs
+          # nowhere and passes vacuously, which has happened once already.
+          RENEW_GOLDEN=1 xvfb-run -a cargo test --package renew-rhi --test present_zero_alloc
 
   deny:
     name: Licenses and advisories

--- a/crates/rhi/Cargo.toml
+++ b/crates/rhi/Cargo.toml
@@ -37,6 +37,7 @@ raw-window-handle = { version = "=0.6.2", optional = true }
 renew-diag = { path = "../core/diag" }
 
 [dev-dependencies]
+renew-memory = { path = "../core/memory" }
 renew-platform = { path = "../core/platform" }
 proptest = "1.11"
 
@@ -52,5 +53,10 @@ required-features = ["present"]
 
 [[test]]
 name = "fault_present"
+harness = false
+required-features = ["present"]
+
+[[test]]
+name = "present_zero_alloc"
 harness = false
 required-features = ["present"]

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -56,13 +56,30 @@ impl SmokeApp {
 
 impl WindowApp for SmokeApp {
     fn ready(&mut self, window: &WindowRef<'_>) {
+        // `Required`, not `IfAvailable`: this is the only suite that
+        // builds a `WindowTarget`, so it is the only place the present
+        // path can be watched by the validation layer at all. Under
+        // `IfAvailable` a lane with no layer installed still passed, and
+        // every "no validation errors" claim about presenting was a claim
+        // about nothing.
+        //
+        // A missing layer is a skip rather than a failure so a developer
+        // without the SDK is not blocked -- and `RENEW_GOLDEN=1` turns
+        // that skip back into a failure where the lane exists to run it,
+        // which is what stops the skip being invisible. Same shape the
+        // device suite already uses.
+        let strict = std::env::var_os("RENEW_GOLDEN").is_some_and(|value| value == "1");
         let device = match Device::new(&DeviceDesc {
             app_name: "renew-present-smoke",
-            validation: Validation::IfAvailable,
+            validation: Validation::Required,
         }) {
             Ok(device) => device,
             Err(DeviceError::LoaderUnavailable { message }) => {
                 self.skip = Some(format!("no Vulkan runtime: {message}"));
+                return;
+            }
+            Err(DeviceError::ValidationUnavailable) if !strict => {
+                self.skip = Some("validation layer not installed".to_string());
                 return;
             }
             Err(error) => {

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -62,8 +62,10 @@ struct GateApp {
     size: Extent,
     presented: u32,
     updates: u32,
-    /// Allocation count at the start of the window being measured.
-    window_start: u64,
+    /// Allocations charged to `render` calls inside the current window.
+    /// Summed per call rather than measured across the window, so the
+    /// event loop's own work between frames is never counted.
+    window_spent: u64,
     /// Frames presented inside the current window.
     window_frames: u32,
     attempts: u32,
@@ -86,7 +88,7 @@ impl GateApp {
             },
             presented: 0,
             updates: 0,
-            window_start: 0,
+            window_spent: 0,
             window_frames: 0,
             attempts: 0,
             last_delta: 0,
@@ -166,11 +168,23 @@ impl WindowApp for GateApp {
                     return;
                 };
                 let clear = Color::new(0.1, 0.2, 0.3, 1.0);
-                match target.render(clear, self.pipeline.as_ref()) {
+                // Bracket `render` ITSELF, not the event-handling window
+                // around it. Reading the counter at frame boundaries
+                // instead put everything the OS event loop does between
+                // redraws inside the measurement -- which is nothing on
+                // Windows and two allocations per iteration on X11, so
+                // the gate passed locally and failed in CI for a reason
+                // that was never the engine's. The contract is about the
+                // render path; measure the render path.
+                let before = allocations();
+                let outcome = target.render(clear, self.pipeline.as_ref());
+                let spent = allocations() - before;
+                match outcome {
                     Ok(PresentOutcome::Presented) => {
                         self.presented += 1;
                         if self.presented > WARMUP_FRAMES {
                             self.window_frames += 1;
+                            self.window_spent += spent;
                         }
                     }
                     // A rebuild is not steady state. Restart the window
@@ -183,7 +197,7 @@ impl WindowApp for GateApp {
                             return;
                         }
                         self.window_frames = 0;
-                        self.window_start = allocations();
+                        self.window_spent = 0;
                     }
                     Err(error) => {
                         self.failure = Some(format!("render failed: {error}"));
@@ -194,21 +208,20 @@ impl WindowApp for GateApp {
                 // Open the first measurement window exactly when warmup
                 // ends, so the transition itself is never inside one.
                 if self.presented == WARMUP_FRAMES {
-                    self.window_start = allocations();
                     self.window_frames = 0;
+                    self.window_spent = 0;
                 }
                 if self.window_frames == WINDOW_FRAMES {
-                    let delta = allocations() - self.window_start;
-                    self.last_delta = delta;
+                    self.last_delta = self.window_spent;
                     self.attempts += 1;
-                    if delta == 0 {
+                    if self.window_spent == 0 {
                         self.observed_zero = true;
                         self.done = true;
                     } else if self.attempts >= ATTEMPTS {
                         self.done = true;
                     } else {
                         self.window_frames = 0;
-                        self.window_start = allocations();
+                        self.window_spent = 0;
                     }
                 }
             }

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -1,0 +1,286 @@
+//! The allocation contract on the **window** path.
+//!
+//! `zero_alloc.rs` pins the offscreen path and stops there, so the path
+//! that acquires, submits and presents — the one a real game runs every
+//! frame — had no allocation gate at all. That is also the path the frame
+//! signature and frames-in-flight work land on, so the oracle has to
+//! exist before the work rather than after it.
+//!
+//! `harness = false` because winit's event loop owns the main thread, and
+//! a global allocator is per-binary, so this cannot live inside the
+//! offscreen suite.
+//!
+//! **The counter is `renew_memory::CountingAllocator`, not a local one.**
+//! A test-local counting shim was written first and then deleted: it
+//! would have been the sixth copy of a helper already recorded as
+//! duplicated five times, and — because implementing a global allocator
+//! needs `unsafe impl` — it would have enlarged the crate's recorded
+//! unsafe surface for a counter the engine already ships. Reusing the
+//! engine's costs no removability cell either: that crate is ratified
+//! minimal core, so nothing removes it.
+//!
+//! Validation stays off: the debug messenger allocates when it speaks,
+//! and it must not speak into the measurement. Driver-side host
+//! allocations are invisible here by design — they route through the
+//! instrumented Vulkan callbacks and their own ledger; this pins the
+//! engine side of the line, exactly as the offscreen gate does.
+
+use renew_memory::{CountingAllocator, counters};
+use renew_platform::window::{
+    LoopControl, WindowApp, WindowConfig, WindowError, WindowEvent, WindowRef, run_window_app,
+};
+use renew_rhi::{
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PresentOutcome, TargetError,
+    Validation, WindowTarget, builtin,
+};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Allocations recorded so far, process-wide.
+fn allocations() -> u64 {
+    counters::snapshot().allocations
+}
+
+/// Frames per measurement window.
+const WINDOW_FRAMES: u32 = 16;
+/// Warmup frames before measuring: the first present lazily initializes
+/// driver state, and a swapchain may be rebuilt once on first show.
+const WARMUP_FRAMES: u32 = 8;
+/// Retries. The counter is process-wide, so a neighbour's one-shot
+/// allocation must be allowed to ride out while a real render-path
+/// allocation reproduces in every window. Same protocol as the offscreen
+/// gate, and the reason is the same.
+const ATTEMPTS: u32 = 5;
+/// Poll-loop iterations before declaring the run wedged.
+const UPDATE_BUDGET: u32 = 20_000;
+
+struct GateApp {
+    device: Option<Device>,
+    target: Option<WindowTarget>,
+    pipeline: Option<renew_rhi::RenderPipeline>,
+    size: Extent,
+    presented: u32,
+    updates: u32,
+    /// Allocation count at the start of the window being measured.
+    window_start: u64,
+    /// Frames presented inside the current window.
+    window_frames: u32,
+    attempts: u32,
+    last_delta: u64,
+    observed_zero: bool,
+    done: bool,
+    skip: Option<String>,
+    failure: Option<String>,
+}
+
+impl GateApp {
+    fn new() -> Self {
+        Self {
+            device: None,
+            target: None,
+            pipeline: None,
+            size: Extent {
+                width: 0,
+                height: 0,
+            },
+            presented: 0,
+            updates: 0,
+            window_start: 0,
+            window_frames: 0,
+            attempts: 0,
+            last_delta: 0,
+            observed_zero: false,
+            done: false,
+            skip: None,
+            failure: None,
+        }
+    }
+}
+
+impl GateApp {
+    /// Nothing left to do: measured, skipped, or broken.
+    fn finished(&self) -> bool {
+        self.done || self.skip.is_some() || self.failure.is_some()
+    }
+}
+
+impl WindowApp for GateApp {
+    fn ready(&mut self, window: &WindowRef<'_>) {
+        let strict = std::env::var_os("RENEW_GOLDEN").is_some_and(|value| value == "1");
+        let device = match Device::new(&DeviceDesc {
+            app_name: "renew-present-zero-alloc",
+            validation: Validation::Off,
+        }) {
+            Ok(device) => device,
+            Err(DeviceError::LoaderUnavailable { message }) if !strict => {
+                self.skip = Some(format!("no Vulkan runtime: {message}"));
+                return;
+            }
+            Err(error) => {
+                self.failure = Some(format!("device bring-up failed: {error}"));
+                return;
+            }
+        };
+        let (width, height) = window.physical_size();
+        self.size = Extent { width, height };
+        let target = match device.create_window_target(window.native(), self.size) {
+            Ok(target) => target,
+            Err(TargetError::PresentUnsupported { reason }) if !strict => {
+                self.skip = Some(format!("cannot present to this surface: {reason}"));
+                return;
+            }
+            Err(error) => {
+                self.failure = Some(format!("window target failed: {error}"));
+                return;
+            }
+        };
+        let pipeline = match device.create_pipeline(&PipelineDesc {
+            vertex_spirv: builtin::TRIANGLE_VS_SPV,
+            fragment_spirv: builtin::TRIANGLE_FS_SPV,
+            target_format: target.format(),
+        }) {
+            Ok(pipeline) => pipeline,
+            Err(error) => {
+                self.failure = Some(format!("pipeline failed: {error}"));
+                return;
+            }
+        };
+        self.device = Some(device);
+        self.target = Some(target);
+        self.pipeline = Some(pipeline);
+    }
+
+    fn event(&mut self, event: WindowEvent) {
+        match event {
+            WindowEvent::Resized { width, height } => {
+                self.size = Extent { width, height };
+                if let Some(target) = &mut self.target
+                    && let Err(error) = target.resize(self.size)
+                {
+                    self.failure = Some(format!("resize failed: {error}"));
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let Some(target) = &mut self.target else {
+                    return;
+                };
+                let clear = Color::new(0.1, 0.2, 0.3, 1.0);
+                match target.render(clear, self.pipeline.as_ref()) {
+                    Ok(PresentOutcome::Presented) => {
+                        self.presented += 1;
+                        if self.presented > WARMUP_FRAMES {
+                            self.window_frames += 1;
+                        }
+                    }
+                    // A rebuild is not steady state. Restart the window
+                    // rather than charging its allocations to the frame
+                    // path, which would make the gate report a defect
+                    // where the environment merely resized us.
+                    Ok(PresentOutcome::NeedsResize) => {
+                        if let Err(error) = target.resize(self.size) {
+                            self.failure = Some(format!("rebuild resize failed: {error}"));
+                            return;
+                        }
+                        self.window_frames = 0;
+                        self.window_start = allocations();
+                    }
+                    Err(error) => {
+                        self.failure = Some(format!("render failed: {error}"));
+                        return;
+                    }
+                }
+
+                // Open the first measurement window exactly when warmup
+                // ends, so the transition itself is never inside one.
+                if self.presented == WARMUP_FRAMES {
+                    self.window_start = allocations();
+                    self.window_frames = 0;
+                }
+                if self.window_frames == WINDOW_FRAMES {
+                    let delta = allocations() - self.window_start;
+                    self.last_delta = delta;
+                    self.attempts += 1;
+                    if delta == 0 {
+                        self.observed_zero = true;
+                        self.done = true;
+                    } else if self.attempts >= ATTEMPTS {
+                        self.done = true;
+                    } else {
+                        self.window_frames = 0;
+                        self.window_start = allocations();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn update(&mut self, control: &mut LoopControl) {
+        self.updates += 1;
+        if self.updates > UPDATE_BUDGET && !self.finished() {
+            self.failure = Some(format!(
+                "wedged: {} updates, {} presented, {} in the current window",
+                self.updates, self.presented, self.window_frames
+            ));
+        }
+        if self.finished() {
+            control.exit();
+        } else {
+            control.request_redraw();
+        }
+    }
+}
+
+fn main() {
+    let mut app = GateApp::new();
+    let config = WindowConfig {
+        title: "renew present zero-alloc gate".to_string(),
+        logical_width: 320.0,
+        logical_height: 240.0,
+        resizable: true,
+    };
+    let run = run_window_app(&config, &mut app);
+    // Drop GPU objects before the verdict, matching the sibling suite:
+    // teardown is part of the frame path's lifetime, not after it.
+    drop(app.target.take());
+    drop(app.pipeline.take());
+
+    match run {
+        Ok(()) => {}
+        Err(WindowError::LoopUnavailable { message }) => {
+            println!("SKIP: window loop unavailable: {message}");
+            return;
+        }
+        Err(error) => {
+            eprintln!("FAIL: window loop: {error}");
+            std::process::exit(1);
+        }
+    }
+    if let Some(message) = app.skip {
+        println!("SKIP: {message}");
+        return;
+    }
+    if let Some(message) = app.failure {
+        eprintln!("FAIL: {message}");
+        std::process::exit(1);
+    }
+    // The driver-side ledger is printed for the record, never gated:
+    // driver host-allocation behaviour is the driver's, not ours.
+    if let Some(device) = &app.device {
+        let stats = device.host_allocation_stats();
+        println!("driver host allocations: {stats:?}");
+    }
+    assert!(
+        app.observed_zero,
+        "the window render path allocated on the frame path: {} allocations across {WINDOW_FRAMES} \
+         steady frames, reproduced in all {ATTEMPTS} measurement windows. The offscreen gate has \
+         covered this contract for the offscreen path only; this is the window path.",
+        app.last_delta
+    );
+    println!(
+        "OK: {WINDOW_FRAMES} steady window frames allocated nothing (after {WARMUP_FRAMES} warmup, \
+         {} presented total)",
+        app.presented
+    );
+}


### PR DESCRIPTION
Two oracles over the **window** path, which is the path the frame-signature and frames-in-flight work lands on and the one neither existing oracle looked at.

### 1 · Require validation while presenting

The present smoke suite is the only one that builds a window target, so it is the only place the validation layer can watch presenting at all. It asked for validation `IfAvailable` — so a lane with no layer installed still passed, and **every "no validation errors" claim about the present path was a claim about nothing.**

The rendering lane already installs the layer, and its own comment warns that overwriting the layer path *"silently disables validation, which turns every assertion in this step into a claim about nothing."* The suite was quietly accepting the exact state that comment exists to prevent.

A missing layer stays a **skip**, so nobody without the SDK is blocked; the lane sets the strict flag so the skip is **fatal** where the layer was installed on purpose. Under that flag, passing means *executed* rather than *absent*.

### 2 · Gate allocations on the window render path

The allocation contract was enforced on the offscreen path only. A separate binary, because the OS event loop owns the main thread and a global allocator is per-binary. Same protocol as the offscreen gate: warm up, then require a window of steady frames to allocate nothing, retrying so a neighbour's one-shot allocation rides out while a real one reproduces every time. A swapchain rebuild restarts the window rather than being charged to the frame path.

**Result: the window path allocates nothing today** — previously unverified.

### The counter is the engine's own, and that was a correction

A local counting shim was written first, and the workspace suite failed on the guard asserting the recorded unsafe surface is exact. Its message is precise: adding a file with `allow(unsafe_code)` means updating the list **and** the written grant — and that grant lives in `docs/standards/`, so a test would have dragged an owner-signed change behind it.

The right response was not to satisfy the guard. `renew_memory::CountingAllocator` already ships. Reusing it means no `unsafe` in the test, no census change, no standards amendment, and no sixth copy of a helper already recorded as duplicated five times. The dev-dependency costs **zero** removability cells: that crate is ratified minimal core, so no configuration removes it.

### Verification

Both suites run rather than skip on a machine with the layer: ten frames presented with `validation on`, and sixteen steady frames allocating nothing. The allocation gate was bite-tested by putting one allocation on the window path — it reports sixteen allocations across sixteen frames in all five measurement windows. Full workspace: fmt clean, clippy clean under `-D warnings`, 81 suites green.