### PR TITLE
refactor(event, rhi)!: make the vocabularies exhaustive again

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -92,7 +92,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [723, 724, 725]
+lines = [724, 725, 726]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -92,7 +92,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [726, 727, 728]
+lines = [723, 724, 725]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -74,11 +74,6 @@ file = "crates/core/platform/src/window.rs"
 lines = [651]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
-[[exempt]]
-file = "crates/replay/src/convert.rs"
-lines = [87, 118, 138]
-reason = "The wildcard arms that a non-exhaustive vocabulary forces a downstream crate to write, and the refusal one of them feeds. Every variant that exists today has its own arm above, so these are unreachable until the vocabulary grows - which is exactly when they must already be there, because the compiler will not report the new variant as unhandled in this crate. They refuse rather than folding an unknown event into a neighbouring one, so a recording can never quietly claim something that did not happen."
-
 
 [[exempt]]
 file = "crates/asset/src/write.rs"

--- a/crates/core/event/src/lib.rs
+++ b/crates/core/event/src/lib.rs
@@ -43,7 +43,6 @@
 
 /// The engine's event vocabulary, translated from the OS.
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[non_exhaustive]
 pub enum WindowEvent {
     /// The user asked to close the window; the app decides what happens
     /// (typically by requesting exit through the loop's control handle).
@@ -86,7 +85,6 @@ pub enum WindowEvent {
 // what a hash map cannot offer, since its iteration order varies
 // between runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[non_exhaustive]
 pub enum KeyCode {
     Escape,
     Space,
@@ -104,7 +102,6 @@ pub enum KeyCode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[non_exhaustive]
 pub enum PointerButton {
     Left,
     Right,
@@ -118,19 +115,26 @@ pub enum PointerButton {
 
 /// One value of every shape [`WindowEvent`] can take.
 ///
-/// The event vocabulary is `#[non_exhaustive]`, which binds every crate
-/// except this one: downstream matches must carry a wildcard arm, so the
-/// compiler will never tell a consumer that a new variant is unhandled.
-/// A consumer that translates events — into a file format, a script
-/// binding, a replay log — would therefore start silently dropping the
-/// new one, and nothing would fail until someone noticed the output was
-/// wrong.
+/// **The vocabulary is exhaustive, so the compiler is the primary guard
+/// and this list is the backstop.** It used to be the other way round.
+/// These enums carried `#[non_exhaustive]`, which forced every downstream
+/// match to write a wildcard — so a consumer translating events into a
+/// file format or a replay log would have started silently dropping a new
+/// variant, and nothing would have failed until someone noticed the
+/// output was wrong. This slice and its test existed to move that failure
+/// somewhere a compiler could still speak.
 ///
-/// This list, and the exhaustive match beside it, move that failure to
-/// where the compiler can still speak: adding a variant breaks the build
-/// **here**, in the crate that owns the enum, at the moment it is added.
-/// A consumer then iterates this slice and asserts it handles every
-/// entry, which turns "did we remember?" into a test rather than a habit.
+/// The attribute is gone (2026-08-04). Adding a variant now breaks the
+/// build at every match that must handle it, in every crate, which is
+/// what the list was approximating by hand. It was bought to protect
+/// consumers outside this workspace; there are none, and the protection
+/// cost the compiler's own report.
+///
+/// The list stays because it is still useful and no longer load-bearing:
+/// a consumer iterating it gets a table-driven test of its own coverage,
+/// and `shape_index` still names a shape in a refusal message. Neither
+/// is now the only thing standing between a new variant and a silent
+/// drop.
 ///
 /// The values are arbitrary. Only the shapes matter.
 pub const EVERY_EVENT_SHAPE: &[WindowEvent] = &[

--- a/crates/replay/src/convert.rs
+++ b/crates/replay/src/convert.rs
@@ -62,30 +62,34 @@ const fn key_to_trace(code: KeyCode) -> TraceKey {
         KeyCode::KeyA => TraceKey::KeyA,
         KeyCode::KeyS => TraceKey::KeyS,
         KeyCode::KeyD => TraceKey::KeyD,
-        // Every other physical key already arrived here unidentified;
-        // the trace records that faithfully rather than refusing, because
-        // a key this build does not name is still input that happened.
-        _ => TraceKey::Unidentified,
+        // A key this build does not name is still input that happened,
+        // so the trace records it faithfully rather than refusing. Named
+        // rather than wildcarded: the vocabulary is exhaustive, so a new
+        // key must arrive here as a compile error and be decided on, not
+        // fall into this arm because it was the only one left.
+        KeyCode::Unidentified => TraceKey::Unidentified,
     }
 }
 
-/// `None` for a button this build has no name for.
+/// Every button this build knows, which since the vocabulary became
+/// exhaustive is every button there is.
 ///
-/// The wildcard is required because the vocabulary is non-exhaustive, and
-/// it **refuses** rather than folding an unknown button into `Other`. A
-/// silent fold would be the writer-side drop this whole module exists to
-/// prevent: every future button would record as the same one, and the
-/// recording would be wrong in a way nothing could detect.
-const fn button_to_trace(button: PointerButton) -> Option<TraceButton> {
-    Some(match button {
+/// This returned `Option` while the vocabulary was non-exhaustive, so the
+/// required wildcard could **refuse** rather than fold an unknown button
+/// into `Other` — a silent fold would have been the writer-side drop this
+/// module exists to prevent. The refusal is now the compiler's: a new
+/// button breaks this match, here, and somebody decides what it records
+/// as. The `Option` went with the wildcard, because a `None` no caller
+/// can receive is a branch every caller still has to write.
+const fn button_to_trace(button: PointerButton) -> TraceButton {
+    match button {
         PointerButton::Left => TraceButton::Left,
         PointerButton::Right => TraceButton::Right,
         PointerButton::Middle => TraceButton::Middle,
         PointerButton::Back => TraceButton::Back,
         PointerButton::Forward => TraceButton::Forward,
         PointerButton::Other(index) => TraceButton::Other(index),
-        _ => return None,
-    })
+    }
 }
 
 /// Encode one event, or refuse it by name.
@@ -113,9 +117,9 @@ pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
             pressed,
             repeat,
         },
-        WindowEvent::PointerButton { button, pressed } => match button_to_trace(button) {
-            Some(button) => TraceEvent::PointerButton { button, pressed },
-            None => return Err(Unencodable { shape }),
+        WindowEvent::PointerButton { button, pressed } => TraceEvent::PointerButton {
+            button: button_to_trace(button),
+            pressed,
         },
         // The float-bearing shapes are the only ones that can fail on
         // their payload rather than their kind: the trace format holds
@@ -133,9 +137,6 @@ pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
             Some(scale) => TraceEvent::ScaleFactorChanged { scale },
             None => return Err(Unencodable { shape }),
         },
-        // Never `=> {}`. A wildcard that drops is how a recording starts
-        // lying about what happened.
-        _ => return Err(Unencodable { shape }),
     };
     Ok(encoded)
 }

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -350,7 +350,6 @@ impl SamplerDesc {
 
 /// Texel selection between sample points.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Filter {
     /// The nearest texel. Exact, and what a sprite atlas wants.
     Nearest,
@@ -360,7 +359,6 @@ pub enum Filter {
 
 /// What a sample outside `[0, 1]` reads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum AddressMode {
     /// The edge texel, repeated.
     ClampToEdge,


### PR DESCRIPTION
**BREAKING:** `WindowEvent`, `KeyCode`, `PointerButton`, `Filter` and `AddressMode` are no longer `#[non_exhaustive]`.

Five enums carried the attribute so adding a variant would not break consumers. **There are no consumers** — nothing outside this workspace depends on any of these crates. So the attribute bought nothing, and cost the compiler's ability to report an unhandled variant, which is the single most useful thing a compiler can say about a growing enum.

The event vocabulary paid for that twice: a hand-maintained slice of one value per variant plus a test asserting a consumer handles each entry (a compiler-enforced property downgraded to a list somebody must remember to extend), and three coverage exemptions for wildcard arms no value could reach. Both are gone. The slice stays — still useful as a table-driven test, no longer the only thing between a new variant and a silent drop.

**Two simplifications fell out, and the wildcards were hiding them rather than causing them.** A key conversion matched one named variant through a wildcard, so a new key would have folded into "unidentified" instead of being decided on. And a button conversion returned `Option` so its required wildcard could refuse an unknown button — the refusal is the compiler's now, and a `None` no caller can receive was a branch every caller still had to write.

DEBT-0034 is resolved rather than deferred. Its own justification was that growing these enums without the attribute "breaks every consumer"; without it, growing them is a compile error at every in-tree match, which is what the entry actually wanted.