### PR TITLE
fix(fuzz): name the tool the installer should install

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,7 +30,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: taiki-e/install-action@cargo-fuzz
+      # The tool named explicitly: the @tool-name tag shorthand resolved
+      # with an empty tool once already -- the action's own warning names
+      # the failure mode -- and an install that silently installs nothing
+      # fails two steps later with a misleading message.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
       # The licence policy is checked here rather than at the root: these
       # harnesses are a separate workspace, so the root check never
       # resolves their dependencies and cannot see the term this allows.

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -1678,8 +1678,22 @@ fn a_rustup_that_cannot_name_its_toolchain_still_counts_as_found() {
     });
     fs::copy(env!("CARGO_BIN_EXE_renew"), &stand_in).expect("stand-in binary should copy");
 
-    let output = run_with_path(inside_the_workspace(), &directory, &["doctor", "--json"])
+    // Retried, bounded: the harness runs tests in parallel, and a
+    // sibling test's child process forked between this copy's
+    // open-for-write and its close inherits the write handle for a
+    // moment — the doctor's probe then reports the stand-in as busy
+    // (ETXTBSY). The window closes when the sibling execs; a real
+    // failure reproduces on every attempt and still fails.
+    let mut output = run_with_path(inside_the_workspace(), &directory, &["doctor", "--json"])
         .expect("binary should spawn");
+    for _ in 0..5 {
+        if !String::from_utf8_lossy(&output.stdout).contains("executable file busy") {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        output = run_with_path(inside_the_workspace(), &directory, &["doctor", "--json"])
+            .expect("binary should spawn");
+    }
     assert_eq!(output.status.code(), Some(1));
     let stdout = String::from_utf8_lossy(&output.stdout);
     let envelope = validated_envelope(stdout.trim(), "doctor")


### PR DESCRIPTION
Second of two stacked silent failures in the scheduled lane: the `@cargo-fuzz` tag shorthand resolved with an empty tool name (the installer's own warning names the dependabot-adjacent failure mode), so no fuzzer was ever installed and the run step failed with a misleading no-such-command — masked until #104 behind the licence refusal that preceded it. The tool is now named explicitly via `install-action@v2` + `tool:`.