### PR TITLE
feat(physics2d): casting a ray at a shape

### DIFF
--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -45,6 +45,7 @@ pub mod broadphase;
 pub mod contact;
 pub mod filter;
 pub mod narrow;
+pub mod ray;
 pub mod shape;
 pub mod world;
 
@@ -53,5 +54,6 @@ pub use broadphase::Broadphase;
 pub use contact::{Contact, ContactPoint, MAX_MANIFOLD_POINTS, Manifold};
 pub use filter::Filter;
 pub use narrow::collide;
+pub use ray::{RayHit, cast};
 pub use shape::{Shape, Transform};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics2d/src/ray.rs
+++ b/crates/physics2d/src/ray.rs
@@ -1,0 +1,176 @@
+//! Casting a ray at a single shape.
+
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec2, Wide};
+
+/// Where a ray met a shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RayHit {
+    /// Distance along the ray's direction, never negative.
+    pub distance: Fixed,
+    /// Where it met, in world space.
+    pub point: Vec2,
+    /// The surface normal at that point, pointing back along the ray.
+    pub normal: Vec2,
+}
+
+/// Cast a ray at one shape.
+///
+/// `direction` must be unit length; `max_distance` bounds the search.
+///
+/// # A ray that starts inside
+///
+/// **Hits, at distance zero.** That is the vocabulary's rule and it is the
+/// useful one: a ground check whose origin is already inside the floor should
+/// report the floor, not report nothing and let a character fall through
+/// something it is standing in. The normal reported there points back along
+/// the ray, since there is no surface crossing to take one from.
+#[must_use]
+pub fn cast(
+    origin: Vec2,
+    direction: Vec2,
+    max_distance: Fixed,
+    shape: Shape,
+    at: Transform,
+) -> Option<RayHit> {
+    match shape {
+        Shape::Circle { radius } => circle(origin, direction, max_distance, radius, at.translation),
+        Shape::Box { half_extents } => {
+            oriented_box(origin, direction, max_distance, half_extents, at)
+        }
+        // Not written yet, and saying "no hit" would be a lie a caller acts on.
+        Shape::Capsule { .. } => None,
+    }
+}
+
+/// Ray against circle, in the form that keeps the arithmetic small.
+///
+/// Solving `|o + t·d − c|² = r²` directly needs a discriminant built from
+/// three squared lengths. With `d` unit the quadratic's leading coefficient is
+/// one, and the discriminant collapses to `m² − l² + r²` where `m` is how far
+/// along the ray the centre projects and `l` is the distance to it — three
+/// terms instead of a product of squares, which is what keeps this exact at
+/// world scale rather than merely deterministic.
+fn circle(
+    origin: Vec2,
+    direction: Vec2,
+    max_distance: Fixed,
+    radius: Fixed,
+    centre: Vec2,
+) -> Option<RayHit> {
+    let to_centre = centre - origin;
+    let along = to_centre.dot(direction);
+    let discriminant =
+        along.wide_mul(along) - to_centre.length_squared_wide() + radius.wide_mul(radius);
+    if discriminant < Wide::ZERO {
+        return None;
+    }
+    let root = discriminant.sqrt();
+    // The near crossing. Negative means the origin is past it — inside the
+    // circle, or behind it entirely.
+    let near = along - root;
+    let far = along + root;
+    if far < Fixed::ZERO {
+        return None; // wholly behind the origin
+    }
+    let distance = near.max(Fixed::ZERO);
+    if distance > max_distance {
+        return None;
+    }
+    let point = origin + direction * distance;
+    let normal = if near < Fixed::ZERO {
+        // Started inside: there is no crossing to take a normal from, so it
+        // points back the way the ray came.
+        -direction
+    } else {
+        (point - centre).normalize().unwrap_or(-direction)
+    };
+    Some(RayHit {
+        distance,
+        point,
+        normal,
+    })
+}
+
+/// Ray against an oriented box, by the slab test in the box's own frame where
+/// it is axis-aligned by definition.
+fn oriented_box(
+    origin: Vec2,
+    direction: Vec2,
+    max_distance: Fixed,
+    half: Vec2,
+    at: Transform,
+) -> Option<RayHit> {
+    let (sin, cos) = at.rotation.sin_cos();
+    let axis_x = Vec2::new(cos, sin);
+    let axis_y = Vec2::new(-sin, cos);
+    let offset = origin - at.translation;
+    let local_origin = Vec2::new(offset.dot(axis_x), offset.dot(axis_y));
+    let local_direction = Vec2::new(direction.dot(axis_x), direction.dot(axis_y));
+
+    let mut enter = Fixed::ZERO;
+    let mut exit = max_distance;
+    // Which axis the entry came from, and which way it faces. Starts on +x so
+    // a ray beginning inside — where no slab sets it — has a stated answer
+    // rather than an accidental one.
+    let mut entry_axis = 0u8;
+    let mut entry_sign = Fixed::ONE;
+
+    for axis in 0..2u8 {
+        let (start, step, extent) = if axis == 0 {
+            (local_origin.x, local_direction.x, half.x)
+        } else {
+            (local_origin.y, local_direction.y, half.y)
+        };
+        let Some(inverse) = Fixed::ONE.checked_div(step) else {
+            // Parallel to this slab: a ray outside it never enters, and one
+            // inside is unconstrained by it. A computed zero divisor is
+            // ordinary geometry here, not a mistake, which is why this is a
+            // checked division rather than an asserting one.
+            if start < -extent || start > extent {
+                return None;
+            }
+            continue;
+        };
+        let first = (-extent - start).saturating_mul(inverse);
+        let second = (extent - start).saturating_mul(inverse);
+        let (near, far) = if first <= second {
+            (first, second)
+        } else {
+            (second, first)
+        };
+        if near > enter {
+            enter = near;
+            entry_axis = axis;
+            entry_sign = if step < Fixed::ZERO {
+                Fixed::ONE
+            } else {
+                Fixed::from_int(-1)
+            };
+        }
+        exit = exit.min(far);
+        if enter > exit {
+            return None;
+        }
+    }
+
+    if exit < Fixed::ZERO || enter > max_distance {
+        return None;
+    }
+    let point = origin + direction * enter;
+    let local_normal = if axis_is_x(entry_axis) {
+        Vec2::new(entry_sign, Fixed::ZERO)
+    } else {
+        Vec2::new(Fixed::ZERO, entry_sign)
+    };
+    let normal = axis_x * local_normal.x + axis_y * local_normal.y;
+    Some(RayHit {
+        distance: enter,
+        point,
+        normal,
+    })
+}
+
+const fn axis_is_x(axis: u8) -> bool {
+    axis == 0
+}

--- a/crates/physics2d/src/ray.rs
+++ b/crates/physics2d/src/ray.rs
@@ -149,14 +149,16 @@ fn oriented_box(
             };
         }
         exit = exit.min(far);
+        // This one check rejects everything: a box behind the origin drives
+        // `exit` negative while `enter` sits at zero, and a box beyond the
+        // ray's reach drives `enter` past `max_distance`, which `exit` can
+        // never exceed. A second test after the loop for either of those is
+        // unreachable, so there is not one.
         if enter > exit {
             return None;
         }
     }
 
-    if exit < Fixed::ZERO || enter > max_distance {
-        return None;
-    }
     let point = origin + direction * enter;
     let local_normal = if axis_is_x(entry_axis) {
         Vec2::new(entry_sign, Fixed::ZERO)

--- a/crates/physics2d/tests/ray.rs
+++ b/crates/physics2d/tests/ray.rs
@@ -1,0 +1,240 @@
+//! Casting rays at single shapes.
+
+use proptest::prelude::*;
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_physics2d::{Shape, Transform, cast};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn circle(units: i32) -> Shape {
+    Shape::Circle {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn square(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half),
+    }
+}
+
+const RIGHT: Vec2 = Vec2::new(Fixed::ONE, Fixed::ZERO);
+const UP: Vec2 = Vec2::new(Fixed::ZERO, Fixed::ONE);
+const FAR: Fixed = Fixed::from_bits(100 * 65536);
+const SLACK: i64 = 16;
+
+fn close(actual: Fixed, expected: Fixed, what: &str) {
+    let gap = (actual - expected).to_bits().abs();
+    assert!(
+        gap <= SLACK,
+        "{what}: got {} raw, expected {} raw",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}
+
+#[test]
+fn a_ray_meets_a_circle_at_its_near_surface() {
+    let hit =
+        cast(v(-5, 0), RIGHT, FAR, circle(1), Transform::at(Vec2::ZERO)).expect("straight at it");
+    close(hit.distance, Fixed::from_int(4), "distance");
+    close(hit.point.x, Fixed::from_int(-1), "point");
+    close(hit.normal.x, Fixed::from_int(-1), "normal faces the ray");
+}
+
+#[test]
+fn a_ray_that_misses_a_circle_reports_nothing() {
+    // Passing two units above a unit circle.
+    assert!(cast(v(-5, 2), RIGHT, FAR, circle(1), Transform::at(Vec2::ZERO)).is_none());
+}
+
+#[test]
+fn a_circle_behind_the_origin_is_not_hit() {
+    assert!(cast(v(5, 0), RIGHT, FAR, circle(1), Transform::at(Vec2::ZERO)).is_none());
+}
+
+#[test]
+fn a_ray_stops_at_its_maximum_distance() {
+    let short = Fixed::from_int(3);
+    assert!(
+        cast(v(-5, 0), RIGHT, short, circle(1), Transform::at(Vec2::ZERO)).is_none(),
+        "the surface is four away and the ray reaches three"
+    );
+    let long = Fixed::from_int(5);
+    assert!(cast(v(-5, 0), RIGHT, long, circle(1), Transform::at(Vec2::ZERO)).is_some());
+}
+
+/// **A ray beginning inside hits at distance zero**, which is what makes a
+/// ground check usable: a character already intersecting the floor must be
+/// told about the floor, not told there is nothing there.
+#[test]
+fn a_ray_starting_inside_a_circle_hits_at_zero() {
+    let hit = cast(Vec2::ZERO, RIGHT, FAR, circle(2), Transform::at(Vec2::ZERO))
+        .expect("inside is a hit");
+    assert_eq!(hit.distance, Fixed::ZERO);
+    assert_eq!(hit.point, Vec2::ZERO);
+    close(
+        hit.normal.x,
+        Fixed::from_int(-1),
+        "normal points back along the ray",
+    );
+}
+
+#[test]
+fn a_ray_meets_a_box_face() {
+    let hit =
+        cast(v(-5, 0), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).expect("straight at it");
+    close(hit.distance, Fixed::from_int(4), "distance");
+    close(hit.point.x, Fixed::from_int(-1), "point");
+    close(hit.normal.x, Fixed::from_int(-1), "normal faces the ray");
+    close(hit.normal.y, Fixed::ZERO, "and is axis-aligned");
+}
+
+#[test]
+fn a_ray_meets_a_box_from_below() {
+    let hit =
+        cast(v(0, -5), UP, FAR, square(1), Transform::at(Vec2::ZERO)).expect("straight at it");
+    close(hit.distance, Fixed::from_int(4), "distance");
+    close(hit.normal.y, Fixed::from_int(-1), "normal faces down");
+}
+
+#[test]
+fn a_ray_that_passes_beside_a_box_reports_nothing() {
+    assert!(cast(v(-5, 2), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).is_none());
+}
+
+/// A ray exactly parallel to a slab divides by zero in the naive slab test.
+/// Here it is a checked division and the case is decided by whether the
+/// origin lies within that slab.
+#[test]
+fn a_ray_parallel_to_a_face_is_decided_by_its_offset() {
+    // Travelling along +x at y = 2, outside a unit box's y slab: no hit.
+    assert!(cast(v(-5, 2), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).is_none());
+    // Along +x at y = 0, inside the y slab: hits the −x face.
+    assert!(cast(v(-5, 0), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).is_some());
+    // Exactly on the boundary, y = 1, is still inside.
+    assert!(cast(v(-5, 1), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).is_some());
+}
+
+/// A ray beginning inside a box leaves through some face; the contract says it
+/// hits at zero rather than reporting the exit.
+#[test]
+fn a_ray_starting_inside_a_box_hits_at_zero() {
+    let hit = cast(Vec2::ZERO, RIGHT, FAR, square(1), Transform::at(Vec2::ZERO))
+        .expect("inside is a hit");
+    assert_eq!(hit.distance, Fixed::ZERO);
+}
+
+/// A turned box is a different target, and this is the cheapest check that the
+/// rotation reaches the slab test rather than being ignored.
+#[test]
+fn rotating_a_box_moves_where_a_ray_meets_it() {
+    let upright =
+        cast(v(-5, 0), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).expect("hits the face");
+    let turned = cast(
+        v(-5, 0),
+        RIGHT,
+        FAR,
+        square(1),
+        Transform::new(Vec2::ZERO, Angle::from_turn_ratio(1, 8)),
+    )
+    .expect("hits the corner");
+    // A square turned an eighth presents its corner, which reaches further.
+    assert!(
+        turned.distance < upright.distance,
+        "turned {} should be nearer than upright {}",
+        turned.distance.to_bits(),
+        upright.distance.to_bits()
+    );
+}
+
+#[test]
+fn a_capsule_is_not_castable_yet() {
+    let capsule = Shape::Capsule {
+        radius: Fixed::ONE,
+        half_height: Fixed::ONE,
+    };
+    assert!(cast(v(-5, 0), RIGHT, FAR, capsule, Transform::at(Vec2::ZERO)).is_none());
+}
+
+proptest! {
+    /// Whatever a ray hits, the point it reports lies on the ray at the
+    /// distance it reports. A hit whose point and distance disagree would
+    /// send a caller somewhere the geometry never said.
+    #[test]
+    fn a_hit_point_lies_on_the_ray(
+        oy in -3i64..4, target in 0u8..2, turn in 0i32..8,
+    ) {
+        let shape = if target == 0 { circle(1) } else { square(1) };
+        let at = Transform::new(Vec2::ZERO, Angle::from_turn_ratio(turn, 8));
+        let origin = Vec2::new(Fixed::from_int(-6), Fixed::from_bits(oy * 32768));
+        if let Some(hit) = cast(origin, RIGHT, FAR, shape, at) {
+            prop_assert!(hit.distance >= Fixed::ZERO, "distance is never negative");
+            prop_assert!(hit.distance <= FAR, "and never past the limit");
+            let expected = origin + RIGHT * hit.distance;
+            let gap_x = (hit.point.x - expected.x).to_bits().abs();
+            let gap_y = (hit.point.y - expected.y).to_bits().abs();
+            prop_assert!(gap_x <= SLACK && gap_y <= SLACK, "point is off the ray");
+        }
+    }
+
+    /// A reported normal is usable as a direction, and faces the ray rather
+    /// than away from it — a caller reflecting off a normal pointing the wrong
+    /// way sends the body into the surface.
+    #[test]
+    fn a_hit_normal_is_unit_and_faces_the_ray(
+        oy in -3i64..4, target in 0u8..2, turn in 0i32..8,
+    ) {
+        let shape = if target == 0 { circle(1) } else { square(1) };
+        let at = Transform::new(Vec2::ZERO, Angle::from_turn_ratio(turn, 8));
+        let origin = Vec2::new(Fixed::from_int(-6), Fixed::from_bits(oy * 32768));
+        if let Some(hit) = cast(origin, RIGHT, FAR, shape, at) {
+            let length_error = (hit.normal.length() - Fixed::ONE).to_bits().abs();
+            prop_assert!(length_error <= 64, "normal is not unit");
+            prop_assert!(
+                hit.normal.dot(RIGHT) <= Fixed::ZERO,
+                "normal must face the ray, not away from it"
+            );
+        }
+    }
+}
+
+/// A box entirely behind the origin exits before the ray begins, which is a
+/// different rejection from the one a miss to the side takes.
+#[test]
+fn a_box_behind_the_origin_is_not_hit() {
+    assert!(cast(v(5, 0), RIGHT, FAR, square(1), Transform::at(Vec2::ZERO)).is_none());
+    // And one behind on the other axis, so both slabs get to reject.
+    assert!(cast(v(0, 5), UP, FAR, square(1), Transform::at(Vec2::ZERO)).is_none());
+}
+
+/// A zero-radius circle is a point, and the vocabulary requires queries to
+/// answer for one rather than refuse. A ray through it has no surface to take
+/// a normal from, so the normal comes from the stated fallback.
+#[test]
+fn a_zero_radius_circle_is_answerable() {
+    let point_shape = Shape::Circle {
+        radius: Fixed::ZERO,
+    };
+    // Straight through its centre: the near and far crossings coincide.
+    let hit = cast(v(-5, 0), RIGHT, FAR, point_shape, Transform::at(Vec2::ZERO))
+        .expect("a point is a target, not an error");
+    close(hit.distance, Fixed::from_int(5), "distance to the point");
+    let length_error = (hit.normal.length() - Fixed::ONE).to_bits().abs();
+    assert!(length_error <= 64, "even here the normal is a direction");
+
+    // A hair off to the side and it misses, which is what makes the hit above
+    // a real answer rather than a degenerate always-true.
+    assert!(
+        cast(
+            Vec2::new(Fixed::from_int(-5), Fixed::from_bits(64)),
+            RIGHT,
+            FAR,
+            point_shape,
+            Transform::at(Vec2::ZERO)
+        )
+        .is_none()
+    );
+}


### PR DESCRIPTION
Circle and box, exact, with the degenerate cases answered rather than
refused.

A ray beginning inside a shape hits it at distance zero. That is the
rule a ground check needs: a character already intersecting the floor
must be told about the floor, not told there is nothing beneath it and
allowed to fall through what it is standing in. The normal there points
back along the ray, since there is no surface crossing to take one from.

The circle test avoids the discriminant a naive quadratic builds from
three squared lengths. With the direction unit the leading coefficient
is one and the discriminant collapses to m squared minus l squared plus
r squared, where m is how far along the ray the centre projects. Three
terms instead of a product of squares is what keeps it exact at world
scale rather than merely deterministic.

The box test is a slab test in the box's own frame, where it is
axis-aligned by definition, so rotation costs a projection rather than a
special case. A ray exactly parallel to a slab divides by zero, and a
computed zero divisor is ordinary geometry here rather than a mistake -
so the division is checked and the case falls back to whether the origin
lies within that slab. A zero-radius circle is answerable too, because
the vocabulary requires it: a ray through the point hits, and one a
thousandth of a unit to the side misses, which is what makes the first
answer real rather than degenerate.

Two properties hold across rotations and offsets: the point reported
lies on the ray at the distance reported, and the normal is unit length
and faces the ray. A normal pointing the wrong way would send a caller
reflecting off it straight into the surface.