### PR TITLE
test(rhi): give the buffer fault rungs labels nothing else answers to

### DIFF
--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -807,21 +807,21 @@ fn every_driver_failure_ladder_behaves() {
     // that never construct a buffer, so their counts are undisturbed.
     let buffer_ladder: &[(&str, &str, &str)] = &[
         (
-            "B1",
+            "PB1",
             "vkCreateBuffer=ERROR_OUT_OF_HOST_MEMORY",
             "vkCreateBuffer",
         ),
         (
-            "B2",
+            "PB2",
             "vkAllocateMemory=ERROR_OUT_OF_HOST_MEMORY",
             "vkAllocateMemory",
         ),
         (
-            "B3",
+            "PB3",
             "vkBindBufferMemory=ERROR_OUT_OF_HOST_MEMORY",
             "vkBindBufferMemory",
         ),
-        ("B4", "vkMapMemory=ERROR_OUT_OF_HOST_MEMORY", "vkMapMemory"),
+        ("PB4", "vkMapMemory=ERROR_OUT_OF_HOST_MEMORY", "vkMapMemory"),
     ];
     for &(name, fault, call) in buffer_ladder {
         verdicts.push(device_case(name, fault, |device| {


### PR DESCRIPTION
The buffer creation ladder reused **B1–B4**, which the offscreen bring-up unwinder ladder has answered to since it was written. Two scenarios sharing a label make a failure report ambiguous in the one sentence a reader gets.

Renamed to **PB1–PB4**, scoped to the buffer ladder's own table so no pre-existing label moved. The full fault suite passes under the layer.