### PR TITLE
ci: prove the audio crate is removable, like every other optional crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,27 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
+      # The audio stack. The game is excluded alongside it because the
+      # game's DEV graph reaches the WAV reader unconditionally -- the
+      # lane's own copy of the parse that `Audio::open` performs on its
+      # way to a device, which exists precisely so a regenerated sound
+      # is checked somewhere other than a machine with speakers. Its
+      # normal graph does not, and the second guard below is what says
+      # so rather than assuming it.
+      - name: Build and test without audio
+        run: |
+          sel="--workspace --exclude renew-audio --exclude renew-sample-glide"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-audio $sel
+          cargo build $sel
+          cargo test $sel
+          # The game without its `audio` feature is the default
+          # configuration, and the mixer must be absent from it -- the
+          # feature is the only edge, so a dependency that stopped being
+          # optional would show up here and nowhere else. Dev edges are
+          # excluded deliberately: the test copy of the parse is
+          # supposed to be there.
+          RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-audio -p renew-sample-glide
+          cargo build -p renew-sample-glide
       # The other direction: the game's window feature builds, lints,
       # and tests. No graph guard -- the build itself proves the WSI
       # stack is reachable, and the absence guards belong to the default


### PR DESCRIPTION
The audio crate is declared optional and had no lane removing it. Every other optional crate in the workspace has one, because "optional" is a claim and a claim with no lane behind it is decoration.

The minimal-core cell does prove the crate absent, but that is a different property: it removes eleven crates at once, so it cannot tell you the tree builds with only this one gone.

The cell excludes the game alongside the mixer, which looks like an over-exclusion and is not. The game's dev graph reaches the WAV reader unconditionally — the lane's own copy of the parse the audio path performs on its way to a device, so that a regenerated sound is checked somewhere other than a machine with speakers. Its normal graph does not, the `audio` feature being the only edge, and the second guard asserts that with dev edges excluded. Without it the first guard would be equally consistent with the game having quietly stopped making the dependency optional.

Verified locally: `cargo build` and `cargo test` both clean on the excluded selection, and `cargo tree -e normal,build -i renew-audio` finds nothing in the game's default graph while the dev-inclusive tree shows the one expected edge.