### PR TITLE
docs: four claims the vocabulary crate outdated, one already wrong

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -66,7 +66,7 @@ reason = "A test double's required method that cannot be called: its argument bo
 
 [[exempt]]
 file = "samples/input_echo/src/convert.rs"
-lines = [82, 113, 133]
+lines = [87, 118, 138]
 reason = "The wildcard arms that a non-exhaustive vocabulary forces a downstream crate to write, and the refusal one of them feeds. Every variant that exists today has its own arm above, so these are unreachable until the vocabulary grows - which is exactly when they must already be there, because the compiler will not report the new variant as unhandled in this crate. They refuse rather than folding an unknown event into a neighbouring one, so a recording can never quietly claim something that did not happen."
 
 

--- a/crates/trace/src/event.rs
+++ b/crates/trace/src/event.rs
@@ -1,13 +1,20 @@
 //! The event vocabulary: what a trace can say happened, spelled in this
 //! crate's own words.
 //!
-//! The vocabulary is owned here rather than borrowed from the windowing
-//! layer, and that is the whole reason this crate depends on nothing. A
-//! codec that named the windowing crate's event enum would pull that
-//! crate — and everything it links, an entire windowing stack — into
-//! every build that merely wants to read a file, headless ones included.
-//! It would also make the meaning of a recorded file hostage to that
-//! enum's growth: a variant added upstream would quietly change what an
+//! The vocabulary is owned here rather than borrowed, and one of the two
+//! reasons that used to be given for it is no longer true.
+//!
+//! **The dead half:** naming the engine's event enum once meant pulling
+//! in a crate that linked an entire windowing stack, in every build that
+//! merely wanted to read a file. That vocabulary now lives in a crate of
+//! its own with no dependencies at all, so borrowing it would cost
+//! nothing. Recorded rather than quietly dropped, because an argument
+//! resting on a premise that has been deleted is the kind of thing a
+//! later reader treats as still load-bearing.
+//!
+//! **The half that survives, and it was always the stronger one:**
+//! borrowing would make the meaning of a recorded file hostage to that
+//! enum's growth. A variant added upstream would quietly change what an
 //! already-written trace means. Owning the words means a new upstream
 //! variant changes only what the *conversion* in the application must
 //! handle, which is one compile error in one place.

--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -164,7 +164,8 @@ the `timing` section of `--dump-stats` and nowhere else.
 `renew-frame` has no dependency on the renderer, and this sample is
 where the two meet. Built with `--no-default-features` there is no
 windowing library and no window-system integration anywhere in its
-graph — `renew-frame`, `renew-platform` and `renew-rhi` only — and the
+graph — `renew-frame`, `renew-platform`, `renew-event` and `renew-rhi`
+only — and the
 same binary produces the same digest line as the windowed build's
 headless mode. Asking that build for a window exits non-zero and says
 why.

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -127,7 +127,9 @@ recording reproduces the run that made it.
 
 It is the complementary proof to `hello_triangle`: a *running*
 frame-loop sample in a workspace with the GPU crate removed. Its
-dependencies are `renew-frame` and `renew-platform`, and nothing else.
+dependencies are `renew-frame`, `renew-input`, `renew-platform` and
+`renew-trace` — four, where this sentence said two until 2026-08-01,
+having been written before the last two were added.
 
 ## Tests
 

--- a/samples/input_echo/src/convert.rs
+++ b/samples/input_echo/src/convert.rs
@@ -16,8 +16,13 @@
 //! fails, instead of writing a file that is quietly missing events and
 //! replays into a different world.
 //!
-//! The other half of that guarantee lives in the platform crate, which
-//! publishes one value of every shape and an exhaustive match over them.
+//! The other half of that guarantee lives in the event vocabulary crate,
+//! which publishes one value of every shape and an exhaustive match over
+//! them. It used to live in the platform crate; the vocabulary moved out
+//! into a crate of its own, and the forcing function moved with it —
+//! deliberately, because splitting the two would have meant adding a
+//! wildcard arm to that match, which compiles green and silently ends
+//! the guarantee this file depends on.
 //! Adding a variant breaks the build there, and the test at the bottom of
 //! this file then fails until this translation learns the new shape.
 


### PR DESCRIPTION
Four claims the vocabulary extraction outdated. One of them was already wrong before it.

**The trace codec's header argued for owning its vocabulary on two grounds, and the extraction deleted one.** Naming the engine's event enum no longer drags a windowing stack into a build that only wants to read a file, because that vocabulary is now a crate with no dependencies. The dead half is **marked dead rather than removed** — an argument resting on a deleted premise is exactly what a later reader takes as still load-bearing. The surviving half was always the stronger one: a recorded file's meaning must not be hostage to an upstream enum's growth.

**The input-echo converter** said the other half of its exhaustiveness guarantee lives in the platform crate. It moved with the enums, and the note now says why splitting them was never an option — it would have required a wildcard arm, which compiles green and ends the guarantee.

**The headless graph claim** in the triangle sample listed three crates and is now four.

**The input-echo dependency sentence** said two crates where the manifest declares four. That one was wrong before this change — written when it was true, and left behind twice since.
