### PR TITLE
ci: assert the input layer cannot reach the platform crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,13 +273,27 @@ jobs:
       # feature flags, so the plain build is the only build, and winit
       # must be absent from it.
       #
-      # Note what this cell does NOT cover: it checks that a windowing
-      # library is absent, not that the input layer keeps its distance
-      # from OS capabilities generally. A dependency-graph rule for the
-      # second is drafted and not yet in force.
+      # The platform crate is asserted absent too, and that is the
+      # substantive half. This crate promises its output is a function of
+      # build, seed and input alone; the lints backing that promise match
+      # a definition path in the crate being compiled, so they stop at
+      # the first wrapper. Reaching a clock through a first-party helper
+      # named nothing they look for -- which is precisely what this crate
+      # could do until the vocabulary moved out.
+      #
+      # Absence from the graph is the form of that promise nothing can
+      # talk its way around. It is asserted separately rather than added
+      # to the loop below: that loop enumerates window-system integration
+      # libraries, and the platform crate is not one.
+      #
+      # Scope, stated so nobody reads more into a green cell than it
+      # earns: this guards ONE crate. The general rule -- no crate
+      # declaring simulation may reach the platform crate by any path --
+      # needs a standards amendment and is not in force.
       - name: Build and test the input layer with no windowing library
         run: |
           sel="-p renew-input"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-platform $sel
           for wsi in winit raw-window-handle; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$wsi" $sel
           done


### PR DESCRIPTION
That cell already asserted no windowing library reaches the input layer. **The substantive absence is the platform crate itself.**

This crate promises its output is a function of build, seed and input alone. The lints backing that promise match a *definition path in the crate being compiled*, so they stop at the first wrapper — reaching a clock through a first-party helper names nothing they look for, which is exactly what this crate could do until the vocabulary moved into its own crate.

**Absence from the build graph is the form of that promise nothing can talk its way around**, and it costs one line of a guard the workflow already stages.

Asserted separately rather than appended to the loop beside it: that loop enumerates window-system integration libraries, and the platform crate is not one.

**Checked both ways** — the guard passes for the platform crate and fails when pointed at a crate that really is in the graph, so a green cell means the question was asked rather than skipped.

Scope is written into the comment so a green cell is not read as more than it earns: this guards one crate. The general rule — no crate declaring `simulation` may reach the platform crate by any path — is drafted and not in force.
