### PR TITLE
feat(fixed): vectors, which the scalar alone was never going to be enough for

### DIFF
--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -67,6 +67,30 @@ does. The counter is thread-local, which is both what the threading standard
 already sanctions and the right shape — simulation is single-threaded, so
 per-thread is per-simulation.
 
+## Vectors
+
+`Vec2` and `Vec3` over `Fixed`, as two concrete types rather than one generic
+over dimension — the same choice the physics contract makes for the same
+reason: a dimension-generic vocabulary infects every signature with a bound,
+and writing `dot` twice costs less than every caller reading one.
+
+Two operations are worth knowing about because physics leans on them.
+
+`slide_along` removes a displacement's component along a unit normal. That is
+the whole of move-and-slide's inner step, named here so an implementation does
+not spell it out at each call site and get the sign wrong at one of them.
+
+`perpendicular` is a quarter turn, and it is **exact** — a swap and a negation,
+no trigonometry, no rounding. General rotation is not available: it needs
+trigonometric functions this type does not have, which is why the physics
+contract defers rotated shapes.
+
+`normalize` is fallible, because the zero vector is a value a simulation
+legitimately produces and an assertion on a path that runs every frame is the
+wrong shape. **The result is unit-length only to the type's resolution** — a
+few hundred parts in 65536 — so callers wanting a strict guarantee should compare
+squared lengths against a tolerance rather than expecting exactly one.
+
 ## Extension points
 
 None. This is a value type; it has no trait to implement and no runtime

--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -88,7 +88,7 @@ contract defers rotated shapes.
 `normalize` is fallible, because the zero vector is a value a simulation
 legitimately produces and an assertion on a path that runs every frame is the
 wrong shape. **The result is unit-length only to the type's resolution** — a
-few hundred parts in 65536 — so callers wanting a strict guarantee should compare
+four parts in 65536 — so callers wanting exact equality should compare
 squared lengths against a tolerance rather than expecting exactly one.
 
 ## Extension points

--- a/crates/fixed/src/lib.rs
+++ b/crates/fixed/src/lib.rs
@@ -33,6 +33,8 @@
 
 mod saturation;
 mod scalar;
+mod vector;
 
 pub use saturation::{Saturations, saturations};
 pub use scalar::Fixed;
+pub use vector::{Vec2, Vec3};

--- a/crates/fixed/src/vector.rs
+++ b/crates/fixed/src/vector.rs
@@ -158,10 +158,12 @@ impl Vec2 {
             Fixed::from_bits(self.x.to_bits() << shift),
             Fixed::from_bits(self.y.to_bits() << shift),
         );
+        // Non-zero after the check above, and rescaling is what makes that
+        // true: the largest component carries 38 significant bits, so its
+        // square alone exceeds 2^60 and the length cannot round to zero.
+        // Before rescaling this needed a second zero check, and that check
+        // was the bug — it turned a short direction into no direction.
         let length = scaled.length();
-        if length == Fixed::ZERO {
-            return None;
-        }
         Some(Self::new(
             scaled.x.saturating_div(length),
             scaled.y.saturating_div(length),
@@ -290,10 +292,12 @@ impl Vec3 {
             Fixed::from_bits(self.y.to_bits() << shift),
             Fixed::from_bits(self.z.to_bits() << shift),
         );
+        // Non-zero after the check above, and rescaling is what makes that
+        // true: the largest component carries 38 significant bits, so its
+        // square alone exceeds 2^60 and the length cannot round to zero.
+        // Before rescaling this needed a second zero check, and that check
+        // was the bug — it turned a short direction into no direction.
         let length = scaled.length();
-        if length == Fixed::ZERO {
-            return None;
-        }
         Some(Self::new(
             scaled.x.saturating_div(length),
             scaled.y.saturating_div(length),

--- a/crates/fixed/src/vector.rs
+++ b/crates/fixed/src/vector.rs
@@ -1,0 +1,325 @@
+//! Vectors over [`Fixed`].
+//!
+//! Two dimensions and three, as separate concrete types rather than one
+//! generic over dimension. The physics contract makes the same choice for the
+//! same reason: dimension-generic vocabularies produce signatures nobody can
+//! read, and the cost of writing `dot` twice is smaller than the cost of every
+//! caller reading a bound.
+
+use core::ops::{Add, Mul, Neg, Sub};
+
+use crate::Fixed;
+
+/// A two-dimensional vector.
+///
+/// # Contract
+///
+/// - **Every operation is deterministic**, because every operation is
+///   [`Fixed`] arithmetic and nothing else.
+/// - **Saturating throughout**, inheriting the scalar's behaviour: a component
+///   that overflows clamps and is counted rather than wrapping.
+/// - **`Eq` and `Hash`**, so a vector can be a map key or enter a state hash
+///   directly — which is the thing a float vector cannot offer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Vec2 {
+    pub x: Fixed,
+    pub y: Fixed,
+}
+
+/// A three-dimensional vector. See [`Vec2`] for the contract; it is the same.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Vec3 {
+    pub x: Fixed,
+    pub y: Fixed,
+    pub z: Fixed,
+}
+
+impl Vec2 {
+    /// The origin.
+    pub const ZERO: Self = Self {
+        x: Fixed::ZERO,
+        y: Fixed::ZERO,
+    };
+    /// One unit along x.
+    pub const X: Self = Self {
+        x: Fixed::ONE,
+        y: Fixed::ZERO,
+    };
+    /// One unit along y.
+    pub const Y: Self = Self {
+        x: Fixed::ZERO,
+        y: Fixed::ONE,
+    };
+
+    /// From components.
+    #[must_use]
+    pub const fn new(x: Fixed, y: Fixed) -> Self {
+        Self { x, y }
+    }
+
+    /// From whole numbers, which is how most call sites write a constant.
+    #[must_use]
+    pub const fn from_ints(x: i32, y: i32) -> Self {
+        Self {
+            x: Fixed::from_int(x),
+            y: Fixed::from_int(y),
+        }
+    }
+
+    /// The dot product.
+    #[must_use]
+    pub fn dot(self, other: Self) -> Fixed {
+        self.x.saturating_mul(other.x) + self.y.saturating_mul(other.y)
+    }
+
+    /// The 2D cross product: a scalar, the z of the 3D cross of these vectors
+    /// lifted into the plane. Positive when `other` is counter-clockwise of
+    /// `self`, which is what a winding test reads.
+    #[must_use]
+    pub fn cross(self, other: Self) -> Fixed {
+        self.x.saturating_mul(other.y) - self.y.saturating_mul(other.x)
+    }
+
+    /// The squared length.
+    ///
+    /// Preferred over [`Vec2::length`] wherever a comparison will do, and not
+    /// only for speed: this is exact where the length is rounded, so two
+    /// vectors that compare equal by squared length may compare unequal by
+    /// length.
+    #[must_use]
+    pub fn length_squared(self) -> Fixed {
+        self.dot(self)
+    }
+
+    /// The length, floored to the representable value below the exact one.
+    #[must_use]
+    pub fn length(self) -> Fixed {
+        self.length_squared().sqrt()
+    }
+
+    /// The distance to another point.
+    #[must_use]
+    pub fn distance(self, other: Self) -> Fixed {
+        (self - other).length()
+    }
+
+    /// A unit vector in the same direction, or `None` for the zero vector.
+    ///
+    /// Fallible rather than asserting, because the zero vector is a value a
+    /// simulation legitimately produces — a body at rest, a contact between
+    /// coincident points — and refusing it would put an assertion on a path
+    /// that runs every frame.
+    ///
+    /// **The result is unit-length only to the type's resolution.** Each
+    /// component is rounded, so the length of the result may differ from one
+    /// by up to about 2⁻¹⁵. Callers that need an exact guarantee should
+    /// compare squared lengths against a tolerance rather than expecting
+    /// exactly [`Fixed::ONE`].
+    #[must_use]
+    pub fn normalize(self) -> Option<Self> {
+        let length = self.length();
+        if length == Fixed::ZERO {
+            return None;
+        }
+        Some(Self::new(
+            self.x.saturating_div(length),
+            self.y.saturating_div(length),
+        ))
+    }
+
+    /// Linear interpolation, `t` clamped to `[0, 1]`.
+    ///
+    /// Written as `a + (b - a) * t` rather than `a*(1-t) + b*t`: the second is
+    /// the numerically better form in floating point and the worse one here,
+    /// because it rounds twice as often and neither form gains anything from
+    /// exactness at the endpoints — this one is exact at both by construction.
+    #[must_use]
+    pub fn lerp(self, other: Self, t: Fixed) -> Self {
+        let t = t.clamp(Fixed::ZERO, Fixed::ONE);
+        self + (other - self) * t
+    }
+
+    /// The component of `self` along `direction`, which must be unit-length.
+    ///
+    /// The building block of move-and-slide: removing this from a
+    /// displacement is what makes a body slide along a wall rather than stop
+    /// at it.
+    #[must_use]
+    pub fn project_onto_unit(self, direction: Self) -> Self {
+        direction * self.dot(direction)
+    }
+
+    /// `self` with its component along `normal` removed.
+    ///
+    /// `normal` must be unit-length. This is the slide operation itself, named
+    /// so the physics implementation does not spell it out at each call site
+    /// and get the sign wrong at one of them.
+    #[must_use]
+    pub fn slide_along(self, normal: Self) -> Self {
+        self - self.project_onto_unit(normal)
+    }
+
+    /// Perpendicular, rotated a quarter turn counter-clockwise.
+    ///
+    /// Exact — a quarter turn is a swap and a negation, needing no
+    /// trigonometry, which is why this is available when general rotation is
+    /// not.
+    #[must_use]
+    pub fn perpendicular(self) -> Self {
+        Self::new(-self.y, self.x)
+    }
+}
+
+impl Vec3 {
+    /// The origin.
+    pub const ZERO: Self = Self {
+        x: Fixed::ZERO,
+        y: Fixed::ZERO,
+        z: Fixed::ZERO,
+    };
+
+    /// From components.
+    #[must_use]
+    pub const fn new(x: Fixed, y: Fixed, z: Fixed) -> Self {
+        Self { x, y, z }
+    }
+
+    /// From whole numbers.
+    #[must_use]
+    pub const fn from_ints(x: i32, y: i32, z: i32) -> Self {
+        Self {
+            x: Fixed::from_int(x),
+            y: Fixed::from_int(y),
+            z: Fixed::from_int(z),
+        }
+    }
+
+    /// The dot product.
+    #[must_use]
+    pub fn dot(self, other: Self) -> Fixed {
+        self.x.saturating_mul(other.x)
+            + self.y.saturating_mul(other.y)
+            + self.z.saturating_mul(other.z)
+    }
+
+    /// The cross product: a vector perpendicular to both.
+    #[must_use]
+    pub fn cross(self, other: Self) -> Self {
+        Self::new(
+            self.y.saturating_mul(other.z) - self.z.saturating_mul(other.y),
+            self.z.saturating_mul(other.x) - self.x.saturating_mul(other.z),
+            self.x.saturating_mul(other.y) - self.y.saturating_mul(other.x),
+        )
+    }
+
+    /// The squared length. See [`Vec2::length_squared`] on why to prefer it.
+    #[must_use]
+    pub fn length_squared(self) -> Fixed {
+        self.dot(self)
+    }
+
+    /// The length, floored.
+    #[must_use]
+    pub fn length(self) -> Fixed {
+        self.length_squared().sqrt()
+    }
+
+    /// The distance to another point.
+    #[must_use]
+    pub fn distance(self, other: Self) -> Fixed {
+        (self - other).length()
+    }
+
+    /// A unit vector in the same direction, or `None` for the zero vector.
+    /// See [`Vec2::normalize`] on how close to unit the result is.
+    #[must_use]
+    pub fn normalize(self) -> Option<Self> {
+        let length = self.length();
+        if length == Fixed::ZERO {
+            return None;
+        }
+        Some(Self::new(
+            self.x.saturating_div(length),
+            self.y.saturating_div(length),
+            self.z.saturating_div(length),
+        ))
+    }
+
+    /// Linear interpolation, `t` clamped to `[0, 1]`.
+    #[must_use]
+    pub fn lerp(self, other: Self, t: Fixed) -> Self {
+        let t = t.clamp(Fixed::ZERO, Fixed::ONE);
+        self + (other - self) * t
+    }
+
+    /// `self` with its component along a unit `normal` removed.
+    #[must_use]
+    pub fn slide_along(self, normal: Self) -> Self {
+        self - normal * self.dot(normal)
+    }
+}
+
+// The operators, rather than inherent `add`/`sub`/`neg`/`scale`. For a vector
+// these read the way the maths does, and inherent methods by those names
+// shadow the traits confusingly enough that the linter says so.
+
+impl Add for Vec2 {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl Sub for Vec2 {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl Neg for Vec2 {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self::new(-self.x, -self.y)
+    }
+}
+
+/// Scaled by a scalar. Saturating componentwise, like everything else here.
+impl Mul<Fixed> for Vec2 {
+    type Output = Self;
+    fn mul(self, factor: Fixed) -> Self {
+        Self::new(self.x.saturating_mul(factor), self.y.saturating_mul(factor))
+    }
+}
+
+impl Add for Vec3 {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self::new(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+}
+
+impl Sub for Vec3 {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.x - other.x, self.y - other.y, self.z - other.z)
+    }
+}
+
+impl Neg for Vec3 {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self::new(-self.x, -self.y, -self.z)
+    }
+}
+
+impl Mul<Fixed> for Vec3 {
+    type Output = Self;
+    fn mul(self, factor: Fixed) -> Self {
+        Self::new(
+            self.x.saturating_mul(factor),
+            self.y.saturating_mul(factor),
+            self.z.saturating_mul(factor),
+        )
+    }
+}

--- a/crates/fixed/src/vector.rs
+++ b/crates/fixed/src/vector.rs
@@ -10,6 +10,28 @@ use core::ops::{Add, Mul, Neg, Sub};
 
 use crate::Fixed;
 
+/// How far to shift a direction left so normalising it keeps its precision.
+///
+/// Normalising is unchanged by scaling, and **shifting a fixed-point value left is
+/// exact** — no rounding, no loss. So a short direction is scaled up before
+/// its length is taken, which is the difference between a normal that is
+/// unit to a thousandth of a percent and one that is forty per cent wrong.
+///
+/// The target is 2³⁸ for the largest component: big enough that squaring
+/// keeps every significant bit, small enough that three squared components
+/// summed stay inside what the type holds (3 × 2⁶⁰ < 2⁶²).
+fn normalising_shift(largest: u64) -> u32 {
+    // A value with `k` significant bits has `64 - k` leading zeros, so
+    // shifting by `64 - k - 26` leaves it with 38. The 26 was 25 in the
+    // first version, which targets 2^39 rather than 2^38 — and three
+    // squared 2^39 components summed overflow an i64, so 3D normalisation
+    // saturated and returned a normal a quarter of a per cent off unit.
+    // Caught by a property test whose generator had just been widened to
+    // reach short vectors; the arithmetic was one bit out and the comment
+    // above was right all along.
+    largest.leading_zeros().saturating_sub(26)
+}
+
 /// A two-dimensional vector.
 ///
 /// # Contract
@@ -110,20 +132,39 @@ impl Vec2 {
     /// coincident points — and refusing it would put an assertion on a path
     /// that runs every frame.
     ///
-    /// **The result is unit-length only to the type's resolution.** Each
-    /// component is rounded, so the length of the result may differ from one
-    /// by up to about 2⁻¹⁵. Callers that need an exact guarantee should
-    /// compare squared lengths against a tolerance rather than expecting
-    /// exactly [`Fixed::ONE`].
+    /// **The result is unit-length to within four parts in 65536**, which is
+    /// asserted by a property test over every magnitude including the
+    /// shortest. Callers wanting an exact equality should compare squared
+    /// lengths against a tolerance rather than expecting [`Fixed::ONE`].
+    ///
+    /// The direction is scaled up before its length is taken, and that is
+    /// not an optimisation. Shifting a fixed-point value left is exact, and
+    /// without it a short direction is divided by a length that rounded to
+    /// something far too coarse: before this, a direction of 41 raw units
+    /// came back as a normal forty-one per cent too long, and anything whose
+    /// components were all below 181 raw had no direction at all.
     #[must_use]
     pub fn normalize(self) -> Option<Self> {
-        let length = self.length();
+        let largest = self
+            .x
+            .to_bits()
+            .unsigned_abs()
+            .max(self.y.to_bits().unsigned_abs());
+        if largest == 0 {
+            return None;
+        }
+        let shift = normalising_shift(largest);
+        let scaled = Self::new(
+            Fixed::from_bits(self.x.to_bits() << shift),
+            Fixed::from_bits(self.y.to_bits() << shift),
+        );
+        let length = scaled.length();
         if length == Fixed::ZERO {
             return None;
         }
         Some(Self::new(
-            self.x.saturating_div(length),
-            self.y.saturating_div(length),
+            scaled.x.saturating_div(length),
+            scaled.y.saturating_div(length),
         ))
     }
 
@@ -234,14 +275,29 @@ impl Vec3 {
     /// See [`Vec2::normalize`] on how close to unit the result is.
     #[must_use]
     pub fn normalize(self) -> Option<Self> {
-        let length = self.length();
+        let largest = self
+            .x
+            .to_bits()
+            .unsigned_abs()
+            .max(self.y.to_bits().unsigned_abs())
+            .max(self.z.to_bits().unsigned_abs());
+        if largest == 0 {
+            return None;
+        }
+        let shift = normalising_shift(largest);
+        let scaled = Self::new(
+            Fixed::from_bits(self.x.to_bits() << shift),
+            Fixed::from_bits(self.y.to_bits() << shift),
+            Fixed::from_bits(self.z.to_bits() << shift),
+        );
+        let length = scaled.length();
         if length == Fixed::ZERO {
             return None;
         }
         Some(Self::new(
-            self.x.saturating_div(length),
-            self.y.saturating_div(length),
-            self.z.saturating_div(length),
+            scaled.x.saturating_div(length),
+            scaled.y.saturating_div(length),
+            scaled.z.saturating_div(length),
         ))
     }
 

--- a/crates/fixed/tests/vectors.proptest-regressions
+++ b/crates/fixed/tests/vectors.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d07c41a49e0935244354b526322fd4b735b7a064f931d264dfb444e4fb66f176 # shrinks to a = Vec3 { x: Fixed(-208), y: Fixed(-252), z: Fixed(158) }, b = Vec3 { x: Fixed(0), y: Fixed(0), z: Fixed(-29363) }

--- a/crates/fixed/tests/vectors.rs
+++ b/crates/fixed/tests/vectors.rs
@@ -1,0 +1,215 @@
+//! Vector properties.
+//!
+//! The interesting ones are the two the physics contract depends on and that
+//! are easy to get subtly wrong: `slide_along` removing exactly the normal
+//! component, and `normalize` producing something close enough to unit length
+//! that a contact normal is usable.
+
+use proptest::prelude::*;
+use renew_fixed::{Fixed, Vec2, Vec3};
+
+/// Components modest enough that squaring cannot saturate, so a property
+/// about geometry is not silently a property about the clamp. Squarable range
+/// is about 1.2e7 units; a few thousand is far inside it.
+fn coordinate() -> impl Strategy<Value = Fixed> {
+    (-4096i64 * 65536..4096i64 * 65536).prop_map(Fixed::from_bits)
+}
+
+fn vec2() -> impl Strategy<Value = Vec2> {
+    (coordinate(), coordinate()).prop_map(|(x, y)| Vec2::new(x, y))
+}
+
+fn vec3() -> impl Strategy<Value = Vec3> {
+    (coordinate(), coordinate(), coordinate()).prop_map(|(x, y, z)| Vec3::new(x, y, z))
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 2048, ..ProptestConfig::default() })]
+
+    #[test]
+    fn addition_commutes_and_subtraction_inverts_it(a in vec2(), b in vec2()) {
+        prop_assert_eq!(a + b, b + a);
+        prop_assert_eq!((a + b) - b, a);
+        prop_assert_eq!(a - a, Vec2::ZERO);
+        prop_assert_eq!(a + Vec2::ZERO, a);
+    }
+
+    #[test]
+    fn negation_is_its_own_inverse(a in vec2()) {
+        prop_assert_eq!(-(-a), a);
+        prop_assert_eq!(a + (-a), Vec2::ZERO);
+    }
+
+    #[test]
+    fn the_dot_product_commutes(a in vec2(), b in vec2()) {
+        prop_assert_eq!(a.dot(b), b.dot(a));
+    }
+
+    /// The 2D cross product is antisymmetric, and zero for parallel vectors —
+    /// which is the property a winding or collinearity test reads.
+    #[test]
+    fn the_cross_product_is_antisymmetric(a in vec2(), b in vec2()) {
+        prop_assert_eq!(a.cross(b), -(b.cross(a)));
+        prop_assert_eq!(a.cross(a), Fixed::ZERO);
+    }
+
+    /// A 3D cross product is perpendicular to both its inputs. Exactly zero
+    /// is too strong under rounding, so the assertion is that the dot is
+    /// small relative to the magnitudes involved.
+    #[test]
+    fn the_3d_cross_product_is_perpendicular_to_its_inputs(a in vec3(), b in vec3()) {
+        let c = a.cross(b);
+        // Each component of the cross rounds once, so the dot accumulates a
+        // few units in the last place scaled by the input magnitudes.
+        let scale = a.length().to_bits().max(b.length().to_bits()) >> 16;
+        let tolerance = 8 * (scale + 1);
+        prop_assert!(c.dot(a).to_bits().abs() <= tolerance, "not perpendicular to a");
+        prop_assert!(c.dot(b).to_bits().abs() <= tolerance, "not perpendicular to b");
+    }
+
+    #[test]
+    fn length_squared_agrees_with_the_dot_product(a in vec2()) {
+        prop_assert_eq!(a.length_squared(), a.dot(a));
+        // And the length is the floored root of it, which is the scalar's
+        // property lifted.
+        prop_assert_eq!(a.length(), a.length_squared().sqrt());
+    }
+
+    #[test]
+    fn distance_is_symmetric_and_zero_only_for_the_same_point(a in vec2(), b in vec2()) {
+        prop_assert_eq!(a.distance(b), b.distance(a));
+        prop_assert_eq!(a.distance(a), Fixed::ZERO);
+    }
+
+    /// **The property a contact normal depends on.** Normalising cannot give
+    /// exactly unit length in a rounded type, so the contract promises "unit
+    /// to the type's resolution" — this is what that means numerically.
+    #[test]
+    fn normalize_produces_something_close_to_unit_length(a in vec2()) {
+        let Some(unit) = a.normalize() else {
+            prop_assert_eq!(a, Vec2::ZERO, "only the zero vector has no direction");
+            return Ok(());
+        };
+        let length = unit.length();
+        let error = (length.to_bits() - Fixed::ONE.to_bits()).abs();
+        // Each component is divided once and the length takes a floored
+        // root, so a few hundred units in the last place — out of 65536 —
+        // is the honest bound. That is about half a percent, which is why
+        // the contract tells callers to compare squared lengths against a
+        // tolerance rather than expecting exactly one.
+        prop_assert!(
+            error <= 512,
+            "normalized {a:?} to length {length:?}, off by {error} raw units"
+        );
+    }
+
+    #[test]
+    fn the_zero_vector_has_no_direction(_ in 0u8..1) {
+        prop_assert_eq!(Vec2::ZERO.normalize(), None);
+        prop_assert_eq!(Vec3::ZERO.normalize(), None);
+    }
+
+    /// **The property move-and-slide depends on.** After sliding, nothing of
+    /// the displacement remains along the normal — which is what stops a
+    /// character creeping into a wall it is pressed against.
+    #[test]
+    fn sliding_removes_the_component_along_the_normal(
+        displacement in vec2(),
+        normal_source in vec2(),
+    ) {
+        let Some(normal) = normal_source.normalize() else {
+            return Ok(());
+        };
+        let slid = displacement.slide_along(normal);
+        let residual = slid.dot(normal);
+        // The normal is itself only unit to the type's resolution, so the
+        // residual is bounded rather than zero. Scaled by the displacement,
+        // because a larger slide carries proportionally more rounding.
+        let magnitude = displacement.length().to_bits() >> 16;
+        let tolerance = 64 * (magnitude + 1);
+        prop_assert!(
+            residual.to_bits().abs() <= tolerance,
+            "residual {residual:?} along the normal exceeds {tolerance}"
+        );
+    }
+
+    /// Interpolation is exact at both ends, which is the reason for the
+    /// `a + (b - a) * t` form.
+    #[test]
+    fn interpolation_is_exact_at_the_endpoints(a in vec2(), b in vec2()) {
+        prop_assert_eq!(a.lerp(b, Fixed::ZERO), a);
+        prop_assert_eq!(a.lerp(b, Fixed::ONE), b);
+        // And `t` outside the range is clamped rather than extrapolated.
+        prop_assert_eq!(a.lerp(b, Fixed::from_int(5)), b);
+        prop_assert_eq!(a.lerp(b, Fixed::from_int(-5)), a);
+    }
+
+    /// A quarter turn is exact — no trigonometry, no rounding — which is why
+    /// it is available when general rotation is not.
+    #[test]
+    fn the_perpendicular_is_exact_and_four_turns_return(a in vec2()) {
+        prop_assert_eq!(a.perpendicular().dot(a), Fixed::ZERO, "exactly perpendicular");
+        prop_assert_eq!(
+            a.perpendicular().perpendicular().perpendicular().perpendicular(),
+            a
+        );
+        prop_assert_eq!(a.perpendicular().length_squared(), a.length_squared());
+    }
+
+    #[test]
+    fn scaling_by_one_and_zero_behaves(a in vec2()) {
+        prop_assert_eq!(a * Fixed::ONE, a);
+        prop_assert_eq!(a * Fixed::ZERO, Vec2::ZERO);
+        prop_assert_eq!(a * Fixed::from_int(-1), -a);
+    }
+
+    #[test]
+    fn the_3d_operations_mirror_the_2d_ones(a in vec3(), b in vec3()) {
+        prop_assert_eq!(a + b, b + a);
+        prop_assert_eq!((a + b) - b, a);
+        prop_assert_eq!(-(-a), a);
+        prop_assert_eq!(a.dot(b), b.dot(a));
+        prop_assert_eq!(a.length_squared(), a.dot(a));
+        prop_assert_eq!(a.distance(b), b.distance(a));
+        prop_assert_eq!(a.lerp(b, Fixed::ZERO), a);
+        prop_assert_eq!(a.lerp(b, Fixed::ONE), b);
+    }
+}
+
+/// The exact values a generator reaches only by luck.
+#[test]
+fn the_named_cases_are_exact() {
+    let three_four = Vec2::from_ints(3, 4);
+    assert_eq!(
+        three_four.length(),
+        Fixed::from_int(5),
+        "the 3-4-5 triangle"
+    );
+    assert_eq!(three_four.length_squared(), Fixed::from_int(25));
+
+    assert_eq!(Vec2::X.dot(Vec2::Y), Fixed::ZERO, "the axes are orthogonal");
+    assert_eq!(Vec2::X.cross(Vec2::Y), Fixed::ONE, "and counter-clockwise");
+    assert_eq!(Vec2::X.perpendicular(), Vec2::Y);
+
+    assert_eq!(
+        Vec2::X.normalize(),
+        Some(Vec2::X),
+        "an axis is already unit"
+    );
+
+    // Sliding a displacement straight into a wall moves nothing: the
+    // property that stops a character drifting through it over a minute of
+    // leaning. Exact here because the normal is an axis.
+    let into_the_wall = Vec2::from_ints(-5, 0);
+    assert_eq!(into_the_wall.slide_along(Vec2::X), Vec2::ZERO);
+
+    // And a diagonal against the same wall keeps exactly its tangent.
+    let diagonal = Vec2::from_ints(-5, 3);
+    assert_eq!(diagonal.slide_along(Vec2::X), Vec2::from_ints(0, 3));
+
+    // 3D: the standard basis cross product, exactly.
+    let x = Vec3::from_ints(1, 0, 0);
+    let y = Vec3::from_ints(0, 1, 0);
+    assert_eq!(x.cross(y), Vec3::from_ints(0, 0, 1));
+    assert_eq!(y.cross(x), Vec3::from_ints(0, 0, -1));
+}

--- a/crates/fixed/tests/vectors.rs
+++ b/crates/fixed/tests/vectors.rs
@@ -173,6 +173,31 @@ proptest! {
         prop_assert_eq!(a.distance(b), b.distance(a));
         prop_assert_eq!(a.lerp(b, Fixed::ZERO), a);
         prop_assert_eq!(a.lerp(b, Fixed::ONE), b);
+        // Interior interpolation, not only the endpoints: a lerp that
+        // returned an endpoint everywhere would satisfy the two above.
+        let midpoint = a.lerp(b, Fixed::from_ratio(1, 2));
+        prop_assert!(
+            midpoint.distance(a).to_bits() <= a.distance(b).to_bits() + 2
+                && midpoint.distance(b).to_bits() <= a.distance(b).to_bits() + 2,
+            "the midpoint left the segment"
+        );
+
+        // Normalising and sliding, the two operations the 2D properties
+        // cover and this one reached only through its endpoints.
+        if let Some(unit) = a.normalize() {
+            let error = (unit.length().to_bits() - Fixed::ONE.to_bits()).abs();
+            prop_assert!(error <= 512, "3D normalize off by {error} raw units");
+
+            let slid = b.slide_along(unit);
+            let magnitude = b.length().to_bits() >> 16;
+            let tolerance = 64 * (magnitude + 1);
+            prop_assert!(
+                slid.dot(unit).to_bits().abs() <= tolerance,
+                "3D slide left a residual along the normal"
+            );
+        } else {
+            prop_assert_eq!(a, Vec3::ZERO);
+        }
     }
 }
 

--- a/crates/fixed/tests/vectors.rs
+++ b/crates/fixed/tests/vectors.rs
@@ -11,8 +11,24 @@ use renew_fixed::{Fixed, Vec2, Vec3};
 /// Components modest enough that squaring cannot saturate, so a property
 /// about geometry is not silently a property about the clamp. Squarable range
 /// is about 1.2e7 units; a few thousand is far inside it.
+///
+/// **Spanning magnitudes, and that is the whole point.** The first version of
+/// this generator drew uniformly from the full range, which meant it produced
+/// short vectors essentially never — and short vectors were where `normalize`
+/// was catastrophically wrong: a direction of (181, 313) raw came back as a
+/// "unit" vector forty-one per cent too long, and every property here passed.
+/// A generator that cannot reach the broken region is a generator that
+/// certifies the bug.
 fn coordinate() -> impl Strategy<Value = Fixed> {
-    (-4096i64 * 65536..4096i64 * 65536).prop_map(Fixed::from_bits)
+    prop_oneof![
+        // Tiny: below the point where a squared component used to round to
+        // zero. This is the band that was broken.
+        3 => (-300i64..300).prop_map(Fixed::from_bits),
+        // Sub-unit, where a normal from two nearly-coincident points lands.
+        3 => (-65536i64..65536).prop_map(Fixed::from_bits),
+        // Ordinary game-scale coordinates.
+        2 => (-4096i64 * 65536..4096i64 * 65536).prop_map(Fixed::from_bits),
+    ]
 }
 
 fn vec2() -> impl Strategy<Value = Vec2> {
@@ -97,10 +113,40 @@ proptest! {
         // is the honest bound. That is about half a percent, which is why
         // the contract tells callers to compare squared lengths against a
         // tolerance rather than expecting exactly one.
+        // Four raw units out of 65536 — six thousandths of a per cent.
+        // This was 512 while `normalize` divided a short vector by its own
+        // rounded-to-zero length; rescaling first earned the tighter bound,
+        // and the bound is what would catch a regression to the old way.
         prop_assert!(
-            error <= 512,
+            error <= 4,
             "normalized {a:?} to length {length:?}, off by {error} raw units"
         );
+    }
+
+    /// **The regression this file exists to prevent from returning.** Every
+    /// non-zero direction has a direction, however short — and pushing
+    /// straight into the normal derived from it must move nothing at all.
+    /// Before `normalize` rescaled, a direction shorter than 256 raw units
+    /// had no length at all, and one of 41 raw units came back as a normal
+    /// that let a body slide 1.4 units per step through the wall it was
+    /// pressed against.
+    #[test]
+    fn even_the_shortest_directions_normalise_and_stop_a_slide(
+        x in -400i64..400,
+        y in -400i64..400,
+    ) {
+        prop_assume!(x != 0 || y != 0);
+        let direction = Vec2::new(Fixed::from_bits(x), Fixed::from_bits(y));
+        let normal = direction.normalize();
+        prop_assert!(normal.is_some(), "{direction:?} has a direction and got none");
+        let normal = normal.expect("checked above");
+
+        let error = (normal.length().to_bits() - Fixed::ONE.to_bits()).abs();
+        prop_assert!(error <= 4, "short direction gave a normal off by {error}");
+
+        // Pressed straight into it, a body must not move.
+        let push = -normal;
+        prop_assert_eq!(push.slide_along(normal).length(), Fixed::ZERO);
     }
 
     #[test]
@@ -186,7 +232,7 @@ proptest! {
         // cover and this one reached only through its endpoints.
         if let Some(unit) = a.normalize() {
             let error = (unit.length().to_bits() - Fixed::ONE.to_bits()).abs();
-            prop_assert!(error <= 512, "3D normalize off by {error} raw units");
+            prop_assert!(error <= 4, "3D normalize off by {error} raw units");
 
             let slid = b.slide_along(unit);
             let magnitude = b.length().to_bits() >> 16;


### PR DESCRIPTION
`Vec2` and `Vec3` over `Fixed`, as two concrete types rather than one generic over dimension — the same choice the physics contract makes, for the same reason: a dimension-generic vocabulary infects every signature with a bound, and writing `dot` twice costs less than every caller reading one.

**Owed rather than new.** The number type shipped as a scalar, and every consumer it was built for works in positions, normals and displacements. A scalar with no vector was half the thing that was asked for; the gap would otherwise have been discovered by whoever wrote the first collision test.

## Three operations designed against something specific

**`slide_along`** removes a displacement's component along a unit normal — the whole inner step of move-and-slide. Named here rather than spelled out at each call site, because a sign error in one of five copies is a character that sinks through one wall in the game and no others.

**`perpendicular`** is a quarter turn and is **exact**: a swap and a negation, no trigonometry, no rounding. It is available precisely because it is the rotation that needs none — general rotation waits on trigonometric functions the number type doesn't have, which is also why the physics contract defers rotated shapes.

**`normalize`** is fallible, because the zero vector is a value a simulation legitimately produces (a body at rest, a contact between coincident points) and an assertion on a path that runs every frame is the wrong shape. What it returns is unit-length only to the type's resolution, and the tests state how far off rather than leaving a caller to find out: a few hundred parts in sixty-five thousand.

## Tests

Fifteen properties, and two are the ones physics will lean on. **Sliding leaves nothing along the normal**, within a bound that scales with the displacement — that's what stops a character creeping into a wall it's pressed against. **Normalising lands close to unit within a stated bound** — a contact normal is unusable if nobody knows how close it is.

Exact cases separately: a 3-4-5 triangle, the axes orthogonal and counter-clockwise, sliding straight into a wall moving nothing at all, and the standard basis cross products in both orders.