### PR TITLE
fix: record the new dev-dependency in the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
  "proptest",
  "raw-window-handle",
  "renew-diag",
+ "renew-memory",
  "renew-platform",
 ]
 


### PR DESCRIPTION
The previous change added a dev-dependency and did not commit the resulting lockfile update, so the manifest and the lock disagreed on `main`. **`cargo --locked` fails outright there** — `cannot update the lock file because --locked was passed` — which I confirmed by stashing and running it against `main` as merged.

### Why CI did not catch it

**No lane passes `--locked`.** Every job lets cargo resolve and silently rewrite the lock in place, so the check that would have failed was never run. The one property the lockfile exists to provide — that a clean clone resolves to exactly these versions — was unenforced at precisely the moment it broke.

That gap is worth more than this one-line fix and is recorded as debt rather than fixed here, because adding `--locked` to the lanes is a change with its own failure modes (a legitimately-updated lock now reddens every job until committed, which is the intended behaviour but is a workflow change, not a bugfix).