### PR TITLE
feat(replay): give deterministic input replay its own crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       # guard catches this rather than passing vacuously.
       - name: Build and test without the trace codec
         run: |
-          sel="--workspace --exclude renew-trace --exclude renew-sample-input-echo"
+          sel="--workspace --exclude renew-trace --exclude renew-replay --exclude renew-sample-input-echo"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-trace $sel
           cargo build $sel
           cargo test $sel
@@ -248,10 +248,17 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-input $sel
           cargo build $sel
           cargo test $sel
+      # The replay tooling, and the sample that consumes it.
+      - name: Build and test without the replay tooling
+        run: |
+          sel="--workspace --exclude renew-replay --exclude renew-sample-input-echo"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-replay $sel
+          cargo build $sel
+          cargo test $sel
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input; do
+          for optional in renew-rhi renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel
@@ -289,7 +296,9 @@ jobs:
       # Scope, stated so nobody reads more into a green cell than it
       # earns: this guards ONE crate. The general rule -- no crate
       # declaring simulation may reach the platform crate by any path --
-      # needs a standards amendment and is not in force.
+      # is enforced by the workspace structure check for every crate
+      # declaring the determinism marker; this per-crate probe predates
+      # it and stays as a second witness on the one crate it names.
       - name: Build and test the input layer with no windowing library
         run: |
           sel="-p renew-input"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,6 +1482,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-replay"
+version = "0.1.0"
+dependencies = [
+ "renew-event",
+ "renew-trace",
+]
+
+[[package]]
 name = "renew-rhi"
 version = "0.1.0"
 dependencies = [
@@ -1519,6 +1527,7 @@ dependencies = [
  "renew-frame",
  "renew-input",
  "renew-platform",
+ "renew-replay",
  "renew-trace",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -75,7 +75,7 @@ lines = [651]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
-file = "samples/input_echo/src/convert.rs"
+file = "crates/replay/src/convert.rs"
 lines = [87, 118, 138]
 reason = "The wildcard arms that a non-exhaustive vocabulary forces a downstream crate to write, and the refusal one of them feeds. Every variant that exists today has its own arm above, so these are unreachable until the vocabulary grows - which is exactly when they must already be there, because the compiler will not report the new variant as unhandled in this crate. They refuse rather than folding an unknown event into a neighbouring one, so a recording can never quietly claim something that did not happen."
 

--- a/crates/core/event/README.md
+++ b/crates/core/event/README.md
@@ -14,16 +14,15 @@ may depend on this one, and adding a dependency here would defeat that
 for every such crate at once. The manifest declares no dependencies and
 must keep declaring none.
 
-**What is enforced, and what is not.** The reverse edge is impossible by
+**Both directions are enforced.** The reverse edge is impossible by
 construction: `renew-platform` depends on this crate, so this crate
-cannot depend on it — a dependency cycle is rejected. **The forward
-direction is not checked yet.** Nothing currently stops a crate that
-promises determinism from adding its own edge back to `renew-platform`
-and reaching a clock through it; the extraction removed the one such
-edge that existed, and a graph rule to prevent new ones is drafted but
-not in force. Until it is, this contract is an obligation maintained by
-review rather than a property enforced by a gate — and saying so is
-worth more than the stronger sentence that used to be here.
+cannot depend on it — a dependency cycle is rejected. The forward
+direction is checked by the workspace structure rules: a crate that
+promises determinism is refused any dependency path back to
+`renew-platform`, at any depth and in any dependency kind. An earlier
+version of this paragraph said the forward rule was drafted but not in
+force; it is in force, and this contract is now a property a gate
+enforces rather than an obligation review maintains.
 
 ## Why it is a separate crate
 

--- a/crates/core/event/src/lib.rs
+++ b/crates/core/event/src/lib.rs
@@ -16,12 +16,12 @@
 //! **How much of this is enforced, stated exactly.** The reverse edge —
 //! this crate depending on the platform crate — is impossible: the
 //! platform crate depends on this one, and a dependency cycle is
-//! rejected. That is a real check. **What is not yet checked is the
-//! forward direction**: nothing today stops a crate that promises
-//! determinism from adding its own edge back to the platform crate and
-//! reaching a clock that way. Keeping this crate dependency-free is
-//! therefore a maintained obligation, not a guaranteed one, until that
-//! rule exists.
+//! rejected. That is a real check. **The forward direction is checked
+//! too**: the workspace structure check walks the dependency graph and
+//! refuses any crate that promises determinism a path back to the
+//! platform crate, at any depth, dev-dependencies included. Keeping this
+//! crate dependency-free is what keeps that walk meaningful — every
+//! crate reachable from a deterministic one inherits the prohibition.
 //!
 //! **The vocabulary used to live inside the platform crate**, beside the
 //! clock, the filesystem and thread spawning, marked "deliberately not

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -30,7 +30,9 @@ simulation = true
 # is a function of build, seed and input alone. The edge below is the
 # whole of what it reaches for that purpose, and keeping it that way is
 # currently a rule enforced by review rather than by a check — a graph
-# rule that would enforce it is drafted and not yet in force.
+# rule that enforces it walks the dependency graph in the workspace
+# structure check: a deterministic crate is refused any path back to
+# the platform crate, at any depth.
 #
 # So: adding anything here with access to the outside world breaks the
 # promise, and nothing will stop you. That includes re-adding the

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "renew-replay"
+description = "Deterministic input replay: translation between the event vocabulary and the trace format, a trace loader, and a recorder"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Replaying recorded input deterministically: event-to-trace translation both ways, a tick-indexed trace loader, and the recorder that produces replayable traces."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+# The vocabulary this crate translates from, and the codec it translates
+# to. Deliberately nothing else: the crate declares `simulation = true`,
+# so the structure check refuses it a path to the platform crate — where
+# the text comes from and where it goes is its caller's business.
+[dependencies]
+renew-event = { path = "../core/event" }
+renew-trace = { path = "../trace" }
+
+[lints]
+workspace = true

--- a/crates/replay/README.md
+++ b/crates/replay/README.md
@@ -1,0 +1,54 @@
+# renew-replay
+
+Deterministic input replay: translation between the engine's event
+vocabulary and the trace format (both directions), a tick-indexed loader
+for stored traces, and the recorder that produces them.
+
+## Why it is a crate
+
+Any game shipping a replay, a demo mode, or a deterministic regression
+harness needs exactly this. The code lived inside one sample until a
+second consumer was committed; copying it would have meant maintaining a
+correctness property in two places, and the property is load-bearing: an
+unknown event **refuses** loudly, because silently dropping one makes a
+replay diverge from its recording in a way no test would catch.
+
+## Contract
+
+**This crate does no I/O and reaches no OS capability, at any dependency
+depth.** It declares the determinism marker, so the workspace structure
+check refuses it a path to the platform crate; its lint file bans the
+filesystem, the clock, threads and self-seeding collections by name.
+Text in, events out; events in, text out. Where bytes come from and
+where they go is the caller's business.
+
+**Events are indexed by tick, counted from zero** — the trace format's
+own meaning. Frame numbering is a driver convention; drivers apply their
+own shift. The one driver that numbers frames from one does exactly
+that, on its own side of the boundary.
+
+## What is here
+
+- `convert` — `to_trace` / `from_trace` between the event vocabulary and
+  trace events, with `Unencodable` carrying the shape index a refusal
+  names.
+- `events(name, text)` — a stored trace's event lines as
+  `(tick, WindowEvent)` pairs; the header is provenance and is not read
+  here.
+- `Recorder` — collects events against the tick they were delivered
+  before, refusing once, at `finish`, so a recording failure does not
+  abandon a run in progress.
+
+## Testing
+
+Unit tests from first commit. Determinism-test row: **N/A with
+reasoning** — this crate is a stateless translator with no simulation to
+run; the round-trip properties here and the committed-trace fixed-point
+test in its consumer are the determinism evidence that exists. Fuzz row:
+the text parser lives in `renew-trace`, which carries the fuzz target;
+this crate consumes the parsed structure.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies
+and extension points. Read it there rather than here.

--- a/crates/replay/clippy.toml
+++ b/crates/replay/clippy.toml
@@ -1,0 +1,47 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate declares `simulation = true`, and this file is the
+# mechanical half of that claim: translation between the event
+# vocabulary and the trace format is a pure function of its arguments,
+# and everything below makes the ways that stops being true unwritable
+# rather than merely documented. The structure check enforces the other
+# half — no dependency path to the platform crate at any depth — so a
+# capability cannot arrive through a wrapper either.
+#
+# The union of the frame crate's bans (clock, threads, unseeded hashing)
+# and the trace codec's (filesystem by every road anyone actually takes,
+# environment): this crate sits between those two and inherits both
+# obligations.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
+    { path = "std::time::SystemTime::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
+    { path = "std::thread::spawn", reason = "a translator spawns nothing; it is a pure function of its input" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act; a translator spawns nothing" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem: callers hand it text they already hold" },
+    { path = "std::fs::read_to_string", reason = "an unbounded whole-file read belongs at the I/O seam, which can refuse an oversized file; this crate never does I/O" },
+    { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road: a handle plus this method is `fs::read_to_string` spelled in two lines" },
+    { path = "std::io::Read::read_to_end", reason = "the same unbounded read by the other road" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem: it returns data for a caller to write" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem, and asking about a file is one line away from opening it" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "a translator is a pure function of its argument; a value from the environment would make one run differ from the next with nothing in the input to explain it" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState" },
+    { path = "std::collections::HashMap", reason = "the default RandomState hasher is seeded per instance, so iteration order varies between runs" },
+    { path = "std::collections::HashSet", reason = "the default RandomState hasher is seeded per instance, so iteration order varies between runs" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/replay/src/convert.rs
+++ b/crates/replay/src/convert.rs
@@ -26,7 +26,7 @@
 //! Adding a variant breaks the build there, and the test at the bottom of
 //! this file then fails until this translation learns the new shape.
 
-use renew_platform::window::{KeyCode, PointerButton, WindowEvent};
+use renew_event::{KeyCode, PointerButton, WindowEvent};
 use renew_trace::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
 
 /// An event this build cannot write down.
@@ -98,7 +98,7 @@ const fn button_to_trace(button: PointerButton) -> Option<TraceButton> {
 pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
     // Taken once, up front, so every refusal below names the same
     // shape the platform does and no arm carries a magic number.
-    let shape = renew_platform::window::shape_index(&event);
+    let shape = renew_event::shape_index(&event);
     let encoded = match event {
         WindowEvent::CloseRequested => TraceEvent::CloseRequested,
         WindowEvent::RedrawRequested => TraceEvent::RedrawRequested,
@@ -213,9 +213,7 @@ pub const fn from_trace(event: TraceEvent) -> WindowEvent {
 #[cfg(test)]
 mod tests {
     use super::{Unencodable, to_trace};
-    use renew_platform::window::{
-        EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index,
-    };
+    use renew_event::{EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index};
 
     /// Every shape the window seam can produce has an encoding.
     ///

--- a/crates/replay/src/lib.rs
+++ b/crates/replay/src/lib.rs
@@ -1,0 +1,38 @@
+//! Replaying recorded input deterministically: the translation between
+//! the engine's event vocabulary and the trace format, a loader for
+//! stored traces, and a recorder that produces them.
+//!
+//! Any game shipping a replay, a demo mode, or a deterministic
+//! regression harness needs exactly this — the need is not "being a
+//! sample", it is a capability the engine claims. The code lived inside
+//! one sample until a second consumer was committed; copying it would
+//! have meant maintaining a correctness property in two places, and the
+//! property here is load-bearing: an unknown event must **refuse**
+//! loudly, because silently dropping one makes a replay diverge from its
+//! recording in a way no test would catch.
+//!
+//! # What deliberately is not here
+//!
+//! No filesystem, no clock, no window. This crate turns text into events
+//! and events into text; where the text comes from and where it goes is
+//! its caller's business. That is not a style preference — the crate
+//! declares `simulation = true`, so the structure check refuses it a
+//! path to any OS capability, at any dependency depth.
+//!
+//! # Indexing: ticks, not frames
+//!
+//! [`events`] returns events indexed by **tick, counted from zero**,
+//! because that is what the trace format itself means. Drivers that
+//! number frames from one apply their own shift — the shift is a driver
+//! convention, and baking one driver's convention into the shared loader
+//! would silently impose it on every future consumer.
+
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+pub mod convert;
+mod load;
+pub mod record;
+
+pub use convert::{Unencodable, from_trace, to_trace};
+pub use load::{LoadError, events};
+pub use record::{RecordError, Recorder};

--- a/crates/replay/src/load.rs
+++ b/crates/replay/src/load.rs
@@ -1,0 +1,79 @@
+//! Loading a stored trace into engine events.
+//!
+//! The parsing itself belongs to `renew-trace`; what this adds is the
+//! translation into the engine vocabulary and an error that names which
+//! trace refused. Events come back indexed by **tick from zero** — the
+//! format's own meaning. Any frame numbering is the caller's convention
+//! to apply, not this crate's to impose.
+
+use renew_event::WindowEvent;
+
+use crate::convert;
+
+/// A stored trace that would not load.
+///
+/// Carries the name the caller knows the trace by and the parse error's
+/// own display, which names a line. Whose *fault* the failure is — a
+/// user's file, a repository fixture — is blame the caller assigns; this
+/// crate only knows what refused.
+#[derive(Debug)]
+pub struct LoadError {
+    pub name: String,
+    pub detail: String,
+}
+
+impl core::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "reading the `{}` trace: {}", self.name, self.detail)
+    }
+}
+
+/// The events of a stored trace, indexed by tick from zero.
+///
+/// Only the event lines are read. The header is provenance — the run the
+/// file was captured from — and callers that want it own that decision;
+/// the one caller that replays a header-owned run reads it through
+/// `renew-trace` directly.
+///
+/// # Errors
+///
+/// [`LoadError`] when the text does not parse, naming `name` and the
+/// parser's line-bearing message.
+pub fn events(name: &str, text: &str) -> Result<Vec<(u64, WindowEvent)>, LoadError> {
+    let parsed = renew_trace::parse(text).map_err(|error| LoadError {
+        name: name.to_string(),
+        detail: error.to_string(),
+    })?;
+    Ok(parsed
+        .events()
+        .iter()
+        .map(|(tick, event)| (*tick, convert::from_trace(*event)))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_trace_that_does_not_parse_names_itself_and_a_line() {
+        let error = events("broken", "not a trace at all\n").expect_err("nonsense must refuse");
+        let shown = error.to_string();
+        assert!(shown.contains("`broken`"), "{shown}");
+        assert!(
+            shown.contains("line"),
+            "the parser's message names a line: {shown}"
+        );
+    }
+
+    #[test]
+    fn events_come_back_tick_indexed_from_zero() {
+        let text = "renew-trace 0 sample=t ticks=2 timestep_ns=1 budget=1\ne 0 close\n";
+        let events = events("t", text).expect("a minimal trace loads");
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].0, 0,
+            "tick zero stays tick zero — no frame shift here"
+        );
+    }
+}

--- a/crates/replay/src/record.rs
+++ b/crates/replay/src/record.rs
@@ -12,7 +12,7 @@
 //! a recording that quietly filtered would replay into a different
 //! world and the digests would disagree with nothing to explain it.
 
-use renew_platform::window::WindowEvent;
+use renew_event::WindowEvent;
 use renew_trace::{Trace, TraceError, TraceHeader};
 
 use crate::convert::{Unencodable, to_trace};

--- a/samples/input_echo/Cargo.toml
+++ b/samples/input_echo/Cargo.toml
@@ -34,6 +34,7 @@ renew-frame = { path = "../../crates/frame" }
 # someone is sitting at, and the simulation receives resolved intent.
 renew-input = { path = "../../crates/input" }
 renew-platform = { path = "../../crates/core/platform" }
+renew-replay = { path = "../../crates/replay" }
 renew-trace = { path = "../../crates/trace" }
 
 [lints]

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -36,10 +36,14 @@ use std::process::ExitCode;
 
 mod app;
 mod cli;
-pub mod convert;
+/// The translation and the recorder moved to `renew-replay` — any game
+/// shipping a replay needs them, and a correctness property maintained
+/// in two copies is maintained in one and a half. Re-exported so every
+/// existing path through this crate keeps meaning what it meant.
+pub use renew_replay as convert;
 mod error;
 mod input;
-pub mod record;
+pub use renew_replay as record;
 mod scripted;
 mod trace;
 mod world;

--- a/samples/input_echo/src/scripted.rs
+++ b/samples/input_echo/src/scripted.rs
@@ -11,12 +11,12 @@ use renew_frame::{FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};
 use renew_trace::TraceHeader;
 
 use crate::cli::{Options, Report};
-use crate::convert;
 use crate::error::SampleError;
 use crate::input::Input;
-use crate::record::Recorder;
 use crate::trace::{self, Trace};
 use crate::world::EchoWorld;
+use renew_replay as convert;
+use renew_replay::Recorder;
 
 /// The synthetic frame interval: exactly one timestep, so a run of N
 /// frames executes exactly N steps, banks nothing and drops nothing. The
@@ -241,8 +241,8 @@ mod tests {
     };
     use crate::cli::Options;
     use crate::error::SampleError;
-    use crate::record::Recorder;
     use crate::trace;
+    use renew_replay::Recorder;
 
     /// A recorded tick is the number of steps that had already run, which
     /// is what the format means and what `record.rs` promises — **not**

--- a/samples/input_echo/src/trace.rs
+++ b/samples/input_echo/src/trace.rs
@@ -46,7 +46,6 @@
 
 use renew_platform::window::WindowEvent;
 
-use crate::convert;
 use crate::error::SampleError;
 
 /// The frame a tick-zero event is delivered before.
@@ -115,21 +114,18 @@ pub fn by_name(name: &str) -> Result<Trace, SampleError> {
 }
 
 fn load(scripted: &Scripted) -> Result<Trace, SampleError> {
-    let parsed = renew_trace::parse(scripted.text).map_err(|error| {
-        SampleError::failed(
-            &format!("reading the built-in `{}` trace", scripted.name),
-            &error,
-        )
-    })?;
-    let events = parsed
-        .events()
-        .iter()
-        .map(|(tick, event)| {
-            (
-                tick.saturating_add(FIRST_FRAME),
-                convert::from_trace(*event),
-            )
-        })
+    // The shared loader hands back ticks from zero — the format's own
+    // meaning. The +1 to this driver's frames-from-one convention
+    // happens here, on the sample side, exactly because it is this
+    // driver's convention: baked into the shared crate it would silently
+    // bind every future consumer to it. Blame stays here too — the
+    // loader reports what refused, and "built-in" (a defect in this
+    // repository, not the caller's command line) is a fact only this
+    // crate knows.
+    let events = renew_replay::events(scripted.name, scripted.text)
+        .map_err(|error| SampleError::Failed(format!("built-in trace: {error}")))?
+        .into_iter()
+        .map(|(tick, event)| (tick.saturating_add(FIRST_FRAME), event))
         .collect();
     Ok(Trace {
         name: scripted.name,


### PR DESCRIPTION
The translation between the event vocabulary and the trace format, the loader for stored traces, and the recorder that produces them lived inside one sample. A second consumer is arriving; copying would mean maintaining a correctness property in two places — and the property is load-bearing: **an unknown event refuses loudly**, because silently dropping one makes a replay diverge from its recording in a way no test would catch.

### The crate's contract

No I/O, no OS capability at any dependency depth. It declares the determinism marker, so the workspace structure check refuses it a path to the platform crate; its lint file bans the filesystem, the clock, threads and self-seeding collections by name. Two dependencies: the vocabulary it translates from, the codec it translates to.

### The boundary decisions

- **Tick-indexed, from zero** — the format's own meaning. The one driver that numbers frames from one applies its own shift on its own side, where it always lived; baked into the shared crate, that convention would bind every future consumer silently.
- **Blame stays with the caller.** The loader reports what refused; whether a bad trace is a repository defect or a user's file is a fact only the caller knows, so the sample keeps its error taxonomy and maps in.
- The sample re-exports the moved modules, so every existing path through it keeps meaning what it meant.

### Obligations carried

Coverage exemption for the translation's wildcard arms moves with the file, lines re-verified against the moved copy. New removability cell; the trace-codec cell grows (upward closure); the minimal-core loop gains the crate. Also corrected: four comments describing the deterministic-crate closure check as drafted-not-in-force — it has been in force since the structure check learned to walk the graph.

### Verification

Workspace: 85 suites / 898 tests, zero failures; format and clippy clean; structure check healthy; the coverage manifest's own self-test caught the stale exemption path mid-development and passes with the re-path.