### PR TITLE
feat(samples): the game opens a window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,17 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
+      # The other direction: the game's window feature builds, lints,
+      # and tests. No graph guard -- the build itself proves the WSI
+      # stack is reachable, and the absence guards belong to the default
+      # graph, where they already stand. Display-less-safe: no test
+      # opens a window. Clippy rides here because the canonical lint
+      # never compiles feature-gated code the default graph omits.
+      - name: Build, lint, and test the game with its window feature
+        run: |
+          cargo build -p renew-sample-glide --features window
+          cargo clippy -p renew-sample-glide --features window --all-targets -- -D warnings
+          cargo test -p renew-sample-glide --features window
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,6 +621,12 @@ jobs:
             --input-trace soar --frames 600
           cargo llvm-cov --no-report run -p renew-sample-glide --bin glide -- \
             --input-trace sink --frames 600
+          # The game's windowed feature, in two instrumented pieces: the
+          # feature-gated unit tests (display-less-safe -- they open no
+          # window), and the windowed arm live under the virtual display.
+          # Keyboardless there: the bird falls; a legal run.
+          cargo llvm-cov --no-report test -p renew-sample-glide --features window
+          xvfb-run -a cargo llvm-cov --no-report run -p renew-sample-glide --features window --bin glide --             --window --frames 30
           # The fault layer is test scaffolding that runs inside the
           # loader, not engine code, and cargo-llvm-cov already keeps
           # test sources out of the denominator — its tool crate

--- a/samples/glide/Cargo.toml
+++ b/samples/glide/Cargo.toml
@@ -21,21 +21,35 @@ name = "glide"
 path = "src/main.rs"
 
 # The driver owns everything the world may not touch: the filesystem for
-# recordings and replays. Windowing arrives later as a feature, which is
-# why the platform dependency compiles the window stack out today.
+# recordings and replays, and — behind the window feature — the window
+# and the GPU. The feature is default-OFF so the default graph stays
+# free of rendering crates, which the build matrix proves.
 [dependencies]
 renew-event = { path = "../../crates/core/event" }
 renew-frame = { path = "../../crates/frame" }
 renew-input = { path = "../../crates/input" }
 renew-platform = { path = "../../crates/core/platform", default-features = false }
+renew-render2d = { path = "../../crates/render2d", optional = true }
 renew-replay = { path = "../../crates/replay" }
+renew-rhi = { path = "../../crates/rhi", default-features = false, optional = true }
 renew-sample-glide-world = { path = "world" }
 renew-trace = { path = "../../crates/trace" }
 
-# The frame-capture oracle's GPU edges live here, in the dev graph, so
-# the game's normal graph stays free of rendering crates and the
-# headless-without-GPU property keeps its witness (a build-only probe in
-# the matrix proves it).
+[features]
+# Play in a window: the platform's window stack, the rendering crate's
+# presentation path, and the sprite renderer. Off by default — the game
+# a player runs headless carries none of it.
+window = [
+    "renew-platform/window",
+    "dep:renew-rhi",
+    "renew-rhi/present",
+    "dep:renew-render2d",
+]
+
+# The frame-capture oracle needs the GPU crates whether or not the
+# window feature is on, so they stay dev-dependencies too; the default
+# NORMAL graph stays free of rendering crates and the build matrix
+# carries a probe proving it.
 [dev-dependencies]
 renew-render2d = { path = "../../crates/render2d" }
 renew-rhi = { path = "../../crates/rhi", default-features = false }

--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -1,8 +1,8 @@
 # renew-sample-glide
 
 A small complete game, headless-first: the glide world driven by
-scripted traces or a recorded replay, with a windowed mode arriving
-later behind a feature.
+scripted traces or a recorded replay — and, behind the `window`
+feature, playable in a window with the score in the title.
 
 ## Running it
 
@@ -24,9 +24,17 @@ pure `scene` module that turns a world into draw-order rectangles with
 no GPU crate in the normal graph. The frame-capture test consumes
 both: committed traces replayed to a checkpoint, drawn through the
 sprite renderer offscreen, compared against committed images. The GPU
-crates enter as dev-dependencies only, and the build matrix carries a
-build-only probe proving the game a player runs still needs none of
-them.
+crates enter the normal graph only behind the `window` feature (and
+the dev graph for the oracle); the default build carries none of
+them, and the build matrix proves it with a build-only probe.
+
+`glide --window` opens the game (`--features window` builds it):
+space or the primary mouse button flaps, the score lives in the
+title, and the digest line prints at close marked `source=window` so
+nothing ever compares a wall-clock run against a scripted one. Flap
+edges ride a saturating counter consumed one per fixed step — a press
+on a frame that plans no steps survives to the next, and two presses
+with two due steps deliver two flaps.
 
 `--replay-trace` owns the whole run — the header carries the seed and
 the length — so the flags it would contradict are refused by name

--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -46,7 +46,7 @@ Two crates. `world/` is the simulation — a pure fixed-step function of
 seed and per-tick input, forbidden by the workspace structure rules
 from reaching a clock, a file or a window at any dependency depth.
 This crate is the driver: it maps input to the world's one action
-through the same bindings a windowed mode will use, runs the loop on a
+through the same bindings the windowed mode uses, runs the loop on a
 synthetic clock, and owns every file that is read or written.
 
 Traces index events by tick from zero, exactly as the loader returns

--- a/samples/glide/src/cli.rs
+++ b/samples/glide/src/cli.rs
@@ -23,7 +23,11 @@ pub struct Options {
     pub window: bool,
     /// The windowed run's tick bound: `None` plays until closed; the
     /// headless `frames` default must not leak into an interactive
-    /// session, so this is derived from an EXPLICIT --frames only.
+    /// session, so this is derived from an EXPLICIT --frames only. The
+    /// bound lands at the first frame boundary at or after N ticks —
+    /// plans are never cut mid-frame, so the digest line's counts and
+    /// the world always agree; a lagging frame may overshoot by at most
+    /// the step budget minus one.
     pub window_ticks: Option<u64>,
 }
 
@@ -128,6 +132,40 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         window,
         window_ticks,
     })
+}
+
+#[cfg(test)]
+mod window_flag_tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Result<Options, SampleError> {
+        parse_args(args.iter().map(ToString::to_string))
+    }
+
+    #[test]
+    fn a_bare_window_run_is_unbounded() {
+        // The centerpiece: the headless default of 2000 frames must not
+        // leak into an interactive session and silently end it mid-play.
+        let options = parse(&["--window"]).expect("bare --window parses");
+        assert!(options.window);
+        assert_eq!(options.window_ticks, None, "no bound unless asked for");
+    }
+
+    #[test]
+    fn an_explicit_frames_bounds_the_window_in_ticks() {
+        let options = parse(&["--window", "--frames", "30"]).expect("parses");
+        assert_eq!(options.window_ticks, Some(30));
+    }
+
+    #[test]
+    fn seed_stays_legal_beside_window() {
+        // The positive half the per-flag seen-set exists for: refusing
+        // trace flags must not take --seed down with them.
+        let options = parse(&["--window", "--seed", "3"]).expect("parses");
+        assert!(options.window);
+        assert_eq!(options.seed, 3);
+        assert_eq!(options.window_ticks, None, "seed alone adds no bound");
+    }
 }
 
 /// A repeated flag silently last-winning is the same defect as a

--- a/samples/glide/src/cli.rs
+++ b/samples/glide/src/cli.rs
@@ -8,7 +8,7 @@ use crate::SampleError;
 /// The sample's name in its digest line.
 const SAMPLE: &str = "glide";
 
-/// A parsed command line. Headless in every mode today.
+/// A parsed command line.
 #[derive(Debug)]
 pub struct Options {
     pub seed: u64,
@@ -19,6 +19,12 @@ pub struct Options {
     pub record_trace: Option<String>,
     /// Replay a recorded file instead; owns the whole run.
     pub replay_trace: Option<String>,
+    /// Open a window and play, instead of any headless mode.
+    pub window: bool,
+    /// The windowed run's tick bound: `None` plays until closed; the
+    /// headless `frames` default must not leak into an interactive
+    /// session, so this is derived from an EXPLICIT --frames only.
+    pub window_ticks: Option<u64>,
 }
 
 /// Parse, refusing combinations that would silently ignore a flag.
@@ -33,7 +39,13 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
     let mut input_trace = String::from("soar");
     let mut record_trace = None;
     let mut replay_trace = None;
-    let mut seen_run_flags = false;
+    let mut window = false;
+    // Per-flag tracking, not one folded bool: refusing an explicit
+    // trace flag beside --window while keeping an explicit seed needs
+    // to know WHICH flags were given.
+    let mut seen_seed = false;
+    let mut seen_frames = false;
+    let mut seen_input_trace = false;
 
     let mut args = args.into_iter();
     while let Some(flag) = args.next() {
@@ -44,15 +56,19 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         match flag.as_str() {
             "--seed" => {
                 seed = parse_number(&value_for("--seed")?, "--seed")?;
-                seen_run_flags = true;
+                seen_seed = true;
             }
             "--frames" => {
                 frames = parse_number(&value_for("--frames")?, "--frames")?;
-                seen_run_flags = true;
+                seen_frames = true;
             }
             "--input-trace" => {
                 input_trace = value_for("--input-trace")?;
-                seen_run_flags = true;
+                seen_input_trace = true;
+            }
+            "--window" => {
+                refuse_repeat("--window", window)?;
+                window = true;
             }
             "--record-trace" => {
                 refuse_repeat("--record-trace", record_trace.is_some())?;
@@ -65,19 +81,43 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
             other => {
                 return Err(SampleError::Usage(format!(
                     "unknown flag `{other}`; this sample takes --seed, --frames, \
-                     --input-trace, --record-trace, --replay-trace"
+                     --input-trace, --record-trace, --replay-trace, --window"
                 )));
             }
         }
     }
 
-    if replay_trace.is_some() && (seen_run_flags || record_trace.is_some()) {
+    let seen_run_flags = seen_seed || seen_frames || seen_input_trace;
+    if replay_trace.is_some() && (seen_run_flags || record_trace.is_some() || window) {
         return Err(SampleError::Usage(
-            "--replay-trace owns the whole run; --seed, --frames, --input-trace and \
-             --record-trace contradict it"
+            "--replay-trace owns the whole run; --seed, --frames, --input-trace, \
+             --record-trace and --window contradict it"
                 .to_string(),
         ));
     }
+    if window && (seen_input_trace || record_trace.is_some()) {
+        return Err(SampleError::Usage(
+            "--window plays from the keyboard; --input-trace and --record-trace \
+             contradict it"
+                .to_string(),
+        ));
+    }
+    // The windowed tick bound comes from an EXPLICIT --frames only: the
+    // headless default of 2000 silently ending an interactive session
+    // would be the exact bare-invocation surprise --window avoids. An
+    // explicit zero is a contradiction, refused rather than reinterpreted.
+    let window_ticks = if window && seen_frames {
+        if frames == 0 {
+            return Err(SampleError::Usage(
+                "--window with --frames 0 is a zero-tick window; leave --frames off \
+                 to play until closed"
+                    .to_string(),
+            ));
+        }
+        Some(frames)
+    } else {
+        None
+    };
 
     Ok(Options {
         seed,
@@ -85,6 +125,8 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         input_trace,
         record_trace,
         replay_trace,
+        window,
+        window_ticks,
     })
 }
 

--- a/samples/glide/src/error.rs
+++ b/samples/glide/src/error.rs
@@ -1,9 +1,8 @@
-//! Why a run stopped: two meanings, two exit codes.
+//! Why a run stopped: two meanings headless, a third with a window.
 //!
-//! No "environment unavailable" variant, deliberately: every mode this
-//! sample has today is headless, so there is no display to be missing.
-//! The variant arrives with the windowed feature, not before — an error
-//! nothing can construct is an arm no test can reach.
+//! The "environment unavailable" variant rides the windowed feature —
+//! in a headless-only build there is no display to be missing, and an
+//! error nothing can construct is an arm no test can reach.
 
 use core::fmt;
 
@@ -14,6 +13,11 @@ pub enum SampleError {
     Usage(String),
     /// Something that should have worked did not.
     Failed(String),
+    /// The environment cannot host this mode: a window was asked for
+    /// and no display can provide one. Named separately so the message
+    /// says whose fault it is — nobody's.
+    #[cfg(feature = "window")]
+    Unavailable(String),
 }
 
 impl SampleError {
@@ -28,6 +32,8 @@ impl fmt::Display for SampleError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Usage(message) | Self::Failed(message) => f.write_str(message),
+            #[cfg(feature = "window")]
+            Self::Unavailable(message) => f.write_str(message),
         }
     }
 }

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -2,10 +2,11 @@
 //! things — files in, files out — and hands the simulation nothing but a
 //! seed and one resolved boolean per tick.
 //!
-//! Headless-first. A windowed mode arrives later behind a feature; every
-//! mode here is a pure function of its command line, which is what lets
-//! the cross-process determinism gate compare runs by their one output
-//! line.
+//! Headless-first, with a windowed mode behind the `window` feature.
+//! Every headless mode is a pure function of its command line, which is
+//! what lets the cross-process determinism gate compare runs by their
+//! one output line; a windowed run rides the real clock and marks its
+//! digest line `source=window` so nothing ever compares the two.
 //!
 //! # Indexing
 //!
@@ -19,6 +20,8 @@ mod error;
 pub mod scene;
 mod scripted;
 mod trace;
+#[cfg(feature = "window")]
+mod windowed;
 
 pub use cli::{Options, Report};
 pub use error::SampleError;
@@ -50,8 +53,12 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
             eprintln!("usage: {message}");
             USAGE_EXIT
         }
-        Err(SampleError::Failed(message)) => {
-            eprintln!("FAIL: {message}");
+        // Variant-agnostic on purpose: Failed and the feature-gated
+        // Unavailable both mean exit 1, and a cfg'd arm here would be a
+        // line no lane can execute — the xvfb lane HAS a display, and no
+        // test may construct an event loop to manufacture the miss.
+        Err(other) => {
+            eprintln!("FAIL: {other}");
             FAILURE_EXIT
         }
     }
@@ -59,6 +66,10 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
 
 fn run<I: IntoIterator<Item = String>>(args: I) -> Result<Report, SampleError> {
     let options = cli::parse_args(args)?;
+
+    if options.window {
+        return windowed_run(&options);
+    }
 
     if let Some(path) = &options.replay_trace {
         // Untrusted input: bounded read, then the codec judges the
@@ -95,4 +106,19 @@ fn run<I: IntoIterator<Item = String>>(args: I) -> Result<Report, SampleError> {
         .map_err(|error| SampleError::failed("writing the trace file", &error))?;
     }
     Ok(report)
+}
+
+#[cfg(feature = "window")]
+fn windowed_run(options: &Options) -> Result<Report, SampleError> {
+    windowed::run(options)
+}
+
+/// The honest answer in a build with the windowing stack compiled out:
+/// name the reason and exit non-zero. Silently pretending to open a
+/// window would make the removability evidence worthless.
+#[cfg(not(feature = "window"))]
+fn windowed_run(_options: &Options) -> Result<Report, SampleError> {
+    Err(SampleError::Usage(
+        "this build has no windowing support; rebuild with --features window".to_string(),
+    ))
 }

--- a/samples/glide/src/scripted.rs
+++ b/samples/glide/src/scripted.rs
@@ -16,11 +16,17 @@ use crate::{SampleError, trace::Trace};
 /// expected numbers are readable without running anything.
 const FRAME_INTERVAL_NS: u64 = Timestep::HZ_60.nanos().get();
 
-/// The bindings a windowed mode will share: space or the primary
-/// button, one action.
-fn input_map() -> InputMap<Action> {
+/// The bindings both modes share: space or the primary button, one
+/// action. The pointer binding is invisible to committed traces (none
+/// carries a pointer event) and makes the windowed mode mouse-playable;
+/// binding it here keeps this doc sentence true instead of aspirational.
+pub(crate) fn input_map() -> InputMap<Action> {
     let mut map = InputMap::new();
     map.bind(Binding::Key(KeyCode::Space), Action::Flap);
+    map.bind(
+        Binding::Pointer(renew_event::PointerButton::Left),
+        Action::Flap,
+    );
     map
 }
 
@@ -172,5 +178,38 @@ fn drive(
         source,
         stats,
         world,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_bindings_resolve_to_the_one_action() {
+        // The doc above the map promises "space or the primary button";
+        // this is the featureless test that keeps the sentence true.
+        let mut map = input_map();
+        map.handle(WindowEvent::Key {
+            code: KeyCode::Space,
+            pressed: true,
+            repeat: false,
+        });
+        assert!(map.state(Action::Flap).just_pressed, "space flaps");
+        map.advance();
+        map.handle(WindowEvent::Key {
+            code: KeyCode::Space,
+            pressed: false,
+            repeat: false,
+        });
+        map.advance();
+        map.handle(WindowEvent::PointerButton {
+            button: renew_event::PointerButton::Left,
+            pressed: true,
+        });
+        assert!(
+            map.state(Action::Flap).just_pressed,
+            "the primary button flaps"
+        );
     }
 }

--- a/samples/glide/src/scripted.rs
+++ b/samples/glide/src/scripted.rs
@@ -1,6 +1,6 @@
 //! Driving the world from a trace: the fixed-step loop on a synthetic
 //! clock, events delivered by tick, input resolved through the same map
-//! a windowed mode will use.
+//! the windowed mode uses.
 
 use renew_event::{KeyCode, WindowEvent};
 use renew_frame::{FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -458,8 +458,10 @@ mod tests {
     /// One 60Hz step interval in nanoseconds.
     const STEP: u64 = Timestep::HZ_60.nanos().get();
 
+    /// Through the seam, not straight into the map: the fall-through
+    /// event arm is part of what these tests witness.
     fn press(app: &mut GlideApp) {
-        app.input.handle(WindowEvent::Key {
+        app.event(WindowEvent::Key {
             code: renew_event::KeyCode::Space,
             pressed: true,
             repeat: false,
@@ -467,7 +469,7 @@ mod tests {
     }
 
     fn release(app: &mut GlideApp) {
-        app.input.handle(WindowEvent::Key {
+        app.event(WindowEvent::Key {
             code: renew_event::KeyCode::Space,
             pressed: false,
             repeat: false,
@@ -608,6 +610,26 @@ mod tests {
         assert!(matches!(&second.failure, Some(SampleError::Failed(_))));
         second.record_bring_up(Ok(()));
         second.record_resize(Ok(()));
+    }
+
+    #[test]
+    fn an_update_before_ready_is_a_quiet_no_op() {
+        // No frame is anchored until ready runs; an update arriving
+        // first must step nothing and fail nothing.
+        let options = Options {
+            seed: 7,
+            frames: 2_000,
+            input_trace: "soar".to_string(),
+            record_trace: None,
+            replay_trace: None,
+            window: true,
+            window_ticks: None,
+        };
+        let mut app = GlideApp::new(&options);
+        let mut control = LoopControl::default();
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert_eq!(app.world.tick(), 0);
+        assert!(app.failure.is_none());
     }
 
     #[test]

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -1,0 +1,673 @@
+//! The game in a window: the same world, a real clock, a key and a
+//! button, the score in the title.
+//!
+//! The shape is the delegation shell both siblings use — every seam
+//! callback is a thin forward to a plain function tests drive with no
+//! window; only `ready` needs a live OS window, and the windowed CI
+//! lane covers it. The one place the scripted loop is deliberately NOT
+//! copied is input: a wall clock plans zero, one, or many steps per
+//! frame, so flap edges ride a saturating counter consumed one per
+//! step — the closest a real clock gets to the scripted loop's
+//! one-edge-one-tick.
+
+use renew_event::WindowEvent;
+use renew_frame::{FrameLoop, FrameStats, Nanos, StepBudget, Timestamp, Timestep};
+use renew_input::InputMap;
+use renew_platform::Clock;
+use renew_platform::window::{
+    LoopControl, NativeWindow, WindowApp, WindowConfig, WindowError, WindowRef, run_window_app,
+};
+use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer};
+use renew_rhi::{Color, Device, DeviceDesc, Extent, PresentOutcome, Validation, WindowTarget};
+use renew_sample_glide_world::{Action, VIEW_HEIGHT, VIEW_WIDTH, World};
+
+use crate::cli::{Options, Report};
+use crate::scene::{SceneSprite, Tile, scene};
+use crate::{SampleError, scripted};
+
+/// The window's base title; the score readout appends to it.
+const TITLE: &str = "renew — glide";
+
+/// The sky, the bird, the pipes: the goldens' test-card look, which is
+/// the game's look until real art arrives.
+const SKY: Color = Color {
+    r: 51.0 / 255.0,
+    g: 102.0 / 255.0,
+    b: 153.0 / 255.0,
+    a: 1.0,
+};
+const BIRD_TEXEL: [u8; 4] = [255, 208, 0, 255];
+const PIPE_TEXEL: [u8; 4] = [0, 160, 40, 255];
+const ATLAS_EXTENT: Extent = Extent {
+    width: 4,
+    height: 2,
+};
+const BIRD_REGION: Region = Region {
+    x: 0,
+    y: 0,
+    width: 2,
+    height: 2,
+};
+const PIPE_REGION: Region = Region {
+    x: 2,
+    y: 0,
+    width: 2,
+    height: 2,
+};
+
+/// How long the run may present nothing before it is declared wedged.
+/// Time-based, not update-counted: the poll loop's iteration rate is a
+/// fact about the machine. A field on the app holds it so tests reach
+/// the path without waiting real seconds. Second copy of this shape;
+/// the third is the cue to extract it.
+const WEDGE_AFTER: Nanos = Nanos::from_nanos(5_000_000_000);
+
+/// The presented frame after which the swapchain is rebuilt once, so
+/// the rebuild-under-a-live-surface path runs everywhere and not only
+/// where a window manager sends resizes.
+const REBUILD_AFTER_FRAME: u64 = 2;
+
+/// Sprite capacity: worst case is five pipes as two bars each plus the
+/// bird; headroom beyond that.
+const SPRITE_CAPACITY: u32 = 32;
+
+/// Open the window and play until closed, wedged, or the tick bound.
+pub fn run(options: &Options) -> Result<Report, SampleError> {
+    let mut app = GlideApp::new(options);
+    let config = WindowConfig {
+        title: TITLE.to_string(),
+        logical_width: 640.0,
+        logical_height: 480.0,
+        resizable: true,
+    };
+    let outcome = run_window_app(&config, &mut app);
+    app.finish(outcome)
+}
+
+/// The fixed-capacity title buffer: format into it, borrow it, never
+/// touch the heap. Score digits and the terminal suffix fit in a
+/// fraction of this.
+struct Title {
+    bytes: [u8; 64],
+    length: usize,
+}
+
+impl Title {
+    fn new() -> Self {
+        Self {
+            bytes: [0; 64],
+            length: 0,
+        }
+    }
+
+    /// The title for a score, with the game-over suffix once dead.
+    /// Returns `None` when the buffer would overflow — unreachable at
+    /// this capacity, kept so the refusal is a branch and not a panic.
+    fn compose(&mut self, score: u64, alive: bool) -> Option<&str> {
+        use core::fmt::Write as _;
+        struct Sink<'a> {
+            bytes: &'a mut [u8; 64],
+            length: &'a mut usize,
+        }
+        impl core::fmt::Write for Sink<'_> {
+            fn write_str(&mut self, text: &str) -> core::fmt::Result {
+                let end = self
+                    .length
+                    .checked_add(text.len())
+                    .ok_or(core::fmt::Error)?;
+                if end > self.bytes.len() {
+                    return Err(core::fmt::Error);
+                }
+                self.bytes[*self.length..end].copy_from_slice(text.as_bytes());
+                *self.length = end;
+                Ok(())
+            }
+        }
+        self.length = 0;
+        let mut sink = Sink {
+            bytes: &mut self.bytes,
+            length: &mut self.length,
+        };
+        let suffix = if alive { "" } else { " — over" };
+        write!(sink, "{TITLE} — score {score}{suffix}").ok()?;
+        core::str::from_utf8(&self.bytes[..self.length]).ok()
+    }
+}
+
+/// The game as the window seam sees it.
+pub struct GlideApp {
+    clock: Clock,
+    seed: u64,
+    /// `None` = play until closed; `Some(n)` = stop after `n` ticks.
+    ticks_wanted: Option<u64>,
+    world: World,
+    input: InputMap<Action>,
+    /// Flap edges not yet consumed by a step. A saturating counter, not
+    /// a bit: a press on a zero-step frame plus a press on a catch-up
+    /// frame are two flaps with two step intervals to land in, and a
+    /// bit would fold them. Only Flap is latched; a second action must
+    /// extend this or lose its edges.
+    pending_flaps: u8,
+    stats: FrameStats,
+    scene_scratch: Vec<SceneSprite>,
+    title: Title,
+    /// The score last written into the title, so relabeling happens on
+    /// change only. Death changes the suffix, tracked beside it.
+    titled: Option<(u64, bool)>,
+    frame: Option<FrameLoop>,
+    window: Option<NativeWindow>,
+    device: Option<Device>,
+    target: Option<WindowTarget>,
+    renderer: Option<SpriteRenderer>,
+    size: Extent,
+    presented: u64,
+    close_requested: bool,
+    last_progress: Timestamp,
+    /// A field rather than the constant so tests reach the wedge path
+    /// without waiting real seconds.
+    wedge_after: Nanos,
+    drawn_since_update: bool,
+    failure: Option<SampleError>,
+}
+
+impl GlideApp {
+    #[must_use]
+    pub fn new(options: &Options) -> Self {
+        Self {
+            clock: Clock::start(),
+            seed: options.seed,
+            ticks_wanted: options.window_ticks,
+            world: World::new(options.seed),
+            input: scripted::input_map(),
+            pending_flaps: 0,
+            stats: FrameStats::new(),
+            scene_scratch: Vec::new(),
+            title: Title::new(),
+            titled: None,
+            frame: None,
+            window: None,
+            device: None,
+            target: None,
+            renderer: None,
+            size: Extent {
+                width: 1,
+                height: 1,
+            },
+            presented: 0,
+            close_requested: false,
+            last_progress: Timestamp::from_nanos(0),
+            wedge_after: WEDGE_AFTER,
+            drawn_since_update: false,
+            failure: None,
+        }
+    }
+
+    fn atlas_bytes() -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        for (index, chunk) in bytes.chunks_exact_mut(4).enumerate() {
+            let texel = if index % 4 < 2 {
+                BIRD_TEXEL
+            } else {
+                PIPE_TEXEL
+            };
+            chunk.copy_from_slice(&texel);
+        }
+        bytes
+    }
+
+    fn bring_up(&mut self, window: NativeWindow, size: Extent) -> Result<(), SampleError> {
+        let device = Device::new(&DeviceDesc {
+            app_name: "renew-glide",
+            validation: Validation::Off,
+        })
+        .map_err(|error| SampleError::failed("bringing up the device", &error))?;
+        let target = device
+            .create_window_target(window, size)
+            .map_err(|error| SampleError::failed("creating the window target", &error))?;
+        let atlas = Self::atlas_bytes();
+        let canvas = Canvas::new(VIEW_WIDTH, VIEW_HEIGHT)
+            .ok_or_else(|| SampleError::Failed("the view has zero size".to_string()))?;
+        let capacity = core::num::NonZeroU32::new(SPRITE_CAPACITY)
+            .ok_or_else(|| SampleError::Failed("zero sprite capacity".to_string()))?;
+        let renderer = SpriteRenderer::new(
+            &device,
+            &AtlasDesc::new(ATLAS_EXTENT, &atlas),
+            canvas,
+            target.format(),
+            capacity,
+        )
+        .map_err(|error| SampleError::failed("building the sprite renderer", &error))?;
+        self.device = Some(device);
+        self.target = Some(target);
+        self.renderer = Some(renderer);
+        Ok(())
+    }
+
+    /// Draw the world as it stands.
+    fn draw(&mut self) {
+        let (Some(target), Some(renderer)) = (&mut self.target, &mut self.renderer) else {
+            return;
+        };
+        scene(&self.world, &mut self.scene_scratch);
+        renderer.begin();
+        for sprite in &self.scene_scratch {
+            let region = match sprite.tile {
+                Tile::Bird => BIRD_REGION,
+                Tile::Pipe => PIPE_REGION,
+            };
+            renderer
+                .push(&Sprite::new(region, sprite.x, sprite.y).size(sprite.width, sprite.height));
+        }
+        let outcome = target.render(&renderer.desc(SKY));
+        self.record_draw(outcome);
+    }
+
+    /// What a draw outcome means for the run — split from [`Self::draw`]
+    /// so tests drive every arm with constructed outcomes, no window.
+    fn record_draw(&mut self, outcome: Result<PresentOutcome, renew_rhi::TargetError>) {
+        match outcome {
+            Ok(PresentOutcome::Presented) => {
+                self.presented = self.presented.saturating_add(1);
+                self.drawn_since_update = true;
+                if self.presented == REBUILD_AFTER_FRAME {
+                    let size = self.size;
+                    self.resize(size);
+                }
+            }
+            Ok(PresentOutcome::NeedsResize) => {
+                let size = self.size;
+                self.resize(size);
+            }
+            Err(error) => {
+                self.failure = Some(SampleError::failed("rendering", &error));
+            }
+        }
+    }
+
+    /// Follow the window's size; the renderer never learns the word
+    /// swapchain.
+    fn resize(&mut self, size: Extent) {
+        self.size = size;
+        if let Some(target) = &mut self.target
+            && let Err(error) = target.resize(size)
+        {
+            self.failure = Some(SampleError::failed("resizing", &error));
+        }
+    }
+
+    /// Whether any reason to keep looping remains.
+    fn done(&self) -> bool {
+        self.failure.is_some()
+            || self.close_requested
+            || self
+                .ticks_wanted
+                .is_some_and(|bound| self.world.tick() >= bound)
+    }
+
+    /// The update the seam asks for, as a pure function of the frame's
+    /// timestamp — the testable core.
+    fn update_at(&mut self, now: Timestamp, control: &mut LoopControl) {
+        if let Some(frame) = &mut self.frame {
+            let plan = frame.begin_frame(now);
+            // Capture the edge before it retires, count it, spend one
+            // per step: a press on a zero-step frame survives to the
+            // next frame's first step, and two presses with two due
+            // steps deliver two flaps.
+            self.pending_flaps = self
+                .pending_flaps
+                .saturating_add(u8::from(self.input.state(Action::Flap).just_pressed));
+            for _step in plan.steps() {
+                let bound = self.ticks_wanted;
+                if bound.is_some_and(|bound| self.world.tick() >= bound) {
+                    break;
+                }
+                self.world.step(self.pending_flaps > 0);
+                self.pending_flaps = self.pending_flaps.saturating_sub(1);
+            }
+            self.input.advance();
+            self.stats.absorb(&plan);
+            self.relabel();
+            if self.drawn_since_update {
+                self.last_progress = now;
+            }
+            self.drawn_since_update = false;
+        }
+        let stalled = now.saturating_since(self.last_progress);
+        if self.failure.is_none() && stalled >= self.wedge_after && !self.done() {
+            self.failure = Some(SampleError::Failed(format!(
+                "wedged: {} frames presented, none in the last {} ms",
+                self.presented,
+                stalled.get() / 1_000_000
+            )));
+        }
+        if self.done() {
+            control.exit();
+        } else {
+            control.request_redraw();
+        }
+    }
+
+    /// Relabel the window when the score or the terminal state changes;
+    /// otherwise the OS hears nothing.
+    fn relabel(&mut self) {
+        let state = (self.world.score(), self.world.alive());
+        if self.titled == Some(state) {
+            return;
+        }
+        if let Some(title) = self.title.compose(state.0, state.1)
+            && let Some(window) = &self.window
+        {
+            window.set_title(title);
+            self.titled = Some(state);
+        }
+    }
+
+    /// Turn the loop's outcome into the run's report.
+    fn finish(self, outcome: Result<(), WindowError>) -> Result<Report, SampleError> {
+        if let Err(error) = outcome {
+            return Err(match error {
+                WindowError::LoopUnavailable { message } => {
+                    SampleError::Unavailable(format!("no window is available here: {message}"))
+                }
+                other => SampleError::failed("running the window loop", &other),
+            });
+        }
+        if let Some(failure) = self.failure {
+            return Err(failure);
+        }
+        Ok(Report {
+            seed: self.seed,
+            source: "window".to_string(),
+            stats: self.stats,
+            world: self.world,
+        })
+    }
+}
+
+impl WindowApp for GlideApp {
+    fn ready(&mut self, window: &WindowRef<'_>) {
+        let (width, height) = window.physical_size();
+        self.size = Extent { width, height };
+        let native = window.native();
+        self.window = Some(native.clone());
+        if let Err(error) = self.bring_up(native, self.size) {
+            self.failure = Some(error);
+        }
+        // Anchor AFTER bring-up, so device creation is not banked as a
+        // clamped burst of catch-up steps.
+        let now = Timestamp::from_nanos(self.clock.elapsed_nanos());
+        self.frame = Some(FrameLoop::new(Timestep::HZ_60, StepBudget::DEFAULT, now));
+        self.last_progress = now;
+    }
+
+    fn event(&mut self, event: WindowEvent) {
+        match event {
+            WindowEvent::RedrawRequested => self.draw(),
+            WindowEvent::Resized { width, height } => self.resize(Extent { width, height }),
+            WindowEvent::CloseRequested => self.close_requested = true,
+            WindowEvent::Focused(false) => self.input.release_all(),
+            other => self.input.handle(other),
+        }
+    }
+
+    fn update(&mut self, control: &mut LoopControl) {
+        let now = Timestamp::from_nanos(self.clock.elapsed_nanos());
+        self.update_at(now, control);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app() -> GlideApp {
+        let options = Options {
+            seed: 7,
+            frames: 2_000,
+            input_trace: "soar".to_string(),
+            record_trace: None,
+            replay_trace: None,
+            window: true,
+            window_ticks: None,
+        };
+        let mut app = GlideApp::new(&options);
+        // Anchor the schedule by hand: these tests say what time it is,
+        // and no window exists.
+        app.frame = Some(FrameLoop::new(
+            Timestep::HZ_60,
+            StepBudget::DEFAULT,
+            Timestamp::from_nanos(0),
+        ));
+        app
+    }
+
+    /// One 60Hz step interval in nanoseconds.
+    const STEP: u64 = Timestep::HZ_60.nanos().get();
+
+    fn press(app: &mut GlideApp) {
+        app.input.handle(WindowEvent::Key {
+            code: renew_event::KeyCode::Space,
+            pressed: true,
+            repeat: false,
+        });
+    }
+
+    fn release(app: &mut GlideApp) {
+        app.input.handle(WindowEvent::Key {
+            code: renew_event::KeyCode::Space,
+            pressed: false,
+            repeat: false,
+        });
+    }
+
+    #[test]
+    fn one_press_on_a_multi_step_frame_flaps_once() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        press(&mut app);
+        // Three step intervals elapse in one frame: three steps run,
+        // exactly one may flap.
+        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 3, "three steps ran");
+        assert_eq!(app.pending_flaps, 0, "the one edge was consumed");
+        // The flap reached the world: velocity is upward (negative) at
+        // some point only if a flap fired; after three ticks with one
+        // flap the world differs from a flapless one.
+        let mut flapless = World::new(7);
+        for _ in 0..3 {
+            flapless.step(false);
+        }
+        assert_ne!(
+            app.world.digest(),
+            flapless.digest(),
+            "the press must have reached exactly one step"
+        );
+    }
+
+    #[test]
+    fn a_press_on_a_zero_step_frame_survives_to_the_next_step() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        press(&mut app);
+        // No step is due yet: the edge retires but the counter holds it.
+        app.update_at(Timestamp::from_nanos(STEP / 4), &mut control);
+        assert_eq!(app.world.tick(), 0, "no step was due");
+        assert_eq!(app.pending_flaps, 1, "the edge survived in the counter");
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert_eq!(app.world.tick(), 1);
+        assert_eq!(app.pending_flaps, 0, "the held edge was consumed");
+    }
+
+    #[test]
+    fn two_presses_across_a_catch_up_frame_deliver_two_flaps() {
+        // The round-one counterexample, pinned: press on a zero-step
+        // frame, a second distinct press on a frame that plans two
+        // catch-up steps. A bit would fold them; the counter must not.
+        let mut app = app();
+        let mut control = LoopControl::default();
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP / 4), &mut control);
+        assert_eq!(app.pending_flaps, 1);
+        release(&mut app);
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(2 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 2, "two catch-up steps ran");
+        assert_eq!(
+            app.pending_flaps, 0,
+            "both presses were consumed, one per step"
+        );
+        // Two flaps in two ticks: differs from one flap in two ticks.
+        let mut one_flap = World::new(7);
+        one_flap.step(true);
+        one_flap.step(false);
+        assert_ne!(
+            app.world.digest(),
+            one_flap.digest(),
+            "the second press must not have been folded away"
+        );
+    }
+
+    #[test]
+    fn two_presses_in_one_event_phase_fold_to_one_edge() {
+        // The fold that remains is per event phase, not per step
+        // interval: press-release-press before a single update is one
+        // just_pressed transition report, so one edge — a fact about
+        // edge reporting, pinned rather than hidden.
+        let mut app = app();
+        let mut control = LoopControl::default();
+        press(&mut app);
+        release(&mut app);
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert_eq!(app.world.tick(), 1);
+        assert_eq!(app.pending_flaps, 0, "one edge, consumed by the one step");
+    }
+
+    #[test]
+    fn presses_on_two_zero_step_frames_carry_as_two_flaps() {
+        // The counter deliberately UN-folds presses that arrive on
+        // separate frames inside one step interval: each frame's edge
+        // counts, and the two flaps fire one tick apart.
+        let mut app = app();
+        let mut control = LoopControl::default();
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP / 8), &mut control);
+        release(&mut app);
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP / 4), &mut control);
+        assert_eq!(app.world.tick(), 0, "still inside the first interval");
+        assert_eq!(app.pending_flaps, 2, "both frames' edges are counted");
+        app.update_at(Timestamp::from_nanos(2 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 2);
+        assert_eq!(app.pending_flaps, 0, "both consumed, one per tick");
+    }
+
+    #[test]
+    fn the_title_reflects_score_and_death_and_only_changes_when_they_do() {
+        let mut title = Title::new();
+        let alive = title.compose(0, true).expect("compose").to_string();
+        assert_eq!(alive, "renew — glide — score 0");
+        let scored = title.compose(12, true).expect("compose").to_string();
+        assert_eq!(scored, "renew — glide — score 12");
+        let over = title.compose(12, false).expect("compose").to_string();
+        assert_eq!(over, "renew — glide — score 12 — over");
+    }
+
+    #[test]
+    fn the_wedge_path_reports_after_the_stall_window() {
+        let mut app = app();
+        app.wedge_after = Nanos::from_nanos(1);
+        let mut control = LoopControl::default();
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert!(
+            matches!(&app.failure, Some(SampleError::Failed(message)) if message.starts_with("wedged")),
+            "a run that never presents must wedge: {:?}",
+            app.failure
+        );
+    }
+
+    #[test]
+    fn draw_outcomes_mean_what_the_run_records() {
+        // Every record_draw arm, driven with constructed outcomes.
+        let mut app = app();
+        app.record_draw(Ok(PresentOutcome::Presented));
+        assert_eq!(app.presented, 1);
+        assert!(app.drawn_since_update);
+        // NeedsResize is not an error and not progress; with no target
+        // built, resize is a no-op and nothing fails.
+        app.record_draw(Ok(PresentOutcome::NeedsResize));
+        assert_eq!(app.presented, 1);
+        assert!(app.failure.is_none());
+        app.record_draw(Err(renew_rhi::TargetError::SurfaceCreation { code: -1 }));
+        assert!(
+            matches!(&app.failure, Some(SampleError::Failed(message)) if message.starts_with("rendering")),
+            "a render error is the run's failure: {:?}",
+            app.failure
+        );
+    }
+
+    #[test]
+    fn the_event_arms_latch_release_and_forward() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        // Focus loss clears held input: a press followed by Focused(false)
+        // must not flap.
+        press(&mut app);
+        app.event(WindowEvent::Focused(false));
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert_eq!(app.world.tick(), 1);
+        // The edge fired before the release_all, so the press itself
+        // still counts once — what must NOT happen is a stuck hold
+        // producing more flaps later.
+        let flaps_now = app.pending_flaps;
+        app.update_at(Timestamp::from_nanos(2 * STEP), &mut control);
+        assert_eq!(
+            app.pending_flaps,
+            flaps_now.saturating_sub(1).min(flaps_now),
+            "no new edges appear after focus loss"
+        );
+        // The close latch ends the run.
+        app.event(WindowEvent::CloseRequested);
+        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        assert!(app.close_requested);
+    }
+
+    #[test]
+    fn finish_maps_outcomes_to_the_report_or_the_named_refusal() {
+        let options = Options {
+            seed: 7,
+            frames: 2_000,
+            input_trace: "soar".to_string(),
+            record_trace: None,
+            replay_trace: None,
+            window: true,
+            window_ticks: None,
+        };
+        // Success: a report with the window's source.
+        let app = GlideApp::new(&options);
+        let report = app.finish(Ok(())).expect("a clean run reports");
+        assert_eq!(report.source, "window");
+        assert_eq!(report.seed, 7);
+        // A recorded failure outranks a clean loop exit.
+        let mut app = GlideApp::new(&options);
+        app.failure = Some(SampleError::Failed("wedged: test".to_string()));
+        assert!(matches!(
+            app.finish(Ok(())),
+            Err(SampleError::Failed(message)) if message.starts_with("wedged")
+        ));
+        // A missing display is the named refusal, not a generic failure.
+        let app = GlideApp::new(&options);
+        assert!(matches!(
+            app.finish(Err(WindowError::LoopUnavailable {
+                message: "no display".to_string()
+            })),
+            Err(SampleError::Unavailable(_))
+        ));
+    }
+
+    #[test]
+    fn the_unavailable_error_displays_its_reason() {
+        let error = SampleError::Unavailable("no display server".to_string());
+        assert_eq!(error.to_string(), "no display server");
+    }
+}

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -321,8 +321,16 @@ impl GlideApp {
 
     /// The update the seam asks for, as a pure function of the frame's
     /// timestamp — the testable core.
+    ///
+    /// The tick bound is checked at frame boundaries, never mid-plan:
+    /// every absorbed plan is fully executed, so the digest line's tick
+    /// count and the world can never disagree. The cost is a bounded
+    /// overshoot of at most the step budget minus one on a lagging
+    /// frame, documented where the flag is.
     fn update_at(&mut self, now: Timestamp, control: &mut LoopControl) {
-        if let Some(frame) = &mut self.frame {
+        if !self.done()
+            && let Some(frame) = &mut self.frame
+        {
             let plan = frame.begin_frame(now);
             // Capture the edge before it retires, count it, spend one
             // per step: a press on a zero-step frame survives to the
@@ -332,16 +340,12 @@ impl GlideApp {
                 .pending_flaps
                 .saturating_add(u8::from(self.input.state(Action::Flap).just_pressed));
             for _step in plan.steps() {
-                let bound = self.ticks_wanted;
-                if bound.is_some_and(|bound| self.world.tick() >= bound) {
-                    break;
-                }
                 self.world.step(self.pending_flaps > 0);
                 self.pending_flaps = self.pending_flaps.saturating_sub(1);
             }
             self.input.advance();
             self.stats.absorb(&plan);
-            self.relabel();
+            let _ = self.relabel();
             if self.drawn_since_update {
                 self.last_progress = now;
             }
@@ -363,18 +367,23 @@ impl GlideApp {
     }
 
     /// Relabel the window when the score or the terminal state changes;
-    /// otherwise the OS hears nothing.
-    fn relabel(&mut self) {
+    /// otherwise the OS hears nothing. Returns whether a compose
+    /// happened, so the change-only gate is a tested fact rather than a
+    /// lane-only one; composing is tracked even windowless, and only
+    /// the delivery needs the OS handle.
+    fn relabel(&mut self) -> bool {
         let state = (self.world.score(), self.world.alive());
         if self.titled == Some(state) {
-            return;
+            return false;
         }
-        if let Some(title) = self.title.compose(state.0, state.1)
-            && let Some(window) = &self.window
-        {
+        let Some(title) = self.title.compose(state.0, state.1) else {
+            return false;
+        };
+        if let Some(window) = &self.window {
             window.set_title(title);
-            self.titled = Some(state);
         }
+        self.titled = Some(state);
+        true
     }
 
     /// Turn the loop's outcome into the run's report.
@@ -633,12 +642,51 @@ mod tests {
     }
 
     #[test]
-    fn the_tick_bound_stops_the_steps_mid_plan() {
+    fn the_tick_bound_stops_at_the_frame_boundary_and_the_line_stays_true() {
+        // The bound never cuts a plan: the lagging frame's three steps
+        // all execute (a bounded overshoot the flag documents), and the
+        // stats agree with the world — the digest line cannot contradict
+        // itself.
         let mut app = app();
         app.ticks_wanted = Some(1);
         let mut control = LoopControl::default();
         app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
-        assert_eq!(app.world.tick(), 1, "the bound break fired inside the plan");
+        assert_eq!(app.world.tick(), 3, "the lagging plan finished whole");
+        assert_eq!(
+            app.stats.ticks(),
+            app.world.tick(),
+            "absorbed and executed are the same number"
+        );
+        assert!(app.done(), "the bound is reached at the boundary");
+        // A further update steps nothing: done at entry skips the plan.
+        app.update_at(Timestamp::from_nanos(6 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 3, "no ticks after the bound");
+    }
+
+    #[test]
+    fn a_latched_close_steps_no_further_ticks() {
+        // The close click is honored before any catch-up burst: done at
+        // entry means the plan is never begun.
+        let mut app = app();
+        let mut control = LoopControl::default();
+        app.event(WindowEvent::CloseRequested);
+        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 0, "no ticks after the close");
+    }
+
+    #[test]
+    fn the_title_composes_on_change_and_only_on_change() {
+        // The change-only gate, as a tested fact: first sight composes,
+        // repetition does not, a score or death change does.
+        let mut app = app();
+        assert!(app.relabel(), "first sight composes");
+        assert!(!app.relabel(), "unchanged state is silent");
+        for _ in 0..240 {
+            app.world.step(false);
+        }
+        assert!(!app.world.alive(), "gravity won");
+        assert!(app.relabel(), "death recomposes");
+        assert!(!app.relabel(), "and then silence again");
     }
 
     #[test]
@@ -721,28 +769,25 @@ mod tests {
     }
 
     #[test]
-    fn the_event_arms_latch_release_and_forward() {
+    fn focus_loss_forgets_the_held_key_so_a_new_press_registers() {
+        // The observable consequence of release_all, which a deleted
+        // arm would fail: without it the key is still "held" and the
+        // second press is no transition — no new edge, a dropped input.
         let mut app = app();
         let mut control = LoopControl::default();
-        // Focus loss clears held input: a press followed by Focused(false)
-        // must not flap.
         press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP / 8), &mut control);
+        assert_eq!(app.pending_flaps, 1, "the first press banked");
         app.event(WindowEvent::Focused(false));
-        app.update_at(Timestamp::from_nanos(STEP), &mut control);
-        assert_eq!(app.world.tick(), 1);
-        // The edge fired before the release_all, so the press itself
-        // still counts once — what must NOT happen is a stuck hold
-        // producing more flaps later.
-        let flaps_now = app.pending_flaps;
-        app.update_at(Timestamp::from_nanos(2 * STEP), &mut control);
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(STEP / 4), &mut control);
         assert_eq!(
-            app.pending_flaps,
-            flaps_now.saturating_sub(1).min(flaps_now),
-            "no new edges appear after focus loss"
+            app.pending_flaps, 2,
+            "focus loss forgot the held key, so the re-press is a real new              edge — with the release_all arm deleted the key stays held and              this press is no transition at all"
         );
         // The close latch ends the run.
         app.event(WindowEvent::CloseRequested);
-        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
         assert!(app.close_requested);
     }
 

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -135,6 +135,29 @@ impl<const N: usize> Title<N> {
     }
 }
 
+/// The relabel decision as a free function, generic over the title's
+/// capacity so the compose-refusal arm is reachable from a test holding
+/// a deliberately tiny buffer — the same reason the capacity is a type
+/// parameter at all.
+fn relabel_into<const N: usize>(
+    title: &mut Title<N>,
+    titled: &mut Option<(u64, bool)>,
+    window: Option<&NativeWindow>,
+    state: (u64, bool),
+) -> bool {
+    if *titled == Some(state) {
+        return false;
+    }
+    let Some(text) = title.compose(state.0, state.1) else {
+        return false;
+    };
+    if let Some(window) = window {
+        window.set_title(text);
+    }
+    *titled = Some(state);
+    true
+}
+
 /// The game as the window seam sees it.
 pub struct GlideApp {
     clock: Clock,
@@ -373,17 +396,12 @@ impl GlideApp {
     /// the delivery needs the OS handle.
     fn relabel(&mut self) -> bool {
         let state = (self.world.score(), self.world.alive());
-        if self.titled == Some(state) {
-            return false;
-        }
-        let Some(title) = self.title.compose(state.0, state.1) else {
-            return false;
-        };
-        if let Some(window) = &self.window {
-            window.set_title(title);
-        }
-        self.titled = Some(state);
-        true
+        relabel_into(
+            &mut self.title,
+            &mut self.titled,
+            self.window.as_ref(),
+            state,
+        )
     }
 
     /// Turn the loop's outcome into the run's report.
@@ -590,9 +608,17 @@ mod tests {
     #[test]
     fn the_title_refuses_a_buffer_it_cannot_fit() {
         // The overflow branch, reachable through a deliberately tiny
-        // capacity — the reason the capacity is a type parameter.
+        // capacity — the reason the capacity is a type parameter — and
+        // the relabel decision that rides the refusal: no compose, no
+        // recorded state, try again next time.
         let mut tiny = Title::<8>::new();
         assert!(tiny.compose(0, true).is_none(), "eight bytes cannot fit");
+        let mut titled = None;
+        assert!(
+            !relabel_into(&mut tiny, &mut titled, None, (0, true)),
+            "a refused compose is not a relabel"
+        );
+        assert_eq!(titled, None, "and records nothing as delivered");
     }
 
     #[test]

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -85,28 +85,29 @@ pub fn run(options: &Options) -> Result<Report, SampleError> {
 }
 
 /// The fixed-capacity title buffer: format into it, borrow it, never
-/// touch the heap. Score digits and the terminal suffix fit in a
-/// fraction of this.
-struct Title {
-    bytes: [u8; 64],
+/// touch the heap. The capacity is a type parameter rather than a
+/// constant — the sibling's trick — so the overflow refusal is
+/// reachable from a test holding a deliberately tiny buffer; a branch
+/// nothing can execute is a branch nobody has checked.
+struct Title<const N: usize = 64> {
+    bytes: [u8; N],
     length: usize,
 }
 
-impl Title {
+impl<const N: usize> Title<N> {
     fn new() -> Self {
         Self {
-            bytes: [0; 64],
+            bytes: [0; N],
             length: 0,
         }
     }
 
     /// The title for a score, with the game-over suffix once dead.
-    /// Returns `None` when the buffer would overflow — unreachable at
-    /// this capacity, kept so the refusal is a branch and not a panic.
+    /// Returns `None` when the buffer would overflow.
     fn compose(&mut self, score: u64, alive: bool) -> Option<&str> {
         use core::fmt::Write as _;
         struct Sink<'a> {
-            bytes: &'a mut [u8; 64],
+            bytes: &'a mut [u8],
             length: &'a mut usize,
         }
         impl core::fmt::Write for Sink<'_> {
@@ -288,10 +289,24 @@ impl GlideApp {
     /// swapchain.
     fn resize(&mut self, size: Extent) {
         self.size = size;
-        if let Some(target) = &mut self.target
-            && let Err(error) = target.resize(size)
-        {
+        if let Some(target) = &mut self.target {
+            let outcome = target.resize(size);
+            self.record_resize(outcome);
+        }
+    }
+
+    /// What a resize outcome means — split so tests drive the error
+    /// arm with a constructed value, no window.
+    fn record_resize(&mut self, outcome: Result<(), renew_rhi::TargetError>) {
+        if let Err(error) = outcome {
             self.failure = Some(SampleError::failed("resizing", &error));
+        }
+    }
+
+    /// What a failed bring-up means — the same driven-seam split.
+    fn record_bring_up(&mut self, outcome: Result<(), SampleError>) {
+        if let Err(error) = outcome {
+            self.failure = Some(error);
         }
     }
 
@@ -390,9 +405,8 @@ impl WindowApp for GlideApp {
         self.size = Extent { width, height };
         let native = window.native();
         self.window = Some(native.clone());
-        if let Err(error) = self.bring_up(native, self.size) {
-            self.failure = Some(error);
-        }
+        let outcome = self.bring_up(native, self.size);
+        self.record_bring_up(outcome);
         // Anchor AFTER bring-up, so device creation is not banked as a
         // clamped burst of catch-up steps.
         let now = Timestamp::from_nanos(self.clock.elapsed_nanos());
@@ -563,8 +577,86 @@ mod tests {
     }
 
     #[test]
+    fn the_title_refuses_a_buffer_it_cannot_fit() {
+        // The overflow branch, reachable through a deliberately tiny
+        // capacity — the reason the capacity is a type parameter.
+        let mut tiny = Title::<8>::new();
+        assert!(tiny.compose(0, true).is_none(), "eight bytes cannot fit");
+    }
+
+    #[test]
+    fn draw_without_a_target_is_a_quiet_no_op() {
+        let mut app = app();
+        app.event(WindowEvent::RedrawRequested);
+        app.event(WindowEvent::Resized {
+            width: 320,
+            height: 240,
+        });
+        assert!(app.failure.is_none());
+        assert_eq!(app.presented, 0);
+    }
+
+    #[test]
+    fn the_outcome_seams_record_their_failures() {
+        let mut first = app();
+        first.record_resize(Err(renew_rhi::TargetError::SurfaceCreation { code: -3 }));
+        assert!(
+            matches!(&first.failure, Some(SampleError::Failed(message)) if message.starts_with("resizing"))
+        );
+        let mut second = app();
+        second.record_bring_up(Err(SampleError::Failed("no device".to_string())));
+        assert!(matches!(&second.failure, Some(SampleError::Failed(_))));
+        second.record_bring_up(Ok(()));
+        second.record_resize(Ok(()));
+    }
+
+    #[test]
+    fn the_tick_bound_stops_the_steps_mid_plan() {
+        let mut app = app();
+        app.ticks_wanted = Some(1);
+        let mut control = LoopControl::default();
+        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 1, "the bound break fired inside the plan");
+    }
+
+    #[test]
+    fn progress_marks_ride_a_drawn_frame() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        app.record_draw(Ok(PresentOutcome::Presented));
+        assert!(app.drawn_since_update);
+        app.update_at(Timestamp::from_nanos(STEP), &mut control);
+        assert_eq!(
+            app.last_progress,
+            Timestamp::from_nanos(STEP),
+            "a drawn frame moves the progress mark"
+        );
+        assert!(!app.drawn_since_update, "consumed by the update");
+    }
+
+    #[test]
+    fn finish_names_a_loop_that_ran_and_failed() {
+        let options = Options {
+            seed: 7,
+            frames: 2_000,
+            input_trace: "soar".to_string(),
+            record_trace: None,
+            replay_trace: None,
+            window: true,
+            window_ticks: None,
+        };
+        let app = GlideApp::new(&options);
+        assert!(matches!(
+            app.finish(Err(WindowError::Loop {
+                message: "test".to_string()
+            })),
+            Err(SampleError::Failed(message)) if message.starts_with("running the window loop")
+        ));
+    }
+
+    #[test]
     fn the_title_reflects_score_and_death_and_only_changes_when_they_do() {
-        let mut title = Title::new();
+        let mut title = Title::<64>::new();
         let alive = title.compose(0, true).expect("compose").to_string();
         assert_eq!(alive, "renew — glide — score 0");
         let scored = title.compose(12, true).expect("compose").to_string();

--- a/samples/glide/tests/library_paths.rs
+++ b/samples/glide/tests/library_paths.rs
@@ -95,6 +95,26 @@ fn a_trace_whose_header_lacks_a_seed_is_refused() {
 fn a_repeated_flag_is_refused_by_name() {
     assert_eq!(run(&["--record-trace", "a", "--record-trace", "b"]), 2);
     assert_eq!(run(&["--replay-trace", "a", "--replay-trace", "b"]), 2);
+    assert_eq!(run(&["--window", "--window"]), 2);
+}
+
+#[test]
+fn window_refuses_the_flags_that_contradict_it() {
+    // The flag parses in every build; only the arm behind it is
+    // feature-gated. Playing from the keyboard contradicts scripted
+    // input and recording; replay owns everything; a zero-tick window
+    // is a contradiction of its own.
+    assert_eq!(run(&["--window", "--input-trace", "soar"]), 2);
+    assert_eq!(run(&["--window", "--record-trace", "out.trace"]), 2);
+    assert_eq!(run(&["--replay-trace", "a.trace", "--window"]), 2);
+    assert_eq!(run(&["--window", "--frames", "0"]), 2);
+}
+
+#[cfg(not(feature = "window"))]
+#[test]
+fn a_window_in_a_headless_build_is_refused_by_name() {
+    // The twin function: same signature, honest answer, exit 2.
+    assert_eq!(run(&["--window"]), 2);
 }
 
 #[test]


### PR DESCRIPTION
The last piece that makes the game a game: `glide --window` (built with `--features window`) opens the world in a window — space or the primary mouse button flaps, the score lives in the title, resize rebuilds the chain, and the digest line prints at close marked `source=window`.

**The graph stays honest.** The feature is default-OFF: the game a player runs headless carries no GPU crate, the two build-matrix probes shipped with the capture harness keep proving it, and a new matrix cell builds and tests the featured graph. The windowed arm consumes exactly what the previous PRs built — the world's render view, the scene module, the sprite renderer, the presentation path. Zero world-crate changes.

**Input under a real clock is the interesting part.** The scripted loop asserts one step per frame; a wall clock plans zero, one, or many. Flap edges ride a **saturating counter** consumed one per fixed step: a press on a zero-step frame survives to the next frame's first step, and two presses with two due catch-up steps deliver two flaps — a plain latch bit provably folds the second press away, and the tests pin that counterexample by name, along with the quantization fact that does remain (folding is per event phase, not per step interval).

**Coverage without a keyboard.** Every seam callback is a one-line delegation to a plain function tests drive without a window — draw outcomes constructed, latches poked, the wedge tripped, the verdict's three endings — while the xvfb lane runs the live arm (keyboardless: the bird falls; a legal run) and the instrumented feature-on unit tests ride the coverage job. Error reporting is variant-agnostic so the feature adds no match arm no lane could ever execute.

Every headless mode and committed trace behaves byte-for-byte as before.
