### PR TITLE
feat(fixed): the fixed-point number type simulation is written in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,17 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
+      # The fixed-point arithmetic. Nothing depends on it yet -- physics is
+      # the consumer it was built for and does not exist -- so the cell is
+      # the whole workspace minus one leaf. That is the cheapest it will
+      # ever be, and adding it now means the first crate to depend on it
+      # discovers the obligation from a red lane rather than from nobody.
+      - name: Build and test without fixed-point arithmetic
+        run: |
+          sel="--workspace --exclude renew-fixed"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
+          cargo build $sel
+          cargo test $sel
       # The audio stack. The game is excluded alongside it because the
       # game's DEV graph reaches the WAV reader unconditionally -- the
       # lane's own copy of the parse that `Audio::open` performs on its
@@ -309,7 +320,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio; do
+          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,6 +1634,13 @@ name = "renew-event"
 version = "0.1.0"
 
 [[package]]
+name = "renew-fixed"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
 name = "renew-frame"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/frame", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/fixed/Cargo.toml
+++ b/crates/fixed/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "renew-fixed"
+description = "Fixed-point arithmetic for simulation code that must reproduce bit-for-bit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The fixed-point number type simulation is written in: Q47.16 in an i64, with no float in any signature and no dependencies."
+maturity = "bootstrap"
+core = false
+extension_points = []
+# Not `true`, and the reason is worth a comment because it looks wrong on the
+# crate physics is written in. The float-closure rule asks of a crate a
+# simulation *reaches* only that its root denies float arithmetic. Declaring
+# `simulation = true` additionally imposes the platform-closure walk and the
+# cross-target comparison's obligations, which belong to code that has state to
+# reproduce; a stateless number type has none. `renew-event` is the same shape.
+simulation = false
+
+[dependencies]
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -1,0 +1,73 @@
+# renew-fixed
+
+Fixed-point arithmetic for simulation code whose output has to reproduce
+bit-for-bit on every target.
+
+**Status: `bootstrap`.** Interface churn expected. See
+[`Cargo.toml`](Cargo.toml) for the machine-readable manifest — maturity,
+dependencies and core status live there, not here.
+
+## Why this exists
+
+Rust guarantees IEEE 754 semantics for `f32` and `f64` *operators*, and the
+guarantee stops there. `sin`, `cos` and their siblings come from the platform's
+maths library and may differ between targets by an ulp. A simulation that calls
+them cannot claim to reproduce across machines.
+
+Integer arithmetic is bit-identical everywhere, with nothing to police. That is
+the entire argument, and it is why physics is written in this type rather than
+in floats.
+
+## The representation
+
+`Q47.16` in an `i64`: 16 fractional bits, resolution 2⁻¹⁶ ≈ 0.0000153, range
+±2⁴⁷ ≈ ±1.4 × 10¹⁴.
+
+Sixteen rather than thirty-two fractional bits **because physics squares
+things**. A squared value has to fit the type that stores it, so the range that
+matters is not what is representable but what is *squarable* — the square root
+of the representable range:
+
+| | representable | squarable |
+|---|---|---|
+| Q47.16 | ±1.4 × 10¹⁴ | **±1.2 × 10⁷** |
+| Q32.32 | ±2.1 × 10⁹ | **±4.6 × 10⁴** |
+
+Two hundred and fifty-six times the working room, for a resolution already
+finer than anything a game perceives.
+
+## What the API refuses
+
+**No `f32` or `f64` in any signature.** Converting to a float is a presentation
+concern; it lives in the maths crate, which depends on this one. A simulation
+cannot reach that crate, so it cannot perform the conversion — enforced by the
+structure checker's float-closure rule rather than by anyone remembering.
+
+Values are constructed from integers: `from_int`, `from_ratio` (how `9.81` is
+written without a float ever existing — `from_ratio(981, 100)`), and
+`from_bits` for serialisation. All three are `const fn`, because game constants
+are written at compile time.
+
+## Two behaviours worth knowing before you use it
+
+**Multiplication rounds to nearest, ties away from zero — not by shifting.**
+The obvious implementation, `(a as i128 * b as i128) >> 16`, uses an arithmetic
+shift, which rounds toward negative infinity and is therefore *asymmetric under
+negation*: `(-a) * b` and `-(a * b)` differ for some inputs. Deterministic, and
+still wrong for physics, because a body moving left and the same body moving
+right would then accumulate different error. There is a property test for this,
+and it fails against the shift — verified by swapping one in.
+
+**Overflow saturates, in every build profile, and is counted.** It never wraps
+and never differs between debug and release: behaviour that differed by profile
+would mean the release behaviour is the one no test ever exercises. Saturation
+is silent by itself, so `saturations()` reports how many times it happened on
+this thread, and a test asserts zero the way the frame loop's allocation gate
+does. The counter is thread-local, which is both what the threading standard
+already sanctions and the right shape — simulation is single-threaded, so
+per-thread is per-simulation.
+
+## Extension points
+
+None. This is a value type; it has no trait to implement and no runtime
+polymorphism. Growing it means adding operations here.

--- a/crates/fixed/clippy.toml
+++ b/crates/fixed/clippy.toml
@@ -1,0 +1,38 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate is not simulation-designated — it holds no state to reproduce —
+# but it is the arithmetic every simulation is written in, so the same
+# tripwires apply for the same reason: a value this type produces reaches a
+# state hash, and anything non-deterministic that leaked in here would
+# reach one too, one call further along.
+#
+# The float deny is at the crate root rather than here, where it sits beside
+# the sentence explaining it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
+    { path = "std::time::SystemTime::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
+    { path = "std::thread::spawn", reason = "this crate has nothing to parallelise and simulation is single-threaded regardless" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, and nothing behind a reproducibility contract may" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same reason as RandomState: self-seeding entropy has no place here" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+# The SAFETY-comment lint accepts the comment above an attribute or
+# on the statement that owns the block.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/fixed/src/lib.rs
+++ b/crates/fixed/src/lib.rs
@@ -1,0 +1,38 @@
+//! Fixed-point arithmetic, for simulation code whose output has to reproduce
+//! bit-for-bit on every target.
+//!
+//! # Why this crate exists
+//!
+//! Rust guarantees IEEE 754 semantics for `f32` and `f64` *operators*, and
+//! that guarantee stops at the operators: `sin`, `cos` and their siblings are
+//! the platform's maths library, and are permitted to differ between targets.
+//! A simulation that calls them has no cross-target claim to make.
+//!
+//! Integer arithmetic is bit-identical everywhere, with nothing to police.
+//! That is the whole argument.
+//!
+//! # Contract
+//!
+//! - **Q47.16 in an `i64`.** 16 fractional bits: a resolution of 2⁻¹⁶, and a
+//!   range of ±2⁴⁷. See [`Fixed`] for why those numbers and not others.
+//! - **No `f32` or `f64` in any signature this crate exposes.** Converting to
+//!   a float is a presentation concern and lives in the maths crate, which
+//!   depends on this one. A simulation cannot reach that crate, so it cannot
+//!   perform the conversion — enforced by the structure checker rather than by
+//!   anyone remembering.
+//! - **Every operation is deterministic and target-independent.** No operation
+//!   here consults a clock, an allocator, an environment variable, or anything
+//!   whose value could differ between two machines running the same build.
+//! - **Overflow saturates, in every build profile, and is counted.** Never
+//!   wraps, never differs between debug and release. See [`Fixed::saturations`].
+
+// This crate is arithmetic; it does not print. And it is the crate simulation
+// arithmetic is written in, so a float operator here would defeat its only
+// purpose — denied rather than left to review, and there is no `allow` below.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
+
+mod saturation;
+mod scalar;
+
+pub use saturation::{Saturations, saturations};
+pub use scalar::Fixed;

--- a/crates/fixed/src/saturation.rs
+++ b/crates/fixed/src/saturation.rs
@@ -1,0 +1,110 @@
+//! The saturation counter: how an overflow that is handled stays visible.
+
+use core::cell::Cell;
+
+thread_local! {
+    /// Saturations on this thread since it started.
+    ///
+    /// Thread-local rather than a global atomic, and that is the design
+    /// rather than a concession. Simulation is single-threaded, so
+    /// per-thread is per-simulation: a count attributable to the run that
+    /// produced it, where one global atomic would have merged unrelated
+    /// threads into a number nobody could act on.
+    ///
+    /// It is also the shape this engine's threading rules already permit —
+    /// thread-local storage for diagnostics only, drained through an
+    /// explicit call on the owning thread — so it needs no exception to the
+    /// rule against global mutable state, which a global atomic would have.
+    static SATURATIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// How many times arithmetic on this thread saturated.
+///
+/// **Diagnostic only.** Never simulation state, never digested, never
+/// consulted for control flow — a simulation that branched on this would
+/// have made the count part of its own behaviour, and two machines whose
+/// counts differ would then diverge for a reason no digest could explain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Saturations(pub u64);
+
+impl Saturations {
+    /// Nothing saturated, which is what a test asserts.
+    #[must_use]
+    pub const fn is_clean(self) -> bool {
+        self.0 == 0
+    }
+}
+
+/// Read this thread's saturation count.
+///
+/// The explicit snapshot call `threading.md` requires: the counter is never
+/// read from another thread and never published except through here.
+///
+/// # Example
+///
+/// The shape a test uses — the counter is the alarm, and saturation is what
+/// it is an alarm about:
+///
+/// ```
+/// # use renew_fixed::{Fixed, saturations};
+/// let before = saturations();
+/// let _ = Fixed::MAX + Fixed::ONE;
+/// assert_eq!(saturations().0, before.0 + 1);
+/// ```
+#[must_use]
+pub fn saturations() -> Saturations {
+    Saturations(SATURATIONS.with(Cell::get))
+}
+
+/// Record one saturation. Called only from the arithmetic that saturated.
+pub(crate) fn record() {
+    SATURATIONS.with(|count| count.set(count.get().saturating_add(1)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{record, saturations};
+
+    #[test]
+    fn the_counter_counts_and_is_readable_only_through_the_snapshot() {
+        let before = saturations();
+        record();
+        record();
+        assert_eq!(saturations().0, before.0 + 2);
+        assert!(!saturations().is_clean());
+    }
+
+    /// The counter must not itself overflow into wrapping, which would be a
+    /// diagnostic silently claiming fewer failures than occurred.
+    #[test]
+    fn the_counter_saturates_rather_than_wrapping() {
+        super::SATURATIONS.with(|count| count.set(u64::MAX));
+        record();
+        assert_eq!(saturations().0, u64::MAX);
+        super::SATURATIONS.with(|count| count.set(0));
+    }
+
+    /// Per-thread, which is the property that makes it attributable. A
+    /// count raised on another thread must not appear on this one.
+    #[test]
+    // Spawning is disallowed in this crate for good reason: arithmetic has
+    // nothing to parallelise. Proving the counter is *per-thread* is the one
+    // thing that cannot be done without a second thread, so the exemption is
+    // taken here, narrowly, in the test that exists to establish the
+    // property the ban's neighbour depends on.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "the property under test is thread-locality, which needs a thread"
+    )]
+    fn a_count_on_another_thread_is_not_visible_here() {
+        let before = saturations();
+        std::thread::spawn(|| {
+            record();
+            record();
+            record();
+        })
+        .join()
+        .expect("the counting thread finished");
+        assert_eq!(saturations(), before, "another thread's count leaked here");
+    }
+}

--- a/crates/fixed/src/scalar.rs
+++ b/crates/fixed/src/scalar.rs
@@ -374,3 +374,136 @@ impl Div for Fixed {
         self.saturating_div(other)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Fixed, round_div};
+    use crate::saturations;
+
+    #[test]
+    fn absolute_value_saturates_at_the_bottom_of_the_range() {
+        assert_eq!(Fixed::from_int(-3).abs(), Fixed::from_int(3));
+        assert_eq!(Fixed::from_int(3).abs(), Fixed::from_int(3));
+        assert_eq!(Fixed::ZERO.abs(), Fixed::ZERO);
+        // MIN has no positive counterpart, which is the one input where
+        // this cannot answer exactly.
+        let before = saturations();
+        assert_eq!(Fixed::MIN.abs(), Fixed::MAX);
+        assert_eq!(saturations().0, before.0 + 1, "the clamp must be counted");
+    }
+
+    #[test]
+    fn signum_reports_whole_units() {
+        assert_eq!(Fixed::from_int(-9).signum(), Fixed::from_int(-1));
+        assert_eq!(Fixed::ZERO.signum(), Fixed::ZERO);
+        assert_eq!(Fixed::from_ratio(1, 1000).signum(), Fixed::ONE);
+    }
+
+    #[test]
+    fn min_max_and_clamp_agree_with_the_ordering() {
+        let low = Fixed::from_int(-2);
+        let high = Fixed::from_int(5);
+        assert_eq!(low.min(high), low);
+        assert_eq!(low.max(high), high);
+        assert_eq!(Fixed::from_int(9).clamp(low, high), high);
+        assert_eq!(Fixed::from_int(-9).clamp(low, high), low);
+        assert_eq!(Fixed::from_int(1).clamp(low, high), Fixed::from_int(1));
+    }
+
+    #[test]
+    #[should_panic(expected = "Fixed::clamp needs low <= high")]
+    fn clamp_refuses_an_inverted_range() {
+        let _ = Fixed::ZERO.clamp(Fixed::ONE, Fixed::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "Fixed::from_ratio needs a nonzero denominator")]
+    fn a_ratio_over_zero_is_refused() {
+        let _ = Fixed::from_ratio(1, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Fixed division by zero")]
+    fn division_by_zero_is_refused() {
+        let _ = Fixed::ONE.saturating_div(Fixed::ZERO);
+    }
+
+    #[test]
+    #[should_panic(expected = "Fixed::sqrt of a negative value")]
+    fn the_square_root_of_a_negative_is_refused() {
+        let _ = Fixed::from_int(-1).sqrt();
+    }
+
+    /// The checked forms answer instead of clamping, which is what a caller
+    /// wanting to handle overflow rather than be told about it asks for.
+    #[test]
+    fn the_checked_forms_report_rather_than_saturate() {
+        assert_eq!(Fixed::ONE.checked_add(Fixed::ONE), Some(Fixed::from_int(2)));
+        assert_eq!(Fixed::MAX.checked_add(Fixed::ONE), None);
+        assert_eq!(Fixed::ONE.checked_sub(Fixed::ONE), Some(Fixed::ZERO));
+        assert_eq!(Fixed::MIN.checked_sub(Fixed::ONE), None);
+        assert_eq!(
+            Fixed::from_int(3).checked_mul(Fixed::from_int(4)),
+            Some(Fixed::from_int(12))
+        );
+        assert_eq!(Fixed::MAX.checked_mul(Fixed::MAX), None);
+
+        // And they do not touch the counter: a caller asking the question
+        // wants the answer, not a diagnostic about having asked.
+        let before = saturations();
+        let _ = Fixed::MAX.checked_add(Fixed::ONE);
+        let _ = Fixed::MAX.checked_mul(Fixed::MAX);
+        assert_eq!(saturations(), before);
+    }
+
+    #[test]
+    fn subtraction_and_negation_saturate_at_both_ends() {
+        assert_eq!(Fixed::from_int(5) - Fixed::from_int(3), Fixed::from_int(2));
+        assert_eq!(-Fixed::from_int(3), Fixed::from_int(-3));
+        let before = saturations();
+        assert_eq!(Fixed::MAX - Fixed::MIN, Fixed::MAX);
+        assert_eq!(-Fixed::MIN, Fixed::MAX);
+        assert_eq!(saturations().0, before.0 + 2);
+    }
+
+    /// The whole and fractional parts of a negative value both carry the
+    /// sign, which is the convention `i64` division already has and the one
+    /// a reader will assume.
+    #[test]
+    fn the_parts_of_a_negative_value_carry_its_sign() {
+        let value = Fixed::from_ratio(-7, 2);
+        assert_eq!(value.trunc_int(), -3);
+        assert_eq!(value.fract(), Fixed::from_ratio(-1, 2));
+    }
+
+    /// Ratios round to nearest with ties away from zero, symmetrically, so
+    /// a negative constant is the negation of its positive twin.
+    #[test]
+    fn ratios_round_symmetrically() {
+        assert_eq!(Fixed::from_ratio(-981, 100), -Fixed::from_ratio(981, 100));
+        assert_eq!(Fixed::from_ratio(981, -100), -Fixed::from_ratio(981, 100));
+        assert_eq!(Fixed::from_ratio(1, 2), Fixed::from_bits(1 << 15));
+    }
+
+    /// The rounding helper on its own, over the sign quadrants and the tie,
+    /// because every constructor and both of the rounded operators go
+    /// through one of these.
+    #[test]
+    fn the_rounding_helper_is_symmetric_and_rounds_ties_away_from_zero() {
+        assert_eq!(round_div(7, 2), 4);
+        assert_eq!(round_div(-7, 2), -4);
+        assert_eq!(round_div(7, -2), -4);
+        assert_eq!(round_div(-7, -2), 4);
+        assert_eq!(round_div(5, 2), 3, "a tie rounds away from zero");
+        assert_eq!(round_div(-5, 2), -3, "and symmetrically");
+        assert_eq!(round_div(4, 2), 2, "an exact quotient is untouched");
+    }
+
+    /// Division saturates like everything else rather than wrapping.
+    #[test]
+    fn division_saturates_when_the_quotient_does_not_fit() {
+        let before = saturations();
+        assert_eq!(Fixed::MAX.saturating_div(Fixed::EPSILON), Fixed::MAX);
+        assert_eq!(saturations().0, before.0 + 1);
+    }
+}

--- a/crates/fixed/src/scalar.rs
+++ b/crates/fixed/src/scalar.rs
@@ -499,6 +499,22 @@ mod tests {
         assert_eq!(round_div(4, 2), 2, "an exact quotient is untouched");
     }
 
+    /// The operators are the ergonomic surface and the named forms are the
+    /// documented ones; nothing but this asserts they are the same
+    /// arithmetic. A `Mul` that reached for the shift while
+    /// `saturating_mul` rounded would pass every other test in this file.
+    #[test]
+    fn the_operators_delegate_to_the_named_forms() {
+        let a = Fixed::from_ratio(7, 3);
+        let b = Fixed::from_ratio(-11, 5);
+        assert_eq!(a * b, a.saturating_mul(b));
+        assert_eq!(a / b, a.saturating_div(b));
+        assert_eq!(a + b, Fixed::from_bits(a.to_bits() + b.to_bits()));
+        assert_eq!(a - b, Fixed::from_bits(a.to_bits() - b.to_bits()));
+        // And the operators saturate, since they are the same code path.
+        assert_eq!(Fixed::MAX * Fixed::MAX, Fixed::MAX);
+    }
+
     /// Division saturates like everything else rather than wrapping.
     #[test]
     fn division_saturates_when_the_quotient_does_not_fit() {

--- a/crates/fixed/src/scalar.rs
+++ b/crates/fixed/src/scalar.rs
@@ -1,0 +1,376 @@
+//! The scalar type.
+
+use core::ops::{Add, Div, Mul, Neg, Sub};
+
+use crate::saturation;
+
+/// Fractional bits. Q47.16.
+const FRAC_BITS: u32 = 16;
+
+/// One whole unit, as a raw pattern.
+const ONE_RAW: i64 = 1 << FRAC_BITS;
+
+/// A fixed-point number: Q47.16 in an `i64`.
+///
+/// # Contract
+///
+/// - **Resolution 2⁻¹⁶ ≈ 0.0000153; range ±2⁴⁷ ≈ ±1.4 × 10¹⁴.**
+/// - **Every operation saturates on overflow**, in every build profile, and
+///   increments the thread's [`crate::saturations`] counter when it does.
+///   Never wraps. Never differs between debug and release.
+/// - **Multiplication and division round to nearest, ties away from zero.**
+///   Symmetric under negation, which the obvious implementation is not — see
+///   [`Fixed::saturating_mul`].
+/// - **Total ordering.** `Ord`, `Eq` and `Hash` are derived from the `i64`,
+///   so this sorts, deduplicates and hashes the way an integer does and
+///   floats cannot.
+///
+/// # Why Q47.16 and not Q32.32
+///
+/// Because physics squares things. A squared value has to fit the type it is
+/// stored in, so the range that matters is not what is representable but what
+/// is **squarable** — the square root of the representable range:
+///
+/// | | representable | squarable |
+/// |---|---|---|
+/// | Q47.16 | ±1.4 × 10¹⁴ | **±1.2 × 10⁷** |
+/// | Q32.32 | ±2.1 × 10⁹ | **±4.6 × 10⁴** |
+///
+/// Two hundred and fifty-six times the working room, for a resolution that is
+/// already finer than anything a game perceives.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Fixed(i64);
+
+impl Fixed {
+    /// Zero.
+    pub const ZERO: Self = Self(0);
+    /// One whole unit.
+    pub const ONE: Self = Self(ONE_RAW);
+    /// The smallest representable value.
+    pub const MIN: Self = Self(i64::MIN);
+    /// The largest representable value.
+    pub const MAX: Self = Self(i64::MAX);
+    /// The smallest step between two values: 2⁻¹⁶.
+    pub const EPSILON: Self = Self(1);
+
+    /// The raw Q47.16 pattern, for serialisation and tests.
+    #[must_use]
+    pub const fn from_bits(raw: i64) -> Self {
+        Self(raw)
+    }
+
+    /// The raw pattern back out.
+    #[must_use]
+    pub const fn to_bits(self) -> i64 {
+        self.0
+    }
+
+    /// A whole number, exactly.
+    ///
+    /// `i32` rather than `i64` so the shift cannot overflow: every `i32`
+    /// shifted left by 16 fits an `i64` with room to spare, which makes this
+    /// total and lets it be `const`.
+    #[must_use]
+    pub const fn from_int(value: i32) -> Self {
+        Self((value as i64) << FRAC_BITS)
+    }
+
+    /// A ratio of two integers — how a value like 9.81 is written without a
+    /// float ever existing: `Fixed::from_ratio(981, 100)`.
+    ///
+    /// Rounds to nearest, ties away from zero, like [`Fixed::saturating_mul`].
+    ///
+    /// # Panics
+    ///
+    /// If `denominator` is zero. A contract violation rather than a runtime
+    /// condition (D5): the arguments are almost always literals, so this
+    /// fails at the call site that wrote it, and in a `const` context it
+    /// fails at compile time.
+    #[must_use]
+    pub const fn from_ratio(numerator: i32, denominator: i32) -> Self {
+        assert!(
+            denominator != 0,
+            "Fixed::from_ratio needs a nonzero denominator"
+        );
+        let scaled = (numerator as i64) << FRAC_BITS;
+        let den = denominator as i64;
+        Self(round_div(scaled, den))
+    }
+
+    /// The whole part, truncated toward zero.
+    #[must_use]
+    pub const fn trunc_int(self) -> i64 {
+        self.0 / ONE_RAW
+    }
+
+    /// The fractional part, with the sign of the whole.
+    #[must_use]
+    pub const fn fract(self) -> Self {
+        Self(self.0 % ONE_RAW)
+    }
+
+    /// Absolute value, saturating at [`Fixed::MAX`] for [`Fixed::MIN`].
+    #[must_use]
+    pub fn abs(self) -> Self {
+        let Some(value) = self.0.checked_abs() else {
+            saturation::record();
+            return Self::MAX;
+        };
+        Self(value)
+    }
+
+    /// -1, 0 or 1, as whole units.
+    #[must_use]
+    pub const fn signum(self) -> Self {
+        Self(ONE_RAW * self.0.signum())
+    }
+
+    /// The smaller of two values.
+    #[must_use]
+    pub const fn min(self, other: Self) -> Self {
+        if self.0 < other.0 { self } else { other }
+    }
+
+    /// The larger of two values.
+    #[must_use]
+    pub const fn max(self, other: Self) -> Self {
+        if self.0 > other.0 { self } else { other }
+    }
+
+    /// Constrained to `[low, high]`.
+    ///
+    /// # Panics
+    ///
+    /// If `low > high`, which is a contract violation rather than a value to
+    /// interpret — the caller has said something they cannot mean.
+    #[must_use]
+    pub const fn clamp(self, low: Self, high: Self) -> Self {
+        assert!(low.0 <= high.0, "Fixed::clamp needs low <= high");
+        self.max(low).min(high)
+    }
+
+    /// Multiply, rounding to nearest with ties away from zero.
+    ///
+    /// **The rounding rule is load-bearing.** The obvious implementation —
+    /// `(a as i128 * b as i128) >> 16` — is an arithmetic shift, which rounds
+    /// toward negative infinity and is therefore *asymmetric under negation*:
+    /// `(-a) * b` and `-(a * b)` differ for some inputs. That is deterministic
+    /// and still wrong for physics, because a body moving left and the same
+    /// body moving right would accumulate different error. Rounding to nearest
+    /// with ties away from zero is symmetric, and halves the worst-case error
+    /// besides.
+    ///
+    /// Saturates rather than wrapping, and counts when it does.
+    #[must_use]
+    pub fn saturating_mul(self, other: Self) -> Self {
+        let product = i128::from(self.0) * i128::from(other.0);
+        Self(narrow(round_shift(product)))
+    }
+
+    /// Divide, rounding to nearest with ties away from zero.
+    ///
+    /// # Panics
+    ///
+    /// If `other` is zero. Division by zero is a contract violation (D5), and
+    /// returning a sentinel would put a NaN-shaped value into a type whose
+    /// whole contract is that it has none.
+    #[must_use]
+    pub fn saturating_div(self, other: Self) -> Self {
+        assert!(other.0 != 0, "Fixed division by zero");
+        let numerator = i128::from(self.0) << FRAC_BITS;
+        Self(narrow(round_div_i128(numerator, i128::from(other.0))))
+    }
+
+    /// The square root, floored to the representable value below the exact
+    /// result.
+    ///
+    /// Uses `u128::isqrt`, which is exact by its own contract, on a `u128`
+    /// intermediate — the shifted value needs 79 bits, so a 64-bit one would
+    /// be wrong rather than merely slower. Not a hand-rolled iteration: the
+    /// standard library's is boring and already correct, and this is the one
+    /// kernel here with a non-trivial correctness argument.
+    ///
+    /// # Panics
+    ///
+    /// If `self` is negative. See [`Fixed::checked_sqrt`] for the form that
+    /// answers instead of refusing.
+    #[must_use]
+    pub fn sqrt(self) -> Self {
+        assert!(self.0 >= 0, "Fixed::sqrt of a negative value");
+        // The assertion above is the whole precondition, so the only `None`
+        // this can produce is one the assertion already refused.
+        self.checked_sqrt().unwrap_or(Self::ZERO)
+    }
+
+    /// The square root, or `None` for a negative value.
+    #[must_use]
+    pub fn checked_sqrt(self) -> Option<Self> {
+        if self.0 < 0 {
+            return None;
+        }
+        // Both casts are guarded by the sign check above: the widening is
+        // value-preserving on a non-negative input, and the root of a value
+        // below 2^63 shifted left by 16 is below 2^40, so narrowing it back
+        // cannot reach the sign bit.
+        #[expect(
+            clippy::cast_sign_loss,
+            clippy::cast_possible_truncation,
+            reason = "guarded by the sign check above and by the root's own magnitude"
+        )]
+        let root = ((self.0 as u128) << FRAC_BITS).isqrt() as i64;
+        Some(Self(root))
+    }
+
+    /// Add, or `None` if the result would not fit.
+    #[must_use]
+    pub const fn checked_add(self, other: Self) -> Option<Self> {
+        match self.0.checked_add(other.0) {
+            Some(sum) => Some(Self(sum)),
+            None => None,
+        }
+    }
+
+    /// Subtract, or `None` if the result would not fit.
+    #[must_use]
+    pub const fn checked_sub(self, other: Self) -> Option<Self> {
+        match self.0.checked_sub(other.0) {
+            Some(difference) => Some(Self(difference)),
+            None => None,
+        }
+    }
+
+    /// Multiply, or `None` if the result would not fit.
+    ///
+    /// `const`, and therefore not counted: a compile-time context has no
+    /// thread to count on, and a caller asking this question wants the answer
+    /// rather than a diagnostic.
+    #[must_use]
+    pub const fn checked_mul(self, other: Self) -> Option<Self> {
+        let rounded = round_shift(self.0 as i128 * other.0 as i128);
+        if rounded > i64::MAX as i128 || rounded < i64::MIN as i128 {
+            None
+        } else {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "the branches above establish the value is in range"
+            )]
+            let narrowed = rounded as i64;
+            Some(Self(narrowed))
+        }
+    }
+}
+
+/// Shift a 128-bit product right by the fractional bits, rounding to nearest
+/// with ties away from zero.
+const fn round_shift(product: i128) -> i128 {
+    let half = 1i128 << (FRAC_BITS - 1);
+    if product >= 0 {
+        (product + half) >> FRAC_BITS
+    } else {
+        // Symmetric: round the magnitude, then restore the sign. Using the
+        // shift directly here is what makes the operation asymmetric.
+        -((-product + half) >> FRAC_BITS)
+    }
+}
+
+/// Divide, rounding to nearest with ties away from zero.
+const fn round_div(numerator: i64, denominator: i64) -> i64 {
+    let (magnitude, negative) = match (numerator < 0, denominator < 0) {
+        (false, false) => (numerator / denominator, false),
+        (true, true) => ((-numerator) / (-denominator), false),
+        (true, false) => ((-numerator) / denominator, true),
+        (false, true) => (numerator / (-denominator), true),
+    };
+    let remainder = (numerator % denominator).abs();
+    let half = denominator.abs() / 2;
+    let rounded = if remainder * 2 >= denominator.abs() && half >= 0 {
+        magnitude + 1
+    } else {
+        magnitude
+    };
+    if negative { -rounded } else { rounded }
+}
+
+/// The 128-bit form of [`round_div`].
+const fn round_div_i128(numerator: i128, denominator: i128) -> i128 {
+    let negative = (numerator < 0) != (denominator < 0);
+    let num = if numerator < 0 { -numerator } else { numerator };
+    let den = if denominator < 0 {
+        -denominator
+    } else {
+        denominator
+    };
+    let quotient = num / den;
+    let rounded = if (num % den) * 2 >= den {
+        quotient + 1
+    } else {
+        quotient
+    };
+    if negative { -rounded } else { rounded }
+}
+
+/// Bring a 128-bit result back to an `i64`, saturating and counting.
+fn narrow(value: i128) -> i64 {
+    if value > i128::from(i64::MAX) {
+        saturation::record();
+        i64::MAX
+    } else if value < i128::from(i64::MIN) {
+        saturation::record();
+        i64::MIN
+    } else {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the branches above establish the value is in range"
+        )]
+        let narrowed = value as i64;
+        narrowed
+    }
+}
+
+impl Add for Fixed {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        let Some(sum) = self.0.checked_add(other.0) else {
+            saturation::record();
+            return if self.0 > 0 { Self::MAX } else { Self::MIN };
+        };
+        Self(sum)
+    }
+}
+
+impl Sub for Fixed {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        let Some(difference) = self.0.checked_sub(other.0) else {
+            saturation::record();
+            return if self.0 > 0 { Self::MAX } else { Self::MIN };
+        };
+        Self(difference)
+    }
+}
+
+impl Neg for Fixed {
+    type Output = Self;
+    fn neg(self) -> Self {
+        let Some(negated) = self.0.checked_neg() else {
+            saturation::record();
+            return Self::MAX;
+        };
+        Self(negated)
+    }
+}
+
+impl Mul for Fixed {
+    type Output = Self;
+    fn mul(self, other: Self) -> Self {
+        self.saturating_mul(other)
+    }
+}
+
+impl Div for Fixed {
+    type Output = Self;
+    fn div(self, other: Self) -> Self {
+        self.saturating_div(other)
+    }
+}

--- a/crates/fixed/tests/properties.proptest-regressions
+++ b/crates/fixed/tests/properties.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cfb00f8a39b31e2a8f4ef2bad8047ab28ec24273ef87534afb81c8c3a121b7c1 # shrinks to a = Fixed(-1), b = Fixed(-1)

--- a/crates/fixed/tests/properties.rs
+++ b/crates/fixed/tests/properties.rs
@@ -1,0 +1,174 @@
+//! The properties this type's whole purpose rests on.
+//!
+//! Two of them are here because the obvious implementation fails them, and
+//! failing them silently is what a physics engine built on this would look
+//! like from the outside: symmetry under negation, and saturation that never
+//! escapes the range.
+//!
+//! The associativity and distributivity properties are stated as **bounds**
+//! rather than as laws, and that is not a weakening of ambition. No rounded
+//! multiply satisfies them exactly, under any rounding rule — the design
+//! note's first draft promised the ring laws and could not have delivered
+//! them. A bound is the true statement.
+
+use proptest::prelude::*;
+use renew_fixed::{Fixed, saturations};
+
+/// Raw patterns small enough that products cannot saturate, so a property
+/// about arithmetic is not silently a property about the saturation clamp.
+/// Squarable range is ±2²³·⁵ ≈ 1.2e7 units; this stays far inside it.
+fn modest() -> impl Strategy<Value = Fixed> {
+    (-(1i64 << 34)..(1i64 << 34)).prop_map(Fixed::from_bits)
+}
+
+/// The whole representable range, for properties that must hold everywhere.
+fn any_fixed() -> impl Strategy<Value = Fixed> {
+    any::<i64>().prop_map(Fixed::from_bits)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 4096, ..ProptestConfig::default() })]
+
+    /// **The property the rounding rule exists for.** The obvious
+    /// implementation — an arithmetic shift — rounds toward negative
+    /// infinity and fails this, which means a body moving left and the same
+    /// body moving right accumulate different error.
+    #[test]
+    fn multiplication_is_symmetric_under_negation(a in modest(), b in modest()) {
+        prop_assert_eq!((-a).saturating_mul(b), -(a.saturating_mul(b)));
+    }
+
+    #[test]
+    fn multiplication_commutes(a in modest(), b in modest()) {
+        prop_assert_eq!(a.saturating_mul(b), b.saturating_mul(a));
+    }
+
+    /// Associativity to a bound, not as a law. Each multiply rounds once, so
+    /// the two groupings can differ — but only by rounding, and the bound
+    /// says how much.
+    #[test]
+    fn multiplication_associates_to_within_the_rounding_error(
+        a in modest(), b in modest(), c in modest()
+    ) {
+        let left = a.saturating_mul(b).saturating_mul(c);
+        let right = a.saturating_mul(b.saturating_mul(c));
+        let difference = (left.to_bits() - right.to_bits()).abs();
+        // One rounding step per multiply, scaled by the magnitude of the
+        // factor the rounded value is then multiplied by.
+        let tolerance = 1 + (a.to_bits().abs() >> 16) + (c.to_bits().abs() >> 16);
+        prop_assert!(
+            difference <= tolerance,
+            "difference {difference} exceeds tolerance {tolerance}"
+        );
+    }
+
+    #[test]
+    fn addition_is_associative_and_commutative(a in modest(), b in modest(), c in modest()) {
+        prop_assert_eq!(a + b, b + a);
+        prop_assert_eq!((a + b) + c, a + (b + c));
+    }
+
+    /// Ordering is the underlying integer's, which is what makes `Ord`
+    /// honest and is the thing floats cannot offer.
+    #[test]
+    fn ordering_follows_the_raw_pattern(a in any_fixed(), b in any_fixed()) {
+        prop_assert_eq!(a.cmp(&b), a.to_bits().cmp(&b.to_bits()));
+    }
+
+    /// **Saturation never escapes the range**, over the whole domain
+    /// including the values that force it. Nothing here can panic and
+    /// nothing can wrap.
+    #[test]
+    fn arithmetic_never_escapes_the_range(a in any_fixed(), b in any_fixed()) {
+        for value in [a + b, a - b, a.saturating_mul(b)] {
+            prop_assert!(value >= Fixed::MIN && value <= Fixed::MAX);
+        }
+    }
+
+    /// The floor-exactness of `sqrt`, stated on raw integers in `u128` so
+    /// that neither the narrowing nor the saturation can intervene — in the
+    /// type, `(s+1)²` saturates at the top of the range and rounds back down
+    /// below one unit, so the property would be false at both ends.
+    #[test]
+    fn sqrt_is_floor_exact(value in 0i64..=i64::MAX) {
+        let x = Fixed::from_bits(value);
+        let root = u128::from(x.sqrt().to_bits().unsigned_abs());
+        #[expect(
+            clippy::cast_sign_loss,
+            reason = "the strategy generates non-negative values only"
+        )]
+        let shifted = (value as u128) << 16;
+        prop_assert!(root * root <= shifted, "root too large");
+        prop_assert!(shifted < (root + 1) * (root + 1), "root too small");
+    }
+
+    /// A negative input is answered, not undefined, and identically in every
+    /// build profile.
+    #[test]
+    fn sqrt_of_a_negative_is_none(value in i64::MIN..0i64) {
+        prop_assert_eq!(Fixed::from_bits(value).checked_sqrt(), None);
+    }
+
+    /// Construction round-trips where it claims to: a whole number is exact.
+    #[test]
+    fn whole_numbers_are_exact(value in -100_000i32..100_000) {
+        prop_assert_eq!(Fixed::from_int(value).trunc_int(), i64::from(value));
+        prop_assert_eq!(Fixed::from_int(value).fract(), Fixed::ZERO);
+    }
+
+    /// Division inverts multiplication to within rounding, which is the
+    /// property a physics author will assume without checking.
+    #[test]
+    fn dividing_by_a_factor_recovers_the_other(a in modest(), b in modest()) {
+        prop_assume!(b.to_bits().abs() > (1 << 16));
+        let product = a.saturating_mul(b);
+        let recovered = product.saturating_div(b);
+        let difference = (recovered.to_bits() - a.to_bits()).abs();
+        prop_assert!(difference <= 2, "recovered {recovered:?} from {a:?}, off by {difference}");
+    }
+
+    /// The counter fires exactly when saturation happens, and stays silent
+    /// when it does not. A counter that over-reports is as useless as one
+    /// that under-reports.
+    #[test]
+    fn the_counter_is_silent_when_nothing_saturates(a in modest(), b in modest()) {
+        let before = saturations();
+        let _ = a + b;
+        let _ = a.saturating_mul(b);
+        prop_assert_eq!(saturations(), before);
+    }
+}
+
+/// Deliberately outside `proptest!`: this asserts the exact values at the
+/// edges, which a generator would reach only by luck.
+#[test]
+fn the_named_edges_behave() {
+    // `const` construction, which is what `glide`'s constants need. At the
+    // top because items exist from the start of a scope regardless of where
+    // they are written.
+    const GRAVITY: Fixed = Fixed::from_ratio(981, 100);
+    const BIRD_X: Fixed = Fixed::from_int(40);
+
+    // Saturation, and the counter noticing.
+    let before = saturations();
+    assert_eq!(Fixed::MAX + Fixed::ONE, Fixed::MAX);
+    assert_eq!(Fixed::MIN - Fixed::ONE, Fixed::MIN);
+    assert_eq!(saturations().0, before.0 + 2);
+
+    // Zero and one behave as the identities they claim to be.
+    assert_eq!(
+        Fixed::ONE.saturating_mul(Fixed::from_int(7)),
+        Fixed::from_int(7)
+    );
+    assert_eq!(Fixed::ZERO.saturating_mul(Fixed::MAX), Fixed::ZERO);
+    assert_eq!(Fixed::ZERO.sqrt(), Fixed::ZERO);
+
+    // A ratio is how a designer writes a decimal without a float existing.
+    let gravity = Fixed::from_ratio(981, 100);
+    assert_eq!(gravity.trunc_int(), 9);
+    // 9.81 in Q47.16 is 642908.16, which rounds to 642908.
+    assert_eq!(gravity.to_bits(), 642_908);
+
+    assert_eq!(GRAVITY, gravity);
+    assert_eq!(BIRD_X.trunc_int(), 40);
+}


### PR DESCRIPTION
Q47.16 in an `i64`, no dependencies, and **no float in any signature it exposes**.

Physics needs it because a simulation that has to reproduce on another machine cannot be written in floats: Rust guarantees IEEE 754 for the *operators* and the guarantee stops there, so `sin`, `cos` and their siblings come from the platform's maths library and may differ between targets. Integer arithmetic is bit-identical everywhere with nothing to police.

**Sixteen fractional bits rather than thirty-two, because physics squares things.** A squared value must fit the type that stores it, so the range that matters is not what is representable but what is *squarable*:

| | representable | squarable |
|---|---|---|
| Q47.16 | ±1.4 × 10¹⁴ | **±1.2 × 10⁷** |
| Q32.32 | ±2.1 × 10⁹ | **±4.6 × 10⁴** |

## Two behaviours worth reading before using it

**Multiplication rounds to nearest, ties away from zero — not by shifting.** The obvious implementation, `(a as i128 * b as i128) >> 16`, is an arithmetic shift: it rounds toward negative infinity and is therefore *asymmetric under negation*. `(-a) * b` and `-(a * b)` differ for some inputs. Deterministic, and still wrong for physics — a body moving left and the same body moving right would accumulate different error, which is a gameplay artifact with a numerical cause and the kind that gets diagnosed as a physics bug for a week. There's a property test for it, and **it fails against the shift — verified by putting one in and watching it go red.**

**Overflow saturates, in every build profile, and is counted.** Never wraps, never differs between debug and release: behaviour that differed by profile would mean the release behaviour is the one no test ever exercises. Saturation alone is silent, so a thread-local counter reports it and a test asserts zero — the same shape the frame loop's allocation gate uses. Thread-local rather than a global atomic because simulation is single-threaded, so per-thread is per-simulation and the count is attributable to the run that produced it.

## Construction

Integers only, and all of it `const`, because game constants are written at compile time: `from_int`, `from_bits`, and `from_ratio` — which is how `9.81` is written when no float may exist. Converting *to* a float is a presentation concern and lives elsewhere, in a crate no simulation can reach.

Twelve property tests plus the named edges. Nothing depends on this yet, and the removability lane covers it from the first commit so the first crate that does discovers the obligation from a red lane rather than from nobody.