### PR TITLE
test(rhi): give the texture failure ladder its own letter

### DIFF
--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -603,7 +603,7 @@ fn every_driver_failure_ladder_behaves() {
         }));
     }
 
-    // ---- E · texture upload ladder ---------------------------------
+    // ---- T · texture upload ladder ---------------------------------
     // Every fallible call `create_texture` makes, in the order it makes
     // them. The upload is synchronous and owns transient staging state,
     // so each failure must both surface the right call and leave
@@ -611,166 +611,166 @@ fn every_driver_failure_ladder_behaves() {
     // case by `device_case`, is what actually proves.
     let texture_ladder: &[(&str, &str, &str, bool)] = &[
         (
-            "E1",
+            "T1",
             "vkCreateImage=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateImage",
             false,
         ),
         (
-            "E2",
+            "T2",
             "vkAllocateMemory=ERROR_OUT_OF_DEVICE_MEMORY",
             "vkAllocateMemory(texture)",
             true,
         ),
         (
-            "E3",
+            "T3",
             "vkBindImageMemory=ERROR_OUT_OF_HOST_MEMORY",
             "vkBindImageMemory",
             false,
         ),
         (
-            "E4",
+            "T4",
             "vkCreateImageView=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateImageView",
             false,
         ),
         (
-            "E5",
+            "T5",
             "vkCreateBuffer=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateBuffer",
             false,
         ),
         (
-            "E6",
+            "T6",
             "vkAllocateMemory=ERROR_OUT_OF_HOST_MEMORY@2",
             "vkAllocateMemory(staging)",
             false,
         ),
         (
-            "E7",
+            "T7",
             "vkBindBufferMemory=ERROR_OUT_OF_HOST_MEMORY",
             "vkBindBufferMemory",
             false,
         ),
         (
-            "E8",
+            "T8",
             "vkMapMemory=ERROR_OUT_OF_HOST_MEMORY",
             "vkMapMemory",
             false,
         ),
         (
-            "E9",
+            "T9",
             "vkCreateCommandPool=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateCommandPool",
             false,
         ),
         (
-            "E10",
+            "T10",
             "vkAllocateCommandBuffers=ERROR_OUT_OF_HOST_MEMORY",
             "vkAllocateCommandBuffers",
             false,
         ),
         (
-            "E11",
+            "T11",
             "vkCreateFence=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateFence",
             false,
         ),
         (
-            "E12",
+            "T12",
             "vkBeginCommandBuffer=ERROR_OUT_OF_HOST_MEMORY",
             "vkBeginCommandBuffer",
             false,
         ),
         (
-            "E13",
+            "T13",
             "vkEndCommandBuffer=ERROR_OUT_OF_HOST_MEMORY",
             "vkEndCommandBuffer",
             false,
         ),
         (
-            "E14",
+            "T14",
             "vkQueueSubmit2=ERROR_OUT_OF_HOST_MEMORY",
             "vkQueueSubmit2",
             false,
         ),
         (
-            "E15",
+            "T15",
             "vkWaitForFences=ERROR_OUT_OF_HOST_MEMORY",
             "vkWaitForFences(texture upload)",
             false,
         ),
     ];
-    // E16 is the same call reporting the one non-error outcome that is
+    // T16 is the same call reporting the one non-error outcome that is
     // still a failure for us: the upload did not finish in time. It sits
     // outside the table because its verdict is a different variant — a
     // timeout is not a creation error, and folding it in would hide the
     // case where a driver merely needs longer.
-    verdicts.push(device_case("E16", "vkWaitForFences=TIMEOUT", |device| {
+    verdicts.push(device_case("T16", "vkWaitForFences=TIMEOUT", |device| {
         match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
             Err(TargetError::Timeout {
                 call: "vkWaitForFences(texture upload)",
             }) => {}
             Err(other) => {
                 return Err(wrong(
-                    "E16",
+                    "T16",
                     "Timeout(vkWaitForFences(texture upload))",
                     &other,
                 ));
             }
             Ok(_) => {
-                return Err("E16: the upload reported success despite timing out".to_owned());
+                return Err("T16: the upload reported success despite timing out".to_owned());
             }
         }
         device
             .create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS))
             .map(|_| ())
-            .map_err(|error| format!("E16: recovery upload failed: {error}"))
+            .map_err(|error| format!("T16: recovery upload failed: {error}"))
     }));
 
-    // E17 is the one submit failure that must do more than report: a
+    // T17 is the one submit failure that must do more than report: a
     // lost device has to be recorded on the shared spine, or every
     // later render passes its own guard and submits to a dead device.
     // Asserted through a second call, because the poison flag is not
     // public and its whole purpose is what the *next* call does.
     verdicts.push(device_case(
-        "E17",
+        "T17",
         "vkQueueSubmit2=ERROR_DEVICE_LOST",
         |device| {
             match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
                 Err(TargetError::DeviceLost) => {}
-                Err(other) => return Err(wrong("E17", "DeviceLost", &other)),
-                Ok(_) => return Err("E17: the upload survived a lost device".to_owned()),
+                Err(other) => return Err(wrong("T17", "DeviceLost", &other)),
+                Ok(_) => return Err("T17: the upload survived a lost device".to_owned()),
             }
             match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
                 Err(TargetError::DeviceLost) => Ok(()),
-                Err(other) => Err(wrong("E17", "DeviceLost on the next call", &other)),
+                Err(other) => Err(wrong("T17", "DeviceLost on the next call", &other)),
                 Ok(_) => {
-                    Err("E17: the device was not poisoned, so the next upload proceeded".to_owned())
+                    Err("T17: the device was not poisoned, so the next upload proceeded".to_owned())
                 }
             }
         },
     ));
 
-    // E18 is the same loss reported one call later. The submit succeeds
+    // T18 is the same loss reported one call later. The submit succeeds
     // and the *wait* discovers the device is gone, which is a separate
-    // arm with its own quiesce — E17 cannot reach it, and a loss that
+    // arm with its own quiesce — T17 cannot reach it, and a loss that
     // only surfaces at the fence is the ordinary way a GPU hang is
     // reported.
     verdicts.push(device_case(
-        "E18",
+        "T18",
         "vkWaitForFences=ERROR_DEVICE_LOST",
         |device| {
             match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
                 Err(TargetError::DeviceLost) => {}
-                Err(other) => return Err(wrong("E18", "DeviceLost", &other)),
-                Ok(_) => return Err("E18: the upload survived a lost device".to_owned()),
+                Err(other) => return Err(wrong("T18", "DeviceLost", &other)),
+                Ok(_) => return Err("T18: the upload survived a lost device".to_owned()),
             }
             match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
                 Err(TargetError::DeviceLost) => Ok(()),
-                Err(other) => Err(wrong("E18", "DeviceLost on the next call", &other)),
+                Err(other) => Err(wrong("T18", "DeviceLost on the next call", &other)),
                 Ok(_) => {
-                    Err("E18: the device was not poisoned, so the next upload proceeded".to_owned())
+                    Err("T18: the device was not poisoned, so the next upload proceeded".to_owned())
                 }
             }
         },


### PR DESCRIPTION
The fault suite reports failures by scenario name — that name is the whole mechanism for saying what broke. The texture upload ladder was labelled `E1` through `E18` while an instance-and-device ladder already occupied `E1` through `E8`. Two unrelated scenarios answered to `E5`, two to `E6`, and a failure message naming either was ambiguous about which had failed.

Renamed to `T1`–`T18`.

**The rename is scoped to the ladder's own lines rather than applied by pattern**, and that is not fussiness: the older scenarios emit messages of the same shape (`"E5: frame after a failed wait-idle"`), and a first attempt by pattern rewrote three of theirs. Verified afterwards that every scenario label in the file is unique and that the pre-existing `E` ladder is untouched.
