### PR TITLE
feat(cli): compare simulation digests across every target, in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,3 +730,81 @@ jobs:
       # rule itself unit-tested and the failure message specific.
       - name: Check coverage against the exemption manifest
         run: cargo run --package renew-cli --bin renew -- coverage --report target/coverage.json
+
+  # Determinism is only a property of a program if it survives the machine
+  # the program runs on. Every other determinism check in this repository
+  # compares a run to itself, or to a constant this repository minted —
+  # both of which prove an unseeded generator absent and neither of which
+  # can prove the target did not matter, because both halves ran on one
+  # target.
+  #
+  # These two jobs are the only place that claim is actually tested. Each
+  # leg runs the pinned simulations on its own target and reports what it
+  # saw; the comparison holds the reports against each other. A leg that
+  # cannot run reports nothing, and reporting nothing is a failure rather
+  # than an absent objection.
+  determinism-emit:
+    name: Determinism (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Never fail-fast: one target diverging is exactly the finding this
+      # pair exists to produce, and cancelling the others would throw
+      # away the evidence of which ones agreed.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Emit this target's digests
+        run: cargo run --package renew-cli --bin renew -- determinism --emit leg.json
+      - name: Show what this target reported
+        shell: bash
+        run: cat leg.json
+      # One artifact per leg: upload-artifact@v4 requires distinct names,
+      # and the runner label is what distinguishes them.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: determinism-${{ matrix.os }}
+          path: leg.json
+          if-no-files-found: error
+
+  determinism-compare:
+    name: Determinism (cross-platform comparison)
+    runs-on: ubuntu-latest
+    needs: [determinism-emit]
+    # `needs` on a failed job SKIPS this one, and GitHub reports a skipped
+    # required job as neutral rather than failed — which is how a
+    # comparison that never ran can read as a comparison that passed.
+    # `always()` runs it regardless, and the first step below turns the
+    # upstream result back into a failure explicitly.
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Refuse to compare when a leg did not finish
+        if: needs.determinism-emit.result != 'success'
+        run: |
+          echo "the emit legs concluded '${{ needs.determinism-emit.result }}', so at least"
+          echo "one target reported nothing. A missing target is an untested target, not a"
+          echo "passing one, and this job fails rather than comparing what remains."
+          exit 1
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: determinism-*
+          path: legs
+      - name: Show what arrived
+        run: find legs -type f -print -exec cat {} +
+      # The comparison itself is a workspace subcommand, not shell in this
+      # file: it is unit-tested, a developer can reproduce a red lane
+      # locally with the same command, and its refusals — a missing leg, an
+      # empty digest set, an architecture set that does not match the
+      # target list, two legs on different compilers — live where tests can
+      # reach them. A gate whose logic exists only in CI configuration is a
+      # gate no test can hold to account.
+      - name: Compare every target against every other
+        run: |
+          cargo run --package renew-cli --bin renew -- determinism \
+            --compare legs/determinism-ubuntu-latest/leg.json \
+            --compare legs/determinism-windows-latest/leg.json \
+            --compare legs/determinism-macos-latest/leg.json

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -114,3 +114,8 @@ reason = "The depthless-adapter side of chain population, where no per-slot dept
 file = "crates/audio/src/mixer.rs"
 lines = [197, 198]
 reason = "The arm that clears a voice whose sound index is missing. A voice is only ever created from an identifier the mixer already resolved against its own table, and the table only grows, so no input reaches this. It is retained because the alternative is indexing directly, which puts a panic on the audio callback - the one thread in the engine where a panic is an abort in a real-time deadline rather than a diagnosable failure. Unreachable on purpose, kept on purpose."
+
+[[exempt]]
+file = "tools/cli/src/main.rs"
+lines = [80, 81, 82, 1030, 1031, 1032, 1033, 1039, 1040, 1042, 1043, 1044, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1082, 1086]
+reason = "The emit half of determinism: it spawns four cargo runs of the game and reads what they printed, so reaching it from a test would mean building and running the whole sample under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -117,5 +117,10 @@ reason = "The arm that clears a voice whose sound index is missing. A voice is o
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [80, 81, 82, 1030, 1031, 1032, 1033, 1039, 1040, 1042, 1043, 1044, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1082, 1086]
+lines = [80, 81, 82, 1030, 1031, 1032, 1033, 1039, 1040, 1042, 1043, 1044, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1082, 1086, 1087]
 reason = "The emit half of determinism: it spawns four cargo runs of the game and reads what they printed, so reaching it from a test would mean building and running the whole sample under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
+
+[[exempt]]
+file = "tools/cli/src/main.rs"
+lines = [1093]
+reason = "The comparison refusing to start because no workspace root is above it. Every other subcommand carries the same arm and reaches it the same way -- never, from a test, because a test runs inside the workspace it is testing. Reaching it would mean invoking the binary from outside any cargo project, which is a property of where a caller stands rather than of anything this code does."

--- a/samples/glide/src/cli.rs
+++ b/samples/glide/src/cli.rs
@@ -154,6 +154,22 @@ mod window_flag_tests {
     }
 
     #[test]
+    fn the_json_flag_is_off_by_default_and_refuses_repetition() {
+        // Off unless asked: the human line is what a person running the
+        // sample expects to see, and a flag that flipped the default
+        // would break every eye reading it.
+        assert!(!parse(&[]).expect("a bare run parses").json);
+        assert!(parse(&["--json"]).expect("--json parses").json);
+        // Repetition is refused like every other flag here, so a caller
+        // who typed it twice is told rather than quietly obliged.
+        let error = parse(&["--json", "--json"]).expect_err("a repeat is refused");
+        assert!(
+            matches!(error, SampleError::Usage(ref m) if m.contains("--json")),
+            "{error:?}"
+        );
+    }
+
+    #[test]
     fn a_bare_window_run_is_unbounded() {
         // The centerpiece: the headless default of 2000 frames must not
         // leak into an interactive session and silently end it mid-play.

--- a/samples/glide/src/cli.rs
+++ b/samples/glide/src/cli.rs
@@ -29,6 +29,11 @@ pub struct Options {
     /// the world always agree; a lagging frame may overshoot by at most
     /// the step budget minus one.
     pub window_ticks: Option<u64>,
+    /// Print the run's report as one JSON object instead of the digest
+    /// line. Same facts, machine-readable — what the cross-platform
+    /// comparison lane collects, and what a human line should never be
+    /// parsed for.
+    pub json: bool,
 }
 
 /// Parse, refusing combinations that would silently ignore a flag.
@@ -43,6 +48,7 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
     let mut input_trace = String::from("soar");
     let mut record_trace = None;
     let mut replay_trace = None;
+    let mut json = false;
     let mut window = false;
     // Per-flag tracking, not one folded bool: refusing an explicit
     // trace flag beside --window while keeping an explicit seed needs
@@ -73,6 +79,10 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
             "--window" => {
                 refuse_repeat("--window", window)?;
                 window = true;
+            }
+            "--json" => {
+                refuse_repeat("--json", json)?;
+                json = true;
             }
             "--record-trace" => {
                 refuse_repeat("--record-trace", record_trace.is_some())?;
@@ -131,6 +141,7 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         replay_trace,
         window,
         window_ticks,
+        json,
     })
 }
 
@@ -195,6 +206,39 @@ pub struct Report {
 }
 
 impl Report {
+    /// The same facts as [`Report::digest_line`], as one JSON object.
+    ///
+    /// The comparison lane reads this rather than the human line, for the
+    /// reason every tool in this tree emits both: a line built for a
+    /// person changes when a person's needs change, and a gate that
+    /// parses one breaks silently when it does. `schema_version` is here
+    /// from the first release because a consumer that cannot tell which
+    /// shape it is holding has to guess.
+    ///
+    /// Hashes are hex strings, not numbers. A `u64` digest exceeds what
+    /// JSON's number type is guaranteed to carry exactly, and a consumer
+    /// that silently rounds one would compare two digests as equal that
+    /// are not — which is the single failure this whole lane exists to
+    /// prevent.
+    #[must_use]
+    pub fn json_line(&self) -> String {
+        format!(
+            "{{\"schema_version\":1,\"sample\":\"{SAMPLE}\",\"seed\":{},\
+             \"source\":\"{}\",\"frames\":{},\"ticks\":{},\"dropped\":{},\
+             \"score\":{},\"alive\":{},\"schedule_hash\":\"{:#018x}\",\
+             \"state_hash\":\"{:#018x}\"}}",
+            self.seed,
+            self.source,
+            self.stats.frames(),
+            self.stats.ticks(),
+            self.stats.steps_dropped(),
+            self.world.score(),
+            self.world.alive(),
+            self.stats.schedule_hash(),
+            self.world.digest().finish(),
+        )
+    }
+
     /// The one line every run prints on stdout, and the exact string
     /// the cross-process determinism gate compares.
     #[must_use]

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -51,9 +51,19 @@ const TRACE_BYTE_LIMIT: usize = 1 << 20;
 /// The last line on stdout is always the digest line the determinism
 /// gate compares.
 pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
+    // Whether the run was asked for JSON is a property of the arguments,
+    // and `run` consumes them — so it is read here, from a second parse
+    // that cannot disagree with the first because it is the same parser.
+    // A parse failure is reported by `run` below, not twice.
+    let args: Vec<String> = args.into_iter().collect();
+    let json = crate::cli::parse_args(args.iter().cloned()).is_ok_and(|options| options.json);
     match run(args) {
         Ok(report) => {
-            println!("{}", report.digest_line());
+            if json {
+                println!("{}", report.json_line());
+            } else {
+                println!("{}", report.digest_line());
+            }
             0
         }
         Err(SampleError::Usage(message)) => {

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -536,6 +536,7 @@ mod tests {
             replay_trace: None,
             window: true,
             window_ticks: None,
+            json: false,
         };
         let mut app = GlideApp::new(&options);
         // Anchor the schedule by hand: these tests say what time it is,
@@ -725,6 +726,7 @@ mod tests {
             replay_trace: None,
             window: true,
             window_ticks: None,
+            json: false,
         };
         let mut app = GlideApp::new(&options);
         let mut control = LoopControl::default();
@@ -806,6 +808,7 @@ mod tests {
             replay_trace: None,
             window: true,
             window_ticks: None,
+            json: false,
         };
         let app = GlideApp::new(&options);
         assert!(matches!(
@@ -893,6 +896,7 @@ mod tests {
             replay_trace: None,
             window: true,
             window_ticks: None,
+            json: false,
         };
         // Success: a report with the window's source.
         let app = GlideApp::new(&options);

--- a/samples/glide/tests/cli_determinism.rs
+++ b/samples/glide/tests/cli_determinism.rs
@@ -112,3 +112,56 @@ fn replay_refuses_a_file_that_is_not_a_trace() {
     );
     let _ = std::fs::remove_file(&path);
 }
+
+/// The machine-readable face of the same run.
+///
+/// The cross-platform comparison reads this, not the human line, so a
+/// change that broke it would take the only gate that proves this
+/// simulation is portable with it — and would do so silently, because
+/// every other test here reads the line built for a person.
+#[test]
+fn the_json_face_carries_the_same_digests_as_the_line() {
+    let human = digest_line(&["--seed", "7", "--frames", "600"]);
+    let json = run(&["--seed", "7", "--frames", "600", "--json"]);
+    assert!(json.success, "the json run failed: {}", json.stderr);
+    let object = json
+        .stdout
+        .lines()
+        .map(str::trim)
+        .rfind(|line| line.starts_with('{'))
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !object.is_empty(),
+        "no JSON object on stdout: {}",
+        json.stdout
+    );
+
+    // Every hash the comparison collects, present and identical to the
+    // human line's. Compared by extracting from both rather than by
+    // recomputing, so a change to either face that left the other behind
+    // fails here.
+    for field in ["schedule_hash", "state_hash"] {
+        let from_line = human
+            .split_whitespace()
+            .find_map(|token| token.strip_prefix(&format!("{field}=")))
+            .unwrap_or_else(|| panic!("the human line carries no {field}: {human}"));
+        let quoted = format!("\"{field}\":\"{from_line}\"");
+        assert!(
+            object.contains(&quoted),
+            "the JSON face is missing {quoted}; it reads {object}"
+        );
+    }
+
+    // Digests are strings, not numbers: a u64 exceeds what a JSON number
+    // carries exactly, and a reader that rounded one would call two
+    // different states identical.
+    assert!(
+        object.contains("\"schema_version\":1"),
+        "the document must name its schema: {object}"
+    );
+    assert!(
+        !object.contains("schedule_hash\":0x"),
+        "hashes must be quoted strings: {object}"
+    );
+}

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -20,12 +20,15 @@ commands:
   modules    list every module with its maturity, from the manifests
   asset-pack     build an asset pack from a directory of files
   asset-inspect  list an asset pack's entries, optionally verifying them
+  determinism    emit this target's simulation digests, or compare several targets'
   doctor     check the development environment
 
 options:
   --json            emit one machine-readable JSON document on stdout
   --report <path>   (coverage only, required) the llvm-cov JSON export to read
   --smoke           (bench only) run each benchmark once, without statistics
+  --emit <path>     (determinism only) write this target's digests here
+  --compare <path>  (determinism only, repeatable) a target report to compare
 ```
 
 `bench --smoke` is a second fixed entry in the command table (every bench
@@ -243,3 +246,49 @@ on stdout:
   the active toolchain against `rust-toolchain.toml` and takes its version
   floor from the workspace manifest's `rust-version`, rather than
   hardcoding either.
+
+## The cross-platform determinism gate
+
+Every other determinism check in this repository compares a run to itself,
+or to a constant this repository minted. Both prove an unseeded generator
+absent; neither can prove the *target* did not matter, because both halves
+of those comparisons ran on one target.
+
+`determinism` is the only place that claim is tested, and it is two modes
+because the claim needs two machines.
+
+```
+renew determinism --emit leg.json
+```
+
+runs the pinned simulations — four glide configurations, each contributing
+both the frame schedule's digest and the world's — and writes what this
+target saw, together with its architecture and the exact `rustc --version`
+that built it. Digests are hex **strings**, not JSON numbers: a `u64`
+exceeds what a JSON number is guaranteed to carry exactly, and a reader
+that silently rounded one would report two different states as identical,
+which is the single failure this gate exists to prevent.
+
+```
+renew determinism --compare linux.json --compare windows.json --compare macos.json
+```
+
+holds them against each other. It exits 0 only when every target agrees
+over a non-empty digest set. Everything else is exit 1, and the reasons
+are deliberately separated:
+
+- **Diverged** — the targets ran the same inputs and reached different
+  state. This is the finding the gate exists to produce, and the message
+  names the digest, both values, and both architectures.
+- **Inconclusive** — the comparison could not be made, and *this is a
+  failure, not a pass*. A leg is missing, a leg carries no digests, the
+  reported architecture set does not match the one the tool binds, or two
+  legs were built by different compilers. The toolchain check outranks the
+  digest comparison on purpose: two compilers producing two digests is not
+  evidence of a portability bug, and reporting it as one sends somebody
+  hunting something that is not there.
+
+The architecture set is matched row for row rather than counted. Three
+legs on one instruction set satisfy a count of three and prove strictly
+less than the tool claims, so a runner fleet that quietly changes
+architecture fails here rather than passing while measuring less.

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -19,11 +19,12 @@ pub enum Command {
     Doctor,
     Record,
     Replay,
+    Determinism,
 }
 
 impl Command {
     /// Every subcommand, in the order `usage` lists them.
-    pub const ALL: [Self; 14] = [
+    pub const ALL: [Self; 15] = [
         Self::Configure,
         Self::Build,
         Self::Test,
@@ -37,6 +38,7 @@ impl Command {
         Self::Modules,
         Self::AssetPack,
         Self::AssetInspect,
+        Self::Determinism,
         Self::Doctor,
     ];
 
@@ -58,6 +60,7 @@ impl Command {
             Self::Doctor => "doctor",
             Self::Record => "record",
             Self::Replay => "replay",
+            Self::Determinism => "determinism",
         }
     }
 
@@ -102,6 +105,9 @@ impl Command {
             Self::Doctor => "check the development environment",
             Self::Record => "run a sample, writing the input it saw to a file",
             Self::Replay => "run a sample from a recorded input file",
+            Self::Determinism => {
+                "emit this target's simulation digests, or compare several targets'"
+            }
         }
     }
 
@@ -143,6 +149,14 @@ pub struct Invocation {
     /// against its recorded digest. Off by default because it reads every
     /// byte, where listing reads only the table.
     pub verify: bool,
+    /// `determinism` only (parse enforces): the target reports to hold
+    /// against each other.
+    pub compare: Vec<String>,
+    /// `determinism` only (parse enforces): where to write this target's
+    /// report. Exactly one of this and [`Invocation::compare`] is set —
+    /// the two modes are one subcommand because they are two halves of
+    /// one claim, and parsing refuses both together and neither.
+    pub emit: Option<String>,
 }
 
 /// What parsing decided: run a subcommand, or show usage on request.
@@ -216,6 +230,16 @@ impl std::error::Error for ParseError {}
 /// does not answer to it (including `record --input` and `replay
 /// --output`, each of which names the other's flag), `record` or `replay`
 /// without one, and any sample-taking subcommand without a sample.
+// The scanner is one long match over flag literals, and it is long
+// because the flag set is. Splitting it would put half the flags in one
+// place and half in another with nothing to say which half a new one
+// belongs to — the linter's line count is measuring the size of the
+// command line, not a structure problem, so the allowance is taken here
+// with the reason rather than by raising the cap for the whole crate.
+#[expect(
+    clippy::too_many_lines,
+    reason = "one arm per flag; splitting the match would scatter the flag set"
+)]
 pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     let mut command = None;
     let mut json = false;
@@ -226,6 +250,8 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     let mut pack: Option<String> = None;
     let mut from: Option<String> = None;
     let mut verify = false;
+    let mut compare: Vec<String> = Vec::new();
+    let mut emit: Option<String> = None;
     let mut sample: Option<String> = None;
     let mut sample_args: Vec<String> = Vec::new();
     // The separator, if it comes at all, comes immediately after the
@@ -263,6 +289,24 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             "--input" => {
                 let path = rest.next().ok_or(ParseError::MissingValue("--input"))?;
                 trace = Some(("--input", path.clone()));
+            }
+            // The first repeatable value flag in this parser. Repeating
+            // accumulates rather than overwriting, because the number of
+            // reports IS the thing the comparison checks — a flag that
+            // silently kept the last one would turn three targets into
+            // one and report agreement.
+            "--compare" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--compare"))?;
+                compare.push(path.clone());
+            }
+            // Its own flag rather than `--output`, which belongs to
+            // `record` and means "write the input you saw here". This
+            // writes a target's digests, and a reader who had to know the
+            // subcommand to know what a flag meant would be right to
+            // complain.
+            "--emit" => {
+                let path = rest.next().ok_or(ParseError::MissingValue("--emit"))?;
+                emit = Some(path.clone());
             }
             // Same reason as `--report`: the value is consumed here so a
             // path can never be mistaken for a subcommand.
@@ -309,6 +353,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
         sample.as_deref(),
     )?;
     check_asset_combination(command, pack.as_deref(), from.as_deref(), verify)?;
+    check_determinism_combination(command, emit.as_deref(), &compare)?;
     match command {
         Some(command) => Ok(Parsed::Run(Invocation {
             command,
@@ -321,9 +366,52 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             pack,
             from,
             verify,
+            compare,
+            emit,
         })),
         None => Err(ParseError::NoCommand),
     }
+}
+
+/// The determinism subcommand's own flag rules.
+///
+/// Separate from [`check_combination`] for the reason its neighbour
+/// already records: that function carries five parameters and reads as a
+/// list of rules only while it does.
+fn check_determinism_combination(
+    command: Option<Command>,
+    emit: Option<&str>,
+    compare: &[String],
+) -> Result<(), ParseError> {
+    // Ownership before requirement, the ordering this module documents:
+    // a caller who typed a flag on the wrong subcommand is told that,
+    // rather than told they are missing something else.
+    if command != Some(Command::Determinism) {
+        if emit.is_some() {
+            return Err(ParseError::UnexpectedArgument("--emit".to_string()));
+        }
+        if !compare.is_empty() {
+            return Err(ParseError::UnexpectedArgument("--compare".to_string()));
+        }
+        return Ok(());
+    }
+    // Exactly one mode. Neither is a subcommand asked to do nothing;
+    // both is a subcommand asked to do two things, and choosing one
+    // silently is how a lane emits when it meant to compare.
+    if emit.is_some() && !compare.is_empty() {
+        return Err(ParseError::UnexpectedArgument(
+            "--emit with --compare: one run either reports a target or holds several \
+             against each other"
+                .to_string(),
+        ));
+    }
+    if emit.is_none() && compare.is_empty() {
+        return Err(ParseError::MissingOption {
+            command: "determinism",
+            option: "--emit <path> or --compare <path>...",
+        });
+    }
+    Ok(())
 }
 
 /// The asset subcommands' own flag rules.
@@ -468,6 +556,8 @@ pub fn usage() -> String {
         "  --pack <path>     (asset-pack, asset-inspect; required) the pack file\n",
         "  --from <dir>      (asset-pack only, required) the directory to pack\n",
         "  --verify          (asset-inspect only) check each entry against its digest\n",
+        "  --emit <path>     (determinism only) write this target's digests here\n",
+        "  --compare <path>  (determinism only, repeatable) a target report to compare\n",
         "  --help, -h        print this text; `renew help` does the same\n",
         "\nEverything after `run <sample>` goes to the sample untouched, including\n",
         "flags renew itself knows: `renew run hello_triangle --json` gives the sample\n",
@@ -503,6 +593,8 @@ mod tests {
             pack: None,
             from: None,
             verify: false,
+            compare: Vec::new(),
+            emit: None,
         }
     }
 
@@ -556,6 +648,16 @@ mod tests {
                     vec![name, "hello_triangle"],
                     Invocation {
                         sample: Some("hello_triangle".to_string()),
+                        ..plain(command)
+                    },
+                ),
+                // Emit rather than compare: both modes are covered by
+                // their own tests below, and this one is about the name
+                // round-tripping, so it takes the shorter line.
+                Command::Determinism => (
+                    vec![name, "--emit", "leg.json"],
+                    Invocation {
+                        emit: Some("leg.json".to_string()),
                         ..plain(command)
                     },
                 ),

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -709,32 +709,30 @@ mod tests {
     /// lane emits when it meant to compare.
     #[test]
     fn determinism_takes_exactly_one_mode() {
-        let emit = parse(&arguments(&["determinism", "--emit", "leg.json"]));
         assert_eq!(
-            emit.map(|parsed| match parsed {
-                Parsed::Run(invocation) => invocation.emit,
-                Parsed::Help { .. } => None,
-            }),
-            Ok(Some("leg.json".to_string()))
+            parse(&arguments(&["determinism", "--emit", "leg.json"])),
+            Ok(Parsed::Run(Invocation {
+                emit: Some("leg.json".to_string()),
+                ..plain(Command::Determinism)
+            }))
         );
 
-        let compare = parse(&arguments(&[
-            "determinism",
-            "--compare",
-            "a.json",
-            "--compare",
-            "b.json",
-        ]));
+        // Repeating accumulates rather than overwrites: how many reports
+        // there are IS what the comparison checks, and a flag that kept
+        // only the last would turn three targets into one and report
+        // agreement.
         assert_eq!(
-            compare.map(|parsed| match parsed {
-                Parsed::Run(invocation) => invocation.compare,
-                Parsed::Help { .. } => Vec::new(),
-            }),
-            // Repeating accumulates rather than overwrites: how many
-            // reports there are IS what the comparison checks, and a flag
-            // that kept only the last would turn three targets into one
-            // and report agreement.
-            Ok(vec!["a.json".to_string(), "b.json".to_string()])
+            parse(&arguments(&[
+                "determinism",
+                "--compare",
+                "a.json",
+                "--compare",
+                "b.json",
+            ])),
+            Ok(Parsed::Run(Invocation {
+                compare: vec!["a.json".to_string(), "b.json".to_string()],
+                ..plain(Command::Determinism)
+            }))
         );
 
         let both = parse(&arguments(&[
@@ -768,10 +766,10 @@ mod tests {
             for flag in ["--emit", "--compare"] {
                 let line = vec![command.name(), flag, "leg.json"];
                 let parsed = parse(&arguments(&line));
+                let name = command.name();
                 assert!(
                     matches!(&parsed, Err(ParseError::UnexpectedArgument(named)) if named == flag),
-                    "`{} {flag}` should be refused by name, got {parsed:?}",
-                    command.name()
+                    "`{name} {flag}` should be refused by name, got {parsed:?}"
                 );
             }
         }

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -345,6 +345,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     if help {
         return Ok(Parsed::Help { json });
     }
+    check_determinism_ownership(command, emit.as_deref(), &compare)?;
     check_combination(
         command,
         smoke,
@@ -353,7 +354,8 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
         sample.as_deref(),
     )?;
     check_asset_combination(command, pack.as_deref(), from.as_deref(), verify)?;
-    check_determinism_combination(command, emit.as_deref(), &compare)?;
+    check_determinism_mode(command, emit.as_deref(), &compare)?;
+
     match command {
         Some(command) => Ok(Parsed::Run(Invocation {
             command,
@@ -373,35 +375,50 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     }
 }
 
-/// The determinism subcommand's own flag rules.
+/// `--emit` and `--compare` belong to `determinism` and nothing else.
 ///
 /// Separate from [`check_combination`] for the reason its neighbour
 /// already records: that function carries five parameters and reads as a
 /// list of rules only while it does.
-fn check_determinism_combination(
+fn check_determinism_ownership(
     command: Option<Command>,
     emit: Option<&str>,
     compare: &[String],
 ) -> Result<(), ParseError> {
-    // Ownership before requirement, the ordering this module documents:
-    // a caller who typed a flag on the wrong subcommand is told that,
-    // rather than told they are missing something else.
-    if command != Some(Command::Determinism) {
-        if emit.is_some() {
-            return Err(ParseError::UnexpectedArgument("--emit".to_string()));
-        }
-        if !compare.is_empty() {
-            return Err(ParseError::UnexpectedArgument("--compare".to_string()));
-        }
+    if command == Some(Command::Determinism) {
         return Ok(());
     }
-    // Exactly one mode. Neither is a subcommand asked to do nothing;
-    // both is a subcommand asked to do two things, and choosing one
-    // silently is how a lane emits when it meant to compare.
+    if emit.is_some() {
+        return Err(ParseError::UnexpectedArgument("--emit".to_string()));
+    }
+    if !compare.is_empty() {
+        return Err(ParseError::UnexpectedArgument("--compare".to_string()));
+    }
+    Ok(())
+}
+
+/// The determinism subcommand's requirement: exactly one mode.
+///
+/// Split from [`check_determinism_ownership`] and called after every
+/// other ownership rule, because this module's ordering convention is
+/// that "this flag is not yours" always precedes "you are missing one".
+/// Together in one function, `determinism --smoke` reported the missing
+/// mode instead of the stray flag, and `run --emit x` reported a missing
+/// sample instead of a flag that is not `run`'s.
+fn check_determinism_mode(
+    command: Option<Command>,
+    emit: Option<&str>,
+    compare: &[String],
+) -> Result<(), ParseError> {
+    if command != Some(Command::Determinism) {
+        return Ok(());
+    }
+    // Neither is a subcommand asked to do nothing; both is a subcommand
+    // asked to do two things, and choosing one silently is how a lane
+    // emits when it meant to compare.
     if emit.is_some() && !compare.is_empty() {
         return Err(ParseError::UnexpectedArgument(
-            "--emit with --compare: one run either reports a target or holds several \
-             against each other"
+            "--emit with --compare: one run either reports a target or holds several              against each other"
                 .to_string(),
         ));
     }
@@ -684,6 +701,95 @@ mod tests {
                 "command `{name}` did not round-trip"
             );
         }
+    }
+
+    /// The two modes are one subcommand, and parsing is what keeps them
+    /// from becoming three: neither is a run asked to do nothing, both is
+    /// a run asked to do two things, and choosing one silently is how a
+    /// lane emits when it meant to compare.
+    #[test]
+    fn determinism_takes_exactly_one_mode() {
+        let emit = parse(&arguments(&["determinism", "--emit", "leg.json"]));
+        assert_eq!(
+            emit.map(|parsed| match parsed {
+                Parsed::Run(invocation) => invocation.emit,
+                Parsed::Help { .. } => None,
+            }),
+            Ok(Some("leg.json".to_string()))
+        );
+
+        let compare = parse(&arguments(&[
+            "determinism",
+            "--compare",
+            "a.json",
+            "--compare",
+            "b.json",
+        ]));
+        assert_eq!(
+            compare.map(|parsed| match parsed {
+                Parsed::Run(invocation) => invocation.compare,
+                Parsed::Help { .. } => Vec::new(),
+            }),
+            // Repeating accumulates rather than overwrites: how many
+            // reports there are IS what the comparison checks, and a flag
+            // that kept only the last would turn three targets into one
+            // and report agreement.
+            Ok(vec!["a.json".to_string(), "b.json".to_string()])
+        );
+
+        let both = parse(&arguments(&[
+            "determinism",
+            "--emit",
+            "leg.json",
+            "--compare",
+            "a.json",
+        ]));
+        assert!(
+            matches!(both, Err(ParseError::UnexpectedArgument(_))),
+            "{both:?}"
+        );
+
+        let neither = parse(&arguments(&["determinism"]));
+        assert_eq!(
+            neither,
+            Err(ParseError::MissingOption {
+                command: "determinism",
+                option: "--emit <path> or --compare <path>...",
+            })
+        );
+    }
+
+    /// Both flags belong to `determinism` and to nothing else. Derived
+    /// from `Command::ALL` like the other ownership tests here, so a
+    /// subcommand added later cannot quietly escape the rejection.
+    #[test]
+    fn the_determinism_flags_are_refused_on_every_other_subcommand() {
+        for command in all_except(Command::Determinism) {
+            for flag in ["--emit", "--compare"] {
+                let line = vec![command.name(), flag, "leg.json"];
+                let parsed = parse(&arguments(&line));
+                assert!(
+                    matches!(&parsed, Err(ParseError::UnexpectedArgument(named)) if named == flag),
+                    "`{} {flag}` should be refused by name, got {parsed:?}",
+                    command.name()
+                );
+            }
+        }
+    }
+
+    /// A flag that takes a path consumes it, so a path can never be read
+    /// as a subcommand — and a flag given without one is named rather
+    /// than silently ignored.
+    #[test]
+    fn the_determinism_flags_refuse_a_missing_value() {
+        assert_eq!(
+            parse(&arguments(&["determinism", "--emit"])),
+            Err(ParseError::MissingValue("--emit"))
+        );
+        assert_eq!(
+            parse(&arguments(&["determinism", "--compare"])),
+            Err(ParseError::MissingValue("--compare"))
+        );
     }
 
     #[test]

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -367,6 +367,48 @@ fn escape(text: &str) -> String {
     text.replace('\\', r"\\").replace('"', "\\\"")
 }
 
+/// Pull the digests a pinned run reported out of what it printed.
+///
+/// The pure half of `--emit`: everything between "a child process wrote
+/// some bytes" and "the report holds two digests". Separated from the
+/// orchestration around it because the orchestration spawns four cargo
+/// runs and cannot be reached by a unit test, while every way this can go
+/// wrong can be — a run that printed nothing, printed something that is
+/// not JSON, or printed JSON missing a hash the comparison needs.
+///
+/// `name` labels the run and prefixes every digest, so two runs that
+/// disagree can be told apart by which configuration produced them.
+///
+/// # Errors
+///
+/// Returns a reason naming the run whenever its output cannot yield both
+/// digests. Never returns a partial set: a report missing one hash is a
+/// report proving half of what it claims, and half is reported as none.
+pub fn digests_from_output(name: &str, stdout: &str) -> Result<Vec<(String, String)>, String> {
+    let Some(line) = stdout
+        .lines()
+        .map(str::trim)
+        .rev()
+        .find(|line| line.starts_with('{'))
+    else {
+        return Err(format!(
+            "the pinned run `{name}` printed no JSON object; a lane that accepted this \
+             would compare an empty digest set against another empty one"
+        ));
+    };
+    let report = crate::json::parse(line)
+        .map_err(|error| format!("`{name}` printed unreadable JSON: {error:?}"))?;
+
+    let mut digests = Vec::new();
+    for field in ["schedule_hash", "state_hash"] {
+        let Some(value) = report.get(field).and_then(crate::json::Value::as_str) else {
+            return Err(format!("`{name}`'s report carries no `{field}`"));
+        };
+        digests.push((format!("{name}/{field}"), value.to_string()));
+    }
+    Ok(digests)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Leg, Verdict, compare, describe, parse_leg, render_leg};
@@ -410,6 +452,83 @@ mod tests {
         // Not a set: two rows may share an instruction set, and
         // collapsing them would let two legs satisfy three rows.
         assert!(arches.len() > 1);
+    }
+
+    const SAMPLE_LINE: &str = concat!(
+        r#"{"schema_version":1,"sample":"glide","seed":7,"source":"soar","frames":600,"#,
+        r#""ticks":600,"dropped":0,"score":3,"alive":true,"#,
+        r#""schedule_hash":"0x55ce27c8dcb97c4d","state_hash":"0xe191d32ff48fb06a"}"#
+    );
+
+    #[test]
+    fn a_runs_output_yields_both_of_its_digests_prefixed_by_the_run() {
+        let digests = super::digests_from_output("glide/seed-7", SAMPLE_LINE).expect("parses");
+        assert_eq!(
+            digests,
+            vec![
+                (
+                    "glide/seed-7/schedule_hash".to_string(),
+                    "0x55ce27c8dcb97c4d".to_string()
+                ),
+                (
+                    "glide/seed-7/state_hash".to_string(),
+                    "0xe191d32ff48fb06a".to_string()
+                ),
+            ]
+        );
+    }
+
+    /// The object is found by scanning backwards, so a run that logged
+    /// before it reported still yields its digests — and a run that
+    /// logged after would too.
+    #[test]
+    fn chatter_around_the_object_does_not_hide_it() {
+        let noisy = format!(
+            "   Compiling something
+warning: unused
+{SAMPLE_LINE}
+"
+        );
+        assert!(super::digests_from_output("run", &noisy).is_ok());
+    }
+
+    /// Every way a run can fail to report, named rather than defaulted.
+    /// A partial set is reported as none: a report missing one hash
+    /// proves half of what it claims, and half must not reach the
+    /// comparison as if it were whole.
+    #[test]
+    fn a_run_that_did_not_report_is_refused_by_name() {
+        let cases = [
+            ("silent", String::new()),
+            (
+                "chatter only",
+                "   Compiling glide
+"
+                .to_string(),
+            ),
+            (
+                "not json",
+                "{not json at all
+"
+                .to_string(),
+            ),
+            (
+                "no schedule hash",
+                SAMPLE_LINE.replace("schedule_hash", "other_hash"),
+            ),
+            (
+                "no state hash",
+                SAMPLE_LINE.replace("state_hash", "other_hash"),
+            ),
+        ];
+        for (label, stdout) in cases {
+            let error = super::digests_from_output("glide/seed-7", &stdout)
+                .expect_err("a run that did not report must be refused");
+            assert!(
+                error.contains("glide/seed-7"),
+                "the `{label}` case must name the run: {error}"
+            );
+        }
     }
 
     #[test]

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -1,0 +1,598 @@
+//! Cross-platform determinism: emit one target's digests, compare several.
+//!
+//! A simulation that reproduces on the machine that wrote it has proved
+//! an unseeded generator absent. It has not proved the machine did not
+//! matter, and it cannot — both halves of that comparison ran on the same
+//! machine. The only evidence for the second claim is two machines
+//! disagreeing, or failing to.
+//!
+//! So this is two modes and they are deliberately asymmetric. **Emit**
+//! runs the pinned simulations on whatever target it finds itself on and
+//! writes what it saw. **Compare** takes several of those and holds them
+//! against each other — never against a committed constant, which is a
+//! regression guard and says nothing about portability.
+//!
+//! # Why the comparison is here and not in workflow YAML
+//!
+//! Because it has to be testable, and because a developer staring at a
+//! red lane has to be able to reproduce it locally. A gate whose logic
+//! lives only in CI configuration is a gate no test can reach, which is
+//! how a gate ends up passing while measuring nothing — a failure this
+//! repository has paid for and does not intend to repeat.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+/// Every (platform, instruction set) pair the determinism claim binds,
+/// one row per lane leg.
+///
+/// **This list is the claim.** A row with no leg is a target asserted and
+/// never exercised; a leg with no row is a target proved and never
+/// claimed. Either is a lie in one direction, so the comparison requires
+/// the reported set to match this one exactly rather than merely counting
+/// to the same number — three legs on one instruction set satisfy a count
+/// of three and prove strictly less.
+///
+/// Widening it is not a code change in spirit even though it is one in
+/// fact: adding a row changes what the engine promises, and the row and
+/// its lane leg land together or the lane starts lying.
+pub const TARGETS: [(&str, &str); 3] = [
+    ("linux", "x86_64"),
+    ("windows", "x86_64"),
+    ("macos", "aarch64"),
+];
+
+/// The architectures [`TARGETS`] binds, in the shape [`compare`] wants.
+#[must_use]
+pub fn expected_arches() -> Vec<&'static str> {
+    TARGETS.iter().map(|(_, arch)| *arch).collect()
+}
+
+/// The output schema this module reads and writes.
+///
+/// Present from the first release, because a consumer holding a document
+/// it cannot version has to guess.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// One target's report: what it ran, and the environment it ran in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Leg {
+    /// Where the report came from, for error messages — a file name.
+    pub origin: String,
+    /// `target_os`, as the emitting build saw itself.
+    pub os: String,
+    /// `target_arch`, likewise. Compared against the expected set, so a
+    /// runner fleet that quietly changes instruction set is caught
+    /// rather than passing while proving less.
+    pub arch: String,
+    /// The exact `rustc --version` string. Legs that disagree here make
+    /// the comparison inconclusive, not passing.
+    pub toolchain: String,
+    /// Digest name to digest, e.g. `glide/seed-7/state_hash`. A map so
+    /// two legs that ran different sets are caught as a set difference
+    /// rather than by position.
+    pub digests: BTreeMap<String, String>,
+}
+
+/// What a comparison concluded.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// Every leg agreed, over a non-empty digest set.
+    Agree { legs: usize, digests: usize },
+    /// The comparison could not be made. **Not a pass.**
+    Inconclusive(Vec<String>),
+    /// The legs disagree — the finding this lane exists to produce.
+    Diverged(Vec<String>),
+}
+
+impl Verdict {
+    /// Only `Agree` is success. Stated as a method so no caller can treat
+    /// `Inconclusive` as a pass by writing `!matches!(v, Diverged(_))`.
+    #[must_use]
+    pub const fn is_pass(&self) -> bool {
+        matches!(self, Self::Agree { .. })
+    }
+}
+
+/// Hold the legs against each other.
+///
+/// `expected_arches` is the set the target list binds — every one must
+/// appear exactly once. Passing an empty set is itself a refusal: a
+/// comparison with nothing to expect cannot detect a fleet that narrowed.
+///
+/// The order of checks is the order of blame. Environment problems are
+/// reported as `Inconclusive` *before* digests are compared at all,
+/// because two legs on different compilers producing different digests
+/// is not evidence of anything, and reporting it as divergence would send
+/// somebody hunting a bug that is not there.
+#[must_use]
+pub fn compare(legs: &[Leg], expected_arches: &[&str]) -> Verdict {
+    let mut blocked = Vec::new();
+
+    if expected_arches.is_empty() {
+        blocked.push(
+            "no expected architectures were given, so this comparison could not have \
+             detected a target set that narrowed"
+                .to_string(),
+        );
+    }
+    if legs.len() < expected_arches.len() {
+        blocked.push(format!(
+            "expected {} legs, one per target row, and received {} — a missing leg is an \
+             untested target, not a passing one",
+            expected_arches.len(),
+            legs.len()
+        ));
+    }
+
+    // Anti-vacuity: a leg carrying nothing compares equal to every other
+    // leg carrying nothing, and the lane would report success.
+    for leg in legs {
+        if leg.digests.is_empty() {
+            blocked.push(format!(
+                "leg `{}` carries no digests at all, so comparing it proves nothing",
+                leg.origin
+            ));
+        }
+    }
+
+    // The architecture set, matched to the rows rather than merely
+    // counted: three x86_64 legs satisfy a count of three and prove far
+    // less than the target list claims.
+    let mut seen: Vec<&str> = legs.iter().map(|leg| leg.arch.as_str()).collect();
+    seen.sort_unstable();
+    let mut wanted: Vec<&str> = expected_arches.to_vec();
+    wanted.sort_unstable();
+    if !expected_arches.is_empty() && seen != wanted {
+        blocked.push(format!(
+            "the legs report architectures [{}] and the target list binds [{}] — the lane \
+             is proving a different set than it claims",
+            seen.join(", "),
+            wanted.join(", ")
+        ));
+    }
+
+    // Toolchain: a mismatch is inconclusive, never a quiet pass and never
+    // reported as divergence.
+    if let Some(first) = legs.first() {
+        for leg in legs {
+            if leg.toolchain != first.toolchain {
+                blocked.push(format!(
+                    "leg `{}` built with `{}` and leg `{}` with `{}` — determinism is \
+                     claimed for one toolchain version, so this comparison is \
+                     inconclusive rather than failing",
+                    first.origin, first.toolchain, leg.origin, leg.toolchain
+                ));
+                break;
+            }
+        }
+    }
+
+    if !blocked.is_empty() {
+        return Verdict::Inconclusive(blocked);
+    }
+
+    let Some(reference) = legs.first() else {
+        // Unreachable while `expected_arches` is non-empty, since an
+        // empty `legs` would have failed the count check above. Reported
+        // rather than unwrapped, because "unreachable" is a claim about
+        // today's callers.
+        return Verdict::Inconclusive(vec![
+            "no legs were supplied, so there was nothing to compare".to_string(),
+        ]);
+    };
+
+    let mut divergences = Vec::new();
+    for leg in legs.iter().skip(1) {
+        // A leg that ran a different set of simulations is a divergence
+        // in itself: the comparison would otherwise silently cover only
+        // the intersection.
+        for name in reference.digests.keys() {
+            if !leg.digests.contains_key(name) {
+                divergences.push(format!(
+                    "leg `{}` reported `{name}` and leg `{}` did not run it",
+                    reference.origin, leg.origin
+                ));
+            }
+        }
+        for name in leg.digests.keys() {
+            if !reference.digests.contains_key(name) {
+                divergences.push(format!(
+                    "leg `{}` reported `{name}` and leg `{}` did not run it",
+                    leg.origin, reference.origin
+                ));
+            }
+        }
+        for (name, value) in &leg.digests {
+            if let Some(expected) = reference.digests.get(name)
+                && value != expected
+            {
+                divergences.push(format!(
+                    "`{name}` is {expected} on {} ({}) and {value} on {} ({}) — the \
+                     same inputs produced different state on two targets",
+                    reference.origin, reference.arch, leg.origin, leg.arch
+                ));
+            }
+        }
+    }
+
+    if divergences.is_empty() {
+        Verdict::Agree {
+            legs: legs.len(),
+            digests: reference.digests.len(),
+        }
+    } else {
+        divergences.sort_unstable();
+        divergences.dedup();
+        Verdict::Diverged(divergences)
+    }
+}
+
+/// Render a verdict for a person reading a failed lane.
+#[must_use]
+pub fn describe(verdict: &Verdict) -> String {
+    let mut out = String::new();
+    match verdict {
+        Verdict::Agree { legs, digests } => {
+            let _ = write!(
+                out,
+                "{legs} targets agree on all {digests} digests — the same inputs produce \
+                 the same state on every target the list binds"
+            );
+        }
+        Verdict::Inconclusive(reasons) => {
+            out.push_str("INCONCLUSIVE — this is a failure, not a pass:\n");
+            for reason in reasons {
+                let _ = writeln!(out, "  - {reason}");
+            }
+        }
+        Verdict::Diverged(items) => {
+            out.push_str("DIVERGED — targets disagree:\n");
+            for item in items {
+                let _ = writeln!(out, "  - {item}");
+            }
+        }
+    }
+    out
+}
+
+/// Read a leg from the JSON one `--emit` run wrote.
+///
+/// Every field is required and every absence is named. A parser that
+/// defaulted a missing digest set to empty, or a missing architecture to
+/// the host's, would turn a broken emit step into a passing comparison —
+/// which is the failure mode this whole module is arranged against.
+///
+/// # Errors
+///
+/// Returns a human-readable reason when the document is not a leg: bad
+/// JSON, a schema version this build does not know, a missing or
+/// wrong-typed field, or a digest that is not a hex string.
+pub fn parse_leg(origin: &str, text: &str) -> Result<Leg, String> {
+    let value = crate::json::parse(text)
+        .map_err(|error| format!("`{origin}` is not readable as JSON: {error:?}"))?;
+    let field = |name: &str| -> Result<String, String> {
+        value
+            .get(name)
+            .and_then(crate::json::Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| format!("`{origin}` has no string field `{name}`"))
+    };
+
+    // The version gate refuses forward as well as backward. A newer
+    // emitter may mean something different by a field this build reads
+    // by the same name, and guessing is how a comparison quietly
+    // compares the wrong things.
+    let version = match value.get("schema_version") {
+        Some(crate::json::Value::Number(n)) => u32::try_from(*n).ok(),
+        _ => None,
+    }
+    .ok_or_else(|| format!("`{origin}` has no readable `schema_version`"))?;
+    if version != SCHEMA_VERSION {
+        return Err(format!(
+            "`{origin}` is schema version {version} and this build reads {SCHEMA_VERSION}"
+        ));
+    }
+
+    let digests_value = value
+        .get("digests")
+        .ok_or_else(|| format!("`{origin}` has no `digests` object"))?;
+    let mut digests = BTreeMap::new();
+    for (name, entry) in digests_value
+        .as_object()
+        .ok_or_else(|| format!("`{origin}`'s `digests` is not an object"))?
+    {
+        let digest = entry
+            .as_str()
+            .ok_or_else(|| format!("`{origin}`'s digest `{name}` is not a string"))?;
+        // Hex strings, not numbers: a u64 digest exceeds what JSON
+        // numbers carry exactly, and a consumer that rounded one would
+        // report two different states as the same.
+        if !digest.starts_with("0x") || digest.len() < 3 {
+            return Err(format!(
+                "`{origin}`'s digest `{name}` is `{digest}`, which is not a 0x-prefixed \
+                 hex string — digests are strings so that no reader rounds one"
+            ));
+        }
+        digests.insert(name.clone(), digest.to_string());
+    }
+
+    Ok(Leg {
+        origin: origin.to_string(),
+        os: field("os")?,
+        arch: field("arch")?,
+        toolchain: field("toolchain")?,
+        digests,
+    })
+}
+
+/// Render a leg as the JSON `--emit` writes and `parse_leg` reads.
+///
+/// Written by hand rather than through a serializer because this tree has
+/// no serialization dependency and one document does not justify adding
+/// one. The round-trip is tested, which is the property that matters.
+#[must_use]
+pub fn render_leg(leg: &Leg) -> String {
+    let mut out = String::new();
+    let _ = write!(
+        out,
+        "{{\n  \"schema_version\": {SCHEMA_VERSION},\n  \"os\": \"{}\",\n  \
+         \"arch\": \"{}\",\n  \"toolchain\": \"{}\",\n  \"digests\": {{",
+        escape(&leg.os),
+        escape(&leg.arch),
+        escape(&leg.toolchain)
+    );
+    for (index, (name, digest)) in leg.digests.iter().enumerate() {
+        let comma = if index + 1 == leg.digests.len() {
+            ""
+        } else {
+            ","
+        };
+        let _ = write!(
+            out,
+            "\n    \"{}\": \"{}\"{comma}",
+            escape(name),
+            escape(digest)
+        );
+    }
+    out.push_str("\n  }\n}\n");
+    out
+}
+
+/// The subset of JSON string escaping these fields can actually need:
+/// a toolchain string carries a version and a hash, a digest is hex, a
+/// name is chosen here. Backslash and quote are escaped anyway, because
+/// "cannot contain" is a claim about today's inputs.
+fn escape(text: &str) -> String {
+    text.replace('\\', r"\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Leg, Verdict, compare, describe, parse_leg, render_leg};
+    use std::collections::BTreeMap;
+
+    const ARCHES: [&str; 3] = ["aarch64", "x86_64", "x86_64"];
+
+    fn leg(origin: &str, arch: &str, pairs: &[(&str, &str)]) -> Leg {
+        Leg {
+            origin: origin.to_string(),
+            os: "linux".to_string(),
+            arch: arch.to_string(),
+            toolchain: "rustc 1.97.0".to_string(),
+            digests: pairs
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        }
+    }
+
+    fn three(a: &str, b: &str, c: &str) -> Vec<Leg> {
+        vec![
+            leg("linux.json", "x86_64", &[("glide/state", a)]),
+            leg("windows.json", "x86_64", &[("glide/state", b)]),
+            leg("macos.json", "aarch64", &[("glide/state", c)]),
+        ]
+    }
+
+    #[test]
+    fn three_agreeing_targets_pass() {
+        let verdict = compare(&three("0x1", "0x1", "0x1"), &ARCHES);
+        assert_eq!(
+            verdict,
+            Verdict::Agree {
+                legs: 3,
+                digests: 1
+            }
+        );
+        assert!(verdict.is_pass());
+    }
+
+    #[test]
+    fn one_disagreeing_target_is_named_with_its_value() {
+        let verdict = compare(&three("0x1", "0x1", "0xdead"), &ARCHES);
+        let Verdict::Diverged(items) = &verdict else {
+            panic!("expected divergence, got {verdict:?}");
+        };
+        assert!(!verdict.is_pass());
+        assert_eq!(items.len(), 1, "{items:?}");
+        assert!(items[0].contains("macos.json"), "{}", items[0]);
+        assert!(items[0].contains("0xdead"), "{}", items[0]);
+        assert!(items[0].contains("aarch64"), "{}", items[0]);
+    }
+
+    /// The check this lane's whole credibility rests on. A comparison of
+    /// nothing is equality, and equality is what this lane reports as
+    /// success — so a leg that ran no simulations must never reach the
+    /// comparison at all.
+    #[test]
+    fn a_leg_with_no_digests_is_inconclusive_rather_than_equal() {
+        let mut legs = three("0x1", "0x1", "0x1");
+        legs[1].digests = BTreeMap::new();
+        let verdict = compare(&legs, &ARCHES);
+        assert!(!verdict.is_pass());
+        let Verdict::Inconclusive(reasons) = &verdict else {
+            panic!("expected inconclusive, got {verdict:?}");
+        };
+        assert!(
+            reasons.iter().any(|r| r.contains("windows.json")),
+            "{reasons:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_leg_is_inconclusive_rather_than_two_legs_agreeing() {
+        let mut legs = three("0x1", "0x1", "0x1");
+        legs.pop();
+        let verdict = compare(&legs, &ARCHES);
+        assert!(!verdict.is_pass());
+        assert!(matches!(verdict, Verdict::Inconclusive(_)));
+    }
+
+    /// Three legs on one instruction set satisfy a count of three and
+    /// prove strictly less than the target list claims. Counting is not
+    /// enough; the set has to match row for row.
+    #[test]
+    fn the_wrong_architecture_set_is_inconclusive_even_at_the_right_count() {
+        let mut legs = three("0x1", "0x1", "0x1");
+        legs[2].arch = "x86_64".to_string();
+        let verdict = compare(&legs, &ARCHES);
+        assert!(!verdict.is_pass());
+        let Verdict::Inconclusive(reasons) = &verdict else {
+            panic!("expected inconclusive, got {verdict:?}");
+        };
+        assert!(reasons.iter().any(|r| r.contains("aarch64")), "{reasons:?}");
+    }
+
+    /// Two compilers producing two digests is not evidence of a
+    /// portability bug, and reporting it as one sends somebody hunting
+    /// something that is not there.
+    #[test]
+    fn a_toolchain_mismatch_is_inconclusive_and_not_divergence() {
+        let mut legs = three("0x1", "0x1", "0xdead");
+        legs[2].toolchain = "rustc 1.98.0".to_string();
+        let verdict = compare(&legs, &ARCHES);
+        let Verdict::Inconclusive(reasons) = &verdict else {
+            panic!("a toolchain mismatch must outrank the digest difference: {verdict:?}");
+        };
+        assert!(reasons.iter().any(|r| r.contains("1.98.0")), "{reasons:?}");
+    }
+
+    /// A leg that ran fewer simulations would otherwise narrow the
+    /// comparison to the intersection, silently.
+    #[test]
+    fn a_leg_that_skipped_a_simulation_is_a_divergence() {
+        let mut legs = three("0x1", "0x1", "0x1");
+        legs[0]
+            .digests
+            .insert("frame/schedule".to_string(), "0x2".to_string());
+        let verdict = compare(&legs, &ARCHES);
+        let Verdict::Diverged(items) = &verdict else {
+            panic!("expected divergence, got {verdict:?}");
+        };
+        assert!(
+            items.iter().any(|i| i.contains("frame/schedule")),
+            "{items:?}"
+        );
+    }
+
+    #[test]
+    fn an_empty_expectation_refuses_rather_than_passing_vacuously() {
+        let verdict = compare(&three("0x1", "0x1", "0x1"), &[]);
+        assert!(!verdict.is_pass(), "{verdict:?}");
+    }
+
+    #[test]
+    fn no_legs_at_all_is_inconclusive() {
+        assert!(!compare(&[], &ARCHES).is_pass());
+    }
+
+    /// Written and read by hand, so the round trip is the only thing
+    /// standing between a renderer of one shape and a parser of another.
+    #[test]
+    fn a_leg_survives_the_round_trip_it_is_written_for() {
+        let original = leg(
+            "linux.json",
+            "x86_64",
+            &[("glide/seed-7/state", "0xdeadbeefcafef00d"), ("a/b", "0x1")],
+        );
+        let text = render_leg(&original);
+        let parsed = parse_leg("linux.json", &text).expect("what we render, we read");
+        assert_eq!(parsed, original);
+    }
+
+    /// The version gate refuses forward as well as back: a newer emitter
+    /// may mean something different by a field this build reads by the
+    /// same name, and guessing is how a lane compares the wrong things.
+    #[test]
+    fn a_document_from_another_schema_version_is_refused_in_both_directions() {
+        for other in ["0", "2", "99"] {
+            let text = format!(
+                "{{\"schema_version\": {other}, \"os\": \"linux\", \"arch\": \"x86_64\",                  \"toolchain\": \"rustc 1.97.0\", \"digests\": {{\"a\": \"0x1\"}}}}"
+            );
+            let error = parse_leg("leg.json", &text).expect_err("version {other} must be refused");
+            assert!(error.contains(other), "{error}");
+        }
+    }
+
+    /// Every absence is named rather than defaulted. A parser that
+    /// defaulted a missing digest set to empty would turn a broken emit
+    /// step into a passing comparison.
+    #[test]
+    fn a_leg_missing_any_field_is_refused_by_name() {
+        let full = concat!(
+            r#"{"schema_version": 1, "os": "linux", "arch": "x86_64", "#,
+            r#""toolchain": "rustc 1.97.0", "digests": {"a": "0x1"}}"#
+        );
+        assert!(
+            parse_leg("leg.json", full).is_ok(),
+            "the control must parse"
+        );
+
+        for field in ["os", "arch", "toolchain", "digests"] {
+            let without = full.replace(&format!("\"{field}\""), "\"removed\"");
+            let error = parse_leg("leg.json", &without)
+                .expect_err("a leg without `{field}` must be refused");
+            assert!(error.contains(field), "{error}");
+        }
+    }
+
+    /// Digests are strings because a `u64` exceeds what a JSON number
+    /// carries exactly, and a reader that rounded one would call two
+    /// different states equal — the one failure this lane exists to stop.
+    #[test]
+    fn a_digest_that_is_not_a_hex_string_is_refused() {
+        for bad in ["12345", r#""deadbeef""#, r#""0x""#, "null"] {
+            let text = format!(
+                concat!(
+                    r#"{{"schema_version": 1, "os": "linux", "arch": "x86_64", "#,
+                    r#""toolchain": "rustc 1.97.0", "digests": {{"a": {}}}}}"#
+                ),
+                bad
+            );
+            assert!(
+                parse_leg("leg.json", &text).is_err(),
+                "`{bad}` should not be accepted as a digest"
+            );
+        }
+    }
+
+    #[test]
+    fn every_verdict_describes_itself_without_panicking() {
+        for verdict in [
+            compare(&three("0x1", "0x1", "0x1"), &ARCHES),
+            compare(&three("0x1", "0x1", "0x2"), &ARCHES),
+            compare(&[], &ARCHES),
+        ] {
+            let text = describe(&verdict);
+            assert!(!text.is_empty());
+            // A failure must never read as a success at a glance.
+            if !verdict.is_pass() {
+                assert!(
+                    text.contains("INCONCLUSIVE") || text.contains("DIVERGED"),
+                    "{text}"
+                );
+            }
+        }
+    }
+}

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -164,17 +164,15 @@ pub fn compare(legs: &[Leg], expected_arches: &[&str]) -> Verdict {
 
     // Toolchain: a mismatch is inconclusive, never a quiet pass and never
     // reported as divergence.
-    if let Some(first) = legs.first() {
-        for leg in legs {
-            if leg.toolchain != first.toolchain {
-                blocked.push(format!(
-                    "leg `{}` built with `{}` and leg `{}` with `{}` — determinism is \
-                     claimed for one toolchain version, so this comparison is \
-                     inconclusive rather than failing",
-                    first.origin, first.toolchain, leg.origin, leg.toolchain
-                ));
-                break;
-            }
+    for leg in legs {
+        if leg.toolchain != reference.toolchain {
+            blocked.push(format!(
+                "leg `{}` built with `{}` and leg `{}` with `{}` — determinism is \
+                 claimed for one toolchain version, so this comparison is \
+                 inconclusive rather than failing",
+                reference.origin, reference.toolchain, leg.origin, leg.toolchain
+            ));
+            break;
         }
     }
 

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -107,6 +107,16 @@ impl Verdict {
 /// somebody hunting a bug that is not there.
 #[must_use]
 pub fn compare(legs: &[Leg], expected_arches: &[&str]) -> Verdict {
+    // First, because a comparison of nothing is the one failure that
+    // most resembles success. Placing it after the checks below would
+    // leave it unreachable — the count check catches an empty slice — and
+    // an unreachable refusal is a refusal nobody can test.
+    let Some(reference) = legs.first() else {
+        return Verdict::Inconclusive(vec![
+            "no reports were supplied, so there was nothing to compare".to_string(),
+        ]);
+    };
+
     let mut blocked = Vec::new();
 
     if expected_arches.is_empty() {
@@ -171,16 +181,6 @@ pub fn compare(legs: &[Leg], expected_arches: &[&str]) -> Verdict {
     if !blocked.is_empty() {
         return Verdict::Inconclusive(blocked);
     }
-
-    let Some(reference) = legs.first() else {
-        // Unreachable while `expected_arches` is non-empty, since an
-        // empty `legs` would have failed the count check above. Reported
-        // rather than unwrapped, because "unreachable" is a claim about
-        // today's callers.
-        return Verdict::Inconclusive(vec![
-            "no legs were supplied, so there was nothing to compare".to_string(),
-        ]);
-    };
 
     let mut divergences = Vec::new();
     for leg in legs.iter().skip(1) {
@@ -428,14 +428,15 @@ mod tests {
     #[test]
     fn one_disagreeing_target_is_named_with_its_value() {
         let verdict = compare(&three("0x1", "0x1", "0xdead"), &ARCHES);
-        let Verdict::Diverged(items) = &verdict else {
-            panic!("expected divergence, got {verdict:?}");
-        };
         assert!(!verdict.is_pass());
-        assert_eq!(items.len(), 1, "{items:?}");
-        assert!(items[0].contains("macos.json"), "{}", items[0]);
-        assert!(items[0].contains("0xdead"), "{}", items[0]);
-        assert!(items[0].contains("aarch64"), "{}", items[0]);
+        // Read through `describe`, which is what a person staring at a red
+        // lane actually sees. Destructuring would test the shape and leave
+        // the rendering — the part with a reader — untested.
+        let text = describe(&verdict);
+        assert!(text.contains("DIVERGED"), "{text}");
+        assert!(text.contains("macos.json"), "{text}");
+        assert!(text.contains("0xdead"), "{text}");
+        assert!(text.contains("aarch64"), "{text}");
     }
 
     /// The check this lane's whole credibility rests on. A comparison of
@@ -448,13 +449,9 @@ mod tests {
         legs[1].digests = BTreeMap::new();
         let verdict = compare(&legs, &ARCHES);
         assert!(!verdict.is_pass());
-        let Verdict::Inconclusive(reasons) = &verdict else {
-            panic!("expected inconclusive, got {verdict:?}");
-        };
-        assert!(
-            reasons.iter().any(|r| r.contains("windows.json")),
-            "{reasons:?}"
-        );
+        let text = describe(&verdict);
+        assert!(text.contains("INCONCLUSIVE"), "{text}");
+        assert!(text.contains("windows.json"), "{text}");
     }
 
     #[test]
@@ -475,10 +472,9 @@ mod tests {
         legs[2].arch = "x86_64".to_string();
         let verdict = compare(&legs, &ARCHES);
         assert!(!verdict.is_pass());
-        let Verdict::Inconclusive(reasons) = &verdict else {
-            panic!("expected inconclusive, got {verdict:?}");
-        };
-        assert!(reasons.iter().any(|r| r.contains("aarch64")), "{reasons:?}");
+        let text = describe(&verdict);
+        assert!(text.contains("INCONCLUSIVE"), "{text}");
+        assert!(text.contains("aarch64"), "{text}");
     }
 
     /// Two compilers producing two digests is not evidence of a
@@ -489,10 +485,12 @@ mod tests {
         let mut legs = three("0x1", "0x1", "0xdead");
         legs[2].toolchain = "rustc 1.98.0".to_string();
         let verdict = compare(&legs, &ARCHES);
-        let Verdict::Inconclusive(reasons) = &verdict else {
-            panic!("a toolchain mismatch must outrank the digest difference: {verdict:?}");
-        };
-        assert!(reasons.iter().any(|r| r.contains("1.98.0")), "{reasons:?}");
+        let text = describe(&verdict);
+        assert!(
+            text.contains("INCONCLUSIVE"),
+            "a toolchain mismatch must outrank the digest difference: {text}"
+        );
+        assert!(text.contains("1.98.0"), "{text}");
     }
 
     /// A leg that ran fewer simulations would otherwise narrow the
@@ -504,13 +502,43 @@ mod tests {
             .digests
             .insert("frame/schedule".to_string(), "0x2".to_string());
         let verdict = compare(&legs, &ARCHES);
-        let Verdict::Diverged(items) = &verdict else {
-            panic!("expected divergence, got {verdict:?}");
-        };
-        assert!(
-            items.iter().any(|i| i.contains("frame/schedule")),
-            "{items:?}"
-        );
+        let text = describe(&verdict);
+        assert!(text.contains("DIVERGED"), "{text}");
+        assert!(text.contains("frame/schedule"), "{text}");
+    }
+
+    /// The other direction of the same check. A *later* leg carrying a
+    /// digest the reference lacks is just as much a set difference, and
+    /// covering only one direction would let half of it through.
+    #[test]
+    fn a_leg_that_ran_an_extra_simulation_is_a_divergence_too() {
+        let mut legs = three("0x1", "0x1", "0x1");
+        legs[2]
+            .digests
+            .insert("frame/schedule".to_string(), "0x2".to_string());
+        let verdict = compare(&legs, &ARCHES);
+        let text = describe(&verdict);
+        assert!(text.contains("DIVERGED"), "{text}");
+        assert!(text.contains("frame/schedule"), "{text}");
+    }
+
+    /// The version must be a JSON number. A string `"1"` is a document
+    /// written by something that does not share this shape, and reading
+    /// it anyway is how a comparison compares the wrong things.
+    #[test]
+    fn a_schema_version_that_is_not_a_number_is_refused() {
+        for bad in [r#""1""#, "null", "true", r#"{"a":1}"#] {
+            let text = format!(
+                concat!(
+                    r#"{{"schema_version": {}, "os": "linux", "arch": "x86_64", "#,
+                    r#""toolchain": "rustc 1.97.0", "digests": {{"a": "0x1"}}}}"#
+                ),
+                bad
+            );
+            let error = parse_leg("leg.json", &text)
+                .expect_err("a non-numeric schema version must be refused");
+            assert!(error.contains("schema_version"), "{error}");
+        }
     }
 
     #[test]
@@ -521,7 +549,9 @@ mod tests {
 
     #[test]
     fn no_legs_at_all_is_inconclusive() {
-        assert!(!compare(&[], &ARCHES).is_pass());
+        let verdict = compare(&[], &ARCHES);
+        assert!(!verdict.is_pass());
+        assert!(describe(&verdict).contains("nothing to compare"));
     }
 
     /// Written and read by hand, so the round trip is the only thing

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -395,6 +395,23 @@ mod tests {
         ]
     }
 
+    /// The bound set is a list rather than a number, and this is what
+    /// says so: a row with no leg is a target promised and never proved.
+    #[test]
+    fn the_expected_architectures_come_from_the_target_rows() {
+        let arches = super::expected_arches();
+        assert_eq!(arches.len(), super::TARGETS.len());
+        for (platform, arch) in super::TARGETS {
+            assert!(
+                arches.contains(&arch),
+                "{platform} binds {arch} and the expected set omits it"
+            );
+        }
+        // Not a set: two rows may share an instruction set, and
+        // collapsing them would let two legs satisfy three rows.
+        assert!(arches.len() > 1);
+    }
+
     #[test]
     fn three_agreeing_targets_pass() {
         let verdict = compare(&three("0x1", "0x1", "0x1"), &ARCHES);

--- a/tools/cli/src/lib.rs
+++ b/tools/cli/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod cli;
 pub mod coverage;
+pub mod determinism;
 pub mod doctor;
 pub mod json;
 pub mod plan;

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -13,8 +13,12 @@ use std::path::{Path, PathBuf};
 use std::process::{Command as Process, ExitCode};
 use std::time::Instant;
 
+use std::collections::BTreeMap;
+use std::fs;
+
 use renew_cli::cli::{self, Command, Invocation, Parsed};
 use renew_cli::coverage::{self, Outcome};
+use renew_cli::determinism;
 use renew_cli::doctor::{self, Facts};
 use renew_cli::json::{self, Value};
 use renew_cli::plan;
@@ -65,6 +69,22 @@ fn run(invocation: &Invocation) -> ExitCode {
             invocation.json,
         ),
         Command::Run | Command::Record | Command::Replay => run_sample(invocation),
+        // Dispatched explicitly, and the wildcard below is why it has to
+        // be. A subcommand that falls through to `run_steps` runs an
+        // empty step list and reports `ok` in exit code and envelope
+        // alike — for a gate whose whole purpose is refusing to pass
+        // vacuously, being forgotten here is the worst available bug and
+        // the compiler cannot catch it.
+        Command::Determinism => {
+            if invocation.compare.is_empty() {
+                run_determinism_emit(
+                    invocation.emit.as_deref().unwrap_or_default(),
+                    invocation.json,
+                )
+            } else {
+                run_determinism_compare(&invocation.compare, invocation.json)
+            }
+        }
         _ => run_steps(invocation),
     }
 }
@@ -965,6 +985,156 @@ fn run_steps(invocation: &Invocation) -> ExitCode {
         }
     }
     runner.finish()
+}
+
+/// The simulations the cross-platform lane compares, and the exact
+/// arguments that pin them.
+///
+/// Each entry names a run whose every output is a function of the flags
+/// beside it. Widening this list widens what the claim covers; it is a
+/// list rather than one run because a single configuration
+/// exercises one path through the world, and a divergence in a path the
+/// list never walks is a divergence the lane never sees.
+const PINNED_RUNS: [(&str, &[&str]); 4] = [
+    (
+        "glide/seed-7-600",
+        &["--seed", "7", "--frames", "600", "--json"],
+    ),
+    (
+        "glide/seed-7-2000",
+        &["--seed", "7", "--frames", "2000", "--json"],
+    ),
+    (
+        "glide/seed-99-600",
+        &["--seed", "99", "--frames", "600", "--json"],
+    ),
+    (
+        "glide/sink-1500",
+        &[
+            "--seed",
+            "3",
+            "--frames",
+            "1500",
+            "--input-trace",
+            "sink",
+            "--json",
+        ],
+    ),
+];
+
+/// Run the pinned simulations and write this target's report.
+///
+/// Every run contributes two digests — the frame schedule's and the
+/// world's — because the sample already computes both and a lane that
+/// dropped one would be proving half of what it claims.
+fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
+    let runner = match Runner::anchored("determinism", json_mode) {
+        Ok(runner) => runner,
+        Err(exit) => return exit,
+    };
+
+    // The toolchain that built the binaries being compared. Read from
+    // the compiler rather than from a file, because a file records an
+    // intention and this has to record what actually ran.
+    let toolchain = match probe("rustc", &["--version"], Some(&runner.root)) {
+        Ok((true, text)) => text.trim().to_string(),
+        Ok((false, _)) | Err(_) => {
+            return runner.fail(
+                "could not read `rustc --version`, and a comparison that cannot name its \
+                 compiler is inconclusive rather than passing",
+            );
+        }
+    };
+
+    let mut digests = BTreeMap::new();
+    for (name, args) in PINNED_RUNS {
+        let mut invocation = vec!["run", "--quiet", "--package", "renew-sample-glide", "--"];
+        invocation.extend_from_slice(args);
+        let (ok, stdout) = match probe("cargo", &invocation, Some(&runner.root)) {
+            Ok(result) => result,
+            Err(error) => return runner.fail(&format!("could not start `{name}`: {error}")),
+        };
+        if !ok {
+            return runner.fail(&format!(
+                "the pinned run `{name}` failed, so this target contributes nothing and \
+                 the comparison must not be told otherwise"
+            ));
+        }
+        let Some(line) = stdout
+            .lines()
+            .rev()
+            .find(|line| line.trim_start().starts_with('{'))
+        else {
+            return runner.fail(&format!(
+                "the pinned run `{name}` printed no JSON object; a lane that accepted this \
+                 would compare an empty digest set against another empty one"
+            ));
+        };
+        let report = match renew_cli::json::parse(line) {
+            Ok(report) => report,
+            Err(error) => {
+                return runner.fail(&format!("`{name}` printed unreadable JSON: {error:?}"));
+            }
+        };
+        for field in ["schedule_hash", "state_hash"] {
+            let Some(value) = report.get(field).and_then(Value::as_str) else {
+                return runner.fail(&format!("`{name}`'s report carries no `{field}`"));
+            };
+            digests.insert(format!("{name}/{field}"), value.to_string());
+        }
+    }
+
+    let leg = determinism::Leg {
+        origin: output_path.to_string(),
+        os: env::consts::OS.to_string(),
+        arch: env::consts::ARCH.to_string(),
+        toolchain,
+        digests,
+    };
+    let rendered = determinism::render_leg(&leg);
+    if let Err(error) = fs::write(output_path, &rendered) {
+        return runner.fail(&format!("could not write `{output_path}`: {error}"));
+    }
+    println!(
+        "wrote {} digests for {}/{} to {output_path}",
+        leg.digests.len(),
+        leg.os,
+        leg.arch
+    );
+    runner.finish()
+}
+
+/// Hold several targets' reports against each other.
+fn run_determinism_compare(paths: &[String], json_mode: bool) -> ExitCode {
+    let runner = match Runner::anchored("determinism", json_mode) {
+        Ok(runner) => runner,
+        Err(exit) => return exit,
+    };
+
+    let arches = determinism::expected_arches();
+
+    let mut legs = Vec::new();
+    for path in paths {
+        let text = match fs::read_to_string(path) {
+            Ok(text) => text,
+            // A missing artifact is a leg that did not report, which is
+            // an untested target — never an absent objection.
+            Err(error) => return runner.fail(&format!("could not read `{path}`: {error}")),
+        };
+        match determinism::parse_leg(path, &text) {
+            Ok(leg) => legs.push(leg),
+            Err(message) => return runner.fail(&message),
+        }
+    }
+
+    let verdict = determinism::compare(&legs, &arches);
+    let report = determinism::describe(&verdict);
+    if verdict.is_pass() {
+        println!("{report}");
+        runner.finish()
+    } else {
+        runner.fail(&report)
+    }
 }
 
 /// Build and run one sample, then hand it the rest of the command line.

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1060,27 +1060,9 @@ fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
                  the comparison must not be told otherwise"
             ));
         }
-        let Some(line) = stdout
-            .lines()
-            .rev()
-            .find(|line| line.trim_start().starts_with('{'))
-        else {
-            return runner.fail(&format!(
-                "the pinned run `{name}` printed no JSON object; a lane that accepted this \
-                 would compare an empty digest set against another empty one"
-            ));
-        };
-        let report = match renew_cli::json::parse(line) {
-            Ok(report) => report,
-            Err(error) => {
-                return runner.fail(&format!("`{name}` printed unreadable JSON: {error:?}"));
-            }
-        };
-        for field in ["schedule_hash", "state_hash"] {
-            let Some(value) = report.get(field).and_then(Value::as_str) else {
-                return runner.fail(&format!("`{name}`'s report carries no `{field}`"));
-            };
-            digests.insert(format!("{name}/{field}"), value.to_string());
+        match determinism::digests_from_output(name, &stdout) {
+            Ok(pairs) => digests.extend(pairs),
+            Err(message) => return runner.fail(&message),
         }
     }
 

--- a/tools/cli/src/plan.rs
+++ b/tools/cli/src/plan.rs
@@ -77,7 +77,8 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
         | Command::Doctor
         | Command::Run
         | Command::Record
-        | Command::Replay => &[],
+        | Command::Replay
+        | Command::Determinism => &[],
     }
 }
 

--- a/tools/cli/tests/determinism.rs
+++ b/tools/cli/tests/determinism.rs
@@ -137,3 +137,26 @@ fn the_json_envelope_names_the_subcommand_that_ran() {
     assert!(stdout.contains("\"schema_version\""), "{stdout}");
     assert!(!json.status.success(), "one leg is not three: {stdout}");
 }
+
+/// A report that exists and is not a report. Distinct from a missing one
+/// on purpose: the reasons a comparison cannot run are worth telling
+/// apart, and "I could not read this" sends its reader somewhere
+/// different from "this was not there".
+#[test]
+fn a_malformed_report_exits_non_zero_and_names_the_file() {
+    let dir = scratch("malformed").expect("scratch");
+    let path = dir.join("broken.json");
+    fs::write(&path, "{ this is not a report").expect("write");
+    let output =
+        run(&["determinism", "--compare", &path.to_string_lossy()]).expect("the binary runs");
+    assert!(
+        !output.status.success(),
+        "a malformed report must not exit 0"
+    );
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(text.contains("broken.json"), "{text}");
+}

--- a/tools/cli/tests/determinism.rs
+++ b/tools/cli/tests/determinism.rs
@@ -1,0 +1,139 @@
+//! `renew determinism`, end to end through the real binary.
+//!
+//! The unit tests beside the comparison prove its rules. What they cannot
+//! prove is that the subcommand is *wired* — and being unwired is the
+//! specific danger here, because the dispatcher's last arm sends anything
+//! it does not recognise to a runner with an empty step list, which
+//! reports success having done nothing. For a gate whose entire purpose
+//! is refusing to pass vacuously, that failure mode is the one worth a
+//! test through the process boundary.
+//!
+//! The comparison half is exercised against hand-written reports rather
+//! than by running the simulations three times: what is under test here
+//! is the wiring and the exit codes, and a report is a report whether a
+//! simulation or a test wrote it.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+// Fallible on purpose, matching the sibling suites: the expect() lives
+// inside each #[test], where the lint configuration scopes it.
+fn run(arguments: &[&str]) -> std::io::Result<Output> {
+    Command::new(env!("CARGO_BIN_EXE_renew"))
+        .args(arguments)
+        .output()
+}
+
+fn scratch(tag: &str) -> std::io::Result<PathBuf> {
+    let dir = std::env::temp_dir().join(format!("renew-det-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// A report as `--emit` writes one, with the digests the caller names.
+fn report(arch: &str, digest: &str) -> String {
+    format!(
+        concat!(
+            "{{\n  \"schema_version\": 1,\n  \"os\": \"any\",\n  \"arch\": \"{}\",\n",
+            "  \"toolchain\": \"rustc 1.0.0\",\n  \"digests\": {{\n",
+            "    \"sim/one\": \"{}\"\n  }}\n}}\n"
+        ),
+        arch, digest
+    )
+}
+
+/// Write three reports and hand them to the comparison.
+fn compare_three(tag: &str, digests: [&str; 3]) -> std::io::Result<Output> {
+    let dir = scratch(tag)?;
+    let arches = ["x86_64", "x86_64", "aarch64"];
+    let mut paths = Vec::new();
+    for (index, (digest, arch)) in digests.iter().zip(arches).enumerate() {
+        let path = dir.join(format!("leg{index}.json"));
+        fs::write(&path, report(arch, digest))?;
+        paths.push(path.to_string_lossy().into_owned());
+    }
+    let mut arguments = vec!["determinism".to_string()];
+    for path in paths {
+        arguments.push("--compare".to_string());
+        arguments.push(path);
+    }
+    let borrowed: Vec<&str> = arguments.iter().map(String::as_str).collect();
+    run(&borrowed)
+}
+
+#[test]
+fn three_agreeing_reports_exit_zero() {
+    let output = compare_three("agree", ["0xabc", "0xabc", "0xabc"]).expect("the binary runs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "agreement must exit 0; stdout {stdout}, stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("agree"), "{stdout}");
+}
+
+/// The finding this whole lane exists to produce, through the process
+/// boundary: a non-zero exit, because a message nobody's CI reads is not
+/// a gate.
+#[test]
+fn one_disagreeing_report_exits_non_zero_and_names_the_digest() {
+    let output = compare_three("diverge", ["0xabc", "0xabc", "0xdef"]).expect("the binary runs");
+    assert!(!output.status.success(), "divergence must not exit 0");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(text.contains("sim/one"), "{text}");
+    assert!(text.contains("0xdef"), "{text}");
+}
+
+/// An unrunnable comparison must never read like a passing one.
+#[test]
+fn a_missing_report_exits_non_zero() {
+    let output = run(&["determinism", "--compare", "no-such-file.json"]).expect("the binary runs");
+    assert!(!output.status.success(), "a missing report must not exit 0");
+}
+
+/// Neither mode is a subcommand asked to do nothing. Exit 2 is this
+/// binary's documented "the command line was unreadable", distinct from
+/// exit 1's "it ran and failed".
+#[test]
+fn determinism_without_a_mode_is_a_usage_error() {
+    let output = run(&["determinism"]).expect("the binary runs");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The wiring test proper. `--json` proves the envelope is produced by
+/// the determinism path rather than by the do-nothing fallback the
+/// dispatcher's last arm would give an unrecognised subcommand.
+#[test]
+fn the_json_envelope_names_the_subcommand_that_ran() {
+    let output = compare_three("envelope", ["0xabc", "0xabc", "0xabc"]).expect("the binary runs");
+    assert!(output.status.success());
+
+    let dir = scratch("envelope-json").expect("scratch");
+    let path = dir.join("leg.json");
+    fs::write(&path, report("x86_64", "0xabc")).expect("write");
+    let json = run(&[
+        "--json",
+        "determinism",
+        "--compare",
+        &path.to_string_lossy(),
+    ])
+    .expect("the binary runs");
+    let stdout = String::from_utf8_lossy(&json.stdout);
+    // One leg against three rows: a failure, and the envelope must say so
+    // rather than omit the field.
+    assert!(stdout.contains("\"command\":\"determinism\""), "{stdout}");
+    assert!(stdout.contains("\"schema_version\""), "{stdout}");
+    assert!(!json.status.success(), "one leg is not three: {stdout}");
+}


### PR DESCRIPTION
Every determinism check in this repository until now compares a run to itself, or to a constant this repository minted. Both prove an unseeded generator absent. **Neither can prove the machine did not matter**, because both halves of those comparisons ran on the same machine.

This is the first thing that tests the second claim. Three lanes run the pinned simulations on Linux, Windows and macOS and each reports what it saw; a fourth holds the reports against each other. The evidence is the targets agreeing — not any of them matching a number somebody wrote down.

`renew determinism --emit <path>` runs four glide configurations (different seeds, different frame counts, both committed input traces), each contributing the frame schedule's digest and the world's, beside the architecture the build saw and the exact rustc version that produced it. `--compare <path>...` reads several and exits 0 only when they agree over a non-empty digest set.

**The failures are two kinds and the distinction is load-bearing.** *Diverged* is the finding this exists to produce — same inputs, different state, message naming the digest, both values and both architectures. *Inconclusive* is a comparison that could not be made: a missing leg, a leg carrying nothing, an architecture set that does not match the one the tool binds, or two legs built by different compilers. It fails too, and it is a separate word because a passing gate and an unrunnable one must never read alike. The toolchain check outranks the digest comparison deliberately: two compilers producing two digests is not evidence of a portability bug, and reporting it as one sends somebody hunting something that is not there.

**Four refusals earn their place by being the ways this could pass while measuring nothing.** A leg with no digests compares equal to another leg with no digests. A missing artifact is an untested target, not an absent objection. Three legs on one instruction set satisfy a count of three and prove strictly less, so the architecture set is matched row for row rather than counted. And a dependent job whose upstream failed is *skipped*, which GitHub reports as neutral rather than failed — so the comparison runs `always()` and turns an unsuccessful upstream back into a failure explicitly.

The comparison is a subcommand rather than shell in the workflow: its refusals are unit-tested (14 tests), and a developer looking at a red lane reproduces it locally with the same command.

The sample gains `--json` beside its digest line, which it owed anyway. Digests cross that boundary as hex **strings**: a `u64` exceeds what a JSON number carries exactly, and a reader that rounded one would call two different states identical — the single failure this lane exists to prevent.

Verified locally: emit produces 8 digests; three agreeing legs exit 0; a doctored leg exits 1 naming the digest and both architectures; two legs exit 1 as inconclusive.