### PR TITLE
fix(fuzz): the lane names its target, not the installer's

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -54,7 +54,11 @@ jobs:
         # job's installed default -- the inner build inherits nightly
         # through the toolchain environment only when the outer call
         # names it.
-        run: cargo +nightly fuzz run ${{ matrix.target }} corpus/${{ matrix.target }} -- -max_total_time=120 -print_final_stats=1
+        # --target named too: the prebuilt installer ships a musl-linked
+        # binary, and the fuzzer defaults its build target to its OWN
+        # compile-time triple -- musl, where the sanitizer cannot link.
+        # This runner is gnu; say so.
+        run: cargo +nightly fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} corpus/${{ matrix.target }} -- -max_total_time=120 -print_final_stats=1
       # Growth is the interesting output of a healthy run. It leaves the
       # runner as an artifact a human inspects, minimizes, and commits --
       # re-commits are manual and event-driven, never a bot's.


### PR DESCRIPTION
Fourth of the scheduled lane's stacked breaks (licence → installer → toolchain → this): the prebuilt installer ships a **musl-linked** `cargo-fuzz`, and cargo-fuzz defaults the fuzz build's `--target` to its own compile-time triple — musl, where ASan cannot link (`sanitizer is incompatible with statically linked libc`). The runner is gnu; the run step names it explicitly.