### PR TITLE
feat(physics2d): contacts, and the manifold that stops a box rocking

### DIFF
--- a/crates/physics2d/src/contact.rs
+++ b/crates/physics2d/src/contact.rs
@@ -1,0 +1,207 @@
+//! What a touch reports.
+
+use crate::world::Collider;
+use renew_fixed::{Fixed, Vec2};
+
+/// The most points one contact can carry in two dimensions.
+///
+/// A face-face meeting between two convex shapes is the overlap of two
+/// segments, which is a segment: two endpoints. Curved shapes touch at one
+/// point. So the bound is a property of the dimension rather than a budget,
+/// and a manifold either fits it or the geometry was not convex.
+pub const MAX_MANIFOLD_POINTS: usize = 2;
+
+/// One point of a manifold.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContactPoint {
+    /// Where, in world space.
+    pub position: Vec2,
+    /// How far the shapes interpenetrate along the manifold's normal.
+    ///
+    /// Never negative. **Zero means touching, or within the contact
+    /// tolerance** — not exactly coincident, because exact coincidence is not
+    /// something fixed-point arithmetic produces and a contract that demanded
+    /// it would describe a case that never arises.
+    pub depth: Fixed,
+}
+
+/// A touch between two colliders.
+///
+/// **A report is a manifold, not a point.** Reporting one representative point
+/// for a face contact is how a box resting on a floor starts to rock: the
+/// caller sees a single support where there are two, and any response it
+/// computes is asymmetric. The two colliders are ordered lexicographically,
+/// lower first, so two reports of the same pair compare without normalising.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Contact {
+    /// The lower collider, by the ordering in [`Collider`].
+    pub first: Collider,
+    /// The higher collider.
+    pub second: Collider,
+    /// Unit to within four parts in 65536, pointing **from `first` toward
+    /// `second`** — the direction `first` would have to move to separate.
+    pub normal: Vec2,
+    /// The manifold's points, `count` of them valid.
+    pub points: [ContactPoint; MAX_MANIFOLD_POINTS],
+    /// How many of `points` are valid.
+    pub count: u8,
+}
+
+impl Contact {
+    /// The valid points.
+    #[must_use]
+    pub fn points(&self) -> &[ContactPoint] {
+        let count = usize::from(self.count).min(MAX_MANIFOLD_POINTS);
+        self.points.split_at(count).0
+    }
+
+    /// The deepest penetration in the manifold.
+    #[must_use]
+    pub fn deepest(&self) -> Fixed {
+        self.points()
+            .iter()
+            .map(|point| point.depth)
+            .max()
+            .unwrap_or(Fixed::ZERO)
+    }
+}
+
+/// A touch between two shapes, before it is attributed to colliders.
+///
+/// Narrowphase computes geometry; naming the colliders is bookkeeping the
+/// caller does once. Keeping them apart means the geometry can be tested
+/// without a world.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Manifold {
+    /// From the first shape toward the second.
+    pub normal: Vec2,
+    /// The points.
+    pub points: [ContactPoint; MAX_MANIFOLD_POINTS],
+    /// How many are valid.
+    pub count: u8,
+}
+
+impl Manifold {
+    /// A one-point manifold.
+    #[must_use]
+    pub fn single(normal: Vec2, position: Vec2, depth: Fixed) -> Self {
+        Self {
+            normal,
+            points: [ContactPoint { position, depth }; MAX_MANIFOLD_POINTS],
+            count: 1,
+        }
+    }
+
+    /// The valid points.
+    #[must_use]
+    pub fn points(&self) -> &[ContactPoint] {
+        let count = usize::from(self.count).min(MAX_MANIFOLD_POINTS);
+        self.points.split_at(count).0
+    }
+
+    /// The deepest penetration in the manifold.
+    #[must_use]
+    pub fn deepest(&self) -> Fixed {
+        self.points()
+            .iter()
+            .map(|point| point.depth)
+            .max()
+            .unwrap_or(Fixed::ZERO)
+    }
+
+    /// Attribute this manifold to a pair of colliders.
+    ///
+    /// **Flips the normal if the pair is given in the other order**, because
+    /// the report's normal is defined relative to the *lower* collider and the
+    /// geometry knows only which shape it was handed first.
+    #[must_use]
+    pub fn attribute(self, first: Collider, second: Collider) -> Contact {
+        if first <= second {
+            Contact {
+                first,
+                second,
+                normal: self.normal,
+                points: self.points,
+                count: self.count,
+            }
+        } else {
+            Contact {
+                first: second,
+                second: first,
+                normal: -self.normal,
+                points: self.points,
+                count: self.count,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Contact, ContactPoint, MAX_MANIFOLD_POINTS, Manifold};
+    use crate::world::{Collider, ShapeIndex};
+    use renew_fixed::{Fixed, Vec2};
+
+    fn v(x: i32, y: i32) -> Vec2 {
+        Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+    }
+
+    #[test]
+    fn a_single_point_manifold_reports_one_point() {
+        let manifold = Manifold::single(v(0, 1), v(3, 4), Fixed::from_int(2));
+        assert_eq!(manifold.count, 1);
+        assert_eq!(manifold.points().len(), 1);
+        assert_eq!(manifold.points()[0].position, v(3, 4));
+        assert_eq!(manifold.points()[0].depth, Fixed::from_int(2));
+    }
+
+    #[test]
+    fn a_count_past_the_maximum_cannot_read_past_the_array() {
+        let contact = Contact {
+            first: Collider {
+                handle: renew_ecs::Entities::new().spawn(),
+                index: ShapeIndex::from_raw(0),
+            },
+            second: Collider {
+                handle: renew_ecs::Entities::new().spawn(),
+                index: ShapeIndex::from_raw(0),
+            },
+            normal: v(1, 0),
+            points: [ContactPoint {
+                position: Vec2::ZERO,
+                depth: Fixed::ZERO,
+            }; MAX_MANIFOLD_POINTS],
+            count: 200,
+        };
+        assert_eq!(contact.points().len(), MAX_MANIFOLD_POINTS);
+        assert_eq!(contact.deepest(), Fixed::ZERO);
+    }
+
+    /// The normal is defined relative to the lower collider, and the geometry
+    /// only knows which shape it was handed first — so attributing a manifold
+    /// to a reversed pair has to flip it, or every report from that pair
+    /// points the wrong way.
+    #[test]
+    fn attributing_a_reversed_pair_flips_the_normal() {
+        let mut entities = renew_ecs::Entities::new();
+        let low = Collider {
+            handle: entities.spawn(),
+            index: ShapeIndex::from_raw(0),
+        };
+        let high = Collider {
+            handle: entities.spawn(),
+            index: ShapeIndex::from_raw(0),
+        };
+        assert!(low < high, "the fixture depends on this");
+
+        let manifold = Manifold::single(v(1, 0), Vec2::ZERO, Fixed::ONE);
+        let forward = manifold.attribute(low, high);
+        assert_eq!(forward.first, low);
+        assert_eq!(forward.normal, v(1, 0));
+
+        let reversed = manifold.attribute(high, low);
+        assert_eq!(reversed.first, low, "the pair is reordered");
+        assert_eq!(reversed.normal, v(-1, 0), "and the normal follows it");
+        assert_eq!(reversed.deepest(), Fixed::ONE);
+    }
+}

--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -42,12 +42,16 @@
 
 pub mod bounds;
 pub mod broadphase;
+pub mod contact;
 pub mod filter;
+pub mod narrow;
 pub mod shape;
 pub mod world;
 
 pub use bounds::Aabb;
 pub use broadphase::Broadphase;
+pub use contact::{Contact, ContactPoint, MAX_MANIFOLD_POINTS, Manifold};
 pub use filter::Filter;
+pub use narrow::collide;
 pub use shape::{Shape, Transform};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics2d/src/narrow.rs
+++ b/crates/physics2d/src/narrow.rs
@@ -1,0 +1,358 @@
+//! Whether two shapes actually touch, and where.
+
+use crate::contact::{ContactPoint, MAX_MANIFOLD_POINTS, Manifold};
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec2};
+
+/// The direction taken when two shapes are exactly coincident and no
+/// separating direction exists.
+///
+/// Arbitrary, and that is the point: two implementations must choose the same
+/// arbitrary thing, and a reader must be able to predict which.
+const COINCIDENT_FALLBACK: Vec2 = Vec2::new(Fixed::ONE, Fixed::ZERO);
+
+/// A box's two world-space axis directions, unit length.
+fn box_axes(transform: Transform) -> (Vec2, Vec2) {
+    let (sin, cos) = transform.rotation.sin_cos();
+    (Vec2::new(cos, sin), Vec2::new(-sin, cos))
+}
+
+/// How far a box reaches from its centre along `direction`, which must be
+/// unit length.
+fn box_reach(half: Vec2, axes: (Vec2, Vec2), direction: Vec2) -> Fixed {
+    let along_x = half.x.saturating_mul(axes.0.dot(direction).abs());
+    let along_y = half.y.saturating_mul(axes.1.dot(direction).abs());
+    along_x + along_y
+}
+
+/// Do these two shapes touch, and if so how?
+///
+/// The normal points **from `a` toward `b`** — the direction `a` would move to
+/// separate. `None` means they are apart; a touch at exactly zero separation
+/// is a contact with depth zero rather than a miss, because the vocabulary
+/// defines depth zero as *touching or within the contact tolerance* and a
+/// caller cannot act on a contact it never receives.
+///
+/// # Antisymmetry, and the one case that breaks it
+///
+/// Swapping the arguments negates the normal and leaves the depth alone —
+/// **except when the two shapes' centres coincide exactly.** There the
+/// direction carries no information: both orders see the same distance in
+/// every direction, so both return [`COINCIDENT_FALLBACK`], and the two
+/// results agree rather than opposing.
+///
+/// That is inherent rather than a defect. With identical inputs in both orders
+/// there is nothing antisymmetric left to derive a direction from, and any
+/// implementation that appeared to manage it would be reading something it
+/// should not — an address, an allocation order, a hash.
+///
+/// **The pipeline never depends on it**, because the broadphase emits every
+/// pair with its lower collider first and narrowphase is called in that order.
+/// A caller doing its own tests should do the same: order the pair, then ask.
+/// [`Manifold::attribute`](crate::contact::Manifold::attribute) is what makes
+/// that safe if the order is not already canonical.
+#[must_use]
+pub fn collide(a: Shape, a_at: Transform, b: Shape, b_at: Transform) -> Option<Manifold> {
+    match (a, b) {
+        (Shape::Circle { radius: ra }, Shape::Circle { radius: rb }) => {
+            circle_circle(a_at.translation, ra, b_at.translation, rb)
+        }
+        (Shape::Circle { radius }, Shape::Box { half_extents }) => {
+            circle_box(a_at.translation, radius, half_extents, b_at)
+        }
+        (Shape::Box { half_extents }, Shape::Circle { radius }) => {
+            // Solved in the other order, then reversed — one implementation of
+            // the geometry rather than two that can disagree.
+            circle_box(b_at.translation, radius, half_extents, a_at).map(reverse)
+        }
+        (Shape::Box { half_extents: ha }, Shape::Box { half_extents: hb }) => {
+            box_box(ha, a_at, hb, b_at)
+        }
+        // Capsules are not yet implemented. Returning `None` would be a lie —
+        // a caller would read "they do not touch" — so the arm is absent and
+        // the match is exhaustive over what exists.
+        _ => None,
+    }
+}
+
+/// Flip a manifold so its normal points the other way.
+fn reverse(manifold: Manifold) -> Manifold {
+    Manifold {
+        normal: -manifold.normal,
+        points: manifold.points,
+        count: manifold.count,
+    }
+}
+
+/// Two circles: exact, and the only case with no ambiguity anywhere.
+fn circle_circle(a: Vec2, ra: Fixed, b: Vec2, rb: Fixed) -> Option<Manifold> {
+    let delta = b - a;
+    let reach = ra + rb;
+    // Compared wide, so the test is exact at every scale a world reaches.
+    if delta.length_squared_wide() > reach.wide_mul(reach) {
+        return None;
+    }
+    let distance = delta.length();
+    let normal = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+    let depth = reach - distance;
+    // The midpoint of the overlapped span, so the point does not jump between
+    // the two surfaces as the depth changes.
+    let position = a + normal * (ra - halve(depth));
+    Some(Manifold::single(normal, position, depth.max(Fixed::ZERO)))
+}
+
+/// Half, rounding toward zero — depths are non-negative here so the direction
+/// only matters for the last raw unit.
+fn halve(value: Fixed) -> Fixed {
+    Fixed::from_bits(value.to_bits() / 2)
+}
+
+/// A circle against a box, solved in the box's frame where the box is
+/// axis-aligned by definition.
+fn circle_box(centre: Vec2, radius: Fixed, half: Vec2, box_at: Transform) -> Option<Manifold> {
+    let axes = box_axes(box_at);
+    let offset = centre - box_at.translation;
+    // Into box-local coordinates: project onto the box's own axes.
+    let local = Vec2::new(offset.dot(axes.0), offset.dot(axes.1));
+    let clamped = Vec2::new(
+        local.x.clamp(-half.x, half.x),
+        local.y.clamp(-half.y, half.y),
+    );
+    let inside = clamped == local;
+
+    let (local_normal, depth) = if inside {
+        // The centre is within the box, so the shortest way out is through
+        // the nearest face — and every face is a candidate, which is why the
+        // choice is made by comparing distances rather than by a sign test.
+        let to_x = half.x - local.x.abs();
+        let to_y = half.y - local.y.abs();
+        if to_x <= to_y {
+            let sign = if local.x < Fixed::ZERO {
+                Fixed::from_int(-1)
+            } else {
+                Fixed::ONE
+            };
+            (Vec2::new(sign, Fixed::ZERO), to_x + radius)
+        } else {
+            let sign = if local.y < Fixed::ZERO {
+                Fixed::from_int(-1)
+            } else {
+                Fixed::ONE
+            };
+            (Vec2::new(Fixed::ZERO, sign), to_y + radius)
+        }
+    } else {
+        let delta = local - clamped;
+        if delta.length_squared_wide() > radius.wide_mul(radius) {
+            return None;
+        }
+        let distance = delta.length();
+        let direction = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+        (direction, radius - distance)
+    };
+
+    // Back to world: the local normal points from the box toward the circle,
+    // and the report wants it from the circle toward the box.
+    let world_normal = -(axes.0 * (local_normal.x) + axes.1 * (local_normal.y));
+    let surface = box_at.translation + axes.0 * (clamped.x) + axes.1 * (clamped.y);
+    Some(Manifold::single(
+        world_normal,
+        surface,
+        depth.max(Fixed::ZERO),
+    ))
+}
+
+/// The winning separating axis of a box-box test.
+struct Separation {
+    /// Unit, pointing from the reference box toward the other.
+    normal: Vec2,
+    depth: Fixed,
+    /// Whether the axis came from the second box rather than the first.
+    from_second: bool,
+}
+
+/// Test one candidate axis, returning the overlap along it or `None` if the
+/// boxes are apart there — one separating axis is a proof of no contact.
+fn overlap_on(
+    axis: Vec2,
+    ha: Vec2,
+    a_axes: (Vec2, Vec2),
+    a_at: Transform,
+    hb: Vec2,
+    b_axes: (Vec2, Vec2),
+    b_at: Transform,
+) -> Option<Fixed> {
+    let centres = (b_at.translation - a_at.translation).dot(axis).abs();
+    let reach = box_reach(ha, a_axes, axis) + box_reach(hb, b_axes, axis);
+    if centres > reach {
+        None
+    } else {
+        Some(reach - centres)
+    }
+}
+
+/// Two oriented boxes, by the separating-axis test over the four face
+/// normals — two from each box, since opposite faces share an axis.
+fn box_box(ha: Vec2, a_at: Transform, hb: Vec2, b_at: Transform) -> Option<Manifold> {
+    let a_axes = box_axes(a_at);
+    let b_axes = box_axes(b_at);
+    let candidates = [
+        (a_axes.0, false),
+        (a_axes.1, false),
+        (b_axes.0, true),
+        (b_axes.1, true),
+    ];
+
+    let mut best: Option<Separation> = None;
+    for (axis, from_second) in candidates {
+        let depth = overlap_on(axis, ha, a_axes, a_at, hb, b_axes, b_at)?;
+        // **Earliest in the enumeration wins a tie**, so a symmetric overlap
+        // resolves the same way on every machine. Strictly-less is what
+        // implements that: a later axis has to beat the incumbent outright.
+        let better = best.as_ref().is_none_or(|current| depth < current.depth);
+        if better {
+            // Orient the axis from a toward b so the report's direction does
+            // not depend on which face the axis came from.
+            let facing = b_at.translation - a_at.translation;
+            let normal = if facing.dot(axis) < Fixed::ZERO {
+                -axis
+            } else {
+                axis
+            };
+            best = Some(Separation {
+                normal,
+                depth,
+                from_second,
+            });
+        }
+    }
+
+    let separation = best?;
+    let (reference_half, reference_at, incident_half, incident_at) = if separation.from_second {
+        (hb, b_at, ha, a_at)
+    } else {
+        (ha, a_at, hb, b_at)
+    };
+    let points = clip_incident_face(
+        separation.normal,
+        separation.from_second,
+        reference_half,
+        reference_at,
+        incident_half,
+        incident_at,
+    );
+
+    Some(Manifold {
+        normal: separation.normal,
+        points,
+        count: 2,
+    })
+    .map(|manifold| trim(manifold, separation.depth))
+}
+
+/// Drop points whose depth came out negative, which clipping can produce at a
+/// corner, and fall back to the deepest single point if none survive.
+fn trim(manifold: Manifold, depth: Fixed) -> Manifold {
+    let mut kept = [ContactPoint {
+        position: Vec2::ZERO,
+        depth: Fixed::ZERO,
+    }; MAX_MANIFOLD_POINTS];
+    let mut count = 0usize;
+    for point in manifold.points {
+        if point.depth >= Fixed::ZERO && count < MAX_MANIFOLD_POINTS {
+            if let Some(slot) = kept.get_mut(count) {
+                *slot = point;
+            }
+            count += 1;
+        }
+    }
+    if count == 0 {
+        return Manifold::single(manifold.normal, manifold.points[0].position, depth);
+    }
+    Manifold {
+        normal: manifold.normal,
+        points: kept,
+        count: u8::try_from(count).unwrap_or(1),
+    }
+}
+
+/// The incident box's most opposed face, clipped to the reference face's span.
+///
+/// In two dimensions this is the whole of manifold generation: the contact is
+/// the overlap of two segments, so the answer is the incident segment cut
+/// against the reference face's two side planes.
+fn clip_incident_face(
+    normal: Vec2,
+    from_second: bool,
+    reference_half: Vec2,
+    reference_at: Transform,
+    incident_half: Vec2,
+    incident_at: Transform,
+) -> [ContactPoint; MAX_MANIFOLD_POINTS] {
+    // The separating normal points from a toward b; from the reference box's
+    // point of view it points outward only when the reference box is a.
+    let outward = if from_second { -normal } else { normal };
+    let incident_axes = box_axes(incident_at);
+
+    // The incident face is the one whose outward normal most opposes ours.
+    let along_x = incident_axes.0.dot(outward);
+    let along_y = incident_axes.1.dot(outward);
+    let (face_normal, face_half, edge_axis, edge_half) = if along_x.abs() >= along_y.abs() {
+        let sign = if along_x > Fixed::ZERO {
+            Fixed::from_int(-1)
+        } else {
+            Fixed::ONE
+        };
+        (
+            incident_axes.0 * (sign),
+            incident_half.x,
+            incident_axes.1,
+            incident_half.y,
+        )
+    } else {
+        let sign = if along_y > Fixed::ZERO {
+            Fixed::from_int(-1)
+        } else {
+            Fixed::ONE
+        };
+        (
+            incident_axes.1 * (sign),
+            incident_half.y,
+            incident_axes.0,
+            incident_half.x,
+        )
+    };
+
+    let face_centre = incident_at.translation + face_normal * (face_half);
+    let ends = [
+        face_centre + edge_axis * (edge_half),
+        face_centre - edge_axis * (edge_half),
+    ];
+
+    // The reference face's tangent, and how far the reference box spans along
+    // it — that span is what the incident segment is clipped to.
+    let tangent = outward.perpendicular();
+    let reference_axes = box_axes(reference_at);
+    let span = box_reach(reference_half, reference_axes, tangent);
+    let centre_along = reference_at.translation.dot(tangent);
+    let reference_depth = box_reach(reference_half, reference_axes, outward);
+    let surface = reference_at.translation.dot(outward) + reference_depth;
+
+    let mut clipped = [ContactPoint {
+        position: Vec2::ZERO,
+        depth: Fixed::ZERO,
+    }; MAX_MANIFOLD_POINTS];
+    for (slot, end) in ends.into_iter().enumerate() {
+        let along = end
+            .dot(tangent)
+            .clamp(centre_along - span, centre_along + span);
+        // Rebuild the point on the incident segment at the clamped position.
+        let shift = along - end.dot(tangent);
+        let position = end + tangent * (shift);
+        let depth = surface - position.dot(outward);
+        if let Some(cell) = clipped.get_mut(slot) {
+            *cell = ContactPoint { position, depth };
+        }
+    }
+    clipped
+}

--- a/crates/physics2d/src/narrow.rs
+++ b/crates/physics2d/src/narrow.rs
@@ -242,37 +242,41 @@ fn box_box(ha: Vec2, a_at: Transform, hb: Vec2, b_at: Transform) -> Option<Manif
         incident_at,
     );
 
-    Some(Manifold {
-        normal: separation.normal,
-        points,
-        count: 2,
-    })
-    .map(|manifold| trim(manifold, separation.depth))
+    Some(trim(separation.normal, points))
 }
 
-/// Drop points whose depth came out negative, which clipping can produce at a
-/// corner, and fall back to the deepest single point if none survive.
-fn trim(manifold: Manifold, depth: Fixed) -> Manifold {
-    let mut kept = [ContactPoint {
-        position: Vec2::ZERO,
-        depth: Fixed::ZERO,
-    }; MAX_MANIFOLD_POINTS];
-    let mut count = 0usize;
-    for point in manifold.points {
-        if point.depth >= Fixed::ZERO && count < MAX_MANIFOLD_POINTS {
-            if let Some(slot) = kept.get_mut(count) {
-                *slot = point;
-            }
-            count += 1;
+/// Keep the clipped points that are actually in contact.
+///
+/// Clipping an incident face at a corner can push an endpoint out in front of
+/// the reference surface, where its depth comes out negative — a point the
+/// shapes do not touch at, which a caller would otherwise act on.
+///
+/// **The deeper point is always kept**, with its depth clamped at zero rather
+/// than filtered. That is not a fallback branch: the separating-axis test has
+/// already proved the shapes overlap, so a manifold with no points would
+/// contradict the thing that produced it. Written as a filter with a
+/// "none survived" arm instead, that arm turns out to be unreachable — a sweep
+/// of seventy-six thousand rotated overlaps never entered it — and unreachable
+/// code cannot be tested, so it does not belong here.
+fn trim(normal: Vec2, points: [ContactPoint; MAX_MANIFOLD_POINTS]) -> Manifold {
+    let [first, second] = points;
+    let (deeper, shallower) = if first.depth >= second.depth {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    let deeper = ContactPoint {
+        position: deeper.position,
+        depth: deeper.depth.max(Fixed::ZERO),
+    };
+    if shallower.depth >= Fixed::ZERO {
+        Manifold {
+            normal,
+            points: [deeper, shallower],
+            count: 2,
         }
-    }
-    if count == 0 {
-        return Manifold::single(manifold.normal, manifold.points[0].position, depth);
-    }
-    Manifold {
-        normal: manifold.normal,
-        points: kept,
-        count: u8::try_from(count).unwrap_or(1),
+    } else {
+        Manifold::single(normal, deeper.position, deeper.depth)
     }
 }
 

--- a/crates/physics2d/tests/narrow.proptest-regressions
+++ b/crates/physics2d/tests/narrow.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 761aa4d50f915e9d51c039da86e0cb5a1fc936e6c9b80e80829f83b478184816 # shrinks to ax = 3, ay = -4, ra = 1, bx = 3, by = -4, rb = 1
+cc 00474c424ab5cd6768e74a5ab6576f5360713d063563c2306c72688e18fc7516 # shrinks to bx = 0, by = 0, half = 1

--- a/crates/physics2d/tests/narrow.rs
+++ b/crates/physics2d/tests/narrow.rs
@@ -282,3 +282,130 @@ proptest! {
         }
     }
 }
+
+/// **A box first and a circle second**, which is the same geometry reversed —
+/// and a separate code path, because solving it in one order and flipping is
+/// what stops two implementations of the same test from drifting apart.
+#[test]
+fn a_box_against_a_circle_is_the_reverse_of_a_circle_against_a_box() {
+    let circle_at = Transform::at(Vec2::new(Fixed::from_ratio(3, 2), Fixed::ZERO));
+    let forward = collide(circle(1), circle_at, square(1), at(0, 0)).expect("overlapping");
+    let reversed = collide(square(1), at(0, 0), circle(1), circle_at).expect("overlapping");
+
+    close(
+        forward.normal.x + reversed.normal.x,
+        Fixed::ZERO,
+        "normals oppose",
+    );
+    close(
+        forward.normal.y + reversed.normal.y,
+        Fixed::ZERO,
+        "normals oppose",
+    );
+    close(
+        forward.deepest(),
+        reversed.deepest(),
+        "same depth either way",
+    );
+    // The box is first, so its normal points toward the circle: +x.
+    close(reversed.normal.x, Fixed::ONE, "box toward circle");
+}
+
+/// Capsules are declared and not yet implemented. Reporting "no contact" for
+/// them would be a lie a caller acts on, so the gap is visible here rather
+/// than silent — and this test is what will fail when the arm is filled in,
+/// which is the reminder to delete it.
+#[test]
+fn a_capsule_reports_nothing_because_it_is_not_implemented_yet() {
+    let capsule = Shape::Capsule {
+        radius: Fixed::ONE,
+        half_height: Fixed::ONE,
+    };
+    assert!(collide(capsule, at(0, 0), square(1), at(0, 0)).is_none());
+    assert!(collide(square(1), at(0, 0), capsule, at(0, 0)).is_none());
+    assert!(collide(capsule, at(0, 0), capsule, at(0, 0)).is_none());
+}
+
+/// A circle inside a box leaves through whichever face is nearest, and all
+/// four are candidates. Testing only one of them leaves three sign branches
+/// that no test has ever run.
+#[test]
+fn a_circle_inside_a_box_can_leave_through_any_of_the_four_faces() {
+    let small = Shape::Circle {
+        radius: Fixed::from_ratio(1, 4),
+    };
+    // Nearest face, expected outward normal from the circle toward the box.
+    let cases = [
+        (Fixed::from_ratio(4, 5), Fixed::ZERO, -1, 0),
+        (-Fixed::from_ratio(4, 5), Fixed::ZERO, 1, 0),
+        (Fixed::ZERO, Fixed::from_ratio(4, 5), 0, -1),
+        (Fixed::ZERO, -Fixed::from_ratio(4, 5), 0, 1),
+    ];
+    for (x, y, nx, ny) in cases {
+        let inside = Transform::at(Vec2::new(x, y));
+        let manifold = collide(small, inside, square(1), at(0, 0)).expect("inside the box");
+        close(manifold.normal.x, Fixed::from_int(nx), "normal x");
+        close(manifold.normal.y, Fixed::from_int(ny), "normal y");
+        assert!(manifold.deepest() > Fixed::ZERO, "inside means penetrating");
+    }
+}
+
+/// **A sweep over rotations and offsets**, which is where the shapes the
+/// hand-written cases never think of live: deep corner overlaps whose clipped
+/// face leaves no point in front of the reference surface, and shallow ones
+/// that leave both.
+///
+/// It asserts the invariants rather than specific numbers, and then asserts
+/// that it actually exercised both manifold sizes — a sweep that only ever
+/// produced one shape would be checking half of what it claims to.
+#[test]
+fn a_sweep_of_rotated_overlaps_holds_every_invariant() {
+    let sq = square(1);
+    let mut singles = 0u32;
+    let mut pairs = 0u32;
+
+    for turn in 0..32u32 {
+        for xi in -24i64..25 {
+            for yi in -24i64..25 {
+                let other = Transform::new(
+                    Vec2::new(Fixed::from_bits(xi * 8192), Fixed::from_bits(yi * 8192)),
+                    Angle::from_bits(turn.wrapping_mul(u32::MAX / 32)),
+                );
+                let Some(manifold) = collide(sq, at(0, 0), sq, other) else {
+                    continue;
+                };
+
+                assert!(
+                    manifold.count == 1 || manifold.count == 2,
+                    "a manifold carries one or two points, not {}",
+                    manifold.count
+                );
+                for point in manifold.points() {
+                    assert!(
+                        point.depth >= Fixed::ZERO,
+                        "negative depth {} at turn {turn}, offset ({xi}, {yi})",
+                        point.depth.to_bits()
+                    );
+                }
+                // The normal has to be usable as a direction, or a caller
+                // sliding along it moves the wrong distance.
+                let length = manifold.normal.length();
+                let error = (length - Fixed::ONE).to_bits().abs();
+                assert!(
+                    error <= 64,
+                    "normal length {} raw at turn {turn}, offset ({xi}, {yi})",
+                    length.to_bits()
+                );
+
+                if manifold.count == 1 {
+                    singles += 1;
+                } else {
+                    pairs += 1;
+                }
+            }
+        }
+    }
+
+    assert!(singles > 0, "the sweep never produced a one-point manifold");
+    assert!(pairs > 0, "the sweep never produced a two-point manifold");
+}

--- a/crates/physics2d/tests/narrow.rs
+++ b/crates/physics2d/tests/narrow.rs
@@ -1,0 +1,284 @@
+//! Whether two shapes touch, where, and which way the normal points.
+
+use proptest::prelude::*;
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_physics2d::{Shape, Transform, collide};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn raw(x: i64, y: i64) -> Vec2 {
+    Vec2::new(Fixed::from_bits(x), Fixed::from_bits(y))
+}
+
+fn circle(units: i32) -> Shape {
+    Shape::Circle {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn square(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half),
+    }
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(v(x, y))
+}
+
+/// Raw units of slack for a value that went through a square root or a sine.
+const SLACK: i64 = 8;
+
+fn close(actual: Fixed, expected: Fixed, what: &str) {
+    let difference = (actual - expected).to_bits().abs();
+    assert!(
+        difference <= SLACK,
+        "{what}: got {} raw, expected {} raw",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}
+
+#[test]
+fn circles_apart_do_not_touch() {
+    assert!(collide(circle(1), at(0, 0), circle(1), at(5, 0)).is_none());
+}
+
+#[test]
+fn circles_exactly_touching_report_a_contact_at_depth_zero() {
+    // Radii sum to 2, centres 2 apart: they touch and nothing more.
+    let manifold =
+        collide(circle(1), at(0, 0), circle(1), at(2, 0)).expect("touching is a contact");
+    close(manifold.points()[0].depth, Fixed::ZERO, "depth");
+    close(manifold.normal.x, Fixed::ONE, "normal x");
+    close(manifold.normal.y, Fixed::ZERO, "normal y");
+}
+
+#[test]
+fn overlapping_circles_report_the_overlap_and_point_from_the_first() {
+    let manifold = collide(circle(2), at(0, 0), circle(2), at(3, 0)).expect("overlapping");
+    close(manifold.deepest(), Fixed::ONE, "depth");
+    close(
+        manifold.normal.x,
+        Fixed::ONE,
+        "the normal points toward the second",
+    );
+    // The point sits in the middle of the overlapped span: 2 - 0.5 = 1.5.
+    close(
+        manifold.points()[0].position.x,
+        Fixed::from_ratio(3, 2),
+        "contact point",
+    );
+}
+
+/// Coincident circles have no direction to separate along, and the contract
+/// picks one rather than leaving it to whatever `normalize` does with zero.
+#[test]
+fn coincident_circles_take_the_stated_fallback_direction() {
+    let manifold = collide(circle(1), at(0, 0), circle(1), at(0, 0)).expect("overlapping");
+    assert_eq!(manifold.normal, v(1, 0), "the stated arbitrary direction");
+    close(manifold.deepest(), Fixed::from_int(2), "fully overlapped");
+}
+
+#[test]
+fn a_circle_beside_a_box_touches_its_face() {
+    // Unit square at the origin, unit circle centred at x = 1.5: they overlap
+    // by half a unit through the +x face.
+    let manifold = collide(
+        circle(1),
+        Transform::at(Vec2::new(Fixed::from_ratio(3, 2), Fixed::ZERO)),
+        square(1),
+        at(0, 0),
+    )
+    .expect("overlapping");
+    close(manifold.deepest(), Fixed::from_ratio(1, 2), "depth");
+    // From the circle toward the box is −x.
+    close(manifold.normal.x, Fixed::from_int(-1), "normal x");
+    close(manifold.normal.y, Fixed::ZERO, "normal y");
+}
+
+#[test]
+fn a_circle_past_a_box_corner_does_not_touch() {
+    // The corner is at (1,1); a unit circle centred at (2.5, 2.5) is about
+    // 2.12 away from it, well past its radius.
+    let far = Transform::at(Vec2::new(Fixed::from_ratio(5, 2), Fixed::from_ratio(5, 2)));
+    assert!(collide(circle(1), far, square(1), at(0, 0)).is_none());
+
+    // Move it in until the corner is inside the radius and it touches.
+    let near = Transform::at(Vec2::new(Fixed::from_ratio(3, 2), Fixed::from_ratio(3, 2)));
+    let manifold = collide(circle(1), near, square(1), at(0, 0)).expect("corner contact");
+    assert!(manifold.deepest() > Fixed::ZERO);
+}
+
+/// A circle whose centre is inside the box has no closest surface point to
+/// measure from, so the direction comes from the nearest face instead.
+#[test]
+fn a_circle_inside_a_box_leaves_through_the_nearest_face() {
+    // Centre at (0.8, 0) inside a unit square: nearest face is +x, 0.2 away.
+    let inside = Transform::at(Vec2::new(Fixed::from_ratio(4, 5), Fixed::ZERO));
+    let manifold = collide(circle(1), inside, square(1), at(0, 0)).expect("inside");
+    close(manifold.normal.x, Fixed::from_int(-1), "out through +x");
+    close(manifold.normal.y, Fixed::ZERO, "normal y");
+    // Depth is the distance to the face plus the radius.
+    close(
+        manifold.deepest(),
+        Fixed::from_ratio(1, 5) + Fixed::ONE,
+        "depth",
+    );
+}
+
+/// **The manifold that stops a box rocking on a floor.** Two axis-aligned
+/// boxes meeting face to face touch along a segment, and reporting one
+/// representative point of it loses half the support.
+#[test]
+fn boxes_meeting_face_to_face_report_two_points() {
+    // A unit square resting on a wide floor, overlapping by a quarter.
+    let floor = Shape::Box {
+        half_extents: v(10, 1),
+    };
+    let resting = Transform::at(Vec2::new(Fixed::ZERO, Fixed::from_ratio(7, 4)));
+    let manifold = collide(square(1), resting, floor, at(0, 0)).expect("resting");
+
+    assert_eq!(manifold.count, 2, "a face contact has two points");
+    close(manifold.normal.x, Fixed::ZERO, "normal x");
+    close(
+        manifold.normal.y,
+        Fixed::from_int(-1),
+        "the box is pushed up",
+    );
+    for point in manifold.points() {
+        close(point.depth, Fixed::from_ratio(1, 4), "each point's depth");
+    }
+    // The two points are the ends of the overlap, one unit either side.
+    let xs: Vec<i64> = manifold
+        .points()
+        .iter()
+        .map(|point| point.position.x.to_bits())
+        .collect();
+    assert!(xs[0] != xs[1], "two distinct points, not one twice");
+}
+
+#[test]
+fn boxes_apart_do_not_touch() {
+    assert!(collide(square(1), at(0, 0), square(1), at(3, 0)).is_none());
+    assert!(collide(square(1), at(0, 0), square(1), at(0, 3)).is_none());
+    // Diagonally apart, where a bounding-circle test would wrongly report a hit.
+    assert!(collide(square(1), at(0, 0), square(1), at(3, 3)).is_none());
+}
+
+#[test]
+fn boxes_that_merely_touch_report_depth_zero() {
+    let manifold = collide(square(1), at(0, 0), square(1), at(2, 0)).expect("touching");
+    close(manifold.deepest(), Fixed::ZERO, "depth");
+    close(manifold.normal.x, Fixed::ONE, "normal points at the second");
+}
+
+/// A box turned by an eighth turn reaches further along the world axes, so a
+/// pair that misses when upright touches when turned. This is the cheapest
+/// check that the rotation actually reaches the separating-axis test.
+#[test]
+fn rotation_changes_whether_boxes_touch() {
+    let apart = Transform::at(Vec2::new(Fixed::from_ratio(11, 5), Fixed::ZERO));
+    assert!(
+        collide(square(1), at(0, 0), square(1), apart).is_none(),
+        "upright, 2.2 apart, they miss"
+    );
+
+    let turned = Transform::new(apart.translation, Angle::from_turn_ratio(1, 8));
+    let manifold =
+        collide(square(1), at(0, 0), square(1), turned).expect("turned, the corner reaches in");
+    assert!(manifold.deepest() > Fixed::ZERO);
+}
+
+proptest! {
+    /// **Swapping the arguments must flip the normal and keep the depth.** A
+    /// narrowphase that is not symmetric makes a contact depend on which
+    /// collider the broadphase happened to name first, and the pair ordering
+    /// exists precisely so it cannot.
+    #[test]
+    fn colliding_is_symmetric_for_circles(
+        ax in -4i64..5, ay in -4i64..5, ra in 1i64..4,
+        bx in -4i64..5, by in -4i64..5, rb in 1i64..4,
+    ) {
+        let a = Shape::Circle { radius: Fixed::from_ratio(i32::try_from(ra).unwrap_or(1), 2) };
+        let b = Shape::Circle { radius: Fixed::from_ratio(i32::try_from(rb).unwrap_or(1), 2) };
+        let a_at = Transform::at(raw(ax * 65536, ay * 65536));
+        let b_at = Transform::at(raw(bx * 65536, by * 65536));
+
+        // Exactly coincident centres carry no direction, so both orders take
+        // the stated fallback and agree rather than opposing. That case is
+        // pinned by `coincident_circles_take_the_stated_fallback_direction`
+        // instead; excluding it here keeps this property about the thing it
+        // is actually testing.
+        prop_assume!((ax, ay) != (bx, by));
+
+        match (collide(a, a_at, b, b_at), collide(b, b_at, a, a_at)) {
+            (Some(forward), Some(backward)) => {
+                let sum_x = (forward.normal.x + backward.normal.x).to_bits().abs();
+                let sum_y = (forward.normal.y + backward.normal.y).to_bits().abs();
+                prop_assert!(sum_x <= SLACK, "normals must oppose on x");
+                prop_assert!(sum_y <= SLACK, "normals must oppose on y");
+                let depth_gap = (forward.deepest() - backward.deepest()).to_bits().abs();
+                prop_assert!(depth_gap <= SLACK, "depth must not depend on argument order");
+            }
+            (None, None) => {}
+            _ => prop_assert!(false, "one order found a contact and the other did not"),
+        }
+    }
+
+    /// The same, for boxes — where the separating-axis enumeration visits the
+    /// two shapes' axes in a fixed order, so symmetry is a real risk rather
+    /// than an obvious property.
+    #[test]
+    fn colliding_is_symmetric_for_boxes(
+        bx in -5i64..6, by in -5i64..6, half in 1i64..4,
+    ) {
+        let a = square(1);
+        let b = Shape::Box {
+            half_extents: Vec2::new(
+                Fixed::from_ratio(i32::try_from(half).unwrap_or(1), 2),
+                Fixed::from_ratio(i32::try_from(half).unwrap_or(1), 2),
+            ),
+        };
+        let a_at = at(0, 0);
+        let b_at = Transform::at(raw(bx * 32768, by * 32768));
+        // Same exclusion, same reason: coincident centres have no direction.
+        prop_assume!((bx, by) != (0, 0));
+
+        match (collide(a, a_at, b, b_at), collide(b, b_at, a, a_at)) {
+            (Some(forward), Some(backward)) => {
+                let sum_x = (forward.normal.x + backward.normal.x).to_bits().abs();
+                let sum_y = (forward.normal.y + backward.normal.y).to_bits().abs();
+                prop_assert!(sum_x <= SLACK, "normals must oppose on x");
+                prop_assert!(sum_y <= SLACK, "normals must oppose on y");
+            }
+            (None, None) => {}
+            _ => prop_assert!(false, "one order found a contact and the other did not"),
+        }
+    }
+
+    /// Depth is never negative, and every reported point carries one. A
+    /// negative depth would mean "they touch, by less than nothing", which a
+    /// caller cannot act on.
+    #[test]
+    fn every_reported_depth_is_non_negative(
+        bx in -4i64..5, by in -4i64..5, turn in 0i32..8,
+    ) {
+        let b_at = Transform::new(
+            raw(bx * 32768, by * 32768),
+            Angle::from_turn_ratio(turn, 8),
+        );
+        if let Some(manifold) = collide(square(1), at(0, 0), square(1), b_at) {
+            prop_assert!(manifold.count >= 1, "a contact has at least one point");
+            for point in manifold.points() {
+                prop_assert!(
+                    point.depth >= Fixed::ZERO,
+                    "depth {} is negative",
+                    point.depth.to_bits()
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Circle against circle, circle against box, box against box, each with a
normal pointing from the first shape toward the second and a depth that
is never negative.

A report is a manifold rather than a point, and that is the part worth
arguing for. Two boxes meeting face to face touch along a segment, so
the contact has two ends; reporting one representative point of it hands
the caller a single support where there are two, and any response it
computes from that is asymmetric - which is how a box resting on a floor
starts to rock. The bound is two because in two dimensions a face
contact is the overlap of two segments, so it is a property of the
dimension rather than a budget somebody chose.

Boxes are oriented, not axis-aligned, so the test is a separating axis
over four candidates - two faces from each, since opposite faces share
an axis. One axis with no overlap is a proof of no contact and returns
immediately. The winner is the shallowest overlap, and a tie goes to the
earliest candidate in the enumeration so a symmetric overlap resolves
the same way everywhere. The manifold then comes from clipping the
incident face against the reference face's span.

Box against circle is solved as circle against box and reversed, so
there is one implementation of that geometry rather than two that can
drift apart.

A circle whose centre is inside a box has no closest surface point to
measure from, so the direction comes from the nearest face - chosen by
comparing distances rather than by a sign test, because every face is a
candidate.

One property is documented rather than fixed, because it cannot be
fixed. Swapping the arguments negates the normal, except when the two
centres coincide exactly: there both orders see the same distance in
every direction, so both take the stated fallback and agree rather than
opposing. With identical inputs in both orders there is nothing
antisymmetric left to derive a direction from, and an implementation
that appeared to manage it would be reading an address or an allocation
order. The pipeline never depends on it, since the broadphase emits
every pair with its lower collider first. Two property tests hold
antisymmetry everywhere else and exclude that case by name.