### PR TITLE
feat(physics2d): the collider set, and the identities everything else keys on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -274,15 +274,24 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
-      # The fixed-point arithmetic. Nothing depends on it yet -- physics is
-      # the consumer it was built for and does not exist -- so the cell is
-      # the whole workspace minus one leaf. That is the cheapest it will
-      # ever be, and adding it now means the first crate to depend on it
-      # discovers the obligation from a red lane rather than from nobody.
+      # The fixed-point arithmetic, and the collision crate written in it.
+      # This cell was a single leaf when it landed, with a comment saying
+      # the first crate to depend on it should discover the obligation
+      # from a red lane rather than from nobody. It did: physics arrived
+      # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
+          cargo build $sel
+          cargo test $sel
+      # Collision detection. No consumers yet -- the platformer that will
+      # drive it is not written -- so the cell is the whole workspace
+      # minus one leaf, and it grows the moment a sample collides.
+      - name: Build and test without collision detection
+        run: |
+          sel="--workspace --exclude renew-physics2d"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics2d $sel
           cargo build $sel
           cargo test $sel
       # The audio stack. The game is excluded alongside it because the
@@ -320,7 +329,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed; do
+          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-physics2d"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-ecs",
+ "renew-fixed",
+]
+
+[[package]]
 name = "renew-platform"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/physics2d/Cargo.toml
+++ b/crates/physics2d/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "renew-physics2d"
+description = "Two-dimensional collision detection for simulation code that must reproduce bit-for-bit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Bodies, shapes, filtering and collision queries in fixed-point 2D: the collider set, its lifecycle, and the orders that make contacts reproducible."
+maturity = "bootstrap"
+core = false
+extension_points = []
+# Physics is state that must reproduce, so unlike the stateless number type
+# underneath it this crate carries the simulation obligations: the float
+# closure walk, and the cross-target digest comparison.
+simulation = true
+
+[dependencies]
+renew-ecs = { path = "../ecs" }
+renew-fixed = { path = "../fixed" }
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/physics2d/clippy.toml
+++ b/crates/physics2d/clippy.toml
@@ -1,0 +1,34 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate is simulation-designated: its state is the collider set, and a
+# contact array it produces reaches a state hash directly. Every tripwire
+# below closes a route by which something outside the inputs could reach that
+# hash — a clock, a thread, a file, or a hasher that seeds itself.
+#
+# The float deny is at the crate root, beside the sentence explaining it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
+    { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "geometry arrives through the caller's operations, never from a path this crate chose" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, and nothing behind a reproducibility contract may" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same reason as RandomState: self-seeding entropy has no place here" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary — and iteration order here is contact order" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/physics2d/src/filter.rs
+++ b/crates/physics2d/src/filter.rs
@@ -1,0 +1,116 @@
+//! Which pairs are allowed to collide, and which shapes a query can see.
+
+/// A bit set naming what a shape *is*, and what it *cares about*.
+///
+/// # Why both halves, and why per shape
+///
+/// The body-kind matrix decides only static/kinematic/dynamic, and two
+/// kinematic bodies always collide by it. A game needs them not to: the
+/// character ignores pickups but collides with boxes, a bullet ignores
+/// whatever fired it, the ground query ignores the character. None of that
+/// is expressible without a filter, and no game can be written without all
+/// three.
+///
+/// It lives on the shape rather than the body because a body may own several
+/// — a one-way platform is one body whose top and volume filter differently,
+/// and one filter per body pushes the caller back into splitting it into two
+/// bodies it must then keep in step by hand.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Filter {
+    /// What this shape is.
+    pub layer: u32,
+    /// What this shape collides with.
+    pub mask: u32,
+}
+
+impl Filter {
+    /// A shape on every layer that collides with everything.
+    pub const ALL: Self = Self {
+        layer: u32::MAX,
+        mask: u32::MAX,
+    };
+
+    /// A shape on no layer that collides with nothing — invisible to pair
+    /// tests, and still visible to a query whose mask names its layer, which
+    /// is `NONE`'s point of difference from simply not existing.
+    pub const NONE: Self = Self { layer: 0, mask: 0 };
+
+    /// Layer and mask, in that order.
+    #[must_use]
+    pub const fn new(layer: u32, mask: u32) -> Self {
+        Self { layer, mask }
+    }
+
+    /// Whether two shapes are eligible to collide.
+    ///
+    /// **Symmetric by construction**, so a pair cannot be eligible in one
+    /// direction only — which would make the answer depend on which of the
+    /// two the broadphase happened to visit first, and that is precisely the
+    /// class of storage-order dependence the ordering rules exist to remove.
+    #[must_use]
+    pub const fn eligible(self, other: Self) -> bool {
+        (self.layer & other.mask) != 0 && (other.layer & self.mask) != 0
+    }
+
+    /// Whether a query carrying `mask` can see this shape.
+    ///
+    /// **One-sided, and deliberately.** A query has no layer, so the
+    /// symmetric rule cannot be evaluated for one at all. Consulting the
+    /// shape's own mask instead would make a trigger configured with an empty
+    /// mask — the ordinary way to write "collides with nothing" — invisible
+    /// to a ray, and casting against triggers is a large part of why rays
+    /// exist.
+    #[must_use]
+    pub const fn visible_to_query(self, mask: u32) -> bool {
+        (self.layer & mask) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Filter;
+
+    #[test]
+    fn eligibility_is_symmetric() {
+        let character = Filter::new(0b0001, 0b0010);
+        let wall = Filter::new(0b0010, 0b0001);
+        assert!(character.eligible(wall));
+        assert!(wall.eligible(character));
+    }
+
+    #[test]
+    fn one_sided_interest_is_not_enough() {
+        // The character wants to collide with the pickup; the pickup does not
+        // want to collide with anything. No contact, in either direction.
+        let character = Filter::new(0b0001, 0b1111);
+        let pickup = Filter::new(0b0100, 0b0000);
+        assert!(!character.eligible(pickup));
+        assert!(!pickup.eligible(character));
+    }
+
+    /// The case the one-sided query rule exists for: a shape that collides
+    /// with nothing must still be findable by a cast, or triggers cannot be
+    /// implemented.
+    #[test]
+    fn a_shape_that_collides_with_nothing_is_still_visible_to_a_query() {
+        let trigger = Filter::new(0b0100, 0b0000);
+        assert!(!trigger.eligible(Filter::ALL), "it blocks nothing");
+        assert!(
+            trigger.visible_to_query(0b0100),
+            "and a query naming its layer still finds it"
+        );
+        assert!(
+            !trigger.visible_to_query(0b1011),
+            "while a query not naming its layer does not"
+        );
+    }
+
+    #[test]
+    fn the_constants_mean_what_they_say() {
+        assert!(Filter::ALL.eligible(Filter::ALL));
+        assert!(!Filter::NONE.eligible(Filter::ALL));
+        assert!(!Filter::NONE.eligible(Filter::NONE));
+        assert!(Filter::ALL.visible_to_query(1));
+        assert!(!Filter::NONE.visible_to_query(u32::MAX));
+    }
+}

--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -1,0 +1,49 @@
+//! Two-dimensional collision detection that reproduces bit-for-bit.
+//!
+//! # What this is
+//!
+//! The collider set and the operations that change it, in fixed-point
+//! arithmetic with no floating point anywhere. Bodies own shapes; shapes carry
+//! a placement and a filter; every ordering this crate emits is a function of
+//! the collider set rather than of how it was built.
+//!
+//! # Status
+//!
+//! `bootstrap`. The lifecycle and identity rules are here; the broadphase,
+//! narrowphase, queries and move-and-slide are not yet.
+//!
+//! # The decisions worth knowing before reading the code
+//!
+//! - **A shape index is stable for the life of its body.** Removing a shape
+//!   leaves a hole; the next one fills the lowest free hole. The index is half
+//!   of every collider identity and part of the broadphase sort key, so
+//!   renumbering would give a different contact order for the same removal
+//!   history.
+//! - **A handle is an ECS entity, stored whole.** `Entity`'s constructor is
+//!   crate-private to `renew-ecs`, so this crate can neither mint a handle nor
+//!   rebuild one from its parts — body identity is stored state, not something
+//!   derived.
+//! - **A stale handle is refused, a foreign one is undetectable.** Two entity
+//!   allocators hand out identical handles by construction, so a handle from
+//!   another world cannot be told from a correct one. It is a caller warrant.
+//! - **Incarnation counters** advance when a collider is rebuilt at an
+//!   identity it already used, so an identifier derived from a collider pair
+//!   cannot outlive the pair.
+//! - **Nothing here is generic over dimension.** A shared vocabulary is
+//!   implemented twice rather than abstracted once, so the generic bounds do
+//!   not infect every signature.
+
+#![forbid(unsafe_code)]
+// The claim above — that there is no floating point anywhere — is enforced
+// rather than reviewed. A float that reached a contact would make the world a
+// function of the compiler's instruction selection, and this crate's whole
+// obligation is that it is not. There is no `allow` below.
+#![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
+
+pub mod filter;
+pub mod shape;
+pub mod world;
+
+pub use filter::Filter;
+pub use shape::{Shape, Transform};
+pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics2d/src/shape.rs
+++ b/crates/physics2d/src/shape.rs
@@ -1,0 +1,209 @@
+//! What a collider is shaped like, and where it sits on its body.
+
+use renew_fixed::{Angle, Fixed, Vec2};
+
+/// A translation and a rotation.
+///
+/// Rotation is an `Angle` — a binary angle, so it wraps exactly and has no
+/// unrepresentable values — which the number type supports in two dimensions
+/// because a rotation there is one scalar. Three dimensions need an
+/// orientation representation that does not exist yet, which is why this type
+/// is 2D-only rather than shared.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Transform {
+    /// Position.
+    pub translation: Vec2,
+    /// Rotation about the origin.
+    pub rotation: Angle,
+}
+
+impl Transform {
+    /// At the origin, unrotated.
+    pub const IDENTITY: Self = Self {
+        translation: Vec2::ZERO,
+        rotation: Angle::ZERO,
+    };
+
+    /// A translation with no rotation.
+    #[must_use]
+    pub const fn at(translation: Vec2) -> Self {
+        Self {
+            translation,
+            rotation: Angle::ZERO,
+        }
+    }
+
+    /// Both.
+    #[must_use]
+    pub const fn new(translation: Vec2, rotation: Angle) -> Self {
+        Self {
+            translation,
+            rotation,
+        }
+    }
+
+    /// This transform applied on top of `outer` — used to put a shape's local
+    /// placement into world space, since a shape sits on a body and the body
+    /// has a transform of its own.
+    ///
+    /// Without a per-shape placement a body could not own two shapes in
+    /// different places, and the one-way platform that motivates multi-shape
+    /// bodies at all would be unbuildable.
+    #[must_use]
+    pub fn compose(self, outer: Self) -> Self {
+        Self {
+            translation: outer.translation + self.translation.rotate(outer.rotation),
+            rotation: outer.rotation + self.rotation,
+        }
+    }
+}
+
+/// The shape families, with their operands named.
+///
+/// Each is defined in **body space**, so a box rotates with its body: its
+/// axis-alignment is to the body's axes rather than the world's. Stating the
+/// frame matters because "axis-aligned box" under a rotated body has two
+/// readings and they are different shapes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Shape {
+    /// Half-extents from the shape's local origin.
+    Box { half_extents: Vec2 },
+    /// Radius about the shape's local origin.
+    Circle { radius: Fixed },
+    /// A segment along the local *y* axis with rounded ends.
+    Capsule { radius: Fixed, half_height: Fixed },
+}
+
+impl Shape {
+    /// The furthest any point of this shape lies from its local origin.
+    ///
+    /// Rotation-invariant, so a caller can bound a rotating shape without
+    /// recomputing per angle. Deliberately not the broadphase interval, which
+    /// wants the exact support along an axis rather than a circle around
+    /// everything — a conservative bound there would change the candidate set.
+    #[must_use]
+    pub fn bounding_radius(self) -> Fixed {
+        match self {
+            Self::Box { half_extents } => half_extents.length(),
+            Self::Circle { radius } => radius,
+            Self::Capsule {
+                radius,
+                half_height,
+            } => radius + half_height,
+        }
+    }
+
+    /// Whether the operands describe a shape at all.
+    ///
+    /// Zero extents are legal — the query vocabulary requires a zero-radius
+    /// circle to be answerable rather than refused — but negative ones are
+    /// not, and they are what a caller produces by subtracting in the wrong
+    /// order.
+    #[must_use]
+    pub fn is_valid(self) -> bool {
+        match self {
+            Self::Box { half_extents } => {
+                half_extents.x >= Fixed::ZERO && half_extents.y >= Fixed::ZERO
+            }
+            Self::Circle { radius } => radius >= Fixed::ZERO,
+            Self::Capsule {
+                radius,
+                half_height,
+            } => radius >= Fixed::ZERO && half_height >= Fixed::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Shape, Transform};
+    use renew_fixed::{Angle, Fixed, Vec2};
+
+    fn v(x: i32, y: i32) -> Vec2 {
+        Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+    }
+
+    #[test]
+    fn composing_with_the_identity_changes_nothing() {
+        let t = Transform::new(v(3, 4), Angle::from_turn_ratio(1, 8));
+        assert_eq!(t.compose(Transform::IDENTITY), t);
+        assert_eq!(Transform::IDENTITY.compose(t), t);
+    }
+
+    /// The property a per-shape placement exists for: a shape offset from its
+    /// body swings around the body when the body turns, rather than sliding.
+    #[test]
+    fn a_local_offset_rotates_with_its_body() {
+        let local = Transform::at(v(1, 0));
+        let body = Transform::new(v(0, 0), Angle::from_turn_ratio(1, 4));
+        let world = local.compose(body);
+        // A quarter turn takes +x to +y.
+        assert_eq!(world.translation.x.trunc_int(), 0);
+        assert_eq!(world.translation.y.trunc_int(), 1);
+    }
+
+    #[test]
+    fn rotations_add_when_composed() {
+        let eighth = Angle::from_turn_ratio(1, 8);
+        let a = Transform::new(Vec2::ZERO, eighth);
+        let b = Transform::new(Vec2::ZERO, eighth);
+        assert_eq!(a.compose(b).rotation, Angle::from_turn_ratio(1, 4));
+    }
+
+    #[test]
+    fn zero_sized_shapes_are_valid_and_negative_ones_are_not() {
+        // The query vocabulary requires a zero-radius circle to answer rather
+        // than refuse, so it has to be constructible.
+        assert!(
+            Shape::Circle {
+                radius: Fixed::ZERO
+            }
+            .is_valid()
+        );
+        assert!(
+            Shape::Box {
+                half_extents: Vec2::ZERO
+            }
+            .is_valid()
+        );
+        assert!(
+            !Shape::Circle {
+                radius: Fixed::from_int(-1)
+            }
+            .is_valid()
+        );
+        assert!(
+            !Shape::Box {
+                half_extents: v(1, -1)
+            }
+            .is_valid()
+        );
+    }
+
+    #[test]
+    fn a_bounding_radius_covers_the_shape() {
+        assert_eq!(
+            Shape::Circle {
+                radius: Fixed::from_int(3)
+            }
+            .bounding_radius(),
+            Fixed::from_int(3)
+        );
+        assert_eq!(
+            Shape::Capsule {
+                radius: Fixed::from_int(1),
+                half_height: Fixed::from_int(4)
+            }
+            .bounding_radius(),
+            Fixed::from_int(5)
+        );
+        // A 3-4 box reaches its corner at 5.
+        assert_eq!(
+            Shape::Box {
+                half_extents: v(3, 4)
+            }
+            .bounding_radius(),
+            Fixed::from_int(5)
+        );
+    }
+}

--- a/crates/physics2d/src/world.rs
+++ b/crates/physics2d/src/world.rs
@@ -47,6 +47,18 @@ impl ShapeIndex {
     pub const fn get(self) -> u32 {
         self.0
     }
+
+    /// An index from a raw position.
+    ///
+    /// Needed because a shape index is *saved* state: it is half of every
+    /// collider identity, so a caller restoring a world has to be able to
+    /// name the same collider it named before. An index that names nothing is
+    /// not an error — every operation refuses it the same way it refuses a
+    /// hole.
+    #[must_use]
+    pub const fn from_raw(position: u32) -> Self {
+        Self(position)
+    }
 }
 
 /// What identifies a collider: a body and one of its shapes.

--- a/crates/physics2d/src/world.rs
+++ b/crates/physics2d/src/world.rs
@@ -1,0 +1,460 @@
+//! The collider set: what is in the world, and every operation that changes it.
+
+use crate::filter::Filter;
+use crate::shape::{Shape, Transform};
+use renew_ecs::Entity;
+
+/// How a body moves, and what it collides with.
+///
+/// `Dynamic` is named and refused. v0 has no solver, so accepting a dynamic
+/// body would mean accepting it and doing something surprising; naming it
+/// keeps the word stable for the implementation that grows one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BodyKind {
+    /// Never moves.
+    Static,
+    /// Moved by the caller, unaffected by contacts.
+    Kinematic,
+    /// Moved by the simulation. **Refused in v0.**
+    Dynamic,
+}
+
+impl BodyKind {
+    /// Whether two kinds may produce a contact at all.
+    ///
+    /// Static-versus-static is the only pair that cannot: neither ever moves,
+    /// so a contact between them can never change, and reporting it every step
+    /// is noise a caller has to filter out forever.
+    #[must_use]
+    pub const fn collides_with(self, other: Self) -> bool {
+        !matches!((self, other), (Self::Static, Self::Static))
+    }
+}
+
+/// A shape's position in its body's list.
+///
+/// **Stable for the life of the body.** Removing a shape leaves a hole rather
+/// than renumbering, because this index is half of every collider identity,
+/// part of the broadphase sort key, and the order overlaps resolve in — and
+/// shift-down, swap-remove and tombstone each give a different contact order
+/// for the same removal history.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShapeIndex(u32);
+
+impl ShapeIndex {
+    /// The raw position.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// What identifies a collider: a body and one of its shapes.
+///
+/// Ordered lexicographically, handle first, and total because both components
+/// are — which is what every emitted ordering in this crate rests on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Collider {
+    /// The body.
+    pub handle: Entity,
+    /// Which of its shapes.
+    pub index: ShapeIndex,
+}
+
+/// How many times a collider has been rebuilt at the same identity.
+///
+/// A contact identifier derived from a collider pair must not survive either
+/// collider's destruction. Purity alone does not give that: a shape removed
+/// and re-added takes the same index back by the lowest-free-hole rule, and a
+/// body destroyed and recreated against a still-live entity takes the same
+/// handle back. Both would make a rebuilt collider bit-identical to the one it
+/// replaced, and a caller's one-shot impact sound would not fire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Incarnation(u32);
+
+impl Incarnation {
+    /// The raw count.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// One shape on a body.
+#[derive(Clone, Copy, Debug)]
+struct Slot {
+    shape: Shape,
+    local: Transform,
+    filter: Filter,
+}
+
+/// One position in a body's shape list, occupied or not.
+///
+/// The incarnation lives on the *cell* rather than on the shape, so it
+/// survives a removal — which is the point of it.
+#[derive(Clone, Copy, Debug, Default)]
+struct Cell {
+    occupied: Option<Slot>,
+    incarnation: u32,
+}
+
+/// One body and its shapes.
+#[derive(Clone, Debug)]
+struct Body {
+    /// **The entity as issued, not its parts.** `Entity`'s constructor is
+    /// crate-private to the ECS, so physics cannot mint or rebuild a handle:
+    /// keeping the whole thing is the only way to hand one back. This is what
+    /// makes body identity saved state rather than something derivable.
+    entity: Entity,
+    live: bool,
+    kind: BodyKind,
+    transform: Transform,
+    /// Holes are unoccupied cells. Never compacted.
+    shapes: Vec<Cell>,
+    incarnation: u32,
+}
+
+/// What this world can say about a handle.
+///
+/// Named rather than folded into an `Option` because the cases are not equally
+/// answerable, and pretending they are is how a specification comes to demand
+/// an assertion on something undetectable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandleState {
+    /// A body exists here at exactly this generation.
+    Live,
+    /// This world knows the index at a different generation — the entity was
+    /// despawned and its slot reused by the allocator.
+    Stale,
+    /// This world has no body for the handle, either because it never had one
+    /// or because the body was destroyed.
+    Unknown,
+}
+
+/// The bodies, their shapes, and nothing else.
+///
+/// Holds no global state, so a caller may hold several worlds and they do not
+/// interact. Owns the transforms: a caller that also stores one for rendering
+/// copies it out.
+#[derive(Debug, Default)]
+pub struct World {
+    /// Indexed by entity index. The vector only grows, so iteration is in
+    /// ascending index order — a function of the collider set rather than of
+    /// insertion order.
+    bodies: Vec<Option<Body>>,
+    live: usize,
+}
+
+impl World {
+    /// An empty world.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many bodies are live.
+    #[must_use]
+    pub const fn body_count(&self) -> usize {
+        self.live
+    }
+
+    /// What this world can say about a handle.
+    ///
+    /// **There is no `Foreign` answer, and that is not an omission.** Two
+    /// entity allocators hand out identical handles by construction — both
+    /// start at index 0, generation 0 — so a handle from another world that
+    /// collides with a live local body is indistinguishable from a correct
+    /// one. It is a caller warrant, and a contract cannot require an
+    /// implementation to detect what it cannot see.
+    #[must_use]
+    pub fn handle_state(&self, handle: Entity) -> HandleState {
+        let Some(body) = self
+            .bodies
+            .get(handle.index() as usize)
+            .and_then(Option::as_ref)
+        else {
+            return HandleState::Unknown;
+        };
+        if body.entity.generation() == handle.generation() {
+            // A destroyed body leaves a tombstone at the same generation. The
+            // world has no body for the handle either way, so it answers
+            // Unknown rather than inventing a fourth case.
+            if body.live {
+                HandleState::Live
+            } else {
+                HandleState::Unknown
+            }
+        } else {
+            HandleState::Stale
+        }
+    }
+
+    fn body(&self, handle: Entity) -> Option<&Body> {
+        self.bodies
+            .get(handle.index() as usize)?
+            .as_ref()
+            .filter(|body| body.live && body.entity == handle)
+    }
+
+    fn body_mut(&mut self, handle: Entity) -> Option<&mut Body> {
+        self.bodies
+            .get_mut(handle.index() as usize)?
+            .as_mut()
+            .filter(|body| body.live && body.entity == handle)
+    }
+
+    // ---- structural mutation: between steps only ----
+
+    /// Create a body against a caller-supplied entity.
+    ///
+    /// `None` if the entity already owns a live body here, or if the kind is
+    /// `Dynamic`. **At most one body per entity** is what keeps collider order
+    /// total: two bodies sharing a handle would compare equal on (handle,
+    /// shape index), and every emitted ordering rests on that being impossible.
+    pub fn create_body(
+        &mut self,
+        entity: Entity,
+        kind: BodyKind,
+        transform: Transform,
+    ) -> Option<Entity> {
+        if kind == BodyKind::Dynamic {
+            return None;
+        }
+        let slot = entity.index() as usize;
+        if self.bodies.len() <= slot {
+            self.bodies.resize(slot + 1, None);
+        }
+        let entry = self.bodies.get_mut(slot)?;
+        let carried = match entry.as_ref() {
+            Some(body) if body.live && body.entity == entity => return None,
+            Some(body) => body.incarnation,
+            None => 0,
+        };
+        *entry = Some(Body {
+            entity,
+            live: true,
+            kind,
+            transform,
+            shapes: Vec::new(),
+            incarnation: carried.wrapping_add(1),
+        });
+        self.live = self.live.saturating_add(1);
+        Some(entity)
+    }
+
+    /// Remove a body and all its shapes. `false` if the handle named none.
+    ///
+    /// The record is kept as a tombstone rather than dropped, because the
+    /// incarnation has to outlive the body: a later body created against the
+    /// same entity must not inherit its identity.
+    pub fn destroy_body(&mut self, handle: Entity) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        body.live = false;
+        body.shapes.clear();
+        self.live = self.live.saturating_sub(1);
+        true
+    }
+
+    /// Add a shape, filling the **lowest free hole**. `None` if the handle
+    /// named no body, or the operands are not a shape.
+    pub fn add_shape(
+        &mut self,
+        handle: Entity,
+        shape: Shape,
+        local: Transform,
+        filter: Filter,
+    ) -> Option<ShapeIndex> {
+        if !shape.is_valid() {
+            return None;
+        }
+        let body = self.body_mut(handle)?;
+        // The lowest free hole, or a new cell at the end. Never a swap, never
+        // a shift: the index is identity.
+        let index = if let Some(hole) = body.shapes.iter().position(|cell| cell.occupied.is_none())
+        {
+            hole
+        } else {
+            body.shapes.push(Cell::default());
+            body.shapes.len() - 1
+        };
+        let cell = body.shapes.get_mut(index)?;
+        cell.occupied = Some(Slot {
+            shape,
+            local,
+            filter,
+        });
+        cell.incarnation = cell.incarnation.wrapping_add(1);
+        u32::try_from(index).ok().map(ShapeIndex)
+    }
+
+    /// Remove a shape, leaving a hole that keeps its index. `false` if there
+    /// was nothing there.
+    pub fn remove_shape(&mut self, handle: Entity, index: ShapeIndex) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        if cell.occupied.is_none() {
+            return false;
+        }
+        cell.occupied = None;
+        true
+    }
+
+    /// Replace a shape in place, keeping its index and advancing its
+    /// incarnation. `false` if there was nothing there.
+    pub fn replace_shape(
+        &mut self,
+        handle: Entity,
+        index: ShapeIndex,
+        shape: Shape,
+        local: Transform,
+    ) -> bool {
+        if !shape.is_valid() {
+            return false;
+        }
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        let Some(slot) = cell.occupied.as_mut() else {
+            return false;
+        };
+        slot.shape = shape;
+        slot.local = local;
+        cell.incarnation = cell.incarnation.wrapping_add(1);
+        true
+    }
+
+    /// Change a shape's filter. `false` if there was nothing there.
+    ///
+    /// Does **not** advance the incarnation: the collider is the same one it
+    /// was, and a contact that persists across a filter change is a persisting
+    /// contact.
+    pub fn set_filter(&mut self, handle: Entity, index: ShapeIndex, filter: Filter) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        match cell.occupied.as_mut() {
+            Some(slot) => {
+                slot.filter = filter;
+                true
+            }
+            None => false,
+        }
+    }
+
+    // ---- movement: legal during the caller's phase, effective immediately ----
+
+    /// Place a body. **Teleports; does not sweep.**
+    ///
+    /// A body moved this way passes through anything between where it was and
+    /// where it lands. That is the caller's choice, and the swept operation is
+    /// the other one — a placement that quietly swept would make the cheap
+    /// operation expensive and leave the expensive one unavailable.
+    pub fn set_transform(&mut self, handle: Entity, transform: Transform) -> bool {
+        match self.body_mut(handle) {
+            Some(body) => {
+                body.transform = transform;
+                true
+            }
+            None => false,
+        }
+    }
+
+    // ---- reading ----
+
+    /// A body's transform.
+    #[must_use]
+    pub fn transform(&self, handle: Entity) -> Option<Transform> {
+        self.body(handle).map(|body| body.transform)
+    }
+
+    /// A body's kind.
+    #[must_use]
+    pub fn kind(&self, handle: Entity) -> Option<BodyKind> {
+        self.body(handle).map(|body| body.kind)
+    }
+
+    /// One shape, in body-local terms.
+    #[must_use]
+    pub fn shape(&self, collider: Collider) -> Option<(Shape, Transform, Filter)> {
+        let slot = self.cell(collider)?.occupied.as_ref()?;
+        Some((slot.shape, slot.local, slot.filter))
+    }
+
+    /// A shape's world transform — its local placement composed onto its
+    /// body's.
+    #[must_use]
+    pub fn world_transform(&self, collider: Collider) -> Option<Transform> {
+        let body = self.body(collider.handle)?;
+        let slot = body
+            .shapes
+            .get(collider.index.get() as usize)?
+            .occupied
+            .as_ref()?;
+        Some(slot.local.compose(body.transform))
+    }
+
+    /// How many times this collider has been rebuilt at the same identity.
+    #[must_use]
+    pub fn incarnation(&self, collider: Collider) -> Option<Incarnation> {
+        let body = self.body(collider.handle)?;
+        let cell = body.shapes.get(collider.index.get() as usize)?;
+        cell.occupied.as_ref()?;
+        Some(Incarnation(
+            body.incarnation
+                .wrapping_mul(31)
+                .wrapping_add(cell.incarnation),
+        ))
+    }
+
+    fn cell(&self, collider: Collider) -> Option<&Cell> {
+        self.body(collider.handle)?
+            .shapes
+            .get(collider.index.get() as usize)
+    }
+
+    /// The highest occupied index plus one — **not** the number of live
+    /// shapes, because holes keep their place.
+    #[must_use]
+    pub fn shape_extent(&self, handle: Entity) -> Option<u32> {
+        let shapes = &self.body(handle)?.shapes;
+        let highest = shapes.iter().rposition(|cell| cell.occupied.is_some());
+        Some(highest.map_or(0, |index| u32::try_from(index).unwrap_or(u32::MAX) + 1))
+    }
+
+    /// Every live collider, **in ascending (handle, shape index) order**.
+    ///
+    /// The order is part of the contract rather than an accident of the
+    /// representation: it is a function of the collider set, so two worlds
+    /// built by different insertion sequences iterate identically.
+    pub fn colliders(&self) -> impl Iterator<Item = Collider> + '_ {
+        self.bodies
+            .iter()
+            .filter_map(Option::as_ref)
+            .filter(|body| body.live)
+            .flat_map(|body| {
+                let handle = body.entity;
+                body.shapes
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(position, cell)| {
+                        cell.occupied.as_ref()?;
+                        Some(Collider {
+                            handle,
+                            index: ShapeIndex(u32::try_from(position).unwrap_or(u32::MAX)),
+                        })
+                    })
+            })
+    }
+}

--- a/crates/physics2d/tests/lifecycle.rs
+++ b/crates/physics2d/tests/lifecycle.rs
@@ -1,0 +1,319 @@
+//! The identity and ordering rules, which everything else rests on.
+//!
+//! These are the properties that cannot be recovered later: if a shape index
+//! moves, or collider order depends on insertion order, then every contact
+//! report downstream is a different report on a different machine, and no
+//! amount of care in the geometry fixes it.
+
+use proptest::prelude::*;
+use renew_ecs::Entities;
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{BodyKind, Collider, Filter, HandleState, Shape, Transform, World};
+
+fn circle(units: i32) -> Shape {
+    Shape::Circle {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(Vec2::new(Fixed::from_int(x), Fixed::from_int(y)))
+}
+
+/// **The property the whole identity scheme rests on.** A removed shape leaves
+/// a hole, and the shapes after it keep their indices.
+///
+/// The tempting implementation — the one the nearest dense-array idiom
+/// suggests — moves the last shape into the hole. That renumbers a collider
+/// that nobody touched, which silently re-keys its contacts.
+#[test]
+fn removing_a_shape_does_not_renumber_the_others() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Kinematic, Transform::IDENTITY)
+        .expect("a fresh entity has no body");
+
+    let first = world
+        .add_shape(body, circle(1), at(0, 0), Filter::ALL)
+        .expect("live body");
+    let second = world
+        .add_shape(body, circle(2), at(1, 0), Filter::ALL)
+        .expect("live body");
+    let third = world
+        .add_shape(body, circle(3), at(2, 0), Filter::ALL)
+        .expect("live body");
+    assert_eq!((first.get(), second.get(), third.get()), (0, 1, 2));
+
+    assert!(world.remove_shape(body, second));
+
+    // The third shape is still index 2, and it is still the radius-3 circle.
+    let (shape, _, _) = world
+        .shape(Collider {
+            handle: body,
+            index: third,
+        })
+        .expect("the third shape kept its index");
+    assert_eq!(shape, circle(3));
+
+    // And the hole is genuinely a hole, not a shifted-down neighbour.
+    assert!(
+        world
+            .shape(Collider {
+                handle: body,
+                index: second
+            })
+            .is_none(),
+        "index 1 must be empty, not occupied by what used to be index 2"
+    );
+
+    // The extent still spans the hole, because the highest occupied index is
+    // what bounds iteration — not the count of live shapes.
+    assert_eq!(world.shape_extent(body), Some(3));
+}
+
+/// A new shape fills the lowest free hole, so indices stay dense from the
+/// bottom without any of them ever moving.
+#[test]
+fn a_new_shape_fills_the_lowest_free_hole() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Static, Transform::IDENTITY)
+        .expect("fresh");
+
+    let indices: Vec<_> = (1..=5)
+        .map(|units| {
+            world
+                .add_shape(body, circle(units), at(0, 0), Filter::ALL)
+                .expect("live")
+        })
+        .collect();
+    assert_eq!(indices[4].get(), 4);
+
+    // Punch two holes, freeing the higher one first so that "lowest" is a
+    // claim about ordering rather than about recency.
+    assert!(world.remove_shape(body, indices[3]));
+    assert!(world.remove_shape(body, indices[1]));
+
+    let first_refill = world
+        .add_shape(body, circle(6), at(0, 0), Filter::ALL)
+        .expect("live");
+    assert_eq!(
+        first_refill, indices[1],
+        "the lowest free hole, not the newest"
+    );
+
+    let second_refill = world
+        .add_shape(body, circle(7), at(0, 0), Filter::ALL)
+        .expect("live");
+    assert_eq!(second_refill, indices[3], "then the next one up");
+
+    // With no holes left, the next shape extends the list.
+    let appended = world
+        .add_shape(body, circle(8), at(0, 0), Filter::ALL)
+        .expect("live");
+    assert_eq!(appended.get(), 5);
+    assert_eq!(world.shape_extent(body), Some(6));
+}
+
+/// The four handle cases, each with the answer the vocabulary gives it.
+#[test]
+fn a_handle_is_live_stale_or_unknown() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+
+    let handle = entities.spawn();
+    assert_eq!(
+        world.handle_state(handle),
+        HandleState::Unknown,
+        "an entity with no body here"
+    );
+
+    let body = world
+        .create_body(handle, BodyKind::Kinematic, Transform::IDENTITY)
+        .expect("fresh");
+    assert_eq!(world.handle_state(body), HandleState::Live);
+
+    // The case the stored generation exists for: despawn, and the allocator
+    // hands the same *index* back at a new generation.
+    entities.despawn(handle);
+    let recycled = entities.spawn();
+    assert_eq!(
+        recycled.index(),
+        handle.index(),
+        "the allocator reused the slot, which is the scenario"
+    );
+    assert_ne!(recycled.generation(), handle.generation());
+    assert_eq!(
+        world.handle_state(recycled),
+        HandleState::Stale,
+        "a reused index must not reach another body's data"
+    );
+
+    // And the operations refuse it rather than answering.
+    assert!(!world.set_transform(recycled, at(5, 5)));
+    assert!(
+        world
+            .add_shape(recycled, circle(1), at(0, 0), Filter::ALL)
+            .is_none()
+    );
+    assert!(world.transform(recycled).is_none());
+
+    // The original handle still works, because nothing about the ECS despawn
+    // reached this world.
+    assert_eq!(world.handle_state(handle), HandleState::Live);
+    assert!(world.set_transform(handle, at(5, 5)));
+}
+
+/// Two bodies sharing a handle would make collider order non-total, and every
+/// emitted ordering rests on it being total.
+#[test]
+fn one_entity_gets_at_most_one_body() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+
+    assert!(
+        world
+            .create_body(handle, BodyKind::Static, Transform::IDENTITY)
+            .is_some()
+    );
+    assert!(
+        world
+            .create_body(handle, BodyKind::Static, Transform::IDENTITY)
+            .is_none(),
+        "a second body against the same entity must be refused"
+    );
+    assert_eq!(world.body_count(), 1);
+}
+
+/// v0 has no solver, so a dynamic body is refused explicitly rather than
+/// accepted and quietly treated as something else.
+#[test]
+fn a_dynamic_body_is_refused_rather_than_silently_reinterpreted() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    assert!(
+        world
+            .create_body(entities.spawn(), BodyKind::Dynamic, Transform::IDENTITY)
+            .is_none()
+    );
+    assert_eq!(world.body_count(), 0);
+}
+
+/// Destroying and recreating against a live entity gives back the same handle.
+/// The incarnation is what stops the rebuilt collider being indistinguishable
+/// from the one it replaced.
+#[test]
+fn a_rebuilt_collider_is_not_the_one_it_replaced() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+    let collider = Collider { handle, index };
+    let before = world.incarnation(collider).expect("occupied");
+
+    // Same index back, by the lowest-free-hole rule.
+    assert!(world.remove_shape(handle, index));
+    let again = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+    assert_eq!(again, index, "the identity is reused, which is the problem");
+    assert_ne!(
+        world.incarnation(collider).expect("occupied"),
+        before,
+        "and the incarnation is what distinguishes them"
+    );
+
+    // Same again across a body destroy/create cycle.
+    let across = world.incarnation(collider).expect("occupied");
+    world.destroy_body(handle);
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(handle, circle(1), at(0, 0), Filter::ALL);
+    assert_ne!(world.incarnation(collider).expect("occupied"), across);
+}
+
+/// A shape's placement is composed onto its body's, which is what lets one
+/// body own two shapes in different places.
+#[test]
+fn a_shape_sits_where_its_local_transform_puts_it() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, at(10, 0));
+
+    let index = world
+        .add_shape(handle, circle(1), at(0, 3), Filter::ALL)
+        .expect("live");
+    let world_transform = world
+        .world_transform(Collider { handle, index })
+        .expect("occupied");
+    assert_eq!(world_transform.translation.x.trunc_int(), 10);
+    assert_eq!(world_transform.translation.y.trunc_int(), 3);
+}
+
+proptest! {
+    /// **Collider order must be a function of the collider set, not of the
+    /// order it was built in.** Two worlds holding the same bodies and shapes
+    /// iterate identically however they were assembled — which is what makes
+    /// a contact array reproducible across machines that reached the same
+    /// state by different routes.
+    #[test]
+    fn collider_order_does_not_depend_on_insertion_order(
+        permutation in Just((0usize..6).collect::<Vec<_>>()).prop_shuffle()
+    ) {
+        let build = |order: &[usize]| {
+            let mut entities = Entities::new();
+            let handles: Vec<_> = (0..6).map(|_| entities.spawn()).collect();
+            let mut world = World::new();
+            for &which in order {
+                let handle = handles[which];
+                world.create_body(handle, BodyKind::Static, Transform::IDENTITY);
+                world.add_shape(handle, circle(1), at(0, 0), Filter::ALL);
+            }
+            world.colliders().collect::<Vec<_>>()
+        };
+
+        let ascending: Vec<usize> = (0..6).collect();
+        let a = build(&ascending);
+        let b = build(&permutation);
+        // Same set of bodies, whatever order they were added in.
+        prop_assert_eq!(a.len(), b.len());
+        prop_assert_eq!(a, b, "iteration order leaked the insertion order");
+    }
+
+    /// However a body's shapes are added and removed, every live shape keeps a
+    /// distinct index and the collider order stays strictly ascending.
+    #[test]
+    fn collider_order_is_strictly_ascending_under_any_history(
+        operations in prop::collection::vec(prop::bool::ANY, 0..24)
+    ) {
+        let mut entities = Entities::new();
+        let mut world = World::new();
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+
+        let mut added: Vec<renew_physics2d::ShapeIndex> = Vec::new();
+        for add in operations {
+            if add || added.is_empty() {
+                if let Some(index) = world.add_shape(handle, circle(1), at(0, 0), Filter::ALL) {
+                    added.push(index);
+                }
+            } else {
+                let victim = added.remove(added.len() / 2);
+                world.remove_shape(handle, victim);
+            }
+        }
+
+        let seen: Vec<Collider> = world.colliders().collect();
+        for pair in seen.windows(2) {
+            prop_assert!(pair[0] < pair[1], "collider order must be strictly ascending");
+        }
+        prop_assert_eq!(seen.len(), added.len(), "every live shape appears exactly once");
+    }
+}

--- a/crates/physics2d/tests/operations.rs
+++ b/crates/physics2d/tests/operations.rs
@@ -1,0 +1,249 @@
+//! The rest of the operations, and what each refuses.
+//!
+//! Split from the identity tests because these are about *behaviour on bad
+//! input* rather than about ordering, and the two fail for different reasons:
+//! an identity bug corrupts every downstream report, while a refusal bug shows
+//! up as a caller silently getting nothing.
+
+use renew_ecs::Entities;
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{
+    BodyKind, Collider, Filter, HandleState, Shape, ShapeIndex, Transform, World,
+};
+
+fn circle(units: i32) -> Shape {
+    Shape::Circle {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(Vec2::new(Fixed::from_int(x), Fixed::from_int(y)))
+}
+
+/// Static bodies never move, so a contact between two of them can never change
+/// — reporting it every step is noise a caller has to filter out forever.
+#[test]
+fn only_two_static_bodies_cannot_produce_a_contact() {
+    use BodyKind::{Dynamic, Kinematic, Static};
+    assert!(!Static.collides_with(Static));
+    assert!(Static.collides_with(Kinematic));
+    assert!(Kinematic.collides_with(Static));
+    assert!(Kinematic.collides_with(Kinematic));
+    // Named for the fork that grows one, even though v0 refuses to create it.
+    assert!(Dynamic.collides_with(Static));
+    assert!(Dynamic.collides_with(Dynamic));
+}
+
+/// A capsule needs both operands non-negative, and a zero-length one is a
+/// circle rather than an error.
+#[test]
+fn a_capsule_validates_both_of_its_operands() {
+    let ok = Shape::Capsule {
+        radius: Fixed::from_int(1),
+        half_height: Fixed::ZERO,
+    };
+    assert!(
+        ok.is_valid(),
+        "a zero-height capsule is a circle, not an error"
+    );
+
+    assert!(
+        !Shape::Capsule {
+            radius: Fixed::from_int(-1),
+            half_height: Fixed::from_int(1),
+        }
+        .is_valid()
+    );
+    assert!(
+        !Shape::Capsule {
+            radius: Fixed::from_int(1),
+            half_height: Fixed::from_int(-1),
+        }
+        .is_valid()
+    );
+}
+
+/// Operands that are not a shape are refused at the door, rather than stored
+/// and discovered by whatever tries to sweep against them.
+#[test]
+fn a_shape_with_negative_operands_is_refused() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Static, Transform::IDENTITY)
+        .expect("fresh");
+
+    assert!(
+        world
+            .add_shape(body, circle(-1), at(0, 0), Filter::ALL)
+            .is_none()
+    );
+    assert_eq!(world.shape_extent(body), Some(0), "and nothing was stored");
+}
+
+/// Replacing keeps the index — which is the point, since the index is identity
+/// — and advances the incarnation, since the collider is not the one it was.
+#[test]
+fn replacing_a_shape_keeps_its_index_and_changes_its_incarnation() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+    let collider = Collider { handle, index };
+    let before = world.incarnation(collider).expect("occupied");
+
+    assert!(world.replace_shape(handle, index, circle(7), at(2, 2)));
+    let (shape, local, _) = world.shape(collider).expect("still occupied");
+    assert_eq!(shape, circle(7));
+    assert_eq!(local.translation.x.trunc_int(), 2);
+    let after = world.incarnation(collider).expect("occupied");
+    assert_ne!(after, before);
+    assert_ne!(after.get(), before.get(), "and the raw counts differ too");
+
+    // Refusals: a hole, an index past the end, an invalid shape, a dead body.
+    assert!(!world.replace_shape(handle, index, circle(-1), at(0, 0)));
+    assert!(!world.replace_shape(handle, ShapeIndex::from_raw(9), circle(1), at(0, 0)));
+    assert!(world.remove_shape(handle, index));
+    assert!(
+        !world.replace_shape(handle, index, circle(1), at(0, 0)),
+        "a hole is not a shape to replace"
+    );
+}
+
+/// A filter change does not advance the incarnation: the collider is the same
+/// one it was, so a contact that persists across the change is a persisting
+/// contact rather than a new one.
+#[test]
+fn changing_a_filter_does_not_change_the_collider() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+    let collider = Collider { handle, index };
+    let before = world.incarnation(collider).expect("occupied");
+
+    assert!(world.set_filter(handle, index, Filter::NONE));
+    let (_, _, filter) = world.shape(collider).expect("occupied");
+    assert_eq!(filter, Filter::NONE);
+    assert_eq!(
+        world.incarnation(collider).expect("occupied"),
+        before,
+        "a filter change is not a rebuild"
+    );
+
+    // Refusals: a hole, and an index past the end.
+    assert!(!world.set_filter(handle, ShapeIndex::from_raw(9), Filter::ALL));
+    assert!(world.remove_shape(handle, index));
+    assert!(!world.set_filter(handle, index, Filter::ALL));
+}
+
+/// Destroying takes the body's shapes with it, and the handle stops answering.
+#[test]
+fn destroying_a_body_takes_its_shapes_and_stops_answering() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, at(1, 2));
+    let index = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+
+    assert_eq!(world.kind(handle), Some(BodyKind::Kinematic));
+    assert!(world.destroy_body(handle));
+    assert_eq!(world.body_count(), 0);
+    assert_eq!(world.handle_state(handle), HandleState::Unknown);
+    assert!(world.kind(handle).is_none());
+    assert!(world.transform(handle).is_none());
+    assert!(world.shape(Collider { handle, index }).is_none());
+    assert!(world.world_transform(Collider { handle, index }).is_none());
+    assert!(world.shape_extent(handle).is_none());
+    assert_eq!(world.colliders().count(), 0);
+
+    // And destroying twice is a no-op rather than an error, because two
+    // systems both deciding something should go is ordinary.
+    assert!(!world.destroy_body(handle));
+}
+
+/// Every operation refuses a handle this world has never seen, rather than
+/// panicking or growing storage for it.
+#[test]
+fn an_unknown_handle_is_refused_by_every_operation() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let stranger = entities.spawn();
+
+    assert_eq!(world.handle_state(stranger), HandleState::Unknown);
+    assert!(!world.destroy_body(stranger));
+    assert!(!world.set_transform(stranger, at(1, 1)));
+    assert!(
+        world
+            .add_shape(stranger, circle(1), at(0, 0), Filter::ALL)
+            .is_none()
+    );
+    assert!(!world.remove_shape(stranger, ShapeIndex::from_raw(0)));
+    assert!(!world.replace_shape(stranger, ShapeIndex::from_raw(0), circle(1), at(0, 0)));
+    assert!(!world.set_filter(stranger, ShapeIndex::from_raw(0), Filter::ALL));
+    assert!(world.kind(stranger).is_none());
+    assert!(world.shape_extent(stranger).is_none());
+    assert!(
+        world
+            .incarnation(Collider {
+                handle: stranger,
+                index: ShapeIndex::from_raw(0)
+            })
+            .is_none()
+    );
+}
+
+/// Removing something that is not there is a no-op rather than an error, and
+/// removing past the end does not grow the list.
+#[test]
+fn removing_nothing_is_a_no_op() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Static, Transform::IDENTITY);
+
+    assert!(!world.remove_shape(handle, ShapeIndex::from_raw(0)));
+    assert!(!world.remove_shape(handle, ShapeIndex::from_raw(4096)));
+    assert_eq!(world.shape_extent(handle), Some(0));
+
+    let index = world
+        .add_shape(handle, circle(1), at(0, 0), Filter::ALL)
+        .expect("live");
+    assert!(world.remove_shape(handle, index));
+    assert!(!world.remove_shape(handle, index), "twice is a no-op");
+}
+
+/// Bodies are stored by entity index, and creating one at a high index must not
+/// disturb the ones below it or invent bodies in the gap.
+#[test]
+fn a_sparse_index_space_does_not_invent_bodies() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+
+    // Burn some indices so the third entity is not adjacent to the first.
+    let first = entities.spawn();
+    for _ in 0..5 {
+        let _ = entities.spawn();
+    }
+    let distant = entities.spawn();
+    assert!(distant.index() > first.index() + 1);
+
+    world.create_body(first, BodyKind::Static, Transform::IDENTITY);
+    world.create_body(distant, BodyKind::Static, Transform::IDENTITY);
+    world.add_shape(first, circle(1), at(0, 0), Filter::ALL);
+    world.add_shape(distant, circle(1), at(0, 0), Filter::ALL);
+
+    assert_eq!(world.body_count(), 2);
+    let seen: Vec<_> = world.colliders().collect();
+    assert_eq!(seen.len(), 2, "the gap contributed nothing");
+    assert!(seen[0] < seen[1], "and they came out in index order");
+}


### PR DESCRIPTION
feat(physics2d): the collider set, and the identities everything else keys on

Bodies, shapes, filters and the operations that change them. No
broadphase, no narrowphase, no queries yet - this is the part that
cannot be repaired later, because every contact report downstream is
keyed on the identities established here.

A shape index is stable for the life of its body. Removing a shape
leaves a hole and the next one fills the lowest free hole, so no shape
that nobody touched is ever renumbered. The tempting implementation is
the dense-array one that swaps the last element into the gap; it moves a
collider that was not part of the operation, and silently re-keys its
contacts. Two property tests hold the line: collider order stays
strictly ascending under any add-and-remove history, and it does not
depend on the order the world was built in.

A handle is an entity stored whole rather than as parts. The entity
constructor is crate-private to the storage layer, so this crate can
neither mint a handle nor rebuild one - which means body identity is
saved state and not something derivable. That was found by the compiler
about four minutes after the first draft assumed otherwise.

The world stores each body's generation, which is the entire staleness
mechanism: physics never sees the allocator, so a slot the allocator has
recycled is only detectable by having kept the generation the body was
created against. A recycled index is refused rather than answered, in
every profile. A handle from a different world is not detectable at all
- two allocators hand out identical handles by construction, both
starting at index zero generation zero - so it is a caller warrant and
there is no assertion pretending otherwise.

Incarnation counters advance when a collider is rebuilt at an identity
it already used. Without them a shape removed and re-added takes its
index back, a body destroyed and recreated against a live entity takes
its handle back, and a contact identifier derived from the pair would be
bit-identical to the one it replaced - so a one-shot impact sound would
not fire for a body that was destroyed and rebuilt.

Filters are per shape rather than per body, because a body owns several
and a one-way platform needs its top and its volume to filter
differently. The pair rule is symmetric so eligibility cannot depend on
which side the broadphase visited first. The query rule is deliberately
one-sided: a query has no layer, and consulting the shape's own mask
would make a trigger configured to collide with nothing invisible to a
ray, which is most of what rays are for.

The removability lane names the new crate in three places, and the
fixed-point cell's own comment predicted this: it said the first crate
to depend on it should discover the obligation from a red lane rather
than from nobody. It did.
