### PR TITLE
chore(simulation): deny float arithmetic in the crates that must reproduce

### DIFF
--- a/crates/ecs/src/lib.rs
+++ b/crates/ecs/src/lib.rs
@@ -55,7 +55,12 @@
 // Storage answers questions; it never reports. A print from inside a
 // query would be output no caller asked for, on a path that runs once
 // per entity per frame.
-#![deny(clippy::print_stdout, clippy::print_stderr)]
+// The determinism rule in the language standard: a simulation crate does not
+// perform floating-point arithmetic whose result can reach digested state.
+// Denied here rather than left to review — the lint covers operators only, so
+// it is necessary and not sufficient, but what it does cover it covers with
+// teeth.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
 mod entity;
 mod store;

--- a/crates/frame/src/lib.rs
+++ b/crates/frame/src/lib.rs
@@ -79,7 +79,17 @@
 
 // This crate reports; it does not print. Diagnostics belong to the caller,
 // which is what keeps the dependency list empty.
-#![deny(clippy::print_stdout, clippy::print_stderr)]
+// The determinism rule in the language standard: a simulation crate does not
+// perform floating-point arithmetic whose result can reach digested state.
+// Denied here rather than left to review — the lint covers operators only, so
+// it is necessary and not sufficient, but what it does cover it covers with
+// teeth.
+//
+// This crate is the one holding an exemption: the interpolation factor in
+// `Schedule::step` is computed in floats. It carries the `allow` at the
+// expression itself, so the exemption is visible where it is taken and a
+// second one cannot be added without writing a second `allow`.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
 mod digest;
 mod report;

--- a/crates/frame/src/schedule.rs
+++ b/crates/frame/src/schedule.rs
@@ -212,7 +212,20 @@ impl FramePlan {
         // rounds up to 1.0 at 1 Hz. An alpha of 1.0 is a renderer popping
         // a full tick ahead of the state it interpolates from — a bug
         // that would have been hunted in the renderer for a week.
-        #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+        // The crate denies float arithmetic, as every simulation crate
+        // does. This is the one exemption the language standard names,
+        // and it is taken here rather than at the crate root so that the
+        // exemption is visible where it applies and a second one cannot
+        // appear without a second `allow`. It is sound because the
+        // result is presentation output: alpha is derived from two
+        // integers, is consumed only by rendering, and never re-enters
+        // world state or a digest — a property `alpha_carries_no_state_
+        // the_digest_does_not_absorb` in tests/determinism.rs asserts.
+        #[allow(
+            clippy::float_arithmetic,
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation
+        )]
         let ratio = (self.remainder.get() as f64 / self.dt.nanos().get() as f64) as f32;
         Alpha(ratio.min(LARGEST_BELOW_ONE))
     }

--- a/crates/input/src/lib.rs
+++ b/crates/input/src/lib.rs
@@ -47,7 +47,12 @@
 
 // This layer resolves state; it never reports. Diagnostics about input
 // belong to whoever is driving the loop.
-#![deny(clippy::print_stdout, clippy::print_stderr)]
+// The determinism rule in the language standard: a simulation crate does not
+// perform floating-point arithmetic whose result can reach digested state.
+// Denied here rather than left to review — the lint covers operators only, so
+// it is necessary and not sufficient, but what it does cover it covers with
+// teeth.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
 use renew_event::{KeyCode, PointerButton, WindowEvent};
 

--- a/crates/replay/src/lib.rs
+++ b/crates/replay/src/lib.rs
@@ -27,7 +27,12 @@
 //! convention, and baking one driver's convention into the shared loader
 //! would silently impose it on every future consumer.
 
-#![deny(clippy::print_stdout, clippy::print_stderr)]
+// The determinism rule in the language standard: a simulation crate does not
+// perform floating-point arithmetic whose result can reach digested state.
+// Denied here rather than left to review — the lint covers operators only, so
+// it is necessary and not sufficient, but what it does cover it covers with
+// teeth.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
 pub mod convert;
 mod load;

--- a/samples/glide/world/src/lib.rs
+++ b/samples/glide/world/src/lib.rs
@@ -23,6 +23,14 @@
 //! so the digest is a fact about the rules and not about anyone's
 //! floating-point unit.
 
+// The determinism rule in the language standard: a simulation crate does not
+// perform floating-point arithmetic whose result can reach digested state.
+// Denied here rather than left to review — the lint covers operators only, so
+// it is necessary and not sufficient, but what it does cover it covers with
+// teeth. This world takes it easily: every quantity it simulates is
+// fixed-point, and the deny is what keeps that true under future edits.
+#![deny(clippy::float_arithmetic)]
+
 use renew_ecs::{Entities, Entity, Store};
 use renew_frame::StateHash;
 use renew_rng::{Rng, Seed, StreamId};


### PR DESCRIPTION
Six crates in this tree produce output that has to be reproducible from a seed and an input trace. Five of them now say so to the compiler; the generator already did.

The interesting result is how little it cost. Four crates take the deny without a line changing — the tree was already computing simulation state in fixed-point throughout, and that was previously a property of how the code happened to have been written rather than something a build could hold it to.

The frame schedule is the exception and gets an explicit one. Its interpolation factor is a remainder divided by a timestep, which is genuinely a float and genuinely has to be: it is the fraction a renderer interpolates by. It is also inert with respect to what the deny protects — derived from two integers, consumed only by rendering, never folded into a state hash, which #111 adds a test for. It takes the deny plus a single `allow` at the expression rather than at the crate root, so the exemption is visible at the site it covers and a second one cannot be added without being written and read.

Worth stating plainly, because a rule oversold is worse than one absent: `clippy::float_arithmetic` catches operators and nothing else. A float-typed signature, a cast, or a comparison passes it. This is a floor under the property, not a proof of it.

Stacked on nothing — independent of #111, though the two are related in subject.