### PR TITLE
docs: stop teaching the mechanism the vocabulary crate replaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,10 +267,16 @@ jobs:
           cargo build $sel
           cargo test $sel
       # The input layer names keys; it must not compile a windowing
-      # library to do it. This is the whole reason the event vocabulary
-      # sits outside the window feature, so it is guarded rather than
-      # assumed -- the crate has no feature flags, so the plain build is
-      # the only build, and winit must be absent from it.
+      # library to do it. The vocabulary now lives in its own crate with
+      # no dependencies, so the input layer reaches nothing else -- and
+      # this cell guards that rather than assuming it. The crate has no
+      # feature flags, so the plain build is the only build, and winit
+      # must be absent from it.
+      #
+      # Note what this cell does NOT cover: it checks that a windowing
+      # library is absent, not that the input layer keeps its distance
+      # from OS capabilities generally. A dependency-graph rule for the
+      # second is drafted and not yet in force.
       - name: Build and test the input layer with no windowing library
         run: |
           sel="-p renew-input"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ windowing feature compiled away.
 | Module | What it does | Maturity |
 |---|---|---|
 | **`renew-diag`** | Log records, severity levels, and the sink interface the engine reports through | `internal` · core |
+| **`renew-event`** | The event vocabulary — key codes, pointer buttons, event shapes — as plain data with no dependencies | `internal` · core |
 | **`renew-math`** | `Vec2/3/4`, `Mat4`, `Quat`, `Aabb3` — plain data, documented layout, branchless kernels | `internal` · core |
 | **`renew-memory`** | `LinearArena`, a generation-checked `Pool<T>`, and a counting global allocator | `internal` · core |
 | **`renew-platform`** | The engine's only doorway to the OS: clock, files, named threads, window | `internal` · core |

--- a/crates/trace/README.md
+++ b/crates/trace/README.md
@@ -250,21 +250,24 @@ writing the call and watching the lint fire.
   advice.** House style says an item should not repeat its crate's name:
   `renew_trace::Event`, not `renew_trace::TraceEvent`. The exception is
   taken deliberately and for one concrete reason — **the only code that
-  imports these types imports the platform's event vocabulary beside
+  imports these types imports the engine's event vocabulary beside
   them**, to translate between the two:
 
   ```rust
-  use renew_platform::event::{KeyCode, PointerButton, WindowEvent};
+  use renew_event::{KeyCode, PointerButton, WindowEvent};
   use renew_trace::{TraceButton, TraceEvent, TraceKey};
   ```
 
-  **`event`, not `window`.** Both paths resolve — `window` re-exports the
-  same items — but `window` is behind a default-on feature and `event` is
-  not, so the second form is the one that also compiles for a consumer
-  that disabled default features. That is not a hypothetical consumer:
-  a replay harness reading traces has no reason to link a windowing
-  stack, and this crate depends on nothing precisely so it never forces
-  one.
+  **`renew-event`, not the platform crate.** Three paths resolve to the
+  same items — the vocabulary crate directly, the platform crate's
+  `event` re-export, or its `window` module — and the first is the one to
+  use. It is a crate with no dependencies, so a consumer takes the
+  vocabulary and nothing else; the other two hand it a crate that owns a
+  clock, a filesystem and thread spawning as well.
+  That is not a hypothetical concern: a replay harness reading traces has
+  no reason to link a windowing stack *or* to acquire the ability to read
+  the wall clock, and this crate depends on nothing precisely so it never
+  forces either.
 
   `WindowEvent` and `TraceEvent` name two vocabularies at a seam whose
   whole job is converting one into the other. `WindowEvent` and a bare


### PR DESCRIPTION
Three shipped documents still explained the event vocabulary in terms of a feature gate — the mechanism the extraction replaced, because a dependency graph cannot see one.

The trace crate's guidance recommended importing the vocabulary *through* the platform crate, justified entirely by that gate. Both paths still resolve, but the direct one is now the right advice for the reason the guidance already cared about: a replay harness has no reason to link a windowing stack, and taking the platform crate hands it a clock and a filesystem as well.

The workflow comment describing the input-layer cell said the gate was "the whole reason" the vocabulary was reachable without a window. It also now records **what that cell does not cover** — it checks a windowing library is absent, not that the input layer keeps its distance from OS capabilities generally — which is the larger question a reader would otherwise assume it answered.

The module table on the front page listed four of five core crates.

These are the remaining nits from the adversarial review of #87; the blockers and should-fixes landed there.
