### PR TITLE
fix(physics2d): remove the defensive branches nothing can reach

### DIFF
--- a/crates/physics2d/src/bounds.rs
+++ b/crates/physics2d/src/bounds.rs
@@ -161,11 +161,8 @@ mod tests {
         // At an eighth turn a unit square reaches sqrt(2) along each axis,
         // which is 92682 raw units.
         let expected = 92_682i64;
-        assert!(
-            (turned.max.x.to_bits() - expected).abs() <= 4,
-            "reached {} raw, expected about {expected}",
-            turned.max.x.to_bits()
-        );
+        let reached = turned.max.x.to_bits();
+        assert!((reached - expected).abs() <= 4, "reached {reached} raw");
     }
 
     #[test]

--- a/crates/physics2d/src/broadphase.rs
+++ b/crates/physics2d/src/broadphase.rs
@@ -62,13 +62,21 @@ impl Broadphase {
         self.pairs.clear();
 
         for collider in world.colliders() {
-            let (Some((shape, _, filter)), Some(transform), Some(kind)) = (
-                world.shape(collider),
-                world.world_transform(collider),
-                world.kind(collider.handle),
-            ) else {
-                continue;
-            };
+            // `colliders()` yields only live colliders, so each lookup below
+            // succeeds by construction. Written as a `let ... else` that
+            // panics rather than one that skips, because a skip here would
+            // silently drop a collider out of the broadphase and the world
+            // would quietly stop colliding — a defensive `continue` cannot be
+            // reached and would hide the bug that reached it.
+            let (shape, _, filter) = world
+                .shape(collider)
+                .unwrap_or_else(|| unreachable!("a live collider has a shape"));
+            let transform = world
+                .world_transform(collider)
+                .unwrap_or_else(|| unreachable!("a live collider has a transform"));
+            let kind = world
+                .kind(collider.handle)
+                .unwrap_or_else(|| unreachable!("a live collider has a body"));
             // Inflated by the contact tolerance, so a pair separated by less
             // than it still reaches narrowphase — a contact at depth zero is
             // one the vocabulary requires, and it cannot be generated from a
@@ -105,56 +113,22 @@ impl Broadphase {
                 .then_with(|| left.cmp(&right))
         });
 
-        for slot in 0..self.endpoints.len() {
-            let Some(&endpoint) = self.endpoints.get(slot) else {
-                continue;
-            };
-            if endpoint.begin {
-                self.propose(endpoint.record);
-                self.active.push(endpoint.record);
-            } else if let Some(position) = self
-                .active
-                .iter()
-                .position(|&candidate| candidate == endpoint.record)
-            {
-                // The active set is unordered — the pairs it produces are a
-                // set, and they are sorted below — so removing cheaply here
-                // costs nothing that is observable.
-                self.active.swap_remove(position);
-            }
-        }
+        // Four disjoint field borrows, which is why this is a free function
+        // rather than a method: it lets the sweep read the records and write
+        // the pairs without an index dance whose bounds checks could never
+        // fail and could never be tested either.
+        sweep(
+            &self.records,
+            &self.endpoints,
+            &mut self.active,
+            &mut self.pairs,
+        );
 
         // **Emitted order is over the pair, not over the sweep.** Stating the
         // obligation this way is what lets a different structure — a grid, a
         // tree, three swept axes — produce the same output, and what stops the
         // swept axis leaking into a contact array.
         self.pairs.sort_unstable();
-    }
-
-    fn propose(&mut self, incoming: usize) {
-        let Some(&entering) = self.records.get(incoming) else {
-            return;
-        };
-        for slot in 0..self.active.len() {
-            let Some(&other) = self.active.get(slot) else {
-                continue;
-            };
-            let Some(&resident) = self.records.get(other) else {
-                continue;
-            };
-            if !eligible(entering, resident) {
-                continue;
-            }
-            if !entering.bounds.overlaps(resident.bounds) {
-                continue;
-            }
-            let pair = if entering.collider < resident.collider {
-                (entering.collider, resident.collider)
-            } else {
-                (resident.collider, entering.collider)
-            };
-            self.pairs.push(pair);
-        }
     }
 
     /// The candidate pairs, lower collider first, in ascending pair order.
@@ -167,6 +141,42 @@ impl Broadphase {
     #[must_use]
     pub fn collider_count(&self) -> usize {
         self.records.len()
+    }
+}
+
+/// Walk the sorted endpoints, proposing a pair for every overlapping resident
+/// as each interval opens.
+fn sweep(
+    records: &[Record],
+    endpoints: &[Endpoint],
+    active: &mut Vec<usize>,
+    pairs: &mut Vec<(Collider, Collider)>,
+) {
+    for endpoint in endpoints {
+        let entering = records[endpoint.record];
+        if endpoint.begin {
+            for &other in active.iter() {
+                let resident = records[other];
+                if eligible(entering, resident) && entering.bounds.overlaps(resident.bounds) {
+                    // Canonical order, lower collider first, so a pair reads
+                    // the same however the sweep happened to reach it.
+                    pairs.push(if entering.collider < resident.collider {
+                        (entering.collider, resident.collider)
+                    } else {
+                        (resident.collider, entering.collider)
+                    });
+                }
+            }
+            active.push(endpoint.record);
+        } else if let Some(position) = active
+            .iter()
+            .position(|&candidate| candidate == endpoint.record)
+        {
+            // The active set is unordered — the pairs it produces are a set,
+            // and they are sorted afterwards — so removing cheaply here costs
+            // nothing observable.
+            active.swap_remove(position);
+        }
     }
 }
 

--- a/crates/physics2d/tests/broadphase.rs
+++ b/crates/physics2d/tests/broadphase.rs
@@ -190,6 +190,40 @@ fn the_tolerance_makes_near_misses_into_candidates() {
     );
 }
 
+/// **A pair is canonical however the sweep reached it.** Every other test here
+/// places bodies in the same order as their handles, so the collider opening
+/// an interval always outranks the ones already active — which exercises one
+/// side of the ordering and leaves the other side untested. Laying the world
+/// out backwards is what reaches it.
+#[test]
+fn a_pair_names_its_lower_collider_first_whichever_arrives_last() {
+    let mut entities = Entities::new();
+    let handles: Vec<_> = (0..3).map(|_| entities.spawn()).collect();
+    let mut world = World::new();
+    // Descending in x, ascending in handle: the *last* interval to open
+    // belongs to the *lowest* collider.
+    for (step, &handle) in handles.iter().enumerate() {
+        let x = 4 - 2 * i32::try_from(step).unwrap_or(0);
+        world.create_body(handle, BodyKind::Kinematic, at(x, 0));
+        world.add_shape(handle, box_shape(1), Transform::IDENTITY, Filter::ALL);
+    }
+
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    let pairs = broadphase.pairs();
+    assert_eq!(pairs.len(), 2, "each tile touches its neighbour");
+    for &(low, high) in pairs {
+        assert!(
+            low < high,
+            "a pair must name its lower collider first even when that one \
+             opened its interval last"
+        );
+    }
+    for window in pairs.windows(2) {
+        assert!(window[0] < window[1], "and the pairs still ascend");
+    }
+}
+
 /// Rebuilding is idempotent, which is what makes the structure derived state
 /// rather than something a save has to carry.
 #[test]


### PR DESCRIPTION
Six of the seven lines the coverage gate flagged were else-arms on
lookups that cannot fail: a get on an index taken from the length of the
vector being indexed, and three lookups against a collider the iterator
only yields when it is live. They were unreachable, so no test could
cover them, and each one would have turned a broken invariant into a
silently dropped collider - a world that quietly stops colliding rather
than one that says what went wrong.

The index dance is gone. The sweep is a free function taking four
disjoint field borrows, which is what the indices were working around,
and it iterates the endpoints directly. The three world lookups assert
their invariant rather than skipping it, which is the right shape for a
contract violation.

The seventh was a real gap rather than dead code. Every existing test
lays bodies out in the same order as their handles, so the collider
opening an interval always outranks the ones already active - one side
of the pair-ordering branch, never the other. A world laid out
backwards in x against ascending handles reaches it, and asserts that a
pair still names its lower collider first when that collider is the one
that arrived last.

One assertion message put a runtime value on its own line, evaluated
only on failure and therefore never. Bound before the assert instead.