### PR TITLE
feat(rhi)!: build PipelineDesc through a constructor, not a literal

### DIFF
--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -30,11 +30,48 @@ impl TargetFormat {
 
 /// Pipeline construction parameters. The SPIR-V is borrowed byte
 /// slices — [`crate::builtin`] provides the embedded v0 shaders.
+///
+/// `#[non_exhaustive]`, so it is built through [`PipelineDesc::new`]
+/// rather than as a struct literal. Every field this will grow — vertex
+/// input, blend state, depth state, push-constant ranges — is optional
+/// with a defined absence, so each can arrive as a builder method
+/// without touching a single existing caller. Without the attribute,
+/// adding one field edits every construction site in the workspace, and
+/// the count only rises.
+///
+/// **Not `Default`.** A default would have to supply empty shader bytes,
+/// and empty SPIR-V is rejected by name during validation — so the
+/// default value would be one that can never successfully build a
+/// pipeline. A constructor taking exactly the parameters with no
+/// sensible absence is the honest shape.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct PipelineDesc<'a> {
     pub vertex_spirv: &'a [u8],
     pub fragment_spirv: &'a [u8],
     pub target_format: TargetFormat,
+}
+
+impl<'a> PipelineDesc<'a> {
+    /// The three parameters a pipeline cannot be built without.
+    ///
+    /// Positional rather than a builder chain because none of these has
+    /// a meaningful default: a pipeline with no vertex stage, no
+    /// fragment stage, or no target format is not a partially-configured
+    /// pipeline, it is not a pipeline. Optional state arrives later as
+    /// builder methods on top of this.
+    #[must_use]
+    pub fn new(
+        vertex_spirv: &'a [u8],
+        fragment_spirv: &'a [u8],
+        target_format: TargetFormat,
+    ) -> Self {
+        Self {
+            vertex_spirv,
+            fragment_spirv,
+            target_format,
+        }
+    }
 }
 
 /// A compiled draw pipeline. Holds its device alive; destroyed on

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -95,11 +95,11 @@ fn full_frame_cycle_clear_then_triangle() {
         .create_offscreen_target(extent)
         .expect("offscreen target");
     let pipeline = device
-        .create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: TargetFormat::Rgba8Unorm,
-        })
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            TargetFormat::Rgba8Unorm,
+        ))
         .expect("triangle pipeline");
 
     let clear = Color::new(0.0, 0.0, 0.0, 1.0);
@@ -165,11 +165,11 @@ fn resources_keep_the_device_alive_past_the_handle() {
         })
         .expect("offscreen target");
     let pipeline = device
-        .create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: TargetFormat::Rgba8Unorm,
-        })
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            TargetFormat::Rgba8Unorm,
+        ))
         .expect("pipeline");
     // The handle goes away; the spine lives on through the resources.
     drop(device);
@@ -186,20 +186,20 @@ fn invalid_spirv_is_rejected_per_stage() {
         return;
     };
     let bad = [0xDEu8, 0xAD, 0xBE, 0xEF];
-    match device.create_pipeline(&PipelineDesc {
-        vertex_spirv: &bad,
-        fragment_spirv: builtin::TRIANGLE_FS_SPV,
-        target_format: TargetFormat::Rgba8Unorm,
-    }) {
+    match device.create_pipeline(&PipelineDesc::new(
+        &bad,
+        builtin::TRIANGLE_FS_SPV,
+        TargetFormat::Rgba8Unorm,
+    )) {
         Err(PipelineError::InvalidSpirv { stage, .. }) => assert_eq!(stage, "vertex"),
         Err(other) => panic!("expected vertex rejection, got {other:?}"),
         Ok(_) => panic!("expected vertex rejection, got a pipeline"),
     }
-    match device.create_pipeline(&PipelineDesc {
-        vertex_spirv: builtin::TRIANGLE_VS_SPV,
-        fragment_spirv: &[],
-        target_format: TargetFormat::Rgba8Unorm,
-    }) {
+    match device.create_pipeline(&PipelineDesc::new(
+        builtin::TRIANGLE_VS_SPV,
+        &[],
+        TargetFormat::Rgba8Unorm,
+    )) {
         Err(PipelineError::InvalidSpirv { stage, .. }) => assert_eq!(stage, "fragment"),
         Err(other) => panic!("expected fragment rejection, got {other:?}"),
         Ok(_) => panic!("expected fragment rejection, got a pipeline"),
@@ -238,11 +238,11 @@ fn cross_device_pipeline_is_a_dev_build_contract_violation() {
         })
         .expect("offscreen target");
     let foreign = device_b
-        .create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: TargetFormat::Rgba8Unorm,
-        })
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            TargetFormat::Rgba8Unorm,
+        ))
         .expect("pipeline on the other device");
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let _ = target.render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&foreign));

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -137,11 +137,11 @@ fn new_device() -> Result<Device, DeviceError> {
 }
 
 fn pipeline_desc() -> PipelineDesc<'static> {
-    PipelineDesc {
-        vertex_spirv: builtin::TRIANGLE_VS_SPV,
-        fragment_spirv: builtin::TRIANGLE_FS_SPV,
-        target_format: TargetFormat::Rgba8Unorm,
-    }
+    PipelineDesc::new(
+        builtin::TRIANGLE_VS_SPV,
+        builtin::TRIANGLE_FS_SPV,
+        TargetFormat::Rgba8Unorm,
+    )
 }
 
 /// A scenario failure, carrying its own name.
@@ -779,11 +779,11 @@ fn every_driver_failure_ladder_behaves() {
         // caller is gone — the layer's own leak check at instance
         // destruction lands in exactly that window.
         verdicts.push(teardown_case("E7 teardown/validation-report", |device| {
-            match device.create_pipeline(&PipelineDesc {
-                vertex_spirv: &IMPLAUSIBLE_SPIRV,
-                fragment_spirv: builtin::TRIANGLE_FS_SPV,
-                target_format: TargetFormat::Rgba8Unorm,
-            }) {
+            match device.create_pipeline(&PipelineDesc::new(
+                &IMPLAUSIBLE_SPIRV,
+                builtin::TRIANGLE_FS_SPV,
+                TargetFormat::Rgba8Unorm,
+            )) {
                 Err(PipelineError::Creation { .. }) => {}
                 Err(other) => return Err(wrong("", "Creation(vkCreateShaderModule)", &other)),
                 Ok(_) => return Err("the layer accepted implausible SPIR-V".to_string()),

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -143,11 +143,11 @@ fn triangle_matches_structure_and_the_committed_golden() {
         })
         .expect("offscreen target");
     let pipeline = device
-        .create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: TargetFormat::Rgba8Unorm,
-        })
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            TargetFormat::Rgba8Unorm,
+        ))
         .expect("triangle pipeline");
     target
         .render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&pipeline))

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -100,11 +100,11 @@ impl WindowApp for SmokeApp {
                 return;
             }
         };
-        let pipeline = match device.create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: target.format(),
-        }) {
+        let pipeline = match device.create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            target.format(),
+        )) {
             Ok(pipeline) => pipeline,
             Err(error) => {
                 self.failure = Some(format!("pipeline failed: {error}"));

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -137,11 +137,11 @@ impl WindowApp for GateApp {
                 return;
             }
         };
-        let pipeline = match device.create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: target.format(),
-        }) {
+        let pipeline = match device.create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            target.format(),
+        )) {
             Ok(pipeline) => pipeline,
             Err(error) => {
                 self.failure = Some(format!("pipeline failed: {error}"));

--- a/crates/rhi/tests/zero_alloc.rs
+++ b/crates/rhi/tests/zero_alloc.rs
@@ -80,11 +80,11 @@ fn steady_state_frames_allocate_nothing() {
         })
         .expect("offscreen target");
     let pipeline = device
-        .create_pipeline(&PipelineDesc {
-            vertex_spirv: builtin::TRIANGLE_VS_SPV,
-            fragment_spirv: builtin::TRIANGLE_FS_SPV,
-            target_format: TargetFormat::Rgba8Unorm,
-        })
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE_VS_SPV,
+            builtin::TRIANGLE_FS_SPV,
+            TargetFormat::Rgba8Unorm,
+        ))
         .expect("triangle pipeline");
     let clear = Color::new(0.1, 0.2, 0.3, 1.0);
     let mut pixels = vec![0u8; target.byte_len()];

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -100,11 +100,11 @@ impl HeadlessRun {
             Draw::ClearOnly => None,
             Draw::Triangle => Some(
                 device
-                    .create_pipeline(&PipelineDesc {
-                        vertex_spirv: builtin::TRIANGLE_VS_SPV,
-                        fragment_spirv: builtin::TRIANGLE_FS_SPV,
-                        target_format: surface.format(),
-                    })
+                    .create_pipeline(&PipelineDesc::new(
+                        builtin::TRIANGLE_VS_SPV,
+                        builtin::TRIANGLE_FS_SPV,
+                        surface.format(),
+                    ))
                     .map_err(pipeline_error)?,
             ),
         };

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -163,11 +163,11 @@ impl TriangleApp {
             .map_err(target_error)?;
         let surface = Surface::Window(target);
         let pipeline = device
-            .create_pipeline(&PipelineDesc {
-                vertex_spirv: builtin::TRIANGLE_VS_SPV,
-                fragment_spirv: builtin::TRIANGLE_FS_SPV,
-                target_format: surface.format(),
-            })
+            .create_pipeline(&PipelineDesc::new(
+                builtin::TRIANGLE_VS_SPV,
+                builtin::TRIANGLE_FS_SPV,
+                surface.format(),
+            ))
             .map_err(pipeline_error)?;
         self.device = Some(device);
         self.surface = Some(surface);


### PR DESCRIPTION
`PipelineDesc` is now `#[non_exhaustive]` and built through `PipelineDesc::new`. Thirteen construction sites across eight files migrated.

**This is the cheap change that makes the expensive ones cheap.** Every field the descriptor will grow — vertex input, blend state, depth state, push-constant ranges — is optional with a defined absence, so each can arrive as a builder method touching **no existing caller**. Without the attribute, adding one field edits every construction site in the workspace, and that count only rises: it was seven a week ago and is thirteen now.

### Deliberately not `Default`

A default would have to supply empty shader bytes, and **empty SPIR-V is rejected by name during validation** — so the default value would be one that can never successfully build a pipeline. A constructor taking exactly the parameters with no sensible absence is the honest shape; optional state arrives on top of it.

Positional rather than a builder chain for the same reason: a pipeline with no vertex stage, no fragment stage, or no target format is not a partially-configured pipeline, it is not a pipeline.

### Verification

Attempted literal construction from outside the crate after the change:

```
error[E0639]: cannot create non-exhaustive struct using struct expression
```

One site needed care that a mechanical rewrite got wrong — a helper returning `PipelineDesc<'static>` by value, where the rewrite added a stray `&`. The compiler caught it; fixed and re-verified.

fmt clean, clippy clean under `-D warnings`, 81 suites green.