### PR TITLE
feat(event): give the event vocabulary its own crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
           cargo test $sel
       - name: Build and test the minimal core alone
         run: |
-          sel="-p renew-platform -p renew-diag -p renew-memory -p renew-math"
+          sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
           for optional in renew-rhi renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-event"
+version = "0.1.0"
+
+[[package]]
 name = "renew-frame"
 version = "0.1.0"
 dependencies = [
@@ -1441,7 +1445,7 @@ name = "renew-input"
 version = "0.1.0"
 dependencies = [
  "proptest",
- "renew-platform",
+ "renew-event",
 ]
 
 [[package]]
@@ -1473,6 +1477,7 @@ name = "renew-platform"
 version = "0.1.0"
 dependencies = [
  "raw-window-handle",
+ "renew-event",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -56,12 +56,12 @@ reason = "A release-mode refusal guarded by a debug assertion on the same condit
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [348, 349]
+lines = [358, 359]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [641]
+lines = [651]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]

--- a/crates/core/event/Cargo.toml
+++ b/crates/core/event/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "renew-event"
+description = "The engine's event vocabulary as plain data, with no dependencies"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The event vocabulary — key codes, pointer buttons and event shapes — as dependency-free plain data."
+maturity = "internal"
+core = true
+extension_points = []
+simulation = false
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/core/event/README.md
+++ b/crates/core/event/README.md
@@ -1,0 +1,76 @@
+# renew-event
+
+The engine's event vocabulary: what happened, as plain data. Three
+enums — `WindowEvent`, `KeyCode`, `PointerButton` — plus `EVERY_EVENT_SHAPE`
+and `shape_index` over it.
+
+No dependencies. Nothing here can make anything happen.
+
+## Contract
+
+**This crate can never acquire a way to observe the outside world.**
+That is what it is for, and it is checked rather than promised: a crate
+declaring that its output depends only on build, seed and input may
+depend on this one, and the ban it lives under is enforced over the
+dependency graph. Adding a dependency here would defeat that guarantee
+for every such crate at once.
+
+The manifest declares no dependencies and must keep declaring none.
+
+## Why it is a separate crate
+
+The vocabulary used to be a module inside the platform crate, beside the
+clock, the filesystem and thread spawning, marked *"deliberately not
+behind the `window` feature"*.
+
+That comment was describing the right instinct with the wrong mechanism.
+A feature gate is a convention — whoever writes the next manifest can
+forget it, and nothing that inspects the dependency graph can see it.
+**A crate boundary is a fact that graph can read.** The isolation it
+describes only became real, rather than intended, when the boundary
+moved.
+
+The types are also not a platform capability in the first place. A key
+code describes something that happened; it cannot cause anything. It sat
+next to three doorways to non-determinism because everything in that
+crate was "platform-ish", and that shared address was the entire reason
+the dependency edge could not simply be forbidden.
+
+## Thread safety
+
+Every type here is a plain `Copy` value with no interior mutability and
+no shared state. They are `Send` and `Sync` by construction, and there is
+nothing to synchronise.
+
+## Relationship to `renew-platform`
+
+`renew-platform` re-exports this crate as its `event` module, so every
+path a consumer already uses keeps working. Code that *produces* these
+values from the operating system lives there and does need a windowing
+library; the vocabulary itself does not.
+
+**The re-export makes `renew-platform` a downstream crate of enums it
+used to define.** The enums are `#[non_exhaustive]`, which binds
+downstream crates only — so the platform crate may still *construct*
+these values, as its translation code does, but may no longer match on
+them exhaustively.
+
+## Testing
+
+Unit tests cover the one invariant with a way to go wrong: that
+`EVERY_EVENT_SHAPE` lists each shape exactly once and in the order
+`shape_index` returns.
+
+Not applicable, recorded rather than skipped silently:
+
+- **Property tests** — not math, containers, or allocators.
+- **Fuzz target** — nothing here parses external data. These values are
+  built by translation from an OS event, never decoded from bytes, so
+  the untrusted-input obligation does not reach this crate.
+- **Determinism test** — no state and no clock; the crate declares
+  `simulation = false` precisely because it has no simulation to run.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies
+and extension points. Read it there rather than here.

--- a/crates/core/event/README.md
+++ b/crates/core/event/README.md
@@ -8,14 +8,22 @@ No dependencies. Nothing here can make anything happen.
 
 ## Contract
 
-**This crate can never acquire a way to observe the outside world.**
-That is what it is for, and it is checked rather than promised: a crate
-declaring that its output depends only on build, seed and input may
-depend on this one, and the ban it lives under is enforced over the
-dependency graph. Adding a dependency here would defeat that guarantee
-for every such crate at once.
+**This crate must never acquire a way to observe the outside world.**
+A crate declaring that its output depends only on build, seed and input
+may depend on this one, and adding a dependency here would defeat that
+for every such crate at once. The manifest declares no dependencies and
+must keep declaring none.
 
-The manifest declares no dependencies and must keep declaring none.
+**What is enforced, and what is not.** The reverse edge is impossible by
+construction: `renew-platform` depends on this crate, so this crate
+cannot depend on it — a dependency cycle is rejected. **The forward
+direction is not checked yet.** Nothing currently stops a crate that
+promises determinism from adding its own edge back to `renew-platform`
+and reaching a clock through it; the extraction removed the one such
+edge that existed, and a graph rule to prevent new ones is drafted but
+not in force. Until it is, this contract is an obligation maintained by
+review rather than a property enforced by a gate — and saying so is
+worth more than the stronger sentence that used to be here.
 
 ## Why it is a separate crate
 

--- a/crates/core/event/clippy.toml
+++ b/crates/core/event/clippy.toml
@@ -1,0 +1,22 @@
+# Crate-local lint configuration: this crate is plain data — it has no
+# dependencies at all, so it cannot read a clock or touch the filesystem. (A crate-local
+# file fully replaces the workspace one, so the test allowances are
+# repeated.)
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "this crate is plain data and never reads a clock" },
+    { path = "std::time::SystemTime::now", reason = "this crate is plain data and never reads a clock" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+# The SAFETY-comment lint accepts the comment above an attribute or
+# on the statement that owns the block.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/core/event/clippy.toml
+++ b/crates/core/event/clippy.toml
@@ -1,7 +1,20 @@
-# Crate-local lint configuration: this crate is plain data — it has no
-# dependencies at all, so it cannot read a clock or touch the filesystem. (A crate-local
-# file fully replaces the workspace one, so the test allowances are
-# repeated.)
+# Crate-local lint configuration.
+#
+# **Having no dependencies is not the reason this file exists — it is the
+# reason it is not enough.** `Instant::now`, `HashMap`'s default hasher
+# and `env::var` all live in the standard library and need no dependency
+# at all, so a crate with an empty `[dependencies]` can still reach a
+# clock, unseeded randomness and the environment. The bans below are what
+# actually prevent that.
+#
+# This crate sits inside the dependency closure of a crate that declares
+# `simulation = true`, so anything it can do, that crate inherits. The
+# list is therefore the union of the pure-computation bans and the
+# non-determinism bans the marker requires — deliberately stricter than a
+# leaf crate would need on its own.
+#
+# (A crate-local file fully replaces the workspace one, so the test
+# allowances are repeated.)
 disallowed-methods = [
     { path = "std::time::Instant::now", reason = "this crate is plain data and never reads a clock" },
     { path = "std::time::SystemTime::now", reason = "this crate is plain data and never reads a clock" },
@@ -10,6 +23,20 @@ disallowed-methods = [
     { path = "std::fs::write", reason = "this crate never touches the filesystem" },
     { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
     { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "the environment is an input this crate must not read" },
+    { path = "std::env::var_os", reason = "the environment is an input this crate must not read" },
+    { path = "std::thread::spawn", reason = "plain data spawns nothing" },
+]
+
+# Unseeded randomness, which needs no dependency and would be inherited by
+# every crate downstream that promises determinism.
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "iteration order is unseeded; use a deterministic map" },
+    { path = "std::collections::HashSet", reason = "iteration order is unseeded; use a deterministic set" },
+    { path = "std::hash::RandomState", reason = "seeds itself from the operating system" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "seeds itself from the operating system" },
 ]
 
 allow-unwrap-in-tests = true

--- a/crates/core/event/src/lib.rs
+++ b/crates/core/event/src/lib.rs
@@ -6,14 +6,22 @@
 //!
 //! # Contract
 //!
-//! **This crate can never acquire a way to observe the outside world.**
-//! That is the whole reason it exists as a crate rather than a module.
-//! A crate promising its output depends only on build, seed and input
-//! may depend on this one; the ban it lives under is checked over the
-//! dependency graph, so a wrapper cannot launder a clock through it.
-//! Adding a dependency here would defeat that for every such crate at
-//! once, which is why the manifest declares none and must keep
-//! declaring none.
+//! **This crate must never acquire a way to observe the outside world**,
+//! and that obligation is the reason it exists as a crate rather than a
+//! module. A crate promising its output depends only on build, seed and
+//! input may depend on this one; adding a dependency here would defeat
+//! that for every such crate at once, which is why the manifest declares
+//! none and must keep declaring none.
+//!
+//! **How much of this is enforced, stated exactly.** The reverse edge —
+//! this crate depending on the platform crate — is impossible: the
+//! platform crate depends on this one, and a dependency cycle is
+//! rejected. That is a real check. **What is not yet checked is the
+//! forward direction**: nothing today stops a crate that promises
+//! determinism from adding its own edge back to the platform crate and
+//! reaching a clock that way. Keeping this crate dependency-free is
+//! therefore a maintained obligation, not a guaranteed one, until that
+//! rule exists.
 //!
 //! **The vocabulary used to live inside the platform crate**, beside the
 //! clock, the filesystem and thread spawning, marked "deliberately not

--- a/crates/core/event/src/lib.rs
+++ b/crates/core/event/src/lib.rs
@@ -1,14 +1,31 @@
-//! The event vocabulary — plain data, no windowing library.
+//! The engine's event vocabulary: what happened, as plain data.
 //!
-//! **Deliberately not behind the `window` feature.** These types are what
-//! a consumer speaks: a key code, a pointer button, an event shape. The
-//! code that *produces* them from the OS lives in [`crate::window`] and
-//! does need a windowing library; the vocabulary itself does not, and a
-//! headless build — a server, a replay harness, an input layer under
-//! test — should not compile one to name a key.
+//! Three enums, the list of every event shape, and the index function
+//! over it. No dependencies, no operating system, nothing that can make
+//! anything happen — a set of types describing an event, and only that.
 //!
-//! [`crate::window`] re-exports everything here, so the paths consumers
-//! already use keep working.
+//! # Contract
+//!
+//! **This crate can never acquire a way to observe the outside world.**
+//! That is the whole reason it exists as a crate rather than a module.
+//! A crate promising its output depends only on build, seed and input
+//! may depend on this one; the ban it lives under is checked over the
+//! dependency graph, so a wrapper cannot launder a clock through it.
+//! Adding a dependency here would defeat that for every such crate at
+//! once, which is why the manifest declares none and must keep
+//! declaring none.
+//!
+//! **The vocabulary used to live inside the platform crate**, beside the
+//! clock, the filesystem and thread spawning, marked "deliberately not
+//! behind the `window` feature". A feature gate is a convention the
+//! dependency graph cannot see; a crate boundary is one it can.
+//!
+//! `renew-platform` re-exports this crate as its `event` module, so
+//! every path a consumer already uses keeps working.
+
+// Diagnostics are not this crate's job; the standard output macros are
+// banned by construction, not convention.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
 
 /// The engine's event vocabulary, translated from the OS.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -23,6 +23,12 @@ default = ["window"]
 window = ["dep:winit", "dep:raw-window-handle"]
 
 [dependencies]
+# The event vocabulary this crate re-exports as its `event` module.
+# Unconditional, not behind the `window` feature: a headless build still
+# needs to name a key, and the whole point of the extraction is that
+# taking the vocabulary does not mean taking a clock.
+renew-event = { path = "../event" }
+
 # Explicit feature selection: both Linux backends and the window-handle
 # interop. Wayland client-side decorations are deliberately OFF — the
 # fallback decoration stack pulls an unmaintained font parser (caught by

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -18,13 +18,18 @@ seam.
   carries a name, and a *joined* thread's panic surfaces as an error
   naming it. Dropping the handle detaches the thread — deliberate, and
   the handle is `#[must_use]` so detaching is always a visible choice.
-- `event` (always available) — the event vocabulary itself: `WindowEvent`,
-  `KeyCode`, `PointerButton`, and the shape table that forces a new
-  variant to be handled. **Not behind the `window` feature, deliberately.**
-  Naming a key is not the same as opening a window, and a consumer that
-  only speaks the vocabulary — an input layer, a replay harness, a
-  headless server — should not compile a windowing library to do it.
-  `window` re-exports all of it, so either path works.
+- `event` — a re-export of **`renew-event`**, which owns the vocabulary:
+  `WindowEvent`, `KeyCode`, `PointerButton`, and the shape table that
+  forces a new variant to be handled. Naming a key is not the same as
+  opening a window, and a consumer that speaks only the vocabulary — an
+  input layer, a replay harness, a headless server — should take
+  `renew-event` directly and not this crate at all.
+  **It used to be a module here, kept out from behind the `window`
+  feature deliberately.** That expressed the right intent through a
+  mechanism the dependency graph cannot see: the consumer still took on
+  a crate owning a clock, a filesystem and thread spawning. A crate
+  boundary is the version of that promise a graph can read.
+  `window` re-exports it too, so every existing path works.
 - `window` (default-on feature) — one OS window, its event loop, and
   keyboard/mouse input behind an engine-only vocabulary: the OS owns
   the loop, a `WindowApp` receives translated events and drives exit

--- a/crates/core/platform/src/lib.rs
+++ b/crates/core/platform/src/lib.rs
@@ -20,9 +20,20 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 mod clock;
-/// The event vocabulary, always available — see the module docs for why
-/// it is not behind the `window` feature.
-pub mod event;
+/// The event vocabulary, re-exported from the crate that owns it.
+///
+/// **It is a neighbour, not a resident.** The types are plain data with
+/// no way to reach the operating system, and they used to live here
+/// only because everything in this crate was "platform-ish" — which is
+/// exactly what made the dependency edge onto this crate impossible to
+/// forbid. They now have their own crate with no dependencies, so a
+/// consumer that needs the vocabulary and nothing else can take it
+/// without taking a clock, a filesystem and thread spawning as well.
+///
+/// Re-exported so every path a consumer already uses keeps working. The
+/// code that *produces* these values from the OS stays here, in
+/// [`window`], and does need a windowing library.
+pub use renew_event as event;
 pub mod fs;
 pub mod thread;
 

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -35,9 +35,19 @@ impl Default for WindowConfig {
     }
 }
 
-/// The event vocabulary lives in [`crate::event`], which is not behind
-/// this feature: naming a key must not require compiling a windowing
-/// library. Re-exported here so existing paths keep working.
+/// The event vocabulary lives in its own dependency-free crate, which
+/// this crate re-exports as [`crate::event`]: naming a key must not
+/// require compiling a windowing library, and a crate boundary is the
+/// only form of that promise the dependency graph can check.
+/// Re-exported here too, so existing paths keep working.
+///
+/// **Note for anyone extending the translation below.** This crate is
+/// now *downstream* of enums it used to define, and they are
+/// `#[non_exhaustive]` — an attribute that binds downstream crates and
+/// never the defining one. Constructing these values is still fine, and
+/// is all the translation does. **Matching on one exhaustively is not**,
+/// and will fail to compile with a message that looks baffling until you
+/// remember the types moved.
 pub use crate::event::{EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index};
 
 /// What the app tells the loop each iteration.

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -27,12 +27,20 @@ simulation = true
 # compiled anyway — it simply was not linked here.
 #
 # **This crate declares `simulation = true`**, which promises its output
-# is a function of build, seed and input alone. That promise is checked
-# over the dependency graph, so the edge below is the whole of what this
-# crate may reach. Adding anything with access to the outside world
-# breaks the promise structurally rather than by convention — including,
-# and especially, re-adding the platform crate as a dev-dependency to
-# make a test compile.
+# is a function of build, seed and input alone. The edge below is the
+# whole of what it reaches for that purpose, and keeping it that way is
+# currently a rule enforced by review rather than by a check — a graph
+# rule that would enforce it is drafted and not yet in force.
+#
+# So: adding anything here with access to the outside world breaks the
+# promise, and nothing will stop you. That includes re-adding the
+# platform crate as a *dev*-dependency to make a test compile, which is
+# the easiest way to undo this without noticing.
+#
+# The dev-dependency below is the acknowledged exception: proptest pulls
+# a filesystem, OS entropy and process spawning into the test graph. It
+# is a test-only edge and no engine code can reach it, but the claim
+# here is about normal dependencies, not the whole tree.
 renew-event = { path = "../core/event" }
 
 [dev-dependencies]

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -19,10 +19,21 @@ simulation = true
 # Taking a copy of it instead would mean every caller converting at the
 # seam, and two enums that must be kept in step by hand.
 [dependencies]
-# default-features = false: this crate needs the event vocabulary, not
-# the OS event loop. An input layer must be buildable — and testable —
-# without compiling a windowing library.
-renew-platform = { path = "../core/platform", default-features = false }
+# The vocabulary, and nothing else. This used to be the platform crate
+# with `default-features = false`, which expressed the intent and did
+# not enforce it: feature selection is invisible to the dependency
+# graph, the crate on the other end still owned a clock, a filesystem
+# and thread spawning, and under a workspace build the windowing library
+# compiled anyway — it simply was not linked here.
+#
+# **This crate declares `simulation = true`**, which promises its output
+# is a function of build, seed and input alone. That promise is checked
+# over the dependency graph, so the edge below is the whole of what this
+# crate may reach. Adding anything with access to the outside world
+# breaks the promise structurally rather than by convention — including,
+# and especially, re-adding the platform crate as a dev-dependency to
+# make a test compile.
+renew-event = { path = "../core/event" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/input/README.md
+++ b/crates/input/README.md
@@ -48,12 +48,21 @@ error rather than an action that silently never fires. The bound is
 
 ## What it compiles against
 
-`renew-platform` with default features **off**: this crate needs the
-event vocabulary in `renew_platform::event`, not the OS event loop, so no
-windowing library enters its dependency graph. A build guard asserts that
-absence rather than trusting it — an input layer that dragged in a window
-system would be a strange thing to discover later, and the vocabulary was
-moved out from behind the `window` feature precisely so it cannot.
+`renew-event`, and nothing else. That crate is the event vocabulary as
+plain data and has no dependencies of its own, so no windowing library —
+and no clock, filesystem or thread spawning — can enter this crate's
+dependency graph at all.
+
+**This used to be the platform crate with default features off**, which
+expressed the same intent and could not enforce it. Feature selection is
+invisible to the dependency graph; the crate on the other end still owned
+the OS capabilities whether or not this one named them; and in a
+workspace build the windowing library compiled anyway, merely unlinked
+here. A build guard asserted the absence, and was asserting something
+weaker than it appeared to.
+
+The vocabulary now has its own crate, so the isolation is a property of
+the graph rather than of a manifest flag someone must remember to set.
 
 ## Thread safety and ownership
 

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```
 //! use renew_input::{Binding, InputMap};
-//! use renew_platform::event::{KeyCode, WindowEvent};
+//! use renew_event::{KeyCode, WindowEvent};
 //!
 //! #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 //! enum Action { Jump, Left }
@@ -49,7 +49,7 @@
 // belong to whoever is driving the loop.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
-use renew_platform::event::{KeyCode, PointerButton, WindowEvent};
+use renew_event::{KeyCode, PointerButton, WindowEvent};
 
 /// One physical input that can be bound to an action.
 ///

--- a/crates/input/tests/actions.rs
+++ b/crates/input/tests/actions.rs
@@ -1,8 +1,8 @@
 //! The action state machine, including the cases that make it worth
 //! having a layer here at all rather than reading keys directly.
 
+use renew_event::{KeyCode, PointerButton, WindowEvent};
 use renew_input::{ActionState, Binding, InputMap};
-use renew_platform::event::{KeyCode, PointerButton, WindowEvent};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Action {

--- a/crates/input/tests/properties.rs
+++ b/crates/input/tests/properties.rs
@@ -12,8 +12,8 @@
 
 use proptest::prelude::*;
 use proptest::test_runner::RngSeed;
+use renew_event::{KeyCode, WindowEvent};
 use renew_input::{Binding, InputMap};
-use renew_platform::event::{KeyCode, WindowEvent};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Action {

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -12,7 +12,13 @@ use crate::json::Value;
 /// The core crate list the `core` flags must agree with. Crates listed
 /// here but not yet in the workspace are fine (the list leads the code);
 /// a crate that exists must match.
-pub const CORE_CRATES: &[&str] = &["renew-diag", "renew-platform", "renew-memory", "renew-math"];
+pub const CORE_CRATES: &[&str] = &[
+    "renew-diag",
+    "renew-event",
+    "renew-platform",
+    "renew-memory",
+    "renew-math",
+];
 
 const MATURITIES: &[&str] = &["bootstrap", "internal", "stable"];
 const REQUIRED_FIELDS: &[&str] = &[


### PR DESCRIPTION
The event vocabulary sat inside the platform crate, beside the clock, the filesystem and thread spawning, marked *"deliberately not behind the `window` feature"*. That comment had the right instinct and the wrong mechanism.

A crate promising its output depends only on build, seed and input needs to name a key without acquiring a way to read the wall clock. It took the platform crate with `default-features = false`, which expressed the intent and **enforced nothing**: feature selection is invisible to the dependency graph, the crate on the other end still owned every OS capability whether or not this one named them, and under a workspace build the windowing library compiled anyway and was merely left unlinked. **A feature gate is a convention; a crate boundary is a fact the graph can read.**

The types are also not a platform capability in the first place. A key code describes something that happened and cannot cause anything. It shared an address with three doorways to non-determinism because everything in that crate was "platform-ish" — and that shared address was the entire reason the dependency edge could not simply be forbidden.

**Compatibility.** The platform crate re-exports the new crate as its `event` module, so every path a consumer already uses keeps working and the fifteen call sites that go through `window` are untouched. That does make the platform crate *downstream* of enums it used to define; since they are `#[non_exhaustive]`, it may still construct them — which is all its translation does — but may no longer match one exhaustively. A comment records this where the next person will hit it.

**Checked by trying the thing the change exists to prevent:** a function in the input crate calling the platform clock no longer compiles, where before it built clean and passed every lint.

The new crate has no dependencies, and its contract says it must never acquire any — that is what the guarantee rests on.
