### PR TITLE
fix(frame): absorb the timestep into the frame digest

### DIFF
--- a/crates/frame/src/digest.rs
+++ b/crates/frame/src/digest.rs
@@ -75,12 +75,24 @@ impl StateHash {
     /// hashing it would add no information and would make the oracle
     /// float-dependent. An unstated exclusion is how a determinism oracle
     /// goes quietly vacuous, so it is stated.
+    ///
+    /// **The timestep was not absorbed until it was checked.** The
+    /// sentence above was written when this folded four fields, none of
+    /// them the timestep, so the exclusion it justified rested on a
+    /// premise that was false: two plans with equal first tick, step
+    /// count, dropped count and remainder, cut against different
+    /// timesteps, digested identically and had different alphas. Nothing
+    /// in the tree could produce that pair, since a loop's timestep is
+    /// fixed at construction — which is exactly why it survived. A digest
+    /// justified by a claim that happens to hold is a digest waiting for
+    /// the day it stops.
     #[must_use]
     pub const fn absorb_plan(self, plan: &FramePlan) -> Self {
         self.absorb_u64(plan.first_tick())
             .absorb_u32(plan.step_count())
             .absorb_u64(plan.dropped())
             .absorb_u64(plan.remainder().get())
+            .absorb_u64(plan.dt().nanos().get())
     }
 
     #[must_use]
@@ -100,6 +112,7 @@ mod tests {
     use super::StateHash;
     use crate::schedule::FrameLoop;
     use crate::time::{StepBudget, Timestamp, Timestep};
+    use core::num::NonZeroU64;
 
     /// The published FNV-1a-64 vector for "a", pinning the constants and
     /// the byte order against a source outside this repository.
@@ -174,7 +187,8 @@ mod tests {
             .absorb_u64(plan.first_tick())
             .absorb_u32(plan.step_count())
             .absorb_u64(plan.dropped())
-            .absorb_u64(plan.remainder().get());
+            .absorb_u64(plan.remainder().get())
+            .absorb_u64(plan.dt().nanos().get());
         assert_eq!(StateHash::new().absorb_plan(&plan), by_hand);
     }
 
@@ -195,6 +209,48 @@ mod tests {
         assert_ne!(
             StateHash::new().absorb_plan(&base),
             StateHash::new().absorb_plan(&next)
+        );
+    }
+
+    /// The timestep is absorbed, asserted the only way that means
+    /// anything: **two plans agreeing in every other absorbed field and
+    /// differing only in timestep.** Elapsed time is chosen per loop so
+    /// both cut three steps and leave the same remainder, which is what
+    /// makes the timestep the sole difference — and their alphas differ,
+    /// since alpha is that shared remainder over two different divisors.
+    /// That pair is exactly what digested identically before the field
+    /// was folded in.
+    ///
+    /// The first version of this test built its two plans from one
+    /// elapsed time and two rates, so they differed in step count and
+    /// remainder as well. It passed with the absorption deleted —
+    /// measured, not assumed — which is the whole reason it is written
+    /// this way now.
+    #[test]
+    fn two_timesteps_agreeing_in_every_other_field_do_not_share_a_digest() {
+        // Three steps and a one-millisecond remainder, at two rates.
+        let plan_at = |step_nanos: u64| {
+            let dt = Timestep::from_nanos(NonZeroU64::new(step_nanos).expect("positive"));
+            let mut frame = FrameLoop::new(dt, StepBudget::DEFAULT, Timestamp::from_nanos(0));
+            frame.begin_frame(Timestamp::from_nanos(3 * step_nanos + 1_000_000))
+        };
+        let slow = plan_at(20_000_000);
+        let fast = plan_at(10_000_000);
+
+        // The premise, asserted rather than assumed: everything the
+        // digest absorbed before the timestep joined it agrees.
+        assert_eq!(slow.first_tick(), fast.first_tick());
+        assert_eq!(slow.step_count(), fast.step_count());
+        assert_eq!(slow.dropped(), fast.dropped());
+        assert_eq!(slow.remainder().get(), fast.remainder().get());
+        assert_ne!(slow.dt().nanos(), fast.dt().nanos());
+        // And the consequence that made the gap matter.
+        assert_ne!(slow.alpha().get().to_bits(), fast.alpha().get().to_bits());
+
+        assert_ne!(
+            StateHash::new().absorb_plan(&slow),
+            StateHash::new().absorb_plan(&fast),
+            "two plans differing only in timestep digested the same, so the oracle cannot              see the loop's rate and alpha carries an input it does not cover"
         );
     }
 

--- a/crates/frame/src/schedule.rs
+++ b/crates/frame/src/schedule.rs
@@ -168,6 +168,17 @@ impl FramePlan {
         self.steps
     }
 
+    /// The timestep this plan was cut against.
+    ///
+    /// Public because the digest absorbs it: anything reconstructing
+    /// what was hashed — a test, a comparison lane, a tool diffing two
+    /// runs — needs every field that went in, and a digested field with
+    /// no accessor is one a consumer has to guess at.
+    #[must_use]
+    pub const fn dt(&self) -> Timestep {
+        self.dt
+    }
+
     /// The tick index of the first step, which is also the loop's tick
     /// count before this frame.
     #[must_use]

--- a/crates/frame/tests/determinism.rs
+++ b/crates/frame/tests/determinism.rs
@@ -29,7 +29,7 @@ const ORIGIN: u64 = 1_000_000_000;
 /// pure `u64` arithmetic with an explicit little-endian absorption order,
 /// so it should hold on every platform; "should" is not evidence, and the
 /// first three-platform run is.
-const FROZEN_SCHEDULE_DIGEST: u64 = 0x8154_30d5_7cc1_5744;
+const FROZEN_SCHEDULE_DIGEST: u64 = 0x5d29_0b68_1d14_462c;
 
 /// The canonical hostile trace, as absolute timestamps from `origin`.
 ///
@@ -239,13 +239,20 @@ fn eight_runs_of_one_trace_produce_one_world_state() {
 #[test]
 fn alpha_carries_no_state_the_digest_does_not_absorb() {
     // The digested fields of a plan, exactly as `absorb_plan` folds
-    // them: first tick, step count, dropped, remainder. All integers.
-    fn digested(plan: &FramePlan) -> (u64, u32, u64, u64) {
+    // them: first tick, step count, dropped, remainder, timestep. All
+    // integers. The timestep is the one that makes this a property
+    // rather than a coincidence — alpha is remainder over timestep, and
+    // until the digest absorbed the divisor, two plans it could not
+    // tell apart could still disagree on alpha. Nothing in the tree
+    // could build that pair, a loop's timestep being fixed at
+    // construction, which is precisely why the gap went unnoticed.
+    fn digested(plan: &FramePlan) -> (u64, u32, u64, u64, u64) {
         (
             plan.first_tick(),
             plan.step_count(),
             plan.dropped(),
             plan.remainder().get(),
+            plan.dt().nanos().get(),
         )
     }
 


### PR DESCRIPTION
The frame digest folded four fields of a plan and documented a fifth as deliberately excluded — alpha, on the stated grounds that it is "a pure function of the remainder and the timestep, **both of which are absorbed here**". The remainder was. The timestep was not.

So the exclusion that keeps a float out of the determinism oracle — a good exclusion, for a good reason — rested on a premise the code did not satisfy. Two plans with the same first tick, step count, dropped count and remainder, cut against different timesteps, digested identically and had different alphas.

The gap is unreachable today: a loop's timestep is fixed at construction and never moves, so nothing in the tree can build that pair. That is exactly why it survived being read several times — the claim was false and unfalsifiable in the same breath. A digest justified by a property that merely happens to hold is a digest waiting for the day it stops.

The frozen schedule digest moves from `0x815430d57cc15744` to `0x5d290b681d14462c`. The cause is the added field and nothing else; no arithmetic in the loop changed.

**The test that proves the absorption is worth a note, because its first version did not.** It built its two plans from one elapsed time and two rates, so they differed in step count and remainder as well — and it passed with the absorption deleted, which was measured rather than assumed. It now picks each loop's elapsed time so both cut three steps and leave the same remainder, asserts that agreement before testing anything, and asserts the two alphas differ, so the pair under test is the pair the old digest genuinely could not distinguish.

`FramePlan::dt` becomes public alongside it: anything reconstructing what was hashed needs every field that went in.