### PR TITLE
feat(rhi)!: take a frame descriptor, not positional frame parameters

### DIFF
--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -72,7 +72,7 @@ pub use config::{AdapterInfo, AdapterKind, Color, DeviceDesc, Extent, Validation
 pub use error::{DeviceError, PipelineError, TargetError};
 pub use vk::device::{Device, HostAllocationStats, ValidationReport};
 pub use vk::offscreen::OffscreenTarget;
-pub use vk::pipeline::{PipelineDesc, RenderPipeline, TargetFormat};
+pub use vk::pipeline::{PipelineDesc, RenderDesc, RenderPipeline, TargetFormat};
 #[cfg(feature = "present")]
 pub use vk::swapchain::{PresentOutcome, WindowTarget};
 

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -6,10 +6,10 @@ use std::rc::Rc;
 
 use ash::vk;
 
-use crate::config::{Color, Extent};
+use crate::config::Extent;
 use crate::error::TargetError;
 use crate::vk::device::{Device, DeviceShared, FENCE_TIMEOUT_NS};
-use crate::vk::pipeline::{RenderPipeline, TargetFormat};
+use crate::vk::pipeline::{RenderDesc, TargetFormat};
 
 /// Bytes per pixel of the fixed RGBA8 format.
 const BPP: u64 = 4;
@@ -410,11 +410,10 @@ impl OffscreenTarget {
         clippy::too_many_lines,
         reason = "one recorded command stream; the barrier ordering reads top to bottom"
     )]
-    pub fn render(
-        &mut self,
-        clear: Color,
-        pipeline: Option<&RenderPipeline>,
-    ) -> Result<(), TargetError> {
+    pub fn render(&mut self, desc: &RenderDesc<'_>) -> Result<(), TargetError> {
+        let RenderDesc {
+            clear, pipeline, ..
+        } = *desc;
         if self.wedged {
             return Err(TargetError::Timeout {
                 call: "target wedged by an earlier incomplete frame",

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -1,10 +1,12 @@
 //! The v0 graphics pipeline: two SPIR-V stages, no vertex buffers, no
 //! descriptors, dynamic rendering into one color attachment.
 
+use std::fmt;
 use std::rc::Rc;
 
 use ash::vk;
 
+use crate::config::Color;
 use crate::error::PipelineError;
 use crate::vk::device::{Device, DeviceShared};
 
@@ -71,6 +73,72 @@ impl<'a> PipelineDesc<'a> {
             fragment_spirv,
             target_format,
         }
+    }
+}
+
+/// Everything one frame needs, for either target.
+///
+/// **One type, not one per target.** `RenderPipeline` already crosses
+/// both targets carrying a field only one of them can satisfy, and each
+/// target refuses a mismatch itself with a `debug_assert!` beside its
+/// device check. So "one descriptor, target-specific fields validated at
+/// the target" is the pattern this crate already uses for the closest
+/// analogue it has, and splitting this one would leave two conventions
+/// for one question.
+///
+/// **`#[non_exhaustive]`, and this is the whole point of the type.** The
+/// old signature took the clear colour and the pipeline positionally,
+/// which meant every frame-level parameter that arrived later broke every
+/// caller. Several are already known to be coming: an in-flight policy, a
+/// load operation, a viewport, a colour-space override. Each of those is
+/// now a builder method that touches nothing.
+///
+/// Passing a field a target cannot satisfy is a contract violation rather
+/// than a recoverable condition -- the caller has asked for something
+/// incoherent, not something that failed -- so targets assert rather than
+/// returning an error, exactly as they already do for pipeline format.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub struct RenderDesc<'a> {
+    /// The colour the target is cleared to before drawing.
+    pub clear: Color,
+    /// The pipeline to draw with, or `None` to clear only.
+    pub pipeline: Option<&'a RenderPipeline>,
+}
+
+impl fmt::Debug for RenderDesc<'_> {
+    /// Reports *whether* a pipeline is bound, not which one.
+    /// `RenderPipeline` has no `Debug` -- a Vulkan handle's address is
+    /// not information -- and presence is the part a reader debugging a
+    /// frame actually wants.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RenderDesc")
+            .field("clear", &self.clear)
+            .field("pipeline", &self.pipeline.map(|_| "bound"))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> RenderDesc<'a> {
+    /// A frame that clears and draws nothing.
+    ///
+    /// The clear colour is positional because a frame has no meaningful
+    /// "no clear" state today -- the load operation is unconditionally a
+    /// clear in both backends. When that becomes configurable it arrives
+    /// as a builder method, and this constructor keeps its meaning.
+    #[must_use]
+    pub fn new(clear: Color) -> Self {
+        Self {
+            clear,
+            pipeline: None,
+        }
+    }
+
+    /// Draw with this pipeline after clearing.
+    #[must_use]
+    pub fn pipeline(mut self, pipeline: &'a RenderPipeline) -> Self {
+        self.pipeline = Some(pipeline);
+        self
     }
 }
 

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -339,3 +339,30 @@ impl Device {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The unbound case, asserted on its content rather than merely run.
+    ///
+    /// A test that only *calls* `Debug` satisfies a line-coverage gate
+    /// while proving nothing -- which is the failure mode a 100% gate
+    /// invites. This asserts the two claims the impl actually makes: the
+    /// clear colour is reported, and the pipeline field says whether one
+    /// is bound rather than naming a handle.
+    #[test]
+    fn the_debug_form_reports_an_unbound_pipeline_as_none() {
+        let desc = RenderDesc::new(Color::new(0.25, 0.5, 0.75, 1.0));
+        let shown = format!("{desc:?}");
+        assert!(shown.contains("RenderDesc"), "{shown}");
+        assert!(
+            shown.contains("0.25"),
+            "the clear colour should be visible: {shown}"
+        );
+        assert!(shown.contains("pipeline: None"), "{shown}");
+        // `finish_non_exhaustive` renders the trailing `..`, which is the
+        // signal to a reader that the struct grows.
+        assert!(shown.contains(".."), "{shown}");
+    }
+}

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -16,10 +16,10 @@ use std::rc::Rc;
 use ash::vk;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 
-use crate::config::{Color, Extent};
+use crate::config::Extent;
 use crate::error::TargetError;
 use crate::vk::device::{Device, DeviceShared, FENCE_TIMEOUT_NS};
-use crate::vk::pipeline::{RenderPipeline, TargetFormat};
+use crate::vk::pipeline::{RenderDesc, TargetFormat};
 
 fn creation(call: &'static str, code: vk::Result) -> TargetError {
     match code {
@@ -353,11 +353,10 @@ impl WindowTarget {
         clippy::too_many_lines,
         reason = "one recorded frame; wait, acquire, record, submit, present read top to bottom"
     )]
-    pub fn render(
-        &mut self,
-        clear: Color,
-        pipeline: Option<&RenderPipeline>,
-    ) -> Result<PresentOutcome, TargetError> {
+    pub fn render(&mut self, desc: &RenderDesc<'_>) -> Result<PresentOutcome, TargetError> {
+        let RenderDesc {
+            clear, pipeline, ..
+        } = *desc;
         if self.shared.lost.poisoned() {
             return Err(TargetError::DeviceLost);
         }

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -102,6 +102,19 @@ fn full_frame_cycle_clear_then_triangle() {
         ))
         .expect("triangle pipeline");
 
+    // The bound case of the descriptor's Debug form. It lives here
+    // rather than in a unit test because reporting "bound" requires a
+    // real pipeline, and building one requires a device. The unbound
+    // case is a unit test beside the impl.
+    let bound = format!(
+        "{:?}",
+        RenderDesc::new(Color::new(0.0, 0.0, 0.0, 1.0)).pipeline(&pipeline)
+    );
+    assert!(
+        bound.contains("pipeline: Some(\"bound\")"),
+        "a bound pipeline should report presence, not a handle: {bound}"
+    );
+
     let clear = Color::new(0.0, 0.0, 0.0, 1.0);
     target
         .render(&RenderDesc::new(clear))

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -7,8 +7,8 @@
 //! layer skip: correctness is proven where the oracle exists.
 
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PipelineError, TargetFormat,
-    Validation, builtin,
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PipelineError, RenderDesc,
+    TargetFormat, Validation, builtin,
 };
 
 /// `Ok(None)` is the graceful skip; other failures surface as `Err`
@@ -103,12 +103,14 @@ fn full_frame_cycle_clear_then_triangle() {
         .expect("triangle pipeline");
 
     let clear = Color::new(0.0, 0.0, 0.0, 1.0);
-    target.render(clear, None).expect("clear-only render");
+    target
+        .render(&RenderDesc::new(clear))
+        .expect("clear-only render");
     let mut cleared = vec![0u8; target.byte_len()];
     target.read_back_into(&mut cleared);
 
     target
-        .render(clear, Some(&pipeline))
+        .render(&RenderDesc::new(clear).pipeline(&pipeline))
         .expect("triangle render");
     let mut drawn = vec![0u8; target.byte_len()];
     target.read_back_into(&mut drawn);
@@ -142,7 +144,7 @@ fn device_churn_three_rounds() {
             })
             .expect("offscreen target");
         target
-            .render(Color::new(0.5, 0.5, 0.5, 1.0), None)
+            .render(&RenderDesc::new(Color::new(0.5, 0.5, 0.5, 1.0)))
             .expect("render");
         // Teardown first, oracle second: destruction-time findings
         // count in every round.
@@ -174,7 +176,7 @@ fn resources_keep_the_device_alive_past_the_handle() {
     // The handle goes away; the spine lives on through the resources.
     drop(device);
     target
-        .render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&pipeline))
+        .render(&RenderDesc::new(Color::new(0.0, 0.0, 0.0, 1.0)).pipeline(&pipeline))
         .expect("render after the device handle dropped");
     let mut pixels = vec![0u8; target.byte_len()];
     target.read_back_into(&mut pixels);
@@ -245,7 +247,7 @@ fn cross_device_pipeline_is_a_dev_build_contract_violation() {
         ))
         .expect("pipeline on the other device");
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let _ = target.render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&foreign));
+        let _ = target.render(&RenderDesc::new(Color::new(0.0, 0.0, 0.0, 1.0)).pipeline(&foreign));
     }));
     assert!(
         outcome.is_err(),

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -22,8 +22,8 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Mutex;
 
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PipelineError, TargetError,
-    TargetFormat, Validation, builtin,
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PipelineError, RenderDesc,
+    TargetError, TargetFormat, Validation, builtin,
 };
 
 const SIZE: Extent = Extent {
@@ -444,7 +444,7 @@ fn every_driver_failure_ladder_behaves() {
                 ));
             }
             recovered
-                .render(CLEAR, None)
+                .render(&RenderDesc::new(CLEAR))
                 .map_err(|error| format!("{name}: recovery render failed: {error}"))
         }));
     }
@@ -486,7 +486,7 @@ fn every_driver_failure_ladder_behaves() {
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("{name}: recovery target failed: {error}"))?;
             target
-                .render(CLEAR, Some(&pipeline))
+                .render(&RenderDesc::new(CLEAR).pipeline(&pipeline))
                 .map_err(|error| format!("{name}: recovery render failed: {error}"))
         }));
     }
@@ -521,13 +521,13 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("{name}: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => creation_named(name, call, &error)?,
                 Ok(()) => return Err(format!("{name}: the frame succeeded despite the fault")),
             }
             // Not wedged, not poisoned: the next frame goes through.
             target
-                .render(CLEAR, None)
+                .render(&RenderDesc::new(CLEAR))
                 .map_err(|error| format!("{name}: recovery frame failed: {error}"))?;
             let mut pixels = vec![0u8; target.byte_len()];
             target.read_back_into(&mut pixels);
@@ -544,11 +544,11 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("D5: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(TargetError::DeviceLost) => {}
                 other => return Err(wrong("D5", "DeviceLost", &other)),
             }
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(TargetError::DeviceLost) => {}
                 other => return Err(wrong("D5", "DeviceLost on the next frame", &other)),
             }
@@ -573,11 +573,11 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("D6: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => timeout_named("D6", "vkWaitForFences", &error)?,
                 Ok(()) => return Err("D6: the frame succeeded despite the fault".to_string()),
             }
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => {
                     timeout_named("D6", "target wedged by an earlier incomplete frame", &error)?;
                 }
@@ -605,12 +605,12 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("D7: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(TargetError::DeviceLost) => {}
                 other => return Err(wrong("D7", "DeviceLost", &other)),
             }
             // Wedged first, so the wedge answer wins over the poison.
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => {
                     timeout_named("D7", "target wedged by an earlier incomplete frame", &error)?;
                 }
@@ -633,11 +633,11 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("D8: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => creation_named("D8", "vkResetFences", &error)?,
                 Ok(()) => return Err("D8: the frame succeeded despite the fault".to_string()),
             }
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => {
                     timeout_named("D8", "target wedged by an earlier incomplete frame", &error)
                 }
@@ -754,7 +754,7 @@ fn every_driver_failure_ladder_behaves() {
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("E5: target: {error}"))?;
             target
-                .render(CLEAR, None)
+                .render(&RenderDesc::new(CLEAR))
                 .map_err(|error| format!("E5: frame after a failed wait-idle: {error}"))
         },
     ));
@@ -827,11 +827,11 @@ fn every_driver_failure_ladder_behaves() {
             let mut target = device
                 .create_offscreen_target(SIZE)
                 .map_err(|error| format!("F1: target: {error}"))?;
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => creation_named("F1", "vkWaitForFences", &error)?,
                 Ok(()) => return Err("F1: the frame succeeded despite the fault".to_string()),
             }
-            match target.render(CLEAR, None) {
+            match target.render(&RenderDesc::new(CLEAR)) {
                 Err(error) => {
                     timeout_named("F1", "target wedged by an earlier incomplete frame", &error)
                 }

--- a/crates/rhi/tests/fault_present.rs
+++ b/crates/rhi/tests/fault_present.rs
@@ -42,8 +42,8 @@ use renew_platform::window::{
     run_window_app,
 };
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PresentOutcome, TargetError, Validation,
-    WindowTarget,
+    Color, Device, DeviceDesc, DeviceError, Extent, PresentOutcome, RenderDesc, TargetError,
+    Validation, WindowTarget,
 };
 
 const CLEAR: Color = Color::new(0.1, 0.2, 0.3, 1.0);
@@ -457,7 +457,7 @@ fn assert_dormant(target: &mut WindowTarget) -> Verdict {
     if extent.width != 0 || extent.height != 0 {
         return Err(format!("expected a dormant target, got extent {extent:?}"));
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::NeedsResize) => Ok(()),
         other => Err(wrong("NeedsResize from a dormant target", &other)),
     }
@@ -468,7 +468,7 @@ fn assert_recovers(target: &mut WindowTarget, size: Extent) -> Verdict {
     target
         .resize(size)
         .map_err(|error| format!("recovery resize failed: {error}"))?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::Presented) => Ok(()),
         other => Err(wrong("Presented after recovery", &other)),
     }
@@ -482,7 +482,7 @@ fn assert_poison_sticks(
     window: &NativeWindow,
     size: Extent,
 ) -> Verdict {
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(TargetError::DeviceLost) => {}
         other => return Err(wrong("DeviceLost from the next frame", &other)),
     }
@@ -638,7 +638,7 @@ fn every_frame_aborts(
     size: Extent,
 ) -> Verdict {
     let mut target = built(target)?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
         Ok(outcome) => return Err(wrong("an error", &outcome)),
     }
@@ -652,7 +652,7 @@ fn every_frame_aborts(
             target.extent()
         ));
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
         Ok(outcome) => return Err(wrong("an error from the rebuilt chain", &outcome)),
     }
@@ -682,7 +682,7 @@ fn presents_at(target: &mut WindowTarget, size: Extent, stage: &str) -> Verdict 
             "expected the chosen extent {size:?} {stage}, got {extent:?}"
         ));
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::Presented) => Ok(()),
         other => Err(wrong(&format!("Presented {stage}"), &other)),
     }
@@ -736,7 +736,7 @@ fn build_fails(
     let mut recovered = device
         .create_window_target(window.clone(), size)
         .map_err(|error| format!("recovery build failed: {error}"))?;
-    match recovered.render(CLEAR, None) {
+    match recovered.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::Presented) => Ok(()),
         other => Err(wrong("Presented after recovery", &other)),
     }
@@ -747,11 +747,11 @@ fn frame_fails_chain_survives(
     target: Result<WindowTarget, TargetError>,
 ) -> Verdict {
     let mut target = built(target)?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
         Ok(outcome) => return Err(wrong("an error", &outcome)),
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::Presented) => Ok(()),
         other => Err(wrong("Presented on the next frame", &other)),
     }
@@ -763,7 +763,7 @@ fn frame_fails_goes_dormant(
     size: Extent,
 ) -> Verdict {
     let mut target = built(target)?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
         Ok(outcome) => return Err(wrong("an error", &outcome)),
     }
@@ -777,11 +777,11 @@ fn second_frame_fails(
     size: Extent,
 ) -> Verdict {
     let mut target = built(target)?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::Presented) => {}
         other => return Err(wrong("Presented on the first frame", &other)),
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
         Ok(outcome) => return Err(wrong("an error on the second frame", &outcome)),
     }
@@ -790,7 +790,7 @@ fn second_frame_fails(
 
 fn stale_swapchain(target: Result<WindowTarget, TargetError>, size: Extent) -> Verdict {
     let mut target = built(target)?;
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Ok(PresentOutcome::NeedsResize) => {}
         other => return Err(wrong("NeedsResize", &other)),
     }
@@ -806,12 +806,12 @@ fn device_lost_on_frame(
 ) -> Verdict {
     let mut target = built(target)?;
     for earlier in 1..frame {
-        match target.render(CLEAR, None) {
+        match target.render(&RenderDesc::new(CLEAR)) {
             Ok(PresentOutcome::Presented) => {}
             other => return Err(wrong(&format!("Presented on frame {earlier}"), &other)),
         }
     }
-    match target.render(CLEAR, None) {
+    match target.render(&RenderDesc::new(CLEAR)) {
         Err(TargetError::DeviceLost) => {}
         other => return Err(wrong(&format!("DeviceLost on frame {frame}"), &other)),
     }

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -22,8 +22,8 @@
 use std::path::{Path, PathBuf};
 
 use renew_rhi::{
-    AdapterKind, Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, TargetFormat,
-    Validation, builtin,
+    AdapterKind, Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, RenderDesc,
+    TargetFormat, Validation, builtin,
 };
 
 fn strict() -> bool {
@@ -106,7 +106,9 @@ fn clear_is_byte_exact_everywhere() {
         .expect("offscreen target");
     // 51/255, 102/255, 153/255: unambiguous UNORM conversions.
     let clear = Color::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0, 1.0);
-    target.render(clear, None).expect("clear render");
+    target
+        .render(&RenderDesc::new(clear))
+        .expect("clear render");
     let mut pixels = vec![0u8; target.byte_len()];
     target.read_back_into(&mut pixels);
 
@@ -150,7 +152,7 @@ fn triangle_matches_structure_and_the_committed_golden() {
         ))
         .expect("triangle pipeline");
     target
-        .render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&pipeline))
+        .render(&RenderDesc::new(Color::new(0.0, 0.0, 0.0, 1.0)).pipeline(&pipeline))
         .expect("triangle render");
     let mut pixels = vec![0u8; target.byte_len()];
     target.read_back_into(&mut pixels);
@@ -158,7 +160,7 @@ fn triangle_matches_structure_and_the_committed_golden() {
     // Determinism self-check: the same frame twice is the same bytes,
     // on every adapter — the cheap local form of the golden property.
     target
-        .render(Color::new(0.0, 0.0, 0.0, 1.0), Some(&pipeline))
+        .render(&RenderDesc::new(Color::new(0.0, 0.0, 0.0, 1.0)).pipeline(&pipeline))
         .expect("second triangle render");
     let mut second = vec![0u8; target.byte_len()];
     target.read_back_into(&mut second);

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -11,8 +11,8 @@ use renew_platform::window::{
     LoopControl, WindowApp, WindowConfig, WindowError, WindowEvent, WindowRef, run_window_app,
 };
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PresentOutcome, TargetError,
-    Validation, WindowTarget, builtin,
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PresentOutcome, RenderDesc,
+    TargetError, Validation, WindowTarget, builtin,
 };
 
 const FRAMES_WANTED: u32 = 10;
@@ -154,7 +154,7 @@ impl WindowApp for SmokeApp {
                         self.failure = Some("dormant target reports a size".to_string());
                         return;
                     }
-                    match target.render(clear, None) {
+                    match target.render(&RenderDesc::new(clear)) {
                         Ok(PresentOutcome::NeedsResize) => {}
                         Ok(PresentOutcome::Presented) => {
                             self.failure = Some("dormant target presented".to_string());
@@ -170,7 +170,11 @@ impl WindowApp for SmokeApp {
                         return;
                     }
                 }
-                match target.render(clear, self.pipeline.as_ref()) {
+                let mut desc = RenderDesc::new(clear);
+                if let Some(pipeline) = self.pipeline.as_ref() {
+                    desc = desc.pipeline(pipeline);
+                }
+                match target.render(&desc) {
                     Ok(PresentOutcome::Presented) => self.frames += 1,
                     Ok(PresentOutcome::NeedsResize) => {
                         if let Err(error) = target.resize(self.size) {

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -30,8 +30,8 @@ use renew_platform::window::{
     LoopControl, WindowApp, WindowConfig, WindowError, WindowEvent, WindowRef, run_window_app,
 };
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PresentOutcome, TargetError,
-    Validation, WindowTarget, builtin,
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, PresentOutcome, RenderDesc,
+    TargetError, Validation, WindowTarget, builtin,
 };
 
 #[global_allocator]
@@ -177,7 +177,11 @@ impl WindowApp for GateApp {
                 // that was never the engine's. The contract is about the
                 // render path; measure the render path.
                 let before = allocations();
-                let outcome = target.render(clear, self.pipeline.as_ref());
+                let mut desc = RenderDesc::new(clear);
+                if let Some(pipeline) = self.pipeline.as_ref() {
+                    desc = desc.pipeline(pipeline);
+                }
+                let outcome = target.render(&desc);
                 let spent = allocations() - before;
                 match outcome {
                     Ok(PresentOutcome::Presented) => {

--- a/crates/rhi/tests/zero_alloc.rs
+++ b/crates/rhi/tests/zero_alloc.rs
@@ -16,7 +16,8 @@ use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use renew_rhi::{
-    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, TargetFormat, Validation, builtin,
+    Color, Device, DeviceDesc, DeviceError, Extent, PipelineDesc, RenderDesc, TargetFormat,
+    Validation, builtin,
 };
 
 static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
@@ -91,7 +92,9 @@ fn steady_state_frames_allocate_nothing() {
 
     // Warmup: first frames may lazily initialize driver state.
     for _ in 0..3 {
-        target.render(clear, Some(&pipeline)).expect("warmup frame");
+        target
+            .render(&RenderDesc::new(clear).pipeline(&pipeline))
+            .expect("warmup frame");
         target.read_back_into(&mut pixels);
     }
 
@@ -105,7 +108,9 @@ fn steady_state_frames_allocate_nothing() {
     for _ in 0..5 {
         let before = ALLOCATIONS.load(Ordering::Relaxed);
         for _ in 0..16 {
-            target.render(clear, Some(&pipeline)).expect("steady frame");
+            target
+                .render(&RenderDesc::new(clear).pipeline(&pipeline))
+                .expect("steady frame");
             target.read_back_into(&mut pixels);
         }
         let after = ALLOCATIONS.load(Ordering::Relaxed);

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -12,7 +12,8 @@ use renew_frame::{
 };
 use renew_platform::Clock;
 use renew_rhi::{
-    AdapterInfo, Device, DeviceDesc, Extent, PipelineDesc, RenderPipeline, Validation, builtin,
+    AdapterInfo, Device, DeviceDesc, Extent, PipelineDesc, RenderDesc, RenderPipeline, Validation,
+    builtin,
 };
 
 use crate::cli::{Options, Report};
@@ -148,10 +149,11 @@ impl HeadlessRun {
             self.world.step(step);
         }
         let clear = clear_color(&self.world, plan.alpha());
-        let drawn = self
-            .surface
-            .render(clear, self.pipeline.as_ref())
-            .map_err(render_error)?;
+        let mut desc = RenderDesc::new(clear);
+        if let Some(pipeline) = self.pipeline.as_ref() {
+            desc = desc.pipeline(pipeline);
+        }
+        let drawn = self.surface.render(&desc).map_err(render_error)?;
         self.stats.absorb(&plan);
         let cpu = self.clock.elapsed_nanos().saturating_sub(started);
         self.timing.record(Nanos::from_nanos(cpu), drawn);
@@ -172,9 +174,11 @@ impl HeadlessRun {
     /// [`SampleError::Failed`] if the renderer could not draw.
     pub fn redraw(&mut self) -> Result<(), SampleError> {
         let clear = clear_color(&self.world, Alpha::ZERO);
-        self.surface
-            .render(clear, self.pipeline.as_ref())
-            .map_err(render_error)?;
+        let mut desc = RenderDesc::new(clear);
+        if let Some(pipeline) = self.pipeline.as_ref() {
+            desc = desc.pipeline(pipeline);
+        }
+        self.surface.render(&desc).map_err(render_error)?;
         Ok(())
     }
 

--- a/samples/hello_triangle/src/render.rs
+++ b/samples/hello_triangle/src/render.rs
@@ -1,7 +1,7 @@
 //! Where a frame goes, and the colour it goes there with.
 
 use renew_frame::Alpha;
-use renew_rhi::{Color, OffscreenTarget, RenderPipeline, TargetError, TargetFormat};
+use renew_rhi::{Color, OffscreenTarget, RenderDesc, TargetError, TargetFormat};
 #[cfg(feature = "window")]
 use renew_rhi::{PresentOutcome, WindowTarget};
 
@@ -45,16 +45,12 @@ impl Surface {
     ///
     /// [`TargetError`] as the renderer reports it: a lost device, a
     /// timed-out submission, an exhausted heap.
-    pub fn render(
-        &mut self,
-        clear: Color,
-        pipeline: Option<&RenderPipeline>,
-    ) -> Result<bool, TargetError> {
+    pub fn render(&mut self, desc: &RenderDesc<'_>) -> Result<bool, TargetError> {
         match self {
-            Self::Offscreen(target) => target.render(clear, pipeline).map(|()| true),
+            Self::Offscreen(target) => target.render(desc).map(|()| true),
             #[cfg(feature = "window")]
             Self::Window(target) => target
-                .render(clear, pipeline)
+                .render(desc)
                 .map(|outcome| outcome == PresentOutcome::Presented),
         }
     }

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -23,7 +23,8 @@ use renew_platform::window::{
     run_window_app,
 };
 use renew_rhi::{
-    Device, DeviceDesc, Extent, PipelineDesc, RenderPipeline, TargetError, Validation, builtin,
+    Device, DeviceDesc, Extent, PipelineDesc, RenderDesc, RenderPipeline, TargetError, Validation,
+    builtin,
 };
 
 use crate::cli::{Options, Report};
@@ -192,7 +193,11 @@ impl TriangleApp {
             return;
         };
         let clear = clear_color(&self.world, self.alpha);
-        let outcome = surface.render(clear, self.pipeline.as_ref());
+        let mut desc = RenderDesc::new(clear);
+        if let Some(pipeline) = self.pipeline.as_ref() {
+            desc = desc.pipeline(pipeline);
+        }
+        let outcome = surface.render(&desc);
         self.record_draw(outcome);
     }
 


### PR DESCRIPTION
`render` took the clear colour and the pipeline **positionally**, in three mirrored implementations across two crates, with no way to add a frame-level parameter without breaking every caller. Several are already known to be coming — an in-flight policy, a load operation, a viewport, a colour-space override — and each would have broken the same forty-odd sites again.

It now takes one `#[non_exhaustive]` descriptor, built through `RenderDesc::new(clear)` with a `pipeline` builder. **This is intended to be the last breaking change to that signature**: every future frame-level parameter is a builder method touching no existing caller.

### One descriptor for both targets, not one each

`RenderPipeline` already crosses both targets carrying a field only one of them can satisfy, and each target refuses a mismatch with its own `debug_assert!` beside its device check. So "one descriptor, target-specific fields validated at the target" is not a pattern being invented here — it is the one this crate already uses for its closest analogue. Splitting it would leave two conventions for one question.

### Three smaller decisions worth flagging

**`Debug` is hand-written.** `RenderPipeline` has none, and a driver handle's address is not information, so the descriptor reports *whether* a pipeline is bound rather than which.

**Callers holding an optional pipeline expand to an explicit conditional** rather than the builder accepting an `Option`. That shape is an artifact of lazy initialisation in tests and samples; a renderer holds a pipeline, and shaping the API around the other case would optimise for the wrong consumer.

**Not `Default`, same reasoning as the pipeline descriptor** — a frame with no clear colour is not a partially-configured frame.

### Migration

41 call sites migrated mechanically (two regular shapes), 5 by hand (the `Option`-holding ones). An unrelated no-arg `render()` on the JSON emitter was correctly left alone.

### Verification

Literal construction from outside the crate is rejected: `error[E0639]: cannot create non-exhaustive struct using struct expression`. Without that check the attribute is decoration. fmt clean, clippy clean under `-D warnings`, 81 suites green.