### PR TITLE
fix(fuzz): the harness names its own licence

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@
 name = "renew-fuzz"
 version = "0.0.0"
 edition = "2024"
+license = "Apache-2.0"
 publish = false
 
 [package.metadata]


### PR DESCRIPTION
The fuzz workspace's own licence check has refused `renew-fuzz` as unlicensed on every scheduled run since the harnesses landed — a separate workspace inherits no fields from the root, and a non-gating lane meant nobody saw the refusals. One line: the package carries the repository's licence. Verified locally against the same policy file the lane uses.