### PR TITLE
fix(fuzz): the lane names the toolchain the repository pin overrides

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -49,7 +49,12 @@ jobs:
         # The directory is corpus-in and findings-out: the run starts
         # from everything already recorded instead of rediscovering the
         # magic numbers, and new coverage lands beside it.
-        run: cargo fuzz run ${{ matrix.target }} corpus/${{ matrix.target }} -- -max_total_time=120 -print_final_stats=1
+        # +nightly explicitly: the repository pins stable via
+        # rust-toolchain.toml, and that directory override outranks the
+        # job's installed default -- the inner build inherits nightly
+        # through the toolchain environment only when the outer call
+        # names it.
+        run: cargo +nightly fuzz run ${{ matrix.target }} corpus/${{ matrix.target }} -- -max_total_time=120 -print_final_stats=1
       # Growth is the interesting output of a healthy run. It leaves the
       # runner as an artifact a human inspects, minimizes, and commits --
       # re-commits are manual and event-driven, never a bot's.


### PR DESCRIPTION
Third and deepest of the scheduled lane's stacked breaks: with the fuzzer finally installed (#105) and licensed (#104), its inner build ran on **stable** — the repository's `rust-toolchain.toml` pin is a rustup directory override that outranks the job's installed default, and the sanitizer flags are nightly-only. `cargo +nightly fuzz` propagates the toolchain to the inner build via the environment (proven by local runs that minted the corpus). The lane has never actually fuzzed until now: each break hid the next.