### PR TITLE
test(fixed): replace a vacuous slide assertion that could not see what it measured

### DIFF
--- a/crates/fixed/tests/vectors.rs
+++ b/crates/fixed/tests/vectors.rs
@@ -144,9 +144,23 @@ proptest! {
         let error = (normal.length().to_bits() - Fixed::ONE.to_bits()).abs();
         prop_assert!(error <= 4, "short direction gave a normal off by {error}");
 
-        // Pressed straight into it, a body must not move.
-        let push = -normal;
-        prop_assert_eq!(push.slide_along(normal).length(), Fixed::ZERO);
+        // Pressed straight into it, a body barely moves — and "barely" is
+        // measured on the components, which is exact, rather than on the
+        // length, which is not.
+        //
+        // **The previous version of this assertion was vacuous.** It read
+        // `push.slide_along(normal).length() == ZERO`, and `length` goes
+        // through `length_squared`, where a residual of k raw units squares
+        // to k²/65536 and rounds to zero for every k up to 181. So it passed
+        // for any residual under 182 raw units while claiming to prove the
+        // residual was none. Measured on components, the true worst over
+        // this domain is 2 raw units — nonzero in about half of all cases.
+        let slid = (-normal).slide_along(normal);
+        let residual = slid.x.to_bits().abs().max(slid.y.to_bits().abs());
+        prop_assert!(
+            residual <= 2,
+            "sliding into the normal moved {residual} raw units, past the bound"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The test asserted that sliding a displacement straight into a normal leaves a residual of exactly zero — and measured that through `length()`. `length` goes through `length_squared`, where a residual of *k* raw units squares to *k*²/65536 and **rounds to zero for every k up to 181**.

So it passed for any residual below 182 raw units while claiming to have proved there was none. **The instrument could not see the quantity the assertion was about**, over precisely the range where the assertion mattered — and it is the same 181 that hid the `normalize` defect two changes ago, for the same reason.

Measured on components, which is exact: the residual is **nonzero in about half of all directions**, worst case two raw units (three parts in a hundred thousand). That is the bound now asserted.

The property was never zero, and a physics contract clause was resting on the belief that it was. That clause now states the bound and says what the implementation owes because of it: the stop-short distance must exceed the per-iteration residual by enough margin to absorb it, rather than a body walking through a wall over a quarter of an hour of leaning on it.