### PR TITLE
docs: describe three comments by what they mean, not where it was decided

### DIFF
--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -35,8 +35,8 @@ criterion = "0.8"
 # Bench-target-only: keeps the library's dependency graph free of the
 # job pool it never uses.
 renew-jobs = { path = "../../crates/jobs" }
-# The storage decision was settled on spikes that live outside the tree;
-# nothing committed could detect a regression in what actually shipped.
+# The storage decision was settled on measurements that were never
+# committed, so nothing here could detect a regression in what shipped.
 renew-ecs = { path = "../../crates/ecs" }
 
 [lints]

--- a/bench/suite/benches/ecs.rs
+++ b/bench/suite/benches/ecs.rs
@@ -1,9 +1,9 @@
 //! Entity and component-store timings: the four shapes a system asks for.
 //!
-//! `M3`'s exit criteria call for recorded ECS baselines and there were
-//! none — the storage decision was settled on spike measurements that
-//! live outside the tree, so nothing committed here could detect the day
-//! the shipped implementation regressed.
+//! Recorded baselines for the entity and component stores were missing:
+//! the storage decision was settled on measurements that were never
+//! committed, so nothing here could detect the day the shipped
+//! implementation regressed.
 //!
 //! What is measured, and why each one rather than a round number of
 //! operations:

--- a/crates/frame/src/schedule.rs
+++ b/crates/frame/src/schedule.rs
@@ -533,7 +533,7 @@ mod tests {
         assert!((alpha - 0.5).abs() < 1e-6, "alpha was {alpha}");
     }
 
-    /// The rounding table from the design note, as a test. A naive
+    /// The rounding table the interpolation contract fixes, as a test. A naive
     /// `rem as f32 / dt as f32` returns exactly 1.0 for the 30 Hz row, and
     /// the `f64` intermediate alone still returns 1.0 for the 1 Hz row —
     /// so the explicit bound is mandatory, not defensive.


### PR DESCRIPTION
Three comments explained a decision by pointing at **where it was recorded** rather than at **what it was**. A reader of this repository cannot follow any of those pointers, so each sentence spent its words on something unavailable and left the actual reasoning implicit.

### What changed

The bench header for the entity and component stores opened by citing a planning identifier and described its evidence as living somewhere other than here; its `Cargo.toml` entry said the same thing more briefly. Both now state the useful half directly — the storage decision rested on measurements that were never committed, so nothing here could catch a regression in what shipped. **That is the entire reason the benchmark exists, and it now reads that way.**

The rounding-table test named an external document as its source. It now names the property under test, the interpolation contract, which is something a reader can actually go and check.

### Scope

Comments only, no behaviour change. Workspace: 896 tests across 83 suites, format and clippy clean.