### PR TITLE
test(hello_triangle): report the allocation counters after the run

### DIFF
--- a/samples/hello_triangle/tests/zero_alloc.rs
+++ b/samples/hello_triangle/tests/zero_alloc.rs
@@ -116,6 +116,25 @@ fn steady_state_frames_allocate_nothing() {
     })
     .expect("planning, stepping, drawing and tallying stay heap-silent");
 
+    // Printed for the record, never gated — the same terms the render
+    // backend reports its own ledgers on.
+    //
+    // **This is the only place a sample's peak is observable.** The
+    // figure comes from the counting allocator, which has to *be* the
+    // process allocator, so a shipped sample cannot carry it: the cost
+    // would land in delivered code to serve a measurement. A test
+    // binary can, and this one already runs the sample's real headless
+    // loop, so the number was one line away the whole time.
+    //
+    // Never asserted on: a peak is a property of the whole process,
+    // this harness included, while the assertion above is about the
+    // frame path alone. Gating on it would make an unrelated change to
+    // the test fail the test.
+    eprintln!(
+        "engine allocation counters after the steady state: {:?}",
+        counters::snapshot()
+    );
+
     // The window did real work: without this the test would pass on a
     // driver that returned early from every frame.
     let report = run.report();


### PR DESCRIPTION
This suite already installs the counting allocator as the process allocator and drives the sample's real headless loop. It compared allocation *counts* and never printed the snapshot — so the peak byte figure was one line away.

That figure matters because this is **the only place a sample's peak is observable**: `peak_bytes` is written solely by the counting allocator, which must be the process `#[global_allocator]`. A test binary can install one; a shipped sample must not, since the cost would land in delivered code purely to serve a measurement.

Printed on the same terms the render backend reports its own ledgers: for the record, never gated. A peak is a property of the whole process — this harness included — while the assertion above it is about the frame path alone. Gating on it would let an unrelated change to the test fail the test.
