### PR TITLE
ci: ask whether the lockfile still describes the manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # FIRST, before any other cargo command. Every other invocation in
+      # this file resolves dependencies and rewrites Cargo.lock in place
+      # if it disagrees with the manifests -- so a --locked check placed
+      # after one of them would pass on a lock the previous step had just
+      # silently repaired, and would report success about nothing.
+      #
+      # Why this exists: a change added a dev-dependency without
+      # committing the lockfile update. Thirteen checks went green and
+      # `cargo --locked` failed outright on the merged result. No lane
+      # asked, so nothing failed. This asks.
+      #
+      # `metadata` rather than `build`: it resolves the whole graph and
+      # refuses, costs seconds, and needs nothing compiled.
+      - name: Check the lockfile still describes the manifests
+        run: cargo metadata --locked --format-version 1 > /dev/null
       - name: Check workspace structure
         run: cargo run --package renew-cli --bin renew -- check
 


### PR DESCRIPTION
No lane asked. A change added a dev-dependency without committing the lockfile update, **thirteen checks went green**, and `cargo --locked` failed outright on the merged result. The one property a lockfile exists to provide was unenforced at the moment it broke.

One job, one command, seconds, nothing compiled. `metadata` resolves the whole graph and **refuses**; every other cargo invocation in this file resolves and **rewrites the lock in place** instead.

### Where the step goes is the load-bearing part

Placed after any other cargo command, it would pass on a lock the previous step had just silently repaired — reporting success about nothing. It runs **first**, before anything else touches cargo.

### Not added to every job

Once one job asks the question the rest add nothing, and the every-job version carries a real behaviour change: a legitimately updated lock would redden unrelated work until committed. That was the version worth arguing about; this one isn't.

### Verification

Removed the same line whose absence caused the incident, then ran the exact command the step runs:

```
error: cannot update the lock file ... because --locked was passed to prevent this
```

exit 101. Reverted byte-for-byte afterwards.

Also verified independently today: a fresh clone of `main` passes `cargo test --workspace --locked --offline` — 81 suites, 883 tests — which is the property this step protects.