### PR TITLE
fix(rhi): record a device lost while aborting a frame

### DIFF
--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -696,9 +696,19 @@ impl WindowTarget {
     fn abort_frame(&mut self, error: TargetError) -> TargetError {
         // SAFETY: category 2: device live; best-effort — the target is
         // going dormant regardless.
-        unsafe {
-            let _ = self.shared.device.device_wait_idle();
-        }
+        let idle = unsafe { self.shared.device.device_wait_idle() };
+        // Best effort about *recovering*, not about *reporting*. Every
+        // other quiesce in this crate records a lost device on the
+        // shared spine, and this one discarded the result entirely — so
+        // a device lost while tearing a frame down left the flag clear
+        // and nothing afterwards reported it.
+        //
+        // Handed the outcome unconditionally rather than through a
+        // branch: `note_result` ignores every code but the lost-device
+        // one, so this records exactly what matters and stays a line
+        // that always runs.
+        self.shared
+            .note_result(idle.err().unwrap_or(vk::Result::SUCCESS));
         self.retire_fence_after_idle();
         self.destroy_chain();
         error


### PR DESCRIPTION
Every other quiesce in this crate hands its result to the shared spine, so a lost device is remembered. The frame-abort path discarded it entirely — a device lost while tearing down a failed frame left the flag clear, and nothing afterwards reported it. `resize`, which performs the same quiesce two functions away, has always checked.

**It matters beyond consistency.** Aborting clears every pending slot on the strength of a wait that may not have succeeded, which would leave the target claiming nothing is outstanding while something is. `render` refuses outright on a lost device — so recording the loss is also what makes that claim *unobservable* rather than merely unlikely.

The outcome is handed over unconditionally rather than through a branch: the recorder ignores every result except the lost-device one, so this records exactly what matters and stays a line that always runs instead of an arm nothing can reach.

**Not regression-tested**, and the reason is mechanical rather than a choice: reaching it needs a frame to fail *and* the following wait to fail as well — two simultaneous injected faults, and the injection layer fires one per run.
