### PR TITLE
refactor(memory): one home for the quiet-window policy

### DIFF
--- a/bench/suite/tests/zero_alloc.rs
+++ b/bench/suite/tests/zero_alloc.rs
@@ -12,7 +12,8 @@
 //! lands in a window either. Own process on purpose; this file holds a
 //! single test so no sibling test allocates alongside it.
 
-use renew_memory::{CountingAllocator, LinearArena, Pool, counters};
+use renew_memory::counters::quiet_window;
+use renew_memory::{CountingAllocator, LinearArena, Pool};
 
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
@@ -20,26 +21,6 @@ static ALLOCATOR: CountingAllocator = CountingAllocator;
 /// Run the window until one pass shows exactly zero allocator activity.
 /// Fallible on purpose: the `expect()` lives inside the test, where the
 /// lint configuration scopes it.
-fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
-    let mut last = (0u64, 0u64);
-    for _ in 0..attempts {
-        let before = counters::snapshot();
-        window();
-        let after = counters::snapshot();
-        if after.allocations == before.allocations && after.deallocations == before.deallocations {
-            return Ok(());
-        }
-        last = (
-            after.allocations - before.allocations,
-            after.deallocations - before.deallocations,
-        );
-    }
-    Err(format!(
-        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
-        last.0, last.1
-    ))
-}
-
 #[test]
 #[cfg_attr(
     feature = "sanitized",

--- a/crates/core/memory/README.md
+++ b/crates/core/memory/README.md
@@ -10,7 +10,11 @@ an instrumented global allocator for counting.
   handles: stale handles miss instead of aliasing recycled slots.
 - `CountingAllocator` — a wrapper over the system allocator that a
   *binary* installs with `#[global_allocator]`; every allocation in the
-  process is then counted, readable through `counters::snapshot()`.
+  process is then counted, readable through `counters::snapshot()`. The
+  retry-until-quiet window policy the allocation gates share lives beside
+  the counters as `counters::quiet_window` — one home for the decision of
+  what counts as a quiet window (no allocations AND no deallocations),
+  however many suites enforce it.
 
 ## Contract
 

--- a/crates/core/memory/src/counters.rs
+++ b/crates/core/memory/src/counters.rs
@@ -1,6 +1,10 @@
 //! Process-wide allocation counters, written by [`crate::CountingAllocator`]
 //! and read through [`snapshot`]. Diagnostics only: monotonic counts and a
-//! byte gauge, never consulted for control flow.
+//! byte gauge, never consulted for engine control flow. The one sanctioned
+//! consumer of these numbers as a decision is [`quiet_window`], the test
+//! oracle that lives here so the policy interpreting the counters sits
+//! beside the counters it interprets — one place to change, however many
+//! suites call it.
 
 use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
@@ -38,6 +42,68 @@ pub fn snapshot() -> Snapshot {
         bytes_in_use: BYTES_IN_USE.load(Ordering::Relaxed),
         peak_bytes: PEAK_BYTES.load(Ordering::Relaxed),
     }
+}
+
+/// Allocator activity across one measured window: what [`quiet_window`]
+/// reports when no window came back quiet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ActivityDelta {
+    /// Allocations recorded during the window.
+    pub allocations: u64,
+    /// Deallocations recorded during the window.
+    pub deallocations: u64,
+}
+
+impl core::fmt::Display for ActivityDelta {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "+{} allocations, +{} deallocations",
+            self.allocations, self.deallocations
+        )
+    }
+}
+
+/// Run `window` up to `attempts` times and succeed on the first run
+/// with zero allocator activity — allocations and deallocations both.
+///
+/// **This is the retry-until-quiet policy, in its one home.** The
+/// counters are process-wide and a test harness's own threads may
+/// allocate concurrently, so a single window cannot distinguish
+/// neighbor noise from a real regression. Retrying can: one-shot noise
+/// rides out, while a defect on the measured path reproduces in every
+/// window and still fails. On failure the returned delta is the LAST
+/// window's activity, for the panic message the caller writes.
+///
+/// The window itself must not allocate on its success path — that is
+/// the very property being measured — and this function allocates
+/// nothing either: the delta formats only when someone reports it.
+///
+/// # Errors
+///
+/// The last window's [`ActivityDelta`] when every attempt saw activity.
+pub fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), ActivityDelta> {
+    // Zero attempts would return a zeros delta that reads as "loud
+    // with no activity" — a caller absurdity the old copies shared
+    // silently; refused by name in dev builds now.
+    debug_assert!(attempts > 0, "a quiet window needs at least one attempt");
+    let mut last = ActivityDelta {
+        allocations: 0,
+        deallocations: 0,
+    };
+    for _ in 0..attempts {
+        let before = snapshot();
+        window();
+        let after = snapshot();
+        last = ActivityDelta {
+            allocations: after.allocations - before.allocations,
+            deallocations: after.deallocations - before.deallocations,
+        };
+        if last.allocations == 0 && last.deallocations == 0 {
+            return Ok(());
+        }
+    }
+    Err(last)
 }
 
 pub(crate) fn record_alloc(size: usize) {

--- a/crates/core/memory/tests/quiet_window.rs
+++ b/crates/core/memory/tests/quiet_window.rs
@@ -1,0 +1,73 @@
+//! The retry-until-quiet policy, exercised against the real allocator:
+//! this binary's global allocator is the counting wrapper, so windows
+//! see genuine deltas. One test on purpose — the counters are
+//! process-wide, and a sibling test's allocations would race the
+//! scenarios below.
+
+use renew_memory::{CountingAllocator, counters};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_policy_retries_reports_and_settles() {
+    // A window that allocates nothing succeeds immediately.
+    assert!(
+        counters::quiet_window(1, || {}).is_ok(),
+        "an empty window must be quiet"
+    );
+
+    // A window that allocates every attempt fails, and the reported
+    // delta is the LAST window's activity, exactly — one boxed byte,
+    // kept alive past the window so the deallocation half stays zero
+    // and the numbers are unambiguous.
+    let mut keep = Vec::with_capacity(16);
+    let error = counters::quiet_window(3, || {
+        keep.push(Box::new(1u8));
+    })
+    .expect_err("an always-allocating window must fail");
+    assert_eq!(
+        (error.allocations, error.deallocations),
+        (1, 0),
+        "the delta must be the last window's own activity"
+    );
+    assert_eq!(
+        error.to_string(),
+        "+1 allocations, +0 deallocations",
+        "the report is what a failing gate prints"
+    );
+
+    // Noise that stops — the reason the policy exists: two loud
+    // windows, then quiet, inside the attempt budget.
+    let mut remaining_noise = 2u32;
+    assert!(
+        counters::quiet_window(5, || {
+            if remaining_noise > 0 {
+                remaining_noise -= 1;
+                keep.push(Box::new(2u8));
+            }
+        })
+        .is_ok(),
+        "one-shot noise must ride out within the attempts"
+    );
+
+    // Deallocations alone are activity too: freeing inside the window
+    // is a dirty window, which is what makes the both-channels check
+    // stronger than counting allocations alone.
+    let boxes: Vec<Box<u8>> = (0..3).map(|_| Box::new(3u8)).collect();
+    let mut boxes = boxes.into_iter();
+    let error = counters::quiet_window(3, || {
+        drop(boxes.next());
+    })
+    .expect_err("a window that frees must be loud");
+    assert_eq!(
+        (error.allocations, error.deallocations),
+        (0, 1),
+        "the dealloc-only delta must be visible"
+    );
+    drop(keep);
+}

--- a/crates/frame/tests/zero_alloc.rs
+++ b/crates/frame/tests/zero_alloc.rs
@@ -15,6 +15,7 @@
 //! `format!` in a hot path, or a boxed callback.
 
 use renew_frame::{FrameLoop, FrameStats, FrameTiming, Nanos, StepBudget, Timestamp, Timestep};
+use renew_memory::counters::quiet_window;
 use renew_memory::{CountingAllocator, counters};
 
 #[global_allocator]
@@ -22,26 +23,6 @@ static ALLOCATOR: CountingAllocator = CountingAllocator;
 
 /// 60 Hz in whole nanoseconds.
 const DT: u64 = 16_666_667;
-
-fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
-    let mut last = (0u64, 0u64);
-    for _ in 0..attempts {
-        let before = counters::snapshot();
-        window();
-        let after = counters::snapshot();
-        if after.allocations == before.allocations && after.deallocations == before.deallocations {
-            return Ok(());
-        }
-        last = (
-            after.allocations - before.allocations,
-            after.deallocations - before.deallocations,
-        );
-    }
-    Err(format!(
-        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
-        last.0, last.1
-    ))
-}
 
 /// One frame of the full steady-state path: plan, execute, interpolate,
 /// tally. Every call a caller makes per frame is here, so a future

--- a/crates/jobs/tests/zero_alloc.rs
+++ b/crates/jobs/tests/zero_alloc.rs
@@ -12,30 +12,11 @@ use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use renew_jobs::{JobPool, PoolConfig};
-use renew_memory::{CountingAllocator, counters};
+use renew_memory::CountingAllocator;
+use renew_memory::counters::quiet_window;
 
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
-
-fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
-    let mut last = (0u64, 0u64);
-    for _ in 0..attempts {
-        let before = counters::snapshot();
-        window();
-        let after = counters::snapshot();
-        if after.allocations == before.allocations && after.deallocations == before.deallocations {
-            return Ok(());
-        }
-        last = (
-            after.allocations - before.allocations,
-            after.deallocations - before.deallocations,
-        );
-    }
-    Err(format!(
-        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
-        last.0, last.1
-    ))
-}
 
 #[test]
 #[cfg_attr(

--- a/crates/render2d/tests/zero_alloc.rs
+++ b/crates/render2d/tests/zero_alloc.rs
@@ -18,11 +18,6 @@ use renew_rhi::{Color, Device, DeviceDesc, DeviceError, Extent, TargetFormat, Va
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
 
-/// Allocations recorded so far, process-wide.
-fn allocations() -> u64 {
-    counters::snapshot().allocations
-}
-
 const SIZE: u32 = 64;
 /// Per-frame variation without per-frame allocation: positions read
 /// from a fixed table, so the packed bytes differ frame to frame and
@@ -165,36 +160,24 @@ fn steady_state_fill_and_render_allocates_nothing() {
     }
     assert_frame_is_live(&pixels, 2, "after warmup");
 
-    // Measurement protocol: the counter is process-wide and the harness
-    // thread can allocate concurrently, so the window retries — one-shot
-    // neighbor noise rides out, while a real fill-or-render allocation
-    // reproduces in every window and still fails.
-    let mut last_delta = 0u64;
-    let mut observed_zero = false;
-    for attempt in 0..5 {
-        let before = allocations();
-        for index in 0..16 {
-            frame(
-                &mut renderer,
-                &mut target,
-                &mut pixels,
-                attempt * 16 + index,
-            );
+    // The retry-until-quiet policy lives with the counters it reads;
+    // both channels now — a fill that frees is as loud as one that
+    // allocates. The frame counter threads through the closure so the
+    // liveness check still knows where this window's last frame put
+    // the wandering sprite.
+    let mut frames_run = 0usize;
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..16 {
+            frame(&mut renderer, &mut target, &mut pixels, frames_run);
+            frames_run += 1;
         }
-        let after = allocations();
-        assert_frame_is_live(&pixels, attempt * 16 + 15, "at the window's end");
-        last_delta = after - before;
-        if last_delta == 0 {
-            observed_zero = true;
-            break;
-        }
-    }
+        assert_frame_is_live(&pixels, frames_run - 1, "at the window's end");
+    });
     eprintln!(
         "engine allocation counters after steady state: {:?}",
         counters::snapshot()
     );
-    assert!(
-        observed_zero,
-        "the fill-and-render path heap-allocated in every window (last delta: {last_delta})"
-    );
+    if let Err(activity) = verdict {
+        panic!("the fill-and-render path was loud in every window (last: {activity})");
+    }
 }

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -49,8 +49,13 @@ const WINDOW_FRAMES: u32 = 16;
 const WARMUP_FRAMES: u32 = 8;
 /// Retries. The counter is process-wide, so a neighbour's one-shot
 /// allocation must be allowed to ride out while a real render-path
-/// allocation reproduces in every window. Same protocol as the offscreen
-/// gate, and the reason is the same.
+/// allocation reproduces in every window — the same reasoning as
+/// `renew_memory::counters::quiet_window`, which every other gate now
+/// calls. This file deliberately does NOT: its window spans event-loop
+/// callbacks with per-call bracketing (the event loop's own allocations
+/// are the environment's, not the engine's) and restarts on resize, a
+/// different measurement no call-frame-shaped helper can express. If
+/// that ever stops being true, the helper is where this goes.
 const ATTEMPTS: u32 = 5;
 /// Poll-loop iterations before declaring the run wedged.
 const UPDATE_BUDGET: u32 = 20_000;

--- a/crates/rhi/tests/zero_alloc.rs
+++ b/crates/rhi/tests/zero_alloc.rs
@@ -28,11 +28,6 @@ use renew_rhi::{
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
 
-/// Allocations recorded so far, process-wide.
-fn allocations() -> u64 {
-    counters::snapshot().allocations
-}
-
 #[test]
 #[cfg_attr(
     feature = "sanitized",
@@ -121,15 +116,11 @@ fn steady_state_frames_allocate_nothing() {
         target.read_back_into(&mut pixels);
     }
 
-    // Measurement protocol: the counter is process-wide and the test
-    // harness's own thread can allocate concurrently. So the window
-    // retries: one-shot neighbor noise rides out, while a real
-    // render-path allocation reproduces in every window and still
-    // fails.
-    let mut last_delta = 0u64;
-    let mut observed_zero = false;
-    for _ in 0..5 {
-        let before = allocations();
+    // The retry-until-quiet policy lives with the counters it reads;
+    // this file used to open-code it, invisible to anyone grepping for
+    // the helper. Both channels now: a steady frame that deallocates is
+    // as loud as one that allocates.
+    let verdict = counters::quiet_window(5, || {
         for _ in 0..16 {
             target
                 .render(&RenderDesc::new(clear).pipeline(&pipeline))
@@ -143,13 +134,7 @@ fn steady_state_frames_allocate_nothing() {
                 .expect("steady instanced frame");
             target.read_back_into(&mut pixels);
         }
-        let after = allocations();
-        last_delta = after - before;
-        if last_delta == 0 {
-            observed_zero = true;
-            break;
-        }
-    }
+    });
     // The driver-side ledger is printed for the record, never gated:
     // driver host-allocation behavior is the driver's, not ours.
     let stats = device.host_allocation_stats();
@@ -163,10 +148,9 @@ fn steady_state_frames_allocate_nothing() {
         "engine allocation counters after steady state: {:?}",
         counters::snapshot()
     );
-    assert!(
-        observed_zero,
-        "the render path heap-allocated in every window (last delta: {last_delta})"
-    );
+    if let Err(activity) = verdict {
+        panic!("the render path was loud in every window (last: {activity})");
+    }
 }
 
 /// The instanced pipeline, its per-frame buffer, and one packed

--- a/crates/rng/tests/zero_alloc.rs
+++ b/crates/rng/tests/zero_alloc.rs
@@ -17,33 +17,14 @@
 
 use core::num::{NonZeroU32, NonZeroU64};
 
-use renew_memory::{CountingAllocator, counters};
+use renew_memory::CountingAllocator;
+use renew_memory::counters::quiet_window;
 use renew_rng::{Rng, Seed, StreamId};
 
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
 
 const SPAWN: StreamId = StreamId::from_name("spawn");
-
-fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
-    let mut last = (0u64, 0u64);
-    for _ in 0..attempts {
-        let before = counters::snapshot();
-        window();
-        let after = counters::snapshot();
-        if after.allocations == before.allocations && after.deallocations == before.deallocations {
-            return Ok(());
-        }
-        last = (
-            after.allocations - before.allocations,
-            after.deallocations - before.deallocations,
-        );
-    }
-    Err(format!(
-        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
-        last.0, last.1
-    ))
-}
 
 /// Everything a simulation does with this crate in one frame: derive a
 /// per-entity stream, draw every shape, snapshot, resume. A future

--- a/samples/glide/world/tests/zero_alloc.rs
+++ b/samples/glide/world/tests/zero_alloc.rs
@@ -17,10 +17,6 @@ use renew_sample_glide_world::World;
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
 
-fn allocations() -> u64 {
-    counters::snapshot().allocations
-}
-
 #[test]
 #[cfg_attr(
     feature = "sanitized",
@@ -38,31 +34,24 @@ fn steady_state_ticks_allocate_nothing() {
         world.step(flap);
     }
 
-    let mut last_delta = 0u64;
-    let mut observed_zero = false;
-    for _ in 0..5 {
+    // The retry-until-quiet policy lives with the counters it reads;
+    // both channels now — a tick that frees is as loud as one that
+    // allocates.
+    let verdict = counters::quiet_window(5, || {
         assert!(
             world.alive() && world.pipes() > 0,
             "the window must open on a live game"
         );
-        let before = allocations();
         for _ in 0..1_000u64 {
             let flap = world.autopilot();
             world.step(flap);
         }
-        let after = allocations();
         assert!(
             world.alive() && world.pipes() > 0,
             "the window must close on a live game"
         );
-        last_delta = after - before;
-        if last_delta == 0 {
-            observed_zero = true;
-            break;
-        }
+    });
+    if let Err(activity) = verdict {
+        panic!("a live tick was loud in every window (last: {activity})");
     }
-    assert!(
-        observed_zero,
-        "a live tick allocated in every window (last delta: +{last_delta})"
-    );
 }

--- a/samples/hello_triangle/tests/zero_alloc.rs
+++ b/samples/hello_triangle/tests/zero_alloc.rs
@@ -23,6 +23,7 @@
 
 #[cfg(feature = "window")]
 use renew_frame::{Nanos, Timestamp};
+use renew_memory::counters::quiet_window;
 use renew_memory::{CountingAllocator, counters};
 #[cfg(feature = "window")]
 use renew_sample_hello_triangle::Readout;
@@ -36,26 +37,6 @@ const WINDOW_FRAMES: u64 = 16;
 
 fn strict() -> bool {
     std::env::var_os("RENEW_FRAME_STRICT").is_some_and(|value| value == "1")
-}
-
-fn quiet_window(attempts: usize, mut window: impl FnMut()) -> Result<(), String> {
-    let mut last = (0u64, 0u64);
-    for _ in 0..attempts {
-        let before = counters::snapshot();
-        window();
-        let after = counters::snapshot();
-        if after.allocations == before.allocations && after.deallocations == before.deallocations {
-            return Ok(());
-        }
-        last = (
-            after.allocations - before.allocations,
-            after.deallocations - before.deallocations,
-        );
-    }
-    Err(format!(
-        "allocator activity in every window (last deltas: +{} allocations, +{} deallocations)",
-        last.0, last.1
-    ))
 }
 
 #[test]


### PR DESCRIPTION
The retry-until-quiet allocation-window policy existed nine times in three shapes: five byte-identical named helpers (`bench`, `frame`, `jobs`, `rng`, `hello_triangle`), three open-coded loops reimplementing it invisibly (`rhi`'s offscreen gate, `render2d`'s, the game world's), and one genuinely different protocol (the windowed presentation gate). A policy that is a decision — how many windows, what counts as quiet — should not live in nine places that must agree.

It now lives in one: `renew_memory::counters::quiet_window`, beside the counters it interprets, with `ActivityDelta` as its failure report. Eight suites call it; the uniform rule is the stronger one the named copies already had (allocations **and** deallocations — a steady path that frees is as loud as one that allocates), and the three previously allocation-only gates pass it on real hardware.

The presentation gate deliberately keeps its own loop and now documents why beside its retry constant: per-call bracketing across event-loop callbacks with restart-on-resize is a different measurement, not a copy.

One shared latent bug died in the consolidation: zero attempts returned a zeros delta reading as "loud with no activity" — refused by name in dev builds now. The policy has its own suite against the real counting allocator: quiet, always-loud, settling, and dealloc-only windows, with the exact deltas asserted.

Net: −70 lines, one decision, one home.
