### PR TITLE
refactor(frame)!: move the interpolation factor out, leaving no float behind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,6 +1754,7 @@ name = "renew-sample-hello-triangle"
 version = "0.1.0"
 dependencies = [
  "renew-frame",
+ "renew-math",
  "renew-memory",
  "renew-platform",
  "renew-rhi",

--- a/crates/core/math/Cargo.toml
+++ b/crates/core/math/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Vector, matrix, quaternion, and bounding-box value types with documented memory layout."
+purpose = "Vector, matrix, quaternion, and bounding-box value types with documented memory layout, and the render interpolation factor."
 maturity = "internal"
 core = true
 extension_points = []

--- a/crates/core/math/src/alpha.rs
+++ b/crates/core/math/src/alpha.rs
@@ -122,14 +122,16 @@ mod tests {
     #[test]
     fn one_nanosecond_short_of_a_step_never_reaches_one() {
         for step_nanos in [16_666_667u64, 33_333_333, 1_000_000_000, 4] {
-            let alpha = Alpha::new(step_nanos - 1, step(step_nanos));
+            // Bound before asserting, rather than inside the failure
+            // message: an argument that is only evaluated on failure is a
+            // line the coverage gate can never see executed.
+            let alpha = Alpha::new(step_nanos - 1, step(step_nanos)).get();
             assert!(
-                alpha.get() < 1.0,
-                "at a {step_nanos} ns step, alpha reached {} — a renderer would draw a \
-                 full tick ahead of the state it interpolates from",
-                alpha.get()
+                alpha < 1.0,
+                "at a {step_nanos} ns step, alpha reached {alpha} — a renderer would draw \
+                 a full tick ahead of the state it interpolates from"
             );
-            assert!(alpha.get() >= 0.0);
+            assert!(alpha >= 0.0, "at a {step_nanos} ns step, alpha was {alpha}");
         }
     }
 

--- a/crates/core/math/src/alpha.rs
+++ b/crates/core/math/src/alpha.rs
@@ -1,0 +1,169 @@
+//! The render interpolation factor.
+
+use core::num::NonZeroU64;
+
+/// The largest `f32` strictly below one.
+///
+/// The bound is load-bearing and not defensive. Measured: the naive
+/// `remainder as f32 / step as f32` returns exactly `1.0` at 30 Hz
+/// (step = `33_333_333` ns, remainder = step − 1), and even the `f64`
+/// division rounds up to `1.0` at 1 Hz. An alpha of one is a renderer
+/// drawing a full tick ahead of the state it interpolates *from* — a bug
+/// that would have been hunted in the renderer for a week.
+const LARGEST_BELOW_ONE: f32 = f32::from_bits(0x3F7F_FFFF);
+
+/// How far past the last executed simulation step a frame stands, as a
+/// fraction of the timestep: a value in `[0, 1)`.
+///
+/// # Contract
+///
+/// - **Always in `[0, 1)`.** Never exactly one, by construction — see
+///   [`Alpha::new`]. A renderer may use it as a blend weight without
+///   bounds-checking it.
+/// - **A hint for presentation, never an input to simulation.** A
+///   newtype with no arithmetic surface: the name is the contract.
+///   Nothing here can be added to, multiplied by, or accumulated into
+///   anything; a caller must ask for the `f32` explicitly.
+///
+/// # Why this type lives in the maths crate
+///
+/// It is the presentation half of the fixed-timestep loop, and it used
+/// to live in the frame crate beside the accumulator that produces its
+/// inputs. That crate is simulation-designated, and computing this ratio
+/// was the only floating-point arithmetic anywhere in a crate whose
+/// output has to reproduce bit-for-bit on three platforms. The
+/// computation was provably inert — derived from two digested integers,
+/// consumed only by rendering — and it was carried as a named exemption
+/// with an `allow` at the expression.
+///
+/// **An exemption defended by the cost of removing it is an exemption
+/// that becomes permanent.** So it moved, and the frame crate now
+/// contains no float at all. Here rather than in a new presentation
+/// crate for one reason that matters more than tidiness: a simulation
+/// crate is *mechanically forbidden* from reaching this one — the
+/// structure checker's float-closure rule fails any simulation whose
+/// shipping closure includes a crate that does not deny float
+/// arithmetic, and this crate does not deny it. A fresh crate would have
+/// needed that same guard to mean anything. The strongest place to put a
+/// float a simulation must not touch is the crate a simulation already
+/// cannot reach.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct Alpha(f32);
+
+impl Alpha {
+    /// Exactly on a step boundary: nothing to interpolate.
+    pub const ZERO: Self = Self(0.0);
+
+    /// The fraction `remainder / step`, clamped below one.
+    ///
+    /// Both arguments are nanoseconds, and both are integers on purpose:
+    /// the caller holds the exact rational and hands it over unrounded,
+    /// so the one rounding that happens is the one here. A consumer that
+    /// wants the exact ratio never needs to call this at all.
+    ///
+    /// The `f64` intermediate is deliberate — see [`LARGEST_BELOW_ONE`].
+    /// A `remainder` at or past `step` saturates rather than exceeding
+    /// one; the frame loop never produces that, and a type whose whole
+    /// contract is a range should not depend on its caller to hold it.
+    #[must_use]
+    pub fn new(remainder_nanos: u64, step_nanos: NonZeroU64) -> Self {
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            reason = "the f64 division is exact well past any timestep a loop uses, and the \
+                      narrowing to f32 is what the renderer consumes"
+        )]
+        let ratio = (remainder_nanos as f64 / step_nanos.get() as f64) as f32;
+        Self(if ratio < LARGEST_BELOW_ONE {
+            ratio
+        } else {
+            LARGEST_BELOW_ONE
+        })
+    }
+
+    /// The factor itself, for a renderer that is about to blend with it.
+    #[must_use]
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Alpha, LARGEST_BELOW_ONE};
+    use core::num::NonZeroU64;
+
+    fn step(nanos: u64) -> NonZeroU64 {
+        NonZeroU64::new(nanos).expect("a positive timestep")
+    }
+
+    #[test]
+    fn a_zero_remainder_is_exactly_zero() {
+        assert_eq!(
+            Alpha::new(0, step(16_666_667)).get().to_bits(),
+            Alpha::ZERO.get().to_bits()
+        );
+        assert!(Alpha::new(0, step(16_666_667)).get().abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn a_half_step_is_a_half() {
+        let alpha = Alpha::new(8_333_333, step(16_666_667)).get();
+        assert!(
+            (alpha - 0.5).abs() < 1e-6,
+            "half a step should read as a half, got {alpha}"
+        );
+    }
+
+    /// The reason the `f64` intermediate and the bound both exist. Each
+    /// of these returns exactly `1.0` under some naive formulation, and
+    /// an alpha of one is a renderer a whole tick ahead of its state.
+    #[test]
+    fn one_nanosecond_short_of_a_step_never_reaches_one() {
+        for step_nanos in [16_666_667u64, 33_333_333, 1_000_000_000, 4] {
+            let alpha = Alpha::new(step_nanos - 1, step(step_nanos));
+            assert!(
+                alpha.get() < 1.0,
+                "at a {step_nanos} ns step, alpha reached {} — a renderer would draw a \
+                 full tick ahead of the state it interpolates from",
+                alpha.get()
+            );
+            assert!(alpha.get() >= 0.0);
+        }
+    }
+
+    /// The type promises a range; it does not promise its caller is
+    /// careful. The frame loop cannot produce this, and the contract
+    /// holds anyway.
+    #[test]
+    fn a_remainder_past_the_step_saturates_rather_than_escaping_the_range() {
+        // Bit patterns, not values: "clamped to exactly the bound" is a
+        // claim about the representation, and `==` on floats is the lint
+        // this crate keeps for good reason everywhere else.
+        assert_eq!(
+            Alpha::new(999, step(10)).get().to_bits(),
+            LARGEST_BELOW_ONE.to_bits()
+        );
+        assert_eq!(
+            Alpha::new(10, step(10)).get().to_bits(),
+            LARGEST_BELOW_ONE.to_bits()
+        );
+        assert!(Alpha::new(u64::MAX, step(1)).get() < 1.0);
+    }
+
+    #[test]
+    fn the_bound_really_is_below_one_and_the_next_value_up_is_not() {
+        // Asserted on bit patterns throughout: the next representable
+        // `f32` above the bound is exactly one, so nothing lies between
+        // them and the clamp costs a renderer no resolution it could
+        // use. Stated this way rather than as `bound < 1.0`, which is a
+        // constant the compiler folds and the linter rightly calls out
+        // as an assertion that cannot fail.
+        assert_eq!(
+            f32::from_bits(LARGEST_BELOW_ONE.to_bits() + 1).to_bits(),
+            1.0_f32.to_bits()
+        );
+        assert_eq!(LARGEST_BELOW_ONE.to_bits(), 0x3F7F_FFFF);
+    }
+}

--- a/crates/core/math/src/lib.rs
+++ b/crates/core/math/src/lib.rs
@@ -1,5 +1,8 @@
 //! Linear algebra value types: vectors, a column-major matrix, a
-//! quaternion, and an axis-aligned bounding box, all `f32`.
+//! quaternion, and an axis-aligned bounding box, all `f32` — plus
+//! [`Alpha`], the render interpolation factor, which lives here because
+//! this is the crate a simulation is mechanically forbidden from
+//! reaching.
 //!
 //! # Contract
 //!
@@ -22,11 +25,13 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 mod aabb;
+mod alpha;
 mod mat4;
 mod quat;
 mod vec;
 
 pub use aabb::Aabb3;
+pub use alpha::Alpha;
 pub use mat4::Mat4;
 pub use quat::Quat;
 pub use vec::{Vec2, Vec3, Vec4};

--- a/crates/core/math/tests/properties.rs
+++ b/crates/core/math/tests/properties.rs
@@ -12,9 +12,11 @@
 //! a zero's sign). Edge-domain behavior is covered by targeted unit tests
 //! in the crate, not by these laws.
 
+use core::num::NonZeroU64;
 use proptest::prelude::*;
 use proptest::test_runner::RngSeed;
-use renew_math::{Aabb3, Mat4, Quat, Vec3};
+
+use renew_math::{Aabb3, Alpha, Mat4, Quat, Vec3};
 
 /// Finite, moderately sized components: large enough to explore, small
 /// enough that tolerance properties are well-conditioned. See the module
@@ -182,6 +184,85 @@ proptest! {
         prop_assert!(
             (left.transform_point(point) - right.transform_point(point)).length() / scale
                 < 1e-3
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Alpha — the render interpolation factor.
+//
+// These two properties moved here with the type. They used to live in
+// the frame crate and be driven through a `FrameLoop`, which could only
+// reach the (timestep, remainder) pairs a loop actually produces. Stated
+// directly against the constructor they cover the whole domain,
+// including pairs no loop can build — which is the domain the type's
+// contract is written over.
+// ---------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 4096,
+        rng_algorithm: proptest::test_runner::RngAlgorithm::ChaCha,
+        ..ProptestConfig::default()
+    })]
+
+    /// The contract, over every representable pair: never below zero,
+    /// never at or above one. The interesting region is one nanosecond
+    /// short of a whole step, where a naive `f32` division returns
+    /// exactly `1.0` — a renderer drawing a full tick ahead of the state
+    /// it interpolates from.
+    #[test]
+    fn alpha_stays_in_the_unit_interval_for_every_timestep_and_remainder(
+        step in 1u64..=u64::MAX,
+        fraction in 0u64..=u64::MAX,
+    ) {
+        let remainder = fraction % step;
+        let alpha = Alpha::new(remainder, NonZeroU64::new(step).expect("nonzero")).get();
+        prop_assert!(alpha >= 0.0, "step {} rem {} gave {}", step, remainder, alpha);
+        prop_assert!(alpha < 1.0, "step {} rem {} gave {}", step, remainder, alpha);
+    }
+
+    /// The clamp holds where the caller does not: a remainder at or past
+    /// the step still cannot escape the range. The frame loop never
+    /// produces this, and a type whose whole contract is a range must not
+    /// depend on its caller to keep it.
+    #[test]
+    fn alpha_cannot_escape_the_range_even_on_an_out_of_contract_remainder(
+        step in 1u64..=u64::MAX,
+        remainder in 0u64..=u64::MAX,
+    ) {
+        let alpha = Alpha::new(remainder, NonZeroU64::new(step).expect("nonzero")).get();
+        prop_assert!((0.0..1.0).contains(&alpha), "step {} rem {} gave {}", step, remainder, alpha);
+    }
+
+    /// Monotone in the remainder: interpolating further between two
+    /// steps never moves the renderer backwards. Stated at the type
+    /// rather than through a loop, so it covers pairs a loop cannot
+    /// reach.
+    #[test]
+    fn alpha_never_decreases_as_the_remainder_grows(
+        step in 2u64..=1_000_000_000,
+        fraction in 0u64..=u64::MAX,
+    ) {
+        let step_nz = NonZeroU64::new(step).expect("nonzero");
+        let low = fraction % step;
+        let high = low.max(step / 2);
+        prop_assert!(Alpha::new(high, step_nz) >= Alpha::new(low, step_nz));
+    }
+
+    /// A pure function of its two arguments — the property the frame
+    /// digest's exclusion of alpha rests on. Same pair, same bits, every
+    /// time, with no state anywhere to carry a difference.
+    #[test]
+    fn alpha_is_a_pure_function_of_its_two_arguments(
+        step in 1u64..=u64::MAX,
+        fraction in 0u64..=u64::MAX,
+    ) {
+        let step_nz = NonZeroU64::new(step).expect("nonzero");
+        let remainder = fraction % step;
+        prop_assert_eq!(
+            Alpha::new(remainder, step_nz).get().to_bits(),
+            Alpha::new(remainder, step_nz).get().to_bits()
         );
     }
 }

--- a/crates/frame/Cargo.toml
+++ b/crates/frame/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Fixed-timestep frame scheduling: the deterministic accumulator, the step budget that bounds a stall, and the interpolation factor for rendering between steps."
+purpose = "Fixed-timestep frame scheduling: the deterministic accumulator, the step budget that bounds a stall, and the exact rational a renderer interpolates by, as integers."
 maturity = "bootstrap"
 core = false
 extension_points = []

--- a/crates/frame/src/digest.rs
+++ b/crates/frame/src/digest.rs
@@ -244,8 +244,15 @@ mod tests {
         assert_eq!(slow.dropped(), fast.dropped());
         assert_eq!(slow.remainder().get(), fast.remainder().get());
         assert_ne!(slow.dt().nanos(), fast.dt().nanos());
-        // And the consequence that made the gap matter.
-        assert_ne!(slow.alpha().get().to_bits(), fast.alpha().get().to_bits());
+        // And the consequence that made the gap matter: the same
+        // remainder over two different divisors is two different
+        // interpolation factors, so a renderer would have drawn these two
+        // plans differently while the digest called them the same.
+        assert_ne!(
+            slow.remainder().get() * fast.dt().nanos().get(),
+            fast.remainder().get() * slow.dt().nanos().get(),
+            "cross-multiplied, the two ratios must differ"
+        );
 
         assert_ne!(
             StateHash::new().absorb_plan(&slow),

--- a/crates/frame/src/lib.rs
+++ b/crates/frame/src/lib.rs
@@ -30,7 +30,8 @@
 //!     for step in plan.steps() {
 //!         let _ = (step.tick, step.dt, step.sim_time); // advance the world here
 //!     }
-//!     let _alpha = plan.alpha(); // render between steps with this
+//!     // Render between steps with `renew_math::Alpha::new(...)`,
+//!     // built from `plan.remainder()` and `plan.timestep()`.
 //!     stats.absorb(&plan);
 //! }
 //!
@@ -85,10 +86,12 @@
 // it is necessary and not sufficient, but what it does cover it covers with
 // teeth.
 //
-// This crate is the one holding an exemption: the interpolation factor in
-// `Schedule::step` is computed in floats. It carries the `allow` at the
-// expression itself, so the exemption is visible where it is taken and a
-// second one cannot be added without writing a second `allow`.
+// This crate held the tree's only exemption: the interpolation factor was
+// computed here, with an `allow` at the expression. It is gone. The
+// factor moved to `renew-math` — a crate a simulation is mechanically
+// forbidden from reaching — and this crate now performs no floating-point
+// arithmetic at all. There is no `allow` below, and adding one would be a
+// change to the language standard, not a local decision.
 #![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
 mod digest;
@@ -98,5 +101,5 @@ mod time;
 
 pub use digest::StateHash;
 pub use report::{FrameStats, FrameStatsJson, FrameTiming, FrameTimingJson};
-pub use schedule::{Alpha, FrameLoop, FramePlan, Step, Steps};
+pub use schedule::{FrameLoop, FramePlan, Step, Steps};
 pub use time::{Nanos, StepBudget, Timestamp, Timestep};

--- a/crates/frame/src/schedule.rs
+++ b/crates/frame/src/schedule.rs
@@ -11,9 +11,6 @@
 
 use crate::time::{Nanos, StepBudget, Timestamp, Timestep};
 
-/// The largest `f32` strictly below one, `0.999_999_94`.
-const LARGEST_BELOW_ONE: f32 = f32::from_bits(0x3F7F_FFFF);
-
 /// The fixed-timestep schedule: a passive integer state machine.
 ///
 /// It never reads a clock — it *cannot*, having no dependency that offers
@@ -195,6 +192,16 @@ impl FramePlan {
 
     /// Elapsed time carried into the next frame; always below
     /// [`FramePlan::timestep`].
+    ///
+    /// This and [`FramePlan::timestep`] are the exact rational a renderer
+    /// interpolates by — `renew_math::Alpha::new(remainder, timestep)`
+    /// turns them into a blend factor. **The division deliberately does
+    /// not happen here.** This crate is simulation-designated and
+    /// contains no floating-point arithmetic at all; a ratio computed in
+    /// this crate would be the single exception to that, and an exception
+    /// defended by the cost of removing it is one that becomes permanent.
+    /// A consumer that wants the exact rational never goes through a
+    /// float.
     #[must_use]
     pub const fn remainder(&self) -> Nanos {
         self.remainder
@@ -203,42 +210,6 @@ impl FramePlan {
     #[must_use]
     pub const fn timestep(&self) -> Timestep {
         self.dt
-    }
-
-    /// Render interpolation in `[0, 1)`: how far past the last executed
-    /// step the frame stands, as a fraction of the timestep.
-    ///
-    /// Never an input to simulation, and deliberately excluded from the
-    /// schedule digest — it is a pure function of two integers that *are*
-    /// digested, so hashing it would only make the oracle float-dependent.
-    /// [`FramePlan::remainder`] and [`FramePlan::timestep`] stay public so
-    /// a consumer that wants the exact rational never goes through the
-    /// float at all.
-    #[must_use]
-    pub fn alpha(&self) -> Alpha {
-        // The `f64` intermediate and the explicit bound are both
-        // load-bearing, and neither is defensive. Measured: the naive
-        // `rem as f32 / dt as f32` returns exactly 1.0 at 30 Hz
-        // (dt = 33_333_333, rem = dt - 1), and the `f64` division still
-        // rounds up to 1.0 at 1 Hz. An alpha of 1.0 is a renderer popping
-        // a full tick ahead of the state it interpolates from — a bug
-        // that would have been hunted in the renderer for a week.
-        // The crate denies float arithmetic, as every simulation crate
-        // does. This is the one exemption the language standard names,
-        // and it is taken here rather than at the crate root so that the
-        // exemption is visible where it applies and a second one cannot
-        // appear without a second `allow`. It is sound because the
-        // result is presentation output: alpha is derived from two
-        // integers, is consumed only by rendering, and never re-enters
-        // world state or a digest — a property `alpha_carries_no_state_
-        // the_digest_does_not_absorb` in tests/determinism.rs asserts.
-        #[allow(
-            clippy::float_arithmetic,
-            clippy::cast_precision_loss,
-            clippy::cast_possible_truncation
-        )]
-        let ratio = (self.remainder.get() as f64 / self.dt.nanos().get() as f64) as f32;
-        Alpha(ratio.min(LARGEST_BELOW_ONE))
     }
 }
 
@@ -297,26 +268,9 @@ impl ExactSizeIterator for Steps {}
 
 impl core::iter::FusedIterator for Steps {}
 
-/// The render interpolation factor, in `[0, 1)`.
-///
-/// A newtype with no arithmetic surface: the name is the contract. It is
-/// a hint for the renderer and never an input to simulation.
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct Alpha(f32);
-
-impl Alpha {
-    /// Exactly on a step boundary.
-    pub const ZERO: Self = Self(0.0);
-
-    #[must_use]
-    pub const fn get(self) -> f32 {
-        self.0
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{Alpha, FrameLoop, LARGEST_BELOW_ONE, StepBudget, Timestamp, Timestep};
+    use super::{FrameLoop, StepBudget, Timestamp, Timestep};
     use crate::time::Nanos;
     use core::num::{NonZeroU32, NonZeroU64};
 
@@ -545,24 +499,32 @@ mod tests {
         assert_eq!(plan.steps().count(), 2);
     }
 
+    /// What this crate hands a renderer, now that the division lives in
+    /// `renew-math`: the exact rational, as two integers.
+    ///
+    /// Three tests stood here and asserted alpha's own behaviour — zero
+    /// on a boundary, one half between steps, and a rounding table
+    /// proving the clamp below one is mandatory rather than defensive.
+    /// They moved to `renew-math` beside the type, where they cover the
+    /// whole `(step, remainder)` domain instead of only the pairs a loop
+    /// can produce. What belongs here is the loop's half of the contract.
     #[test]
-    fn alpha_is_zero_on_a_step_boundary_and_proportional_between_steps() {
+    fn the_remainder_is_the_exact_position_between_two_steps() {
         let mut frame = loop_at_60hz();
+
+        // On a boundary: nothing pending, so nothing to interpolate.
         let plan = frame.begin_frame(at(DT));
-        assert_eq!(plan.alpha(), Alpha::ZERO);
-        assert!((plan.alpha().get() - 0.0).abs() < f32::EPSILON);
+        assert_eq!(plan.remainder(), Nanos::from_nanos(0));
+        assert_eq!(plan.timestep().nanos().get(), DT);
 
+        // Half a step past it, exactly — no rounding anywhere, because
+        // no division has happened yet.
         let plan = frame.begin_frame(at(DT + DT / 2));
-        let alpha = plan.alpha().get();
-        assert!((alpha - 0.5).abs() < 1e-6, "alpha was {alpha}");
-    }
+        assert_eq!(plan.remainder(), Nanos::from_nanos(DT / 2));
 
-    /// The rounding table the interpolation contract fixes, as a test. A naive
-    /// `rem as f32 / dt as f32` returns exactly 1.0 for the 30 Hz row, and
-    /// the `f64` intermediate alone still returns 1.0 for the 1 Hz row —
-    /// so the explicit bound is mandatory, not defensive.
-    #[test]
-    fn alpha_never_reaches_one_even_one_nanosecond_short_of_a_step() {
+        // And one nanosecond short of a whole step, which is the pair
+        // that used to make a naive `f32` division return exactly one.
+        // Here it is just an integer, and an exact one.
         for dt in [
             16_666_667_u64,
             4_166_667,
@@ -572,21 +534,12 @@ mod tests {
         ] {
             let mut frame = FrameLoop::new(timestep(dt), budget(1), at(0));
             let plan = frame.begin_frame(at(dt - 1));
-            let alpha = plan.alpha().get();
             assert_eq!(plan.remainder(), Nanos::from_nanos(dt - 1));
-            assert!(alpha < 1.0, "dt {dt} produced alpha {alpha}");
-            assert!(alpha <= LARGEST_BELOW_ONE);
-            assert!(alpha > 0.999_99, "dt {dt} produced alpha {alpha}");
+            assert!(
+                plan.remainder().get() < plan.timestep().nanos().get(),
+                "the remainder must stay a proper fraction of the step"
+            );
         }
-    }
-
-    /// Asserted on bit patterns rather than values: the next representable
-    /// `f32` above the bound is exactly one, so nothing lies between them
-    /// and the clamp loses no resolution a renderer could use.
-    #[test]
-    fn the_bound_is_the_largest_float_below_one() {
-        assert_eq!(LARGEST_BELOW_ONE.to_bits(), 0x3F7F_FFFF);
-        assert_eq!(LARGEST_BELOW_ONE.to_bits() + 1, 1.0_f32.to_bits());
     }
 
     /// The parity oracle for absorbing hello-engine's `Accumulator`: its

--- a/crates/frame/tests/determinism.rs
+++ b/crates/frame/tests/determinism.rs
@@ -222,30 +222,38 @@ fn eight_runs_of_one_trace_produce_one_world_state() {
     }
 }
 
-/// E5 — the property the alpha exemption rests on.
+/// E5 — everything a renderer can read off a plan is digested.
 ///
-/// Alpha is the one float this crate computes, and this crate is
-/// simulation-designated, so the language standard names it an
-/// exemption rather than covering it by rule. The exemption is only
-/// honest if alpha carries no state of its own: it must be derivable
-/// from the integers the digest already absorbs, so that a machine
-/// agreeing on the digest agrees on alpha too.
+/// **This test used to guard an exemption that no longer exists.** Alpha
+/// was computed here, in a simulation-designated crate, and was the one
+/// piece of floating-point arithmetic anywhere in it; the exemption was
+/// justified by alpha being derivable from digested integers, and this
+/// test asserted exactly that. The type moved to `renew-math` and the
+/// exemption is gone, so what remains to assert is the half that was
+/// always the load-bearing one: **a plan carries nothing a renderer uses
+/// that the digest does not cover.**
 ///
-/// Stated as a property rather than by recomputing the formula — which
-/// would only assert that the implementation equals itself: **if the
-/// digest cannot tell two plans apart, neither can alpha.** The day
-/// somebody smooths alpha across frames, or seeds it, or lets it
-/// accumulate, that stops being true and this test says so.
+/// That is what makes the digest an honest presentation oracle. Two
+/// machines agreeing on the digest agree on what their renderers will
+/// draw, because the pair a renderer interpolates from — the remainder
+/// and the timestep — is inside the hash rather than beside it.
+///
+/// Stated as a property over two independent walks rather than by
+/// recomputing the fields, which would only assert the implementation
+/// equals itself.
 #[test]
-fn alpha_carries_no_state_the_digest_does_not_absorb() {
+fn nothing_a_renderer_reads_off_a_plan_escapes_the_digest() {
     // The digested fields of a plan, exactly as `absorb_plan` folds
     // them: first tick, step count, dropped, remainder, timestep. All
-    // integers. The timestep is the one that makes this a property
-    // rather than a coincidence — alpha is remainder over timestep, and
-    // until the digest absorbed the divisor, two plans it could not
-    // tell apart could still disagree on alpha. Nothing in the tree
+    // integers.
+    //
+    // The timestep is in that list because of a defect this test's
+    // ancestor could not see. Alpha is remainder over timestep, and the
+    // digest did not absorb the divisor — so two plans it could not tell
+    // apart could disagree on what a renderer drew. Nothing in the tree
     // could build that pair, a loop's timestep being fixed at
-    // construction, which is precisely why the gap went unnoticed.
+    // construction, which is precisely why it went unnoticed through
+    // several readings.
     fn digested(plan: &FramePlan) -> (u64, u32, u64, u64, u64) {
         (
             plan.first_tick(),
@@ -256,9 +264,17 @@ fn alpha_carries_no_state_the_digest_does_not_absorb() {
         )
     }
 
+    // What a renderer reads: the exact rational it interpolates by.
+    // Both halves are in the digested tuple above, which is the whole
+    // claim — asserted rather than asserted-by-inspection, so that a
+    // field added to one and not the other fails here.
+    fn presented(plan: &FramePlan) -> (u64, u64) {
+        (plan.remainder().get(), plan.dt().nanos().get())
+    }
+
     // Two independent walks over the same hostile trace produce plans
-    // pairwise equal in their digested fields; alpha must agree
-    // wherever they do. Two walks rather than one because a plan
+    // pairwise equal in their digested fields; the presented pair must
+    // agree wherever they do. Two walks rather than one because a plan
     // compared against itself proves nothing about derivation.
     let (left, _) = run(ORIGIN);
     let (right, _) = run(ORIGIN);
@@ -268,10 +284,10 @@ fn alpha_carries_no_state_the_digest_does_not_absorb() {
     for (a, b) in left.iter().zip(right.iter()) {
         if digested(a) == digested(b) {
             assert_eq!(
-                a.alpha().get().to_bits(),
-                b.alpha().get().to_bits(),
-                "two plans the digest cannot distinguish disagree on alpha, \
-                 so alpha holds state the digest does not cover"
+                presented(a),
+                presented(b),
+                "two plans the digest cannot distinguish present differently, \
+                 so a renderer can see state the digest does not cover"
             );
             compared += 1;
         }
@@ -285,7 +301,7 @@ fn alpha_carries_no_state_the_digest_does_not_absorb() {
 
     // The other direction, so the test cannot pass by comparing
     // nothing: somewhere in this trace, two plans DO differ in their
-    // digested fields, and there alpha is free to differ too.
+    // digested fields, and there the presented pair is free to differ.
     let distinct = left.iter().any(|plan| digested(plan) != digested(&left[0]));
     assert!(
         distinct,

--- a/crates/frame/tests/properties.rs
+++ b/crates/frame/tests/properties.rs
@@ -12,7 +12,7 @@ use core::num::{NonZeroU32, NonZeroU64};
 
 use proptest::prelude::*;
 use proptest::test_runner::RngSeed;
-use renew_frame::{Alpha, FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};
+use renew_frame::{FrameLoop, FrameStats, StepBudget, Timestamp, Timestep};
 
 // Test helpers (called only from #[test] fns): the tests-only expect
 // allowance covers #[test] fns, not their helpers; this allow extends it,
@@ -79,7 +79,12 @@ proptest! {
             due_total += u64::from(plan.step_count()) + plan.dropped();
             prop_assert_eq!(frame.tick(), executed);
             prop_assert_eq!(frame.remainder(), plan.remainder());
-            prop_assert!((0.0..1.0).contains(&plan.alpha().get()));
+            // The invariant a renderer's blend factor rests on,
+            // stated where it is produced rather than where it is
+            // divided: the remainder is always a proper fraction of
+            // the timestep, so `Alpha::new` of the two can only
+            // land in `[0, 1)`.
+            prop_assert!(plan.remainder().get() < plan.timestep().nanos().get());
         }
 
         prop_assert_eq!(submitted, due_total * dt + frame.remainder().get());
@@ -110,7 +115,7 @@ proptest! {
             prop_assert!(plan.remainder().get() < dt);
             prop_assert_eq!(plan.first_tick(), before);
             prop_assert_eq!(frame.tick(), before + u64::from(plan.step_count()));
-            prop_assert!((0.0..1.0).contains(&plan.alpha().get()));
+            prop_assert!(plan.remainder().get() < plan.timestep().nanos().get());
         }
     }
 
@@ -132,16 +137,20 @@ proptest! {
         prop_assert_eq!(plan.step_count(), 0);
         prop_assert_eq!(plan.dropped(), 0);
         prop_assert_eq!(plan.remainder().get(), 0);
-        prop_assert_eq!(plan.alpha(), Alpha::ZERO);
     }
 
-    /// Alpha over the whole `(timestep, remainder)` domain. A loop that
-    /// never reaches a step has a bank equal to its remainder, so
-    /// generating `fraction % dt` sweeps every representable pair —
-    /// including the one-nanosecond-short cases where a naive `f32`
-    /// division returns exactly 1.0.
+    /// What this crate promises a renderer, over the whole
+    /// `(timestep, remainder)` domain: the remainder is a *proper*
+    /// fraction of the timestep. That integer invariant is what makes a
+    /// blend factor built from the pair land in `[0, 1)`; the factor's
+    /// own behaviour is `renew-math`'s property to state, and it does,
+    /// over the same domain and over pairs no loop can produce.
+    ///
+    /// A loop that never reaches a step has a bank equal to its
+    /// remainder, so generating `fraction % dt` sweeps every
+    /// representable pair — including the one-nanosecond-short cases.
     #[test]
-    fn alpha_stays_in_the_unit_interval_for_every_timestep_and_remainder(
+    fn the_remainder_is_always_a_proper_fraction_of_the_timestep(
         dt in 1u64..=u64::MAX,
         fraction in 0u64..=u64::MAX,
     ) {
@@ -154,21 +163,18 @@ proptest! {
         let plan = frame.begin_frame(Timestamp::from_nanos(remainder));
         prop_assert_eq!(plan.step_count(), 0);
         prop_assert_eq!(plan.remainder().get(), remainder);
-
-        let alpha = plan.alpha().get();
-        prop_assert!(alpha >= 0.0, "dt {} rem {} gave {}", dt, remainder, alpha);
-        prop_assert!(alpha < 1.0, "dt {} rem {} gave {}", dt, remainder, alpha);
+        prop_assert!(plan.remainder().get() < plan.timestep().nanos().get());
     }
 
-    /// The assumption the digest exclusion rests on: alpha is a function
-    /// of the remainder and the timestep and of nothing else. Two plans
-    /// that land on the same remainder must agree even though one arrived
-    /// through a stall — different tick, different step count, thousands
-    /// of refused steps. Alpha is also monotone in the remainder, so
-    /// interpolating further between two steps never moves the renderer
-    /// backwards.
+    /// The pair a renderer interpolates from depends on the remainder and
+    /// the timestep and on nothing else. Two plans that land on the same
+    /// remainder must present identically even though one arrived through
+    /// a stall — different tick, different step count, hundreds of
+    /// refused steps. This is the property the digest exclusion rests on,
+    /// kept here after the division moved out, because it is a statement
+    /// about *plans*, not about arithmetic.
     #[test]
-    fn alpha_is_a_function_of_the_remainder_and_the_timestep_alone(
+    fn the_presented_pair_is_a_function_of_the_remainder_and_timestep_alone(
         dt in 2u64..=1_000_000_000,
         fraction in 0u64..=u64::MAX,
     ) {
@@ -184,11 +190,7 @@ proptest! {
         prop_assert_ne!(stalled.first_tick(), calm.first_tick());
         prop_assert_ne!(stalled.step_count(), calm.step_count());
         prop_assert!(stalled.dropped() > 0);
-        prop_assert_eq!(stalled.alpha(), calm.alpha());
-
-        let mut later = FrameLoop::new(timestep(dt), budget(1), Timestamp::from_nanos(0));
-        let ahead = later.begin_frame(Timestamp::from_nanos(remainder.max(dt / 2)));
-        prop_assert!(ahead.alpha() >= calm.alpha());
+        prop_assert_eq!(stalled.timestep().nanos(), calm.timestep().nanos());
     }
 
     /// Identical input traces produce identical plans, identical loop

--- a/crates/frame/tests/zero_alloc.rs
+++ b/crates/frame/tests/zero_alloc.rs
@@ -40,7 +40,9 @@ fn frame_body(
             .wrapping_add(step.tick)
             .wrapping_add(step.sim_time.get());
     }
-    *sink = sink.wrapping_add(u64::from(plan.alpha().get().to_bits()));
+    *sink = sink
+        .wrapping_add(plan.remainder().get())
+        .wrapping_add(plan.timestep().nanos().get());
     stats.absorb(&plan);
     timing.record(Nanos::from_nanos(now % 4_000_000), plan.step_count() > 0);
 }

--- a/samples/hello_triangle/Cargo.toml
+++ b/samples/hello_triangle/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/main.rs"
 
 [dependencies]
 renew-frame = { path = "../../crates/frame" }
+renew-math = { path = "../../crates/core/math" }
 renew-platform = { path = "../../crates/core/platform", default-features = false }
 renew-rhi = { path = "../../crates/rhi", default-features = false }
 

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -7,9 +7,8 @@
 //! processes and machines. The one clock it does read brackets each
 //! frame for the timing summary, which is recorded and never gated.
 
-use renew_frame::{
-    Alpha, FrameLoop, FrameStats, FrameTiming, Nanos, StepBudget, Timestamp, Timestep,
-};
+use renew_frame::{FrameLoop, FrameStats, FrameTiming, Nanos, StepBudget, Timestamp, Timestep};
+use renew_math::Alpha;
 use renew_platform::Clock;
 use renew_rhi::{
     AdapterInfo, Device, DeviceDesc, Extent, Item, Pass, PipelineDesc, RenderDesc, RenderPipeline,
@@ -144,7 +143,10 @@ impl HeadlessRun {
         for step in plan.steps() {
             self.world.step(step);
         }
-        let clear = clear_color(&self.world, plan.alpha());
+        let clear = clear_color(
+            &self.world,
+            Alpha::new(plan.remainder().get(), plan.timestep().nanos()),
+        );
         // The frame, composed on this stack: one pass, cleared to the
         // world's colour, drawing the triangle when a pipeline exists.
         // The borrows end at the render call.

--- a/samples/hello_triangle/src/render.rs
+++ b/samples/hello_triangle/src/render.rs
@@ -1,6 +1,6 @@
 //! Where a frame goes, and the colour it goes there with.
 
-use renew_frame::Alpha;
+use renew_math::Alpha;
 use renew_rhi::{
     Attachment, ClearValue, Color, LoadOp, OffscreenTarget, RenderDesc, StoreOp, TargetError,
     TargetFormat,
@@ -111,7 +111,8 @@ pub fn clear_color(world: &World, alpha: Alpha) -> Color {
 mod tests {
     use super::clear_color;
     use crate::world::World;
-    use renew_frame::{Alpha, Nanos, Step};
+    use renew_frame::{Nanos, Step};
+    use renew_math::Alpha;
     use renew_rhi::Color;
 
     fn stepped(seed: u64, steps: u64) -> World {
@@ -150,7 +151,7 @@ mod tests {
             renew_frame::Timestamp::from_nanos(0),
         );
         let plan = frame.begin_frame(renew_frame::Timestamp::from_nanos(8_333_333));
-        let alpha = plan.alpha();
+        let alpha = Alpha::new(plan.remainder().get(), plan.timestep().nanos());
         assert!(alpha.get() > 0.49 && alpha.get() < 0.51, "{alpha:?}");
         let colour = clear_color(&world, alpha);
         let low = 8.0 / 255.0;

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -14,9 +14,8 @@
 //!   cannot exit the loop where it arrives. It is latched, and `update`
 //!   acts on it. That is the seam's requirement, not a sample quirk.
 
-use renew_frame::{
-    Alpha, FrameLoop, FrameStats, FrameTiming, Nanos, StepBudget, Timestamp, Timestep,
-};
+use renew_frame::{FrameLoop, FrameStats, FrameTiming, Nanos, StepBudget, Timestamp, Timestep};
+use renew_math::Alpha;
 use renew_platform::Clock;
 use renew_platform::window::{
     LoopControl, NativeWindow, WindowApp, WindowConfig, WindowError, WindowEvent, WindowRef,
@@ -364,7 +363,7 @@ impl TriangleApp {
             for step in plan.steps() {
                 self.world.step(step);
             }
-            self.alpha = plan.alpha();
+            self.alpha = Alpha::new(plan.remainder().get(), plan.timestep().nanos());
             self.stats.absorb(&plan);
             // The measured cost of one loop iteration. Nothing sleeps
             // here (the seam polls), so the interval between updates is


### PR DESCRIPTION
**BREAKING:** `renew_frame::Alpha` and `FramePlan::alpha()` are gone. The factor is `renew_math::Alpha::new(plan.remainder().get(), plan.timestep().nanos())` — same value, computed by the consumer.

The frame crate's output has to reproduce bit-for-bit on three platforms, and it contained exactly one piece of floating-point arithmetic: the interpolation factor. The computation really was inert — two digested integers divided, consumed only by rendering, never re-entering world state — so it was carried as an exemption, deny at the crate root and an `allow` at the expression.

**The argument for keeping it was that moving it would break a public API and need a deprecation path. That argument does not survive contact with the facts.** Those rules exist to protect consumers; this engine has none; the cost quoted for doing it properly was almost entirely imaginary. An exemption defended by the cost of removing it is an exemption that becomes permanent.

The crate now has no float at all and no `allow` anywhere in it. It hands a renderer the exact rational as two integers, unrounded, and the one rounding that happens happens at the consumer.

**Why the maths crate and not a new presentation crate** — one reason that matters more than tidiness: a simulation crate is *mechanically* forbidden from reaching it. The structure checker's float-closure rule fails any simulation whose shipping closure includes a crate that does not deny float arithmetic, and the maths crate does not deny it. A fresh crate would have needed the same guard to mean anything.

**The tests moved with the type and got stronger.** Alpha's behaviour used to be driven through a frame loop, which can only reach the (timestep, remainder) pairs a loop produces. Stated against the constructor they cover the whole domain — including an out-of-contract remainder past the step, which the clamp now handles rather than trusting the caller. Four properties: range, clamp, monotonicity, purity.

What stays behind is the frame crate's own half — the remainder is always a proper fraction of the timestep, and two plans landing on the same remainder present identically however differently they got there. That second one is the property the digest's exclusion always rested on, and it is about plans rather than arithmetic.