### PR TITLE
feat(rhi): run two frames in flight on the window target

### DIFF
--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -50,18 +50,55 @@ struct Chain {
     extent: Extent,
     views: Vec<vk::ImageView>,
     images: Vec<vk::Image>,
-    /// The acquire semaphore. Chain-owned so a teardown after a
-    /// mid-frame failure also retires any pending signal operation with
-    /// it — the next chain starts with a fresh, unsignaled semaphore.
-    image_available: vk::Semaphore,
+    /// One acquire semaphore **per frame in flight**, not per image.
+    ///
+    /// `vkAcquireNextImageKHR` signals this *before* the image index is
+    /// known, so indexing it by image would be circular: it belongs to
+    /// the frame slot.
+    ///
+    /// Chain-owned, as the single semaphore was and for the same
+    /// reason: a teardown after a mid-frame failure retires every
+    /// pending signal operation along with it, and the next chain starts
+    /// with fresh unsignaled semaphores. Moving the ring onto the target
+    /// so it survives a rebuild reopens that question — a semaphore
+    /// signalled against a destroyed swapchain is not simply reusable.
+    image_available: [vk::Semaphore; FRAMES_IN_FLIGHT],
     /// One per swapchain image: the present engine may still wait on
     /// the semaphore for image N after our fence signals, so per-image
     /// signaling is the simplest correct scheme.
     render_finished: Vec<vk::Semaphore>,
 }
 
-/// A window-backed render target. One frame in flight; presentation is
-/// FIFO (vsync) — the guaranteed-available mode.
+/// How many frames the CPU may have submitted and not yet waited for.
+///
+/// **Not the swapchain image count.** That is chosen by the driver and
+/// the surface; this is chosen by us, and the two are different numbers
+/// that happen to be small. Every per-frame resource below multiplies by
+/// this one; `render_finished` multiplies by the other.
+///
+/// Two rather than three: presentation is FIFO, so a third frame buys
+/// queueing depth that shows up as latency rather than throughput at this
+/// scale. A capability claim, not a measured one — no frame-time budget
+/// exists to justify a specific number yet.
+const FRAMES_IN_FLIGHT: usize = 2;
+
+/// The same count as Vulkan wants it. Derived rather than written twice,
+/// and checked where a mistake costs nothing: a second literal is a
+/// hand-maintained pair, and a runtime conversion would put a panic on
+/// the creation path for a question the compiler can answer.
+const FRAMES_IN_FLIGHT_U32: u32 = {
+    assert!(FRAMES_IN_FLIGHT <= u32::MAX as usize);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the assertion above rejects any value that would truncate, at compile time"
+    )]
+    {
+        FRAMES_IN_FLIGHT as u32
+    }
+};
+
+/// A window-backed render target. `FRAMES_IN_FLIGHT` frames in flight;
+/// presentation is FIFO (vsync) — the guaranteed-available mode.
 pub struct WindowTarget {
     shared: Rc<DeviceShared>,
     /// Keep-alive for the platform window backing `surface`.
@@ -74,13 +111,24 @@ pub struct WindowTarget {
     color_space: vk::ColorSpaceKHR,
     chain: Option<Chain>,
     pool: vk::CommandPool,
-    cmd: vk::CommandBuffer,
-    /// Created unsignaled; `fence_pending` tracks whether a submit is
-    /// outstanding on it. The invariant at every public-call boundary:
-    /// `fence_pending == false` implies the fence is unsignaled with
-    /// nothing outstanding.
-    fence: vk::Fence,
-    fence_pending: bool,
+    /// One recording per frame slot: a buffer must not be re-recorded
+    /// while a submit reading it is still outstanding.
+    cmds: [vk::CommandBuffer; FRAMES_IN_FLIGHT],
+    /// Created unsignaled; `pending[i]` tracks whether a submit is
+    /// outstanding on fence `i`. The invariant at every public-call
+    /// boundary, now per slot: **`pending[i] == false` implies fence `i`
+    /// is unsignaled with nothing outstanding.**
+    ///
+    /// Two distinct questions come off this, and they were one question
+    /// when there was one fence. *"May I record into slot i?"* is
+    /// `!pending[i]`, and it is the frame path. *"Is anything
+    /// outstanding at all?"* is `pending.iter().any(..)`, and it is the
+    /// teardown path — retiring one fence where several may be pending
+    /// is the defect this split exists to prevent.
+    fences: [vk::Fence; FRAMES_IN_FLIGHT],
+    pending: [bool; FRAMES_IN_FLIGHT],
+    /// The slot the next frame records into; advances after each submit.
+    frame: usize,
 }
 
 impl Device {
@@ -231,34 +279,54 @@ impl Device {
         let cmd_info = vk::CommandBufferAllocateInfo::default()
             .command_pool(pool)
             .level(vk::CommandBufferLevel::PRIMARY)
-            .command_buffer_count(1);
+            .command_buffer_count(FRAMES_IN_FLIGHT_U32);
         // SAFETY: category 2: pool live; info local.
         // ash sizes the vector it returns from the create info's own
         // `command_buffer_count`, so a success always carries exactly
-        // the one buffer asked for; an empty success would be a broken
-        // ash rather than a broken driver, and it reports through the
-        // same return as a driver failure rather than costing a branch
-        // of its own.
-        let allocated = unsafe { shared.device.allocate_command_buffers(&cmd_info) }
-            .and_then(|buffers| buffers.into_iter().next().ok_or(vk::Result::ERROR_UNKNOWN));
-        let cmd = match allocated {
-            Ok(cmd) => cmd,
+        // the buffers asked for; a short success would be a broken ash
+        // rather than a broken driver, and it reports through the same
+        // return as a driver failure rather than costing a branch of its
+        // own.
+        let allocated =
+            unsafe { shared.device.allocate_command_buffers(&cmd_info) }.and_then(|buffers| {
+                <[vk::CommandBuffer; FRAMES_IN_FLIGHT]>::try_from(buffers)
+                    .map_err(|_| vk::Result::ERROR_UNKNOWN)
+            });
+        let cmds = match allocated {
+            Ok(cmds) => cmds,
             Err(code) => {
                 return Err(fail_pool(self, creation("vkAllocateCommandBuffers", code)));
             }
         };
 
-        // Unsignaled: `fence_pending` starts false, and the protocol
-        // only waits when a submit is actually outstanding.
-        // SAFETY: category 2: device live; default info local.
-        let fence = match unsafe {
-            shared
-                .device
-                .create_fence(&vk::FenceCreateInfo::default(), Some(&shared.alloc_cbs()))
-        } {
-            Ok(fence) => fence,
-            Err(code) => return Err(fail_pool(self, creation("vkCreateFence", code))),
-        };
+        // Unsignaled: every `pending` entry starts false, and the
+        // protocol only waits when a submit is actually outstanding.
+        // Built one at a time so a failure part-way destroys the ones
+        // already made -- `Partial` cannot express a half-built ring.
+        let mut fences = [vk::Fence::null(); FRAMES_IN_FLIGHT];
+        for slot in 0..FRAMES_IN_FLIGHT {
+            // SAFETY: category 2: device live; default info local.
+            match unsafe {
+                shared
+                    .device
+                    .create_fence(&vk::FenceCreateInfo::default(), Some(&shared.alloc_cbs()))
+            } {
+                Ok(fence) => fences[slot] = fence,
+                Err(code) => {
+                    for made in &fences[..slot] {
+                        // SAFETY: category 2: device live; each handle
+                        // was created just above with these callbacks
+                        // and nothing has been submitted against it.
+                        unsafe {
+                            shared
+                                .device
+                                .destroy_fence(*made, Some(&shared.alloc_cbs()));
+                        }
+                    }
+                    return Err(fail_pool(self, creation("vkCreateFence", code)));
+                }
+            }
+        }
 
         let mut target = WindowTarget {
             shared: Rc::clone(shared),
@@ -271,9 +339,10 @@ impl Device {
             color_space: surface_format.color_space,
             chain: None,
             pool,
-            cmd,
-            fence,
-            fence_pending: false,
+            cmds,
+            fences,
+            pending: [false; FRAMES_IN_FLIGHT],
+            frame: 0,
         };
         // Build the initial chain; zero extents stay dormant. From here
         // the target's Drop owns cleanup on failure.
@@ -380,12 +449,13 @@ impl WindowTarget {
         // single-threaded by the crate contract; every info struct is a
         // local outliving its call.
         unsafe {
-            if self.fence_pending {
-                match self
-                    .shared
-                    .device
-                    .wait_for_fences(&[self.fence], true, FENCE_TIMEOUT_NS)
-                {
+            let frame = self.frame;
+            if self.pending[frame] {
+                match self.shared.device.wait_for_fences(
+                    &[self.fences[frame]],
+                    true,
+                    FENCE_TIMEOUT_NS,
+                ) {
                     Ok(()) => {}
                     Err(vk::Result::TIMEOUT) => {
                         return Err(TargetError::Timeout {
@@ -401,10 +471,10 @@ impl WindowTarget {
                         });
                     }
                 }
-                if let Err(code) = self.shared.device.reset_fences(&[self.fence]) {
+                if let Err(code) = self.shared.device.reset_fences(&[self.fences[frame]]) {
                     return Err(creation("vkResetFences", code));
                 }
-                self.fence_pending = false;
+                self.pending[frame] = false;
             }
 
             let Some(chain) = self.chain.as_ref() else {
@@ -413,7 +483,7 @@ impl WindowTarget {
             let acquired = self.swapchain_loader.acquire_next_image(
                 chain.swapchain,
                 FENCE_TIMEOUT_NS,
-                chain.image_available,
+                chain.image_available[frame],
                 vk::Fence::null(),
             );
             let (index, suboptimal) = match acquired {
@@ -441,29 +511,36 @@ impl WindowTarget {
             // pending signal that only the submit will retire: any
             // failure must tear the chain down (which quiesces first),
             // never merely return.
-            let slot = index as usize;
+            // The SWAPCHAIN IMAGE index -- not the frame slot, and not
+            // bounded by `FRAMES_IN_FLIGHT`. It was called `slot` until
+            // 2026-08-01, when introducing the frame ring let it shadow
+            // the frame's own slot and index frame-sized arrays by
+            // image: three images into two slots, caught by the present
+            // suites. Both names now say which they are.
+            let image_index = index as usize;
             let (Some(&image), Some(&view), Some(&finished)) = (
-                chain.images.get(slot),
-                chain.views.get(slot),
-                chain.render_finished.get(slot),
+                chain.images.get(image_index),
+                chain.views.get(image_index),
+                chain.render_finished.get(image_index),
             ) else {
                 return Err(self.abort_frame(TargetError::Creation {
                     call: "vkAcquireNextImageKHR(index)",
                     code: 0,
                 }));
             };
-            let image_available = chain.image_available;
+            let image_available = chain.image_available[frame];
+            let cmd = self.cmds[frame];
             let swapchain = chain.swapchain;
             let chain_extent = chain.extent;
             let device = &self.shared.device;
 
             if let Err(code) =
-                device.reset_command_buffer(self.cmd, vk::CommandBufferResetFlags::empty())
+                device.reset_command_buffer(cmd, vk::CommandBufferResetFlags::empty())
             {
                 return Err(self.abort_frame(creation("vkResetCommandBuffer", code)));
             }
             if let Err(code) = device.begin_command_buffer(
-                self.cmd,
+                cmd,
                 &vk::CommandBufferBeginInfo::default()
                     .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT),
             ) {
@@ -487,7 +564,7 @@ impl WindowTarget {
                 .subresource_range(color_range());
             let barriers = [to_color];
             device.cmd_pipeline_barrier2(
-                self.cmd,
+                cmd,
                 &vk::DependencyInfo::default().image_memory_barriers(&barriers),
             );
 
@@ -511,18 +588,14 @@ impl WindowTarget {
                 },
             };
             device.cmd_begin_rendering(
-                self.cmd,
+                cmd,
                 &vk::RenderingInfo::default()
                     .render_area(area)
                     .layer_count(1)
                     .color_attachments(&attachments),
             );
             if let Some(pipeline) = pipeline {
-                device.cmd_bind_pipeline(
-                    self.cmd,
-                    vk::PipelineBindPoint::GRAPHICS,
-                    pipeline.pipeline,
-                );
+                device.cmd_bind_pipeline(cmd, vk::PipelineBindPoint::GRAPHICS, pipeline.pipeline);
                 // Extents are far below f32's exact-integer range; the
                 // casts are lossless in practice.
                 #[allow(clippy::cast_precision_loss)]
@@ -534,11 +607,11 @@ impl WindowTarget {
                     min_depth: 0.0,
                     max_depth: 1.0,
                 };
-                device.cmd_set_viewport(self.cmd, 0, &[viewport]);
-                device.cmd_set_scissor(self.cmd, 0, &[area]);
-                device.cmd_draw(self.cmd, 3, 1, 0, 0);
+                device.cmd_set_viewport(cmd, 0, &[viewport]);
+                device.cmd_set_scissor(cmd, 0, &[area]);
+                device.cmd_draw(cmd, 3, 1, 0, 0);
             }
-            device.cmd_end_rendering(self.cmd);
+            device.cmd_end_rendering(cmd);
 
             // COLOR_ATTACHMENT_OPTIMAL → PRESENT_SRC; the signal
             // semaphore orders presentation, so no destination stage.
@@ -553,18 +626,18 @@ impl WindowTarget {
                 .subresource_range(color_range());
             let barriers = [to_present];
             device.cmd_pipeline_barrier2(
-                self.cmd,
+                cmd,
                 &vk::DependencyInfo::default().image_memory_barriers(&barriers),
             );
 
-            if let Err(code) = device.end_command_buffer(self.cmd) {
+            if let Err(code) = device.end_command_buffer(cmd) {
                 return Err(self.abort_frame(creation("vkEndCommandBuffer", code)));
             }
 
             let wait_infos = [vk::SemaphoreSubmitInfo::default()
                 .semaphore(image_available)
                 .stage_mask(vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT)];
-            let cmd_infos = [vk::CommandBufferSubmitInfo::default().command_buffer(self.cmd)];
+            let cmd_infos = [vk::CommandBufferSubmitInfo::default().command_buffer(cmd)];
             let signal_infos = [vk::SemaphoreSubmitInfo::default()
                 .semaphore(finished)
                 .stage_mask(vk::PipelineStageFlags2::ALL_COMMANDS)];
@@ -572,7 +645,9 @@ impl WindowTarget {
                 .wait_semaphore_infos(&wait_infos)
                 .command_buffer_infos(&cmd_infos)
                 .signal_semaphore_infos(&signal_infos);
-            if let Err(code) = device.queue_submit2(self.shared.queue, &[submit], self.fence) {
+            if let Err(code) =
+                device.queue_submit2(self.shared.queue, &[submit], self.fences[frame])
+            {
                 self.shared.note_result(code);
                 let error = if code == vk::Result::ERROR_DEVICE_LOST {
                     TargetError::DeviceLost
@@ -581,7 +656,11 @@ impl WindowTarget {
                 };
                 return Err(self.abort_frame(error));
             }
-            self.fence_pending = true;
+            self.pending[frame] = true;
+            // Advance only after a successful submit: a frame that failed
+            // to submit left its slot unused, and skipping it would leak a
+            // slot per failure.
+            self.frame = (self.frame + 1) % FRAMES_IN_FLIGHT;
 
             let swapchains = [swapchain];
             let indices = [index];
@@ -628,14 +707,39 @@ impl WindowTarget {
     /// is signaled: reset it so the unsignaled-when-not-pending
     /// invariant holds.
     fn retire_fence_after_idle(&mut self) {
-        if self.fence_pending {
-            // SAFETY: category 2: fence live; nothing outstanding after
-            // the caller's quiesce.
-            unsafe {
-                let _ = self.shared.device.reset_fences(&[self.fence]);
+        for slot in 0..FRAMES_IN_FLIGHT {
+            if self.pending[slot] {
+                // SAFETY: category 2: fence live; nothing outstanding
+                // after the caller's quiesce.
+                unsafe {
+                    let _ = self.shared.device.reset_fences(&[self.fences[slot]]);
+                }
+                self.pending[slot] = false;
             }
-            self.fence_pending = false;
         }
+    }
+
+    /// How many frames this target may have in flight at once.
+    ///
+    /// **Public because a consumer needs it, not for testing.** The
+    /// resource model requires the caller to double-buffer any buffer a
+    /// live frame may read -- the RHI deliberately owns no scratch -- and
+    /// the correct number of copies is exactly this. A consumer that
+    /// guesses two while the target runs three writes into memory the GPU
+    /// is reading.
+    #[must_use]
+    pub fn frames_in_flight(&self) -> usize {
+        FRAMES_IN_FLIGHT
+    }
+
+    /// Which slot the next frame will use, in `0..frames_in_flight()`.
+    ///
+    /// The other half of what a double-buffering consumer needs: knowing
+    /// how many copies to keep is useless without knowing which one this
+    /// frame belongs to. Advances after each successful submit.
+    #[must_use]
+    pub fn frame_slot(&self) -> usize {
+        self.frame
     }
 
     /// Build the swapchain and its per-image resources for `extent`
@@ -715,7 +819,7 @@ impl WindowTarget {
             extent: chosen,
             views: Vec::new(),
             images: Vec::new(),
-            image_available: vk::Semaphore::null(),
+            image_available: [vk::Semaphore::null(); FRAMES_IN_FLIGHT],
             render_finished: Vec::new(),
         };
         let built = self.populate_chain(&mut chain);
@@ -732,14 +836,21 @@ impl WindowTarget {
     /// for a fresh swapchain.
     fn populate_chain(&self, chain: &mut Chain) -> Result<(), TargetError> {
         let shared = &self.shared;
-        // SAFETY: category 2: device live; default info local.
-        chain.image_available = unsafe {
-            shared.device.create_semaphore(
-                &vk::SemaphoreCreateInfo::default(),
-                Some(&shared.alloc_cbs()),
-            )
+        // One per frame slot. Built in a loop rather than as an array
+        // expression because each is fallible, and a partial ring must
+        // be torn down by `destroy_chain` rather than left half-made:
+        // the nulls this started as are what makes that safe, since
+        // destroying a null handle is defined as doing nothing.
+        for slot in 0..FRAMES_IN_FLIGHT {
+            // SAFETY: category 2: device live; default info local.
+            chain.image_available[slot] = unsafe {
+                shared.device.create_semaphore(
+                    &vk::SemaphoreCreateInfo::default(),
+                    Some(&shared.alloc_cbs()),
+                )
+            }
+            .map_err(|code| creation("vkCreateSemaphore", code))?;
         }
-        .map_err(|code| creation("vkCreateSemaphore", code))?;
         // SAFETY: category 2: swapchain live.
         chain.images = unsafe { self.swapchain_loader.get_swapchain_images(chain.swapchain) }
             .map_err(|code| creation("vkGetSwapchainImagesKHR", code))?;
@@ -792,9 +903,11 @@ impl WindowTarget {
                     .device
                     .destroy_semaphore(semaphore, Some(&self.shared.alloc_cbs()));
             }
-            self.shared
-                .device
-                .destroy_semaphore(chain.image_available, Some(&self.shared.alloc_cbs()));
+            for semaphore in chain.image_available {
+                self.shared
+                    .device
+                    .destroy_semaphore(semaphore, Some(&self.shared.alloc_cbs()));
+            }
             self.swapchain_loader
                 .destroy_swapchain(chain.swapchain, Some(&self.shared.alloc_cbs()));
         }
@@ -848,9 +961,11 @@ impl Drop for WindowTarget {
         self.destroy_chain();
         // SAFETY: as above.
         unsafe {
-            self.shared
-                .device
-                .destroy_fence(self.fence, Some(&self.shared.alloc_cbs()));
+            for fence in self.fences {
+                self.shared
+                    .device
+                    .destroy_fence(fence, Some(&self.shared.alloc_cbs()));
+            }
             self.shared
                 .device
                 .destroy_command_pool(self.pool, Some(&self.shared.alloc_cbs()));

--- a/crates/rhi/tests/fault_present.rs
+++ b/crates/rhi/tests/fault_present.rs
@@ -232,6 +232,15 @@ const LADDER: &[(&str, &str, Shape)] = &[
         Shape::BuildFails(Expect::Creation("vkCreateFence")),
     ),
     (
+        // The fence ring is built one at a time, so a failure part-way
+        // must destroy the ones already made. Failing the FIRST call
+        // leaves nothing to clean up and never runs that path -- this
+        // fails the second, which is the only ordinal that exercises it.
+        "Q5b fence-ring-partial",
+        "vkCreateFence=ERROR_OUT_OF_HOST_MEMORY@2",
+        Shape::BuildFails(Expect::Creation("vkCreateFence")),
+    ),
+    (
         "Q6 surface-capabilities",
         "vkGetPhysicalDeviceSurfaceCapabilitiesKHR=ERROR_OUT_OF_HOST_MEMORY",
         Shape::BuildFails(Expect::Creation(
@@ -264,8 +273,23 @@ const LADDER: &[(&str, &str, Shape)] = &[
         Shape::BuildFails(Expect::Creation("vkCreateImageView")),
     ),
     (
-        "Q12 per-image-semaphore",
+        // RETARGETED 2026-08-01. This was named per-image and aimed at
+        // ordinal 2, which was the second per-image semaphore while the
+        // chain made exactly one acquire semaphore. The acquire ring is
+        // created first and is FRAMES_IN_FLIGHT long, so ordinal 2 is
+        // now the second acquire semaphore -- the scenario kept passing
+        // while testing a different call, which is what a process-global
+        // ordinal does when new calls appear ahead of it.
+        "Q12 acquire-ring-semaphore",
         "vkCreateSemaphore=ERROR_OUT_OF_HOST_MEMORY@2",
+        Shape::BuildFails(Expect::Creation("vkCreateSemaphore")),
+    ),
+    (
+        // The first PER-IMAGE semaphore, which now sits after the
+        // acquire ring. Kept as its own scenario rather than moving the
+        // one above, so both sides of that boundary stay covered.
+        "Q12b per-image-semaphore",
+        "vkCreateSemaphore=ERROR_OUT_OF_HOST_MEMORY@3",
         Shape::BuildFails(Expect::Creation("vkCreateSemaphore")),
     ),
     // ---- the frame: failures the chain survives --------------------

--- a/crates/rhi/tests/fault_present.rs
+++ b/crates/rhi/tests/fault_present.rs
@@ -178,7 +178,13 @@ enum Shape {
     FrameFailsGoesDormant(Expect),
     /// The first frame presents and the second fails on the frame
     /// fence; a resize quiesces, retires the fence, and presents again.
-    SecondFrameFails(Expect),
+    SlotReuseFails(Expect),
+    /// Device loss surfacing from the fence wait, which does not happen
+    /// until a slot is reused. Distinct from `DeviceLostOnFrame` because
+    /// the frame number is a function of the ring depth rather than a
+    /// constant, and a constant here silently stops testing the fence
+    /// the day the depth changes.
+    DeviceLostOnSlotReuse,
     /// Not an error at all: the swapchain is stale, so the frame asks
     /// to be resized.
     StaleSwapchain,
@@ -299,21 +305,27 @@ const LADDER: &[(&str, &str, Shape)] = &[
         "vkQueuePresentKHR=ERROR_SURFACE_LOST_KHR",
         Shape::FrameFailsGoesDormant(Expect::Creation("vkQueuePresentKHR")),
     ),
-    // ---- the frame fence: only waited on from frame two on ---------
+    // ---- the frame fence: waited only when a slot is REUSED --------
+    //
+    // With a ring of N frames in flight, the first N frames each take a
+    // fresh slot with nothing outstanding on it and wait no fence at
+    // all. The wait happens on frame N+1, when the ring wraps. These
+    // said "second frame" until 2026-08-01, which was the same statement
+    // only while N was one.
     (
         "P8 fence-timeout",
         "vkWaitForFences=TIMEOUT",
-        Shape::SecondFrameFails(Expect::Timeout("vkWaitForFences")),
+        Shape::SlotReuseFails(Expect::Timeout("vkWaitForFences")),
     ),
     (
         "P9 fence-failure",
         "vkWaitForFences=ERROR_OUT_OF_HOST_MEMORY",
-        Shape::SecondFrameFails(Expect::Creation("vkWaitForFences")),
+        Shape::SlotReuseFails(Expect::Creation("vkWaitForFences")),
     ),
     (
         "P10 reset-fences",
         "vkResetFences=ERROR_OUT_OF_HOST_MEMORY",
-        Shape::SecondFrameFails(Expect::Creation("vkResetFences")),
+        Shape::SlotReuseFails(Expect::Creation("vkResetFences")),
     ),
     // ---- stale swapchain: protocol outcomes, not errors ------------
     (
@@ -345,7 +357,7 @@ const LADDER: &[(&str, &str, Shape)] = &[
     (
         "L4 fence/device-lost",
         "vkWaitForFences=ERROR_DEVICE_LOST",
-        Shape::DeviceLostOnFrame(2),
+        Shape::DeviceLostOnSlotReuse,
     ),
     // ---- resize: the only caller of wait-idle in this path ---------
     (
@@ -569,7 +581,18 @@ fn walk(
         Shape::BuildFails(expect) => build_fails(expect, device, target, size, window),
         Shape::FrameFailsChainSurvives(expect) => frame_fails_chain_survives(expect, target),
         Shape::FrameFailsGoesDormant(expect) => frame_fails_goes_dormant(expect, target, size),
-        Shape::SecondFrameFails(expect) => second_frame_fails(expect, target, size),
+        Shape::SlotReuseFails(expect) => slot_reuse_fails(expect, target, size),
+        Shape::DeviceLostOnSlotReuse => {
+            // The ring must be full before the fence is waited at all,
+            // so the losing frame is depth + 1. Asked of a freshly built
+            // target rather than assumed.
+            let depth = match &target {
+                Ok(built) => built.frames_in_flight(),
+                Err(_) => 1,
+            };
+            let frame = u32::try_from(depth).unwrap_or(u32::MAX).saturating_add(1);
+            device_lost_on_frame(frame, device, target, size, window)
+        }
         Shape::StaleSwapchain => stale_swapchain(target, size),
         Shape::DeviceLostOnFrame(frame) => {
             device_lost_on_frame(frame, device, target, size, window)
@@ -771,19 +794,38 @@ fn frame_fails_goes_dormant(
     assert_recovers(&mut target, size)
 }
 
-fn second_frame_fails(
+/// Fill the ring, then fail on the frame that reuses a slot.
+///
+/// Asked of the target rather than hardcoded: the fence wait first
+/// happens on frame `frames_in_flight() + 1`, and writing that as a
+/// literal would silently stop testing the fence the day the ring
+/// changes depth -- it would just pass, on a frame that waits nothing.
+fn slot_reuse_fails(
     expect: Expect,
     target: Result<WindowTarget, TargetError>,
     size: Extent,
 ) -> Verdict {
     let mut target = built(target)?;
-    match target.render(&RenderDesc::new(CLEAR)) {
-        Ok(PresentOutcome::Presented) => {}
-        other => return Err(wrong("Presented on the first frame", &other)),
+    let depth = target.frames_in_flight();
+    for frame in 0..depth {
+        match target.render(&RenderDesc::new(CLEAR)) {
+            Ok(PresentOutcome::Presented) => {}
+            other => {
+                return Err(wrong(
+                    &format!("Presented on frame {} of the first {depth}", frame + 1),
+                    &other,
+                ));
+            }
+        }
     }
     match target.render(&RenderDesc::new(CLEAR)) {
         Err(error) => expect.matched(&error)?,
-        Ok(outcome) => return Err(wrong("an error on the second frame", &outcome)),
+        Ok(outcome) => {
+            return Err(wrong(
+                &format!("an error on frame {}, the first to reuse a slot", depth + 1),
+                &outcome,
+            ));
+        }
     }
     assert_recovers(&mut target, size)
 }

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -27,6 +27,8 @@ struct SmokeApp {
     frames: u32,
     updates: u32,
     cycled: bool,
+    /// Bitmask of the frame slots observed across the run.
+    slots_seen: u32,
     skip: Option<String>,
     failure: Option<String>,
 }
@@ -44,6 +46,7 @@ impl SmokeApp {
             frames: 0,
             updates: 0,
             cycled: false,
+            slots_seen: 0,
             skip: None,
             failure: None,
         }
@@ -174,6 +177,13 @@ impl WindowApp for SmokeApp {
                 if let Some(pipeline) = self.pipeline.as_ref() {
                     desc = desc.pipeline(pipeline);
                 }
+                // The ring must actually cycle. A ring stuck on slot
+                // zero is still *correct* -- every frame just waits its
+                // own fence and the pipeline serialises -- so no other
+                // assertion here can tell the difference. Record which
+                // slots were used and check at the end that more than
+                // one was.
+                self.slots_seen |= 1u32 << target.frame_slot();
                 match target.render(&desc) {
                     Ok(PresentOutcome::Presented) => self.frames += 1,
                     Ok(PresentOutcome::NeedsResize) => {
@@ -250,6 +260,11 @@ fn main() {
         std::process::exit(1);
     }
     assert!(app.frames >= FRAMES_WANTED);
+    assert!(
+        app.slots_seen.count_ones() > 1,
+        "the frame ring never advanced past one slot ({:#b}); frames pipeline correctly but          serially, which no other assertion here can detect",
+        app.slots_seen
+    );
     // State the oracle in the output: "validation on" means the frames
     // above ran under the layer (with synchronization checking) and the
     // zero-error verdict is meaningful, not vacuous.

--- a/samples/hello_triangle/src/render.rs
+++ b/samples/hello_triangle/src/render.rs
@@ -15,6 +15,18 @@ use crate::world::World;
 /// engine chose; inventing a second one in another crate — with exactly
 /// one implementation behind it — would be an interface built to dodge a
 /// dependency.
+///
+/// **Not boxed, deliberately.** The window variant is the larger of the
+/// two and grew when the target gained a frame ring — 320 bytes against
+/// 96. Boxing would trade 224 bytes of stack, on a value held exactly
+/// once for the lifetime of the sample, for a heap allocation at creation
+/// and a pointer chase on **every frame**. That is the wrong direction on
+/// the one path this crate is here to measure, and the allocation gate on
+/// the window path now watches it.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "one long-lived value; indirection would cost a pointer chase per frame to save stack               bytes that are never duplicated"
+)]
 pub enum Surface {
     Offscreen(OffscreenTarget),
     #[cfg(feature = "window")]


### PR DESCRIPTION
The window target ran one frame at a time: submit, wait, repeat. The CPU sat idle while the GPU drew and the GPU sat idle while the CPU recorded. Command buffers, fences and acquire semaphores now come in rings of two.

### There are two counts, and they are not the same number

**Frames in flight** is chosen by us; **swapchain images** are chosen by the driver and the surface. Command buffers, fences and acquire semaphores multiply by the first; the present-completion semaphores stay per image, as their own comment already explained.

The acquire semaphore is the one that gets this wrong, and the reason is structural: `vkAcquireNextImageKHR` signals it **before the image index is known**, so indexing it by image is circular. It belongs to the frame slot.

**I walked into this while implementing it.** A pre-existing local named `slot` held the *image* index, and my frame slot shadowed it — so frame-sized arrays got indexed by image. Three images into two slots, caught immediately by the present suites: `index out of bounds: the len is 2 but the index is 2`. Both names now say which they are.

### Semaphore ownership

The acquire semaphores stay **owned by the swapchain**, as the single one was. A teardown after a mid-frame failure retires every pending signal along with them. Moving the ring onto the target so it survives a rebuild reopens a solved problem: a semaphore signalled against a destroyed swapchain is not simply reusable, and re-deriving safety for that lands back here with extra steps.

### One predicate becomes two

The outstanding-submit flag becomes a per-slot array, and that splits one question into two: *"may I record into this slot"* (the frame path) and *"is anything outstanding at all"* (the teardown path). **Retiring one fence where several may be pending is the defect that split prevents.**

### Two public accessors, for a consumer rather than a test

The resource model requires callers to double-buffer anything a live frame may read — the RHI deliberately owns no scratch — and doing that needs both the depth and the current slot. A consumer that guesses two while the target runs three writes into memory the GPU is reading.

### Verification

- Ten frames on real glass with validation **required** and synchronization validation chained.
- The window allocation gate still reports zero on the frame path.
- **A new assertion that the ring actually advances.** A ring pinned to one slot is still *correct* — every frame waits its own fence and the pipeline serialises — so no other assertion here could tell the difference. Bite-tested by pinning it: `the frame ring never advanced past one slot (0b1)`.

Also in the diff: a runtime `expect` on a compile-time constant replaced with a const-block derivation (a panic on the creation path for a question the compiler can answer), and the sample's two-variant enum documented rather than boxed — 320 bytes against 96, held once, where indirection would cost a pointer chase per frame to save stack bytes that are never duplicated.

fmt clean, clippy clean under `-D warnings`, 81 suites green.