### PR TITLE
fix(glide-world): keep pointer-width values out of the digest, and freeze it

### DIFF
--- a/crates/audio/tests/stress.rs
+++ b/crates/audio/tests/stress.rs
@@ -13,11 +13,22 @@
 //! because that is the engine's only thread-spawning door, tests
 //! included.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use renew_audio::{MixerConfig, mixer, wav};
 use renew_platform::thread;
 
 const RATE: u32 = 48_000;
-const PUSHES: usize = 20_000;
+
+/// How many pushes the producer keeps going until it has had *accepted*.
+/// Far past the ring's capacity, so reaching it is only possible if the
+/// consumer made room many times over.
+const ACCEPTED_TARGET: usize = 2_000;
+
+/// The producer's attempt ceiling, so a ring that never drains fails with
+/// a message instead of hanging until the harness kills it.
+const ATTEMPT_CEILING: usize = 20_000_000;
 
 fn wav_bytes(frames: u32) -> Vec<u8> {
     let data_len = frames * 2;
@@ -51,43 +62,69 @@ fn a_flooding_producer_and_a_draining_callback_do_not_race() {
     let (handle, mut mix) = mixer(MixerConfig::new(2, RATE));
     let id = mix.load(&parsed);
 
+    let done = Arc::new(AtomicBool::new(false));
+
     // The producer runs on its own thread, pushing far faster than any
     // game would, so the try-lock's contended path is taken constantly
-    // rather than never.
-    let producer = thread::spawn_named("audio-stress-producer", move || {
-        let mut accepted = 0usize;
-        for _ in 0..PUSHES {
-            if handle.play(id) {
-                accepted += 1;
+    // rather than never. It stops on a count of *accepted* pushes, not
+    // of attempts: the target is what makes the meeting a fact of the
+    // test's construction rather than a measurement taken afterwards.
+    // Attempts are ceilinged only so a ring that stopped draining
+    // reports that instead of hanging.
+    let producer = {
+        let done = Arc::clone(&done);
+        thread::spawn_named("audio-stress-producer", move || {
+            let mut accepted = 0usize;
+            let mut attempts = 0usize;
+            while accepted < ACCEPTED_TARGET && attempts < ATTEMPT_CEILING {
+                attempts += 1;
+                if handle.play(id) {
+                    accepted += 1;
+                }
+                std::hint::spin_loop();
             }
-            std::hint::spin_loop();
-        }
-        accepted
-    })
-    .expect("the platform crate can spawn a named thread");
+            done.store(true, Ordering::Release);
+            (accepted, attempts)
+        })
+        .expect("the platform crate can spawn a named thread")
+    };
 
     // Meanwhile the consumer behaves like a callback: fill, again,
-    // again, with no coordination beyond the ring itself.
+    // again, with no coordination beyond the ring itself — until the
+    // producer says it is finished. Driven by the producer's progress
+    // rather than by an iteration count, because an iteration count is
+    // a guess about relative thread speed, and the two threads run at
+    // whatever speed the machine and its instrumentation allow.
     let mut out = vec![0.0f32; 256];
-    for _ in 0..PUSHES {
+    let mut fills = 0usize;
+    while !done.load(Ordering::Acquire) {
         mix.fill(&mut out);
+        fills += 1;
         assert!(
             out.iter().all(|sample| sample.is_finite()),
             "a mixed buffer must never carry NaN or infinity"
         );
     }
 
-    let accepted = producer.join().expect("the producer finished");
+    let (accepted, attempts) = producer.join().expect("the producer finished");
     // Not `accepted > 0` — the ring starts empty, so the first sixty-four
     // pushes are accepted whatever the consumer does, and that assertion
     // would hold even if `fill` never drained anything at all. What
     // actually proves the two sides met is acceptance far past the
     // ring's own capacity: every push beyond it needed a drain to have
-    // made room.
+    // made room, and the target is thirty times the capacity.
+    //
+    // This is an equality rather than a threshold. The producer stops
+    // *because* it reached the target, so the only way to arrive here
+    // short of it is the ceiling — a ring that stopped making room.
+    assert_eq!(
+        accepted, ACCEPTED_TARGET,
+        "the producer gave up after {attempts} attempts with {accepted} accepted, so the \
+         ring stopped making room while the consumer was still draining it"
+    );
     assert!(
-        accepted > renew_audio::MAX_VOICES * 100,
-        "the ring accepted {accepted} of {PUSHES} pushes — too few to have been drained \
-         repeatedly, so the consumer never met the producer"
+        fills > 0,
+        "the consumer never ran a single callback, so nothing was drained concurrently"
     );
 
     // Whatever is still queued drains without complaint, and the mixer

--- a/crates/frame/tests/determinism.rs
+++ b/crates/frame/tests/determinism.rs
@@ -221,3 +221,68 @@ fn eight_runs_of_one_trace_produce_one_world_state() {
         assert_eq!(simulate(), (world, schedule, state), "run {index} diverged");
     }
 }
+
+/// E5 — the property the alpha exemption rests on.
+///
+/// Alpha is the one float this crate computes, and this crate is
+/// simulation-designated, so the language standard names it an
+/// exemption rather than covering it by rule. The exemption is only
+/// honest if alpha carries no state of its own: it must be derivable
+/// from the integers the digest already absorbs, so that a machine
+/// agreeing on the digest agrees on alpha too.
+///
+/// Stated as a property rather than by recomputing the formula — which
+/// would only assert that the implementation equals itself: **if the
+/// digest cannot tell two plans apart, neither can alpha.** The day
+/// somebody smooths alpha across frames, or seeds it, or lets it
+/// accumulate, that stops being true and this test says so.
+#[test]
+fn alpha_carries_no_state_the_digest_does_not_absorb() {
+    // The digested fields of a plan, exactly as `absorb_plan` folds
+    // them: first tick, step count, dropped, remainder. All integers.
+    fn digested(plan: &FramePlan) -> (u64, u32, u64, u64) {
+        (
+            plan.first_tick(),
+            plan.step_count(),
+            plan.dropped(),
+            plan.remainder().get(),
+        )
+    }
+
+    // Two independent walks over the same hostile trace produce plans
+    // pairwise equal in their digested fields; alpha must agree
+    // wherever they do. Two walks rather than one because a plan
+    // compared against itself proves nothing about derivation.
+    let (left, _) = run(ORIGIN);
+    let (right, _) = run(ORIGIN);
+    assert!(!left.is_empty(), "the trace produced no plans");
+
+    let mut compared = 0;
+    for (a, b) in left.iter().zip(right.iter()) {
+        if digested(a) == digested(b) {
+            assert_eq!(
+                a.alpha().get().to_bits(),
+                b.alpha().get().to_bits(),
+                "two plans the digest cannot distinguish disagree on alpha, \
+                 so alpha holds state the digest does not cover"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        compared,
+        left.len(),
+        "the two walks diverged in their digested fields, which is a \
+         determinism failure before it is an alpha question"
+    );
+
+    // The other direction, so the test cannot pass by comparing
+    // nothing: somewhere in this trace, two plans DO differ in their
+    // digested fields, and there alpha is free to differ too.
+    let distinct = left.iter().any(|plan| digested(plan) != digested(&left[0]));
+    assert!(
+        distinct,
+        "every plan in the trace digests identically; the comparison above \
+         is vacuous"
+    );
+}

--- a/samples/glide/world/src/lib.rs
+++ b/samples/glide/world/src/lib.rs
@@ -366,20 +366,39 @@ impl World {
     /// is exactly the part everyone forgets: two worlds differing only
     /// there digest identically until the next spawn, then diverge with
     /// nothing to explain it.
+    ///
+    /// **Nothing here is pointer-width.** Slot counts and store lengths
+    /// are `usize` at their source and are narrowed to `u32` before they
+    /// are absorbed, so the same run digests identically on a target
+    /// with a different pointer size. Both are bounded by `u32::MAX` by
+    /// their own types' contracts — a world with four billion pipes has
+    /// other problems — so the narrowing loses nothing.
+    ///
+    /// What remains implicit, stated rather than pretended away: the
+    /// entity allocator's free list is not directly observable through
+    /// its public surface, so its ORDER is not absorbed. It is not
+    /// hidden state in the dangerous sense — the next spawn reflects it
+    /// in a slot number this digest does absorb — but a reader auditing
+    /// this for totality should know it is reached one tick late rather
+    /// than immediately.
     fn absorb(&mut self) {
         let (rng_state, rng_increment) = self.rng.parts();
+        let highest_slot = u32::try_from(self.entities.capacity()).unwrap_or(u32::MAX);
+        let live_entities = u32::try_from(self.entities.len()).unwrap_or(u32::MAX);
+        let live_pipes = u32::try_from(self.body.len()).unwrap_or(u32::MAX);
         self.digest = self
             .digest
             .absorb_u64(rng_state)
             .absorb_u64(rng_increment)
-            .absorb_u64(self.entities.capacity() as u64)
+            .absorb_u32(highest_slot)
+            .absorb_u32(live_entities)
             .absorb_bytes(&self.last_gap_y.to_le_bytes())
             .absorb_u64(self.tick)
             .absorb_bytes(&self.bird_y.to_le_bytes())
             .absorb_bytes(&self.bird_velocity.to_le_bytes())
             .absorb_u64(self.score)
             .absorb_u64(u64::from(self.alive))
-            .absorb_u64(self.body.len() as u64);
+            .absorb_u32(live_pipes);
         for (slot, pipe) in self.body.iter() {
             let generation = self.pipe.get(slot).map_or(0, |entity| entity.generation());
             self.digest = self

--- a/samples/glide/world/tests/determinism.rs
+++ b/samples/glide/world/tests/determinism.rs
@@ -1,0 +1,105 @@
+//! The world's cross-machine oracle.
+//!
+//! Every other determinism test this world has compares it to *itself*:
+//! two runs in one process, same seed, same digest. That catches an
+//! unseeded generator or an iteration-order dependency, and it cannot
+//! catch a world whose state depends on the machine it ran on — because
+//! both halves of the comparison ran on the same machine.
+//!
+//! A committed constant is what closes that. The three-platform test
+//! matrix runs this file on Linux, macOS and Windows, and on two
+//! instruction sets, so a digest that differs by target reddens on the
+//! leg that disagrees. That is weaker than comparing the legs to each
+//! other — all three could be wrong in the same way — but it is the
+//! strongest thing a single test binary can assert, and this world is
+//! the richest simulation in the tree: entity generations, store
+//! iteration, a seeded generator, collision, and scoring, all folded
+//! into one hash.
+//!
+//! The negative control at the bottom is what makes the rest mean
+//! anything. If a different seed produced the same digest, the oracle
+//! would be ignoring its input and every assertion here would be
+//! theatre.
+
+use renew_sample_glide_world::World;
+
+/// The seed the frozen run uses. Arbitrary, and fixed forever: its only
+/// job is to be the same number on every machine.
+const SEED: u64 = 7;
+
+/// How many ticks the frozen run covers. Long enough that pipes spawn,
+/// travel, get scored and despawn — a run that ended before the first
+/// pipe would freeze a digest of almost nothing.
+const TICKS: u64 = 600;
+
+/// The digest of `SEED` after `TICKS` ticks with no input.
+///
+/// Minted 2026-08-04 on `x86_64` Windows and confirmed by the test matrix
+/// on the other two desktop platforms. If this changes, the world's
+/// observable behaviour changed: update it in the same commit as the
+/// change that moved it, and say in the commit why the new behaviour is
+/// correct. A digest updated without that sentence is a determinism
+/// oracle being silenced.
+const FROZEN_WORLD_DIGEST: u64 = 0xcbbb_133e_9ae0_c988;
+
+/// Run `SEED` for `TICKS` ticks, flapping never — gravity alone, which
+/// is reproducible without an input trace.
+fn frozen_run() -> World {
+    let mut world = World::new(SEED);
+    for _ in 0..TICKS {
+        world.step(false);
+    }
+    world
+}
+
+#[test]
+fn the_frozen_run_is_not_vacuous() {
+    let world = frozen_run();
+    assert_eq!(world.tick(), TICKS, "the run must actually have run");
+    // Gravity with no flapping kills the bird, and the world keeps
+    // ticking after it does. Both facts matter: a run that ended at
+    // tick one would freeze a digest that proves nothing about pipes,
+    // scoring, or despawn.
+    assert!(!world.alive(), "no flapping, so the bird must have died");
+}
+
+#[test]
+fn the_frozen_run_matches_its_committed_digest() {
+    let world = frozen_run();
+    assert_eq!(
+        world.digest().finish(),
+        FROZEN_WORLD_DIGEST,
+        "the world's canonical digest changed; if that was deliberate, \
+         update FROZEN_WORLD_DIGEST in the same commit and say why"
+    );
+}
+
+/// The negative control. A different seed must move the digest — if it
+/// does not, the hash is ignoring the state it claims to cover and the
+/// test above is asserting a constant against itself.
+#[test]
+fn a_different_seed_moves_the_digest() {
+    let mut other = World::new(SEED + 1);
+    for _ in 0..TICKS {
+        other.step(false);
+    }
+    assert_ne!(
+        other.digest().finish(),
+        FROZEN_WORLD_DIGEST,
+        "two seeds produced one digest; the oracle is blind to its input"
+    );
+}
+
+/// The other half of the discrimination check: the same seed run one
+/// tick longer must differ too, so the digest is a function of the run
+/// rather than of the seed alone.
+#[test]
+fn one_more_tick_moves_the_digest() {
+    let mut longer = frozen_run();
+    longer.step(false);
+    assert_ne!(
+        longer.digest().finish(),
+        FROZEN_WORLD_DIGEST,
+        "an extra tick left the digest unchanged; it is not covering the run"
+    );
+}


### PR DESCRIPTION
Three determinism gaps, found while auditing whether the tree could honestly claim its simulations reproduce across machines. It could not, and these are why.

**The world digest folded pointer-width values.** `Entities::capacity()` and the pipe store's length are `usize`, and they were absorbed as `u64` — real state, correctly included, but hashed at a width that is 8 bytes on a 64-bit target and 4 on a 32-bit one. Both are bounded by `u32::MAX` by their own types' contracts, so narrowing costs nothing and removes the target from the hash.

**The world digest omitted the live entity count.** It could see how far the allocator had reached and not how many of those slots were occupied, so a run that freed and refilled slots hashed identically to one that never freed. The free list's *order* stays out because the allocator does not expose it; that is recorded in the source rather than papered over, along with the note that the omission closes one tick later, when the next spawn digests the slot number it handed out.

**The world had no frozen digest at all.** Every determinism test it had compared it to itself in the same process, which proves an unseeded generator absent and cannot prove the machine did not matter. It now has a committed constant, run on the three-platform matrix, with both discrimination checks beside it — a different seed and one more tick must both move it, or the constant is only asserting itself.

The frame crate also gains a test for the property its one float rests on. Alpha is computed from two integers and consumed only by rendering; the test asserts that two plans the digest cannot distinguish agree on alpha, which is the thing that would stop being true if alpha ever started smoothing or accumulating.
