### PR TITLE
fix(cli): tell a drifted coverage exemption from a stale one

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -30,6 +30,16 @@
 # means re-checking its entry here — and if it is forgotten, the gate says
 # so, in whichever direction the mistake went.
 #
+# Drift reads as staleness, so the report distinguishes them for you. An
+# entry left behind by moved code now points at whatever occupies the old
+# number, which is usually covered — so the gate calls it covered and, on
+# its own, that reads as "delete this". It is not: the exemption is still
+# earned, at a new number. Whenever a covered-now finding shares its file
+# with lines that are uncovered and unexempted, the finding names them,
+# because that is where the code most likely went. Re-point the entry
+# instead of deleting it, and check the reason still describes what is
+# there.
+#
 # A `reason` must never cite a line number, and must name the code it
 # describes — "the keyboard arm", not "line 390". The gate reads `lines`
 # and never reads this prose, so a number written here has no guard at all

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -154,6 +154,12 @@ The ratchet runs both ways, and both fail:
   a hole in the gate on exactly the line someone once proved could not be
   closed.
 
+An entry left behind by code that moved shows up as the second of those,
+because the old number now points at whatever took its place. Deleting it
+would be wrong — the exemption is still earned, at a new line — so a
+covered-now finding also names any lines of the same file that are
+uncovered and unexempted. That is where the code most likely went.
+
 The subcommand does not run the collection: CI produces the export and
 hands it over. That keeps the command pure and fast, keeps the rule itself
 under unit test, and keeps the ignore filter in one place (the collection),

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -680,6 +680,47 @@ fn coverage_envelope(outcome: &Outcome, started: Instant) -> Value {
     ])
 }
 
+/// The unexempted gaps in one file, rendered as the parenthetical a
+/// drifted exemption needs.
+///
+/// Line numbers move when the text above them moves. The gate then reports
+/// the old line as covered — which is true, and reads as "delete this",
+/// which is wrong when the code has merely moved down. Both halves of that
+/// fact are already computed on every run; only the correlation was
+/// missing, so a developer had to delete the entry, watch the next run
+/// fail on the new line, and re-add it there.
+///
+/// The wording names the adjacent gaps and stops. A file can hold an
+/// unrelated new gap beside a genuinely dead exemption, so this is a fact
+/// offered to a reader, never an inference about what happened.
+///
+/// Capped: a collection that failed wholesale would otherwise print
+/// hundreds of line numbers into a single finding.
+fn drift_hint(outcome: &Outcome, file: &str) -> Option<String> {
+    const SHOWN: usize = 6;
+    let lines: Vec<u32> = outcome
+        .gaps
+        .iter()
+        .filter(|site| site.file == file)
+        .map(|site| site.line)
+        .collect();
+    let (shown, rest) = lines.split_at(lines.len().min(SHOWN));
+    let listed = shown
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<String>>()
+        .join(", ");
+    match (shown.len(), rest.len()) {
+        (0, _) => None,
+        (_, 0) => Some(format!(
+            " (unless the code moved: this file is uncovered and unexempted at {listed})"
+        )),
+        (_, more) => Some(format!(
+            " (unless the code moved: this file is uncovered and unexempted at {listed}, and {more} more)"
+        )),
+    }
+}
+
 /// One line per finding, in `check`'s shape, then a summary.
 fn coverage_report(outcome: &Outcome) -> String {
     let mut report = String::new();
@@ -691,12 +732,20 @@ fn coverage_report(outcome: &Outcome) -> String {
         );
     }
     for stale in &outcome.stale {
+        // Only the covered-now direction can be a drift: `FileAbsent` means
+        // the report does not measure the file at all, so it has no gaps to
+        // name and a hint would be incoherent.
+        let hint = match stale.kind {
+            coverage::StaleKind::NowCovered => drift_hint(outcome, &stale.site.file),
+            coverage::StaleKind::FileAbsent => None,
+        };
         let _ = writeln!(
             report,
-            "FAIL {:<17} {} {}",
+            "FAIL {:<17} {} {}{}",
             "stale-exemption",
             stale.site,
-            stale.kind.explanation()
+            stale.kind.explanation(),
+            hint.as_deref().unwrap_or_default()
         );
     }
     let summary = if outcome.passes() {

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -1115,6 +1115,57 @@ fn coverage_fails_on_an_exemption_whose_line_is_covered_now() {
     let _ = fs::remove_dir_all(&directory);
 }
 
+/// Lines 1 to 7 never ran; line 20 did. Enough gaps to overflow the hint.
+const SEVEN_GAPS: &str = "[1,1,7,9,0,0,0,0],[20,1,20,9,3,0,0,0]";
+
+#[test]
+fn coverage_names_the_files_other_gaps_when_an_exemption_may_have_drifted() {
+    // Drift, in the shape it actually takes: text is inserted above an
+    // exempt line, so the entry now points at covered code while the line
+    // it was written for has moved and become an unexempted gap. Both
+    // findings are true, and "delete this exemption" is the wrong
+    // instruction for them -- the entry is still earned, at a new number.
+    //
+    // Here the manifest exempts line 20, which ran; line 10, which did
+    // not, is left unexempted to stand for the moved code.
+    let directory = coverage_workspace("drift", &exempting("crates/a.rs", "[20]"), ONE_GAP)
+        .expect("scratch workspace should be creatable");
+
+    let output =
+        run_in(&directory, &["coverage", "--report", "report.json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(
+            "crates/a.rs:20 is covered now — delete this exemption (unless the code moved: \
+             this file is uncovered and unexempted at 10)"
+        ),
+        "the stale finding must name the file's remaining gaps: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
+#[test]
+fn the_drift_hint_is_capped_so_one_finding_cannot_print_every_gap() {
+    // A collection that failed wholesale leaves hundreds of gaps in one
+    // file. The hint exists to be read at a glance, so it names the first
+    // few and counts the rest rather than becoming the failure output.
+    let directory = coverage_workspace("drift-cap", &exempting("crates/a.rs", "[20]"), SEVEN_GAPS)
+        .expect("scratch workspace should be creatable");
+
+    let output =
+        run_in(&directory, &["coverage", "--report", "report.json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("unexempted at 1, 2, 3, 4, 5, 6, and 1 more)"),
+        "the hint must be capped and count the remainder: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
 #[test]
 fn coverage_fails_on_an_exemption_the_report_never_measured() {
     let directory = coverage_workspace(


### PR DESCRIPTION
An exemption entry names a line by number, so inserting text above that line leaves the entry pointing at whatever now occupies the old number. That is usually ordinary covered code, so the gate reports the entry as covered-now and prints "delete this exemption" — which is the wrong instruction. The exemption is still earned; it has simply moved.

**The verdict was never wrong.** The moved line becomes an unexempted gap in the same run, so the ratchet still fails and nothing is silently accepted. Only the advice was wrong, and both halves of the fact were already being computed and reported separately.

A covered-now finding now names the same file's uncovered, unexempted lines in its own sentence:

```
FAIL stale-exemption   crates/a.rs:20 is covered now — delete this exemption (unless the code moved: this file is uncovered and unexempted at 10)
```

It is capped, so a wholesale collection failure cannot turn one finding into a wall of numbers. The wording states the adjacent fact and stops short of claiming the code moved, because a file can hold an unrelated new gap beside a genuinely dead exemption.

### Scope

No manifest format change, no JSON schema change, no new public type, and no run whose pass/fail can flip — the change is confined to how one finding is rendered. Machine consumers already receive both arrays and can correlate them.

### Tests

Two new cases cover a shape the suite did not contain: an exemption on a covered line in a file that *still* has an unexempted gap, and the cap. Both were confirmed to fail when the hint is disabled, and the cap case additionally fails when only the cap is raised, so the two test distinct properties.

The existing covered-now test is unchanged and still passes, which is the evidence that no verdict moved. Workspace: 892 tests across 83 suites, format and clippy clean.
