### PR TITLE
feat(fuzz): add coverage-guided harnesses for the two untrusted parsers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,52 @@
+# Fuzzing: scheduled, and never a merge gate.
+#
+# The harnesses need the nightly toolchain for sanitizer instrumentation,
+# so a break here can be nightly moving rather than the engine regressing.
+# Gating merges on that would make an upstream change able to stop work,
+# which is why this runs on a schedule and reports instead.
+#
+# Short runs on a schedule are a smoke test, not a campaign: they catch a
+# harness that stopped building and shallow input bugs. Finding deep ones
+# needs a corpus that outlives a job, which is a later change.
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "37 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [asset_pack, trace_parse]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: taiki-e/install-action@cargo-fuzz
+      # The licence policy is checked here rather than at the root: these
+      # harnesses are a separate workspace, so the root check never
+      # resolves their dependencies and cannot see the term this allows.
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Check the harness licences
+        working-directory: fuzz
+        run: cargo deny --config ../deny.toml check licenses
+      - name: Run ${{ matrix.target }}
+        working-directory: fuzz
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=120 -print_final_stats=1
+      # A crash is the whole point of the job, so the input that caused it
+      # has to leave the runner. Without this the log says a crash happened
+      # and the bytes that caused it are deleted with the workspace.
+      - name: Keep any crashing input
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/
+          if-no-files-found: ignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 resolver = "3"
+# The fuzz harnesses are their own workspace: they link a runtime that
+# needs nightly and sanitizer instrumentation, and pulling that into the
+# stable build every merge depends on would break it.
+exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,12 @@ allow = [
 # review; this entry only permits the named crate's expression.
 exceptions = [
     { name = "unicode-ident", allow = ["Unicode-3.0"] },
+    # The fuzzing runtime vendors LLVM's libFuzzer, whose NCSA term cannot
+    # be elected away by taking the other side of the OR. Permissive, and
+    # confined to the fuzz harnesses, which are never linked into a shipped
+    # binary. The harnesses live in their own workspace, so this entry
+    # applies when the policy is checked there.
+    { name = "libfuzzer-sys", allow = ["NCSA"] },
 ]
 
 [advisories]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,43 @@
+# Deliberately its own workspace, not a member of the root one.
+#
+# A libFuzzer target links a runtime that needs the nightly toolchain and
+# sanitizer instrumentation. Making this a workspace member would put both
+# in the path of `cargo build --workspace`, which runs on stable and gates
+# every merge — so the harness would break the build it exists to protect.
+[workspace]
+
+[package]
+name = "renew-fuzz"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+renew-asset = { path = "../crates/asset" }
+renew-trace = { path = "../crates/trace" }
+
+# Fuzzing measures the parser, not the optimiser's mood. Debug assertions
+# stay on so a violated internal invariant is a finding rather than
+# undefined behaviour the harness never sees.
+[profile.release]
+debug = true
+debug-assertions = true
+overflow-checks = true
+
+[[bin]]
+name = "asset_pack"
+path = "fuzz_targets/asset_pack.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "trace_parse"
+path = "fuzz_targets/trace_parse.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,56 @@
+# renew-fuzz
+
+Fuzz harnesses for the two parsers that read data the engine did not
+write: the asset pack reader and the input-trace codec.
+
+## Why this is a separate workspace
+
+A libFuzzer target links a runtime needing the nightly toolchain and
+sanitizer instrumentation. As a workspace member it would sit in the path
+of `cargo build --workspace`, which runs on stable and gates every merge —
+so the harness would break the build it exists to protect. The root
+manifest excludes this directory by name.
+
+The consequence worth knowing: the root licence check never resolves these
+dependencies, so the scheduled job runs that check here instead.
+
+## What these add over the existing suites
+
+Both parsers already assert the property these targets test. The pack
+reader's suite says it "answers, one way or the other, for every byte
+string it can be handed"; the codec has the same over arbitrary text, plus
+a mutation property shaped like a real file.
+
+**Those run a few hundred cases from a fixed seed. These are coverage
+guided** — inputs reaching new branches are kept and mutated, so the
+fuzzer works past the magic number and the header into the entry table,
+where uniform random bytes essentially never land. That is the difference:
+not a first line of defence, a deeper one.
+
+## Running one
+
+```
+cargo fuzz run asset_pack
+cargo fuzz run trace_parse -- -max_total_time=60
+```
+
+Nightly is required. `cargo fuzz list` names the targets.
+
+## What a finding looks like
+
+A crash writes the offending input to `artifacts/<target>/`. That file is
+the bug report: it reproduces with
+
+```
+cargo fuzz run <target> artifacts/<target>/<file>
+```
+
+Keep it. A crash without its input is an anecdote, which is why the
+scheduled job uploads the directory when a run fails.
+
+## What these targets deliberately do not assert
+
+Only that the parser answers. Whether the answer is *correct* belongs to
+the round-trip properties beside each parser — a fuzz target that asserted
+on content would fail on inputs that are legitimately malformed, and the
+corpus would fill with noise.

--- a/fuzz/fuzz_targets/asset_pack.rs
+++ b/fuzz/fuzz_targets/asset_pack.rs
@@ -1,0 +1,23 @@
+//! The pack reader, against bytes nobody wrote on purpose.
+//!
+//! The reader takes a byte string from disk and hands back either a pack
+//! or a refusal. Both are answers; a panic, a hang, or a read past the
+//! end are not, and this target exists to look for those.
+//!
+//! The suite already asserts the same property over generated inputs with
+//! a fixed budget. What this adds is coverage guidance — the fuzzer keeps
+//! the inputs that reach new branches, so it works its way past the magic
+//! number and the header into the entry table, where random bytes almost
+//! never land.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // The result is deliberately discarded: the property under test is
+    // that the call returns at all. What it returns is the round-trip
+    // suite's business, and asserting on it here would fail the corpus
+    // rather than the code.
+    let _ = renew_asset::Pack::read(data);
+});

--- a/fuzz/fuzz_targets/trace_parse.rs
+++ b/fuzz/fuzz_targets/trace_parse.rs
@@ -1,0 +1,20 @@
+//! The trace codec, against text nobody wrote on purpose.
+//!
+//! `parse` reads a recorded input trace — a file the engine did not write
+//! and must not trust. It answers with a trace or a refusal naming a
+//! line; anything else is a defect.
+//!
+//! Non-UTF-8 input is skipped rather than lossily converted. The reader's
+//! contract starts at `&str`, so feeding it replacement characters would
+//! fuzz the conversion instead of the parser, and every crash found that
+//! way would be unreachable from a real file.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = core::str::from_utf8(data) {
+        let _ = renew_trace::parse(text);
+    }
+});


### PR DESCRIPTION
The pack reader and the trace codec read files the engine did not write. Both already assert that they answer for arbitrary input — but from a fixed seed, a few hundred cases per run.

**These are coverage guided:** inputs reaching a new branch are kept and mutated, so the fuzzer works past the magic number and the header into the entry table, where uniformly random bytes essentially never land. A deeper line rather than a first one.

### Its own workspace, deliberately

A libFuzzer target links a runtime needing nightly and sanitizer instrumentation. As a workspace member it would sit in the path of the stable build that gates every merge — **it would break the build it exists to protect**. The root manifest excludes the directory by name; member list, structure check and stable build are all unchanged (verified: 19 members, `renew-fuzz` absent, `cargo build --workspace` clean).

The consequence: the root licence check never resolves these dependencies, so the scheduled job runs that check inside the harness workspace instead.

### Scheduled, never a gate

It needs nightly, so a break can be the toolchain moving rather than the engine regressing. Gating merges on that would let an upstream change stop work. A crashing input is uploaded as an artifact — a crash without the bytes that caused it is an anecdote.

### What the targets do not assert

Only that the parser answers. Correctness belongs to the round-trip properties beside each parser; asserting content here would fail on legitimately malformed inputs and fill the corpus with noise.

Harness verified to compile on nightly; both targets check clean.