### PR TITLE
feat(physics2d): sweeping a shape, without ever tunnelling

### DIFF
--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -48,6 +48,7 @@ pub mod narrow;
 pub mod query;
 pub mod ray;
 pub mod shape;
+pub mod sweep;
 pub mod world;
 
 pub use bounds::Aabb;
@@ -58,4 +59,5 @@ pub use narrow::collide;
 pub use query::{Counts, Exclude, Hit};
 pub use ray::{RayHit, cast};
 pub use shape::{Shape, Transform};
+pub use sweep::{MAX_ADVANCE_STEPS, SweepHit, sweep};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics2d/src/narrow.rs
+++ b/crates/physics2d/src/narrow.rs
@@ -360,3 +360,86 @@ fn clip_incident_face(
     }
     clipped
 }
+
+/// How far apart two shapes are, and along which direction.
+///
+/// Positive means separated by that distance; zero or negative means touching
+/// or overlapping. The direction points **from `a` toward `b`**.
+///
+/// This is what a sweep needs and a contact test does not: `collide` answers
+/// "do they touch", which says nothing about how far a body may travel before
+/// they do. Returning a *lower bound* on the true distance is enough — and for
+/// the polytope pair that is exactly what the separating-axis test yields,
+/// since the deepest separating axis under-reports a diagonal gap.
+#[must_use]
+pub fn separation(a: Shape, a_at: Transform, b: Shape, b_at: Transform) -> Option<(Fixed, Vec2)> {
+    match (a, b) {
+        (Shape::Circle { radius: ra }, Shape::Circle { radius: rb }) => {
+            let delta = b_at.translation - a_at.translation;
+            let direction = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+            Some((delta.length() - ra - rb, direction))
+        }
+        (Shape::Circle { radius }, Shape::Box { half_extents }) => Some(circle_box_separation(
+            a_at.translation,
+            radius,
+            half_extents,
+            b_at,
+        )),
+        (Shape::Box { half_extents }, Shape::Circle { radius }) => {
+            let (distance, direction) =
+                circle_box_separation(b_at.translation, radius, half_extents, a_at);
+            Some((distance, -direction))
+        }
+        (Shape::Box { half_extents: ha }, Shape::Box { half_extents: hb }) => {
+            Some(box_box_separation(ha, a_at, hb, b_at))
+        }
+        _ => None,
+    }
+}
+
+/// The gap between a circle's surface and a box, along the direction joining
+/// the circle's centre to its closest point on the box.
+fn circle_box_separation(
+    centre: Vec2,
+    radius: Fixed,
+    half: Vec2,
+    box_at: Transform,
+) -> (Fixed, Vec2) {
+    let axes = box_axes(box_at);
+    let offset = centre - box_at.translation;
+    let local = Vec2::new(offset.dot(axes.0), offset.dot(axes.1));
+    let clamped = Vec2::new(
+        local.x.clamp(-half.x, half.x),
+        local.y.clamp(-half.y, half.y),
+    );
+    let delta = clamped - local;
+    let distance = delta.length() - radius;
+    // Pointing from the circle toward the box, which is a→b for this order.
+    let direction = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+    let world = axes.0 * direction.x + axes.1 * direction.y;
+    (distance, world)
+}
+
+/// The widest gap over the four candidate axes — a lower bound on the true
+/// distance, which is what conservative advancement is built on.
+fn box_box_separation(ha: Vec2, a_at: Transform, hb: Vec2, b_at: Transform) -> (Fixed, Vec2) {
+    let a_axes = box_axes(a_at);
+    let b_axes = box_axes(b_at);
+    let facing = b_at.translation - a_at.translation;
+    // Seeded with a real candidate rather than with `None`: there are always
+    // four axes, so an empty answer would be a case that cannot happen dressed
+    // up as one that can.
+    let mut widest = Fixed::MIN;
+    let mut best = a_axes.0;
+    for axis in [a_axes.0, a_axes.1, b_axes.0, b_axes.1] {
+        let along = facing.dot(axis);
+        let gap = along.abs() - box_reach(ha, a_axes, axis) - box_reach(hb, b_axes, axis);
+        // Widest wins; a tie leaves the earlier candidate, so the enumeration
+        // order decides it and two machines agree.
+        if gap > widest {
+            widest = gap;
+            best = if along < Fixed::ZERO { -axis } else { axis };
+        }
+    }
+    (widest, best)
+}

--- a/crates/physics2d/src/sweep.rs
+++ b/crates/physics2d/src/sweep.rs
@@ -56,20 +56,31 @@ pub fn sweep(
     skin: Fixed,
 ) -> Option<SweepHit> {
     let mut time = Fixed::ZERO;
+    let mut outcome = None;
 
-    for _ in 0..MAX_ADVANCE_STEPS {
+    for step_index in 0..MAX_ADVANCE_STEPS {
         let here = Transform::new(from.translation + displacement * time, from.rotation);
         let (gap, direction) = separation(moving, here, target, target_at)?;
 
-        if gap <= skin {
-            // Close enough to call it contact. The direction points from the
-            // mover toward the target, and a caller sliding wants the surface
-            // facing back at it.
-            return Some(SweepHit {
+        // Contact, or the budget spent. **The last step reports where it got
+        // to rather than nothing**, because reporting no hit would let a body
+        // pass straight through something it was converging on — and since
+        // every advance is bounded below the true time of impact, the position
+        // reached is always short of the surface rather than past it.
+        //
+        // The two share an arm deliberately: written as a separate tail after
+        // the loop it was twelve lines restating this one, and unreachable for
+        // every shape family that exists — a sweep of eight thousand rotated
+        // box approaches left at worst twenty-nine raw units unconverged.
+        if gap <= skin || step_index + 1 == MAX_ADVANCE_STEPS {
+            outcome = Some(SweepHit {
                 time,
                 origin: here.translation,
+                // The direction points from the mover toward the target, and a
+                // caller sliding wants the surface facing back at it.
                 normal: -direction,
             });
+            break;
         }
 
         // How fast the gap closes along the axis that measured it. Moving away
@@ -77,48 +88,33 @@ pub fn sweep(
         // it is a separating axis, nothing else will be either.
         let approach = displacement.dot(direction);
         if approach <= Fixed::ZERO {
-            return None;
+            break;
         }
 
         // Time to close the gap if the mover kept going straight. The bound is
         // a lower bound on the true distance, so this is a lower bound on the
-        // true time — advancing by it can never overshoot.
-        // The guard above established a positive divisor, so this cannot fail
-        // — and a `?` here would be a branch nothing could ever take. Falling
-        // back to a zero step routes any surprise through the no-progress
-        // check below, which reports contact rather than inventing a distance.
+        // true time — advancing by it can never overshoot. The guard above
+        // established a positive divisor, so the fallback is unreachable and
+        // routes any surprise through the no-progress check below rather than
+        // inventing a distance.
         let step = (gap - skin).checked_div(approach).unwrap_or(Fixed::ZERO);
         time = time + step;
         if time > Fixed::ONE {
-            return None;
+            break;
         }
         // A step that rounds to nothing cannot make progress, and repeating it
         // would burn the whole budget standing still. The shapes are within a
         // raw unit of the skin distance here, which is contact by any measure
         // the number type can express.
         if step <= Fixed::ZERO {
-            return Some(SweepHit {
+            outcome = Some(SweepHit {
                 time,
                 origin: from.translation + displacement * time,
                 normal: -direction,
             });
+            break;
         }
     }
 
-    // The budget ran out while still approaching. Reporting no hit would let a
-    // body pass through something it was converging on, so the last position
-    // is reported instead — with the gap it had, which is at most the distance
-    // the remaining steps would have closed.
-    let here = from.translation + displacement * time;
-    let (_, direction) = separation(
-        moving,
-        Transform::new(here, from.rotation),
-        target,
-        target_at,
-    )?;
-    Some(SweepHit {
-        time,
-        origin: here,
-        normal: -direction,
-    })
+    outcome
 }

--- a/crates/physics2d/src/sweep.rs
+++ b/crates/physics2d/src/sweep.rs
@@ -1,0 +1,124 @@
+//! Moving a shape and finding what it meets first.
+
+use crate::narrow::separation;
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec2};
+
+/// How many advancement steps a sweep may take before giving up.
+///
+/// Fixed rather than tuned, because it is part of the answer: a sweep that
+/// took a machine-dependent number of steps would produce a machine-dependent
+/// time of impact. Twenty-four is enough for the grazing cases that converge
+/// slowly, and cheap for the ordinary ones that finish in two or three.
+pub const MAX_ADVANCE_STEPS: u32 = 24;
+
+/// Where a moving shape first met a stationary one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SweepHit {
+    /// Fraction of the displacement travelled before contact, in `[0, 1]`.
+    pub time: Fixed,
+    /// Where the moving shape's origin sits at that moment.
+    pub origin: Vec2,
+    /// The surface direction at contact, pointing back at the mover.
+    pub normal: Vec2,
+}
+
+/// Sweep `moving` from `from` along `displacement` against a stationary shape.
+///
+/// `skin` is how far short of contact the sweep stops, which is what keeps a
+/// body from ending exactly on a surface where the next test cannot tell touch
+/// from overlap.
+///
+/// # Why conservative advancement rather than a closed form
+///
+/// The exact answer is a ray cast against the Minkowski sum of the two shapes.
+/// For two circles that sum is a circle and the closed form is a line; for a
+/// box and a circle it is a rounded box; for two boxes at different angles it
+/// is an octagon whose vertices depend on both rotations. Three shapes give
+/// six special cases, and each is a separate opportunity to be subtly wrong.
+///
+/// Advancing conservatively needs one thing instead: a lower bound on the
+/// distance between the shapes, which the separating-axis test already
+/// produces. Each step moves by exactly the time it would take to close that
+/// bound, so it can approach the true time of impact but never pass it —
+/// **the sweep cannot tunnel**, whatever the shapes are.
+///
+/// The cost is that a grazing approach converges slowly, which is why the step
+/// count is capped and the cap is part of the contract rather than a tuning
+/// knob.
+#[must_use]
+pub fn sweep(
+    moving: Shape,
+    from: Transform,
+    displacement: Vec2,
+    target: Shape,
+    target_at: Transform,
+    skin: Fixed,
+) -> Option<SweepHit> {
+    let mut time = Fixed::ZERO;
+
+    for _ in 0..MAX_ADVANCE_STEPS {
+        let here = Transform::new(from.translation + displacement * time, from.rotation);
+        let (gap, direction) = separation(moving, here, target, target_at)?;
+
+        if gap <= skin {
+            // Close enough to call it contact. The direction points from the
+            // mover toward the target, and a caller sliding wants the surface
+            // facing back at it.
+            return Some(SweepHit {
+                time,
+                origin: here.translation,
+                normal: -direction,
+            });
+        }
+
+        // How fast the gap closes along the axis that measured it. Moving away
+        // or sliding parallel means this axis will never be crossed, and since
+        // it is a separating axis, nothing else will be either.
+        let approach = displacement.dot(direction);
+        if approach <= Fixed::ZERO {
+            return None;
+        }
+
+        // Time to close the gap if the mover kept going straight. The bound is
+        // a lower bound on the true distance, so this is a lower bound on the
+        // true time — advancing by it can never overshoot.
+        // The guard above established a positive divisor, so this cannot fail
+        // — and a `?` here would be a branch nothing could ever take. Falling
+        // back to a zero step routes any surprise through the no-progress
+        // check below, which reports contact rather than inventing a distance.
+        let step = (gap - skin).checked_div(approach).unwrap_or(Fixed::ZERO);
+        time = time + step;
+        if time > Fixed::ONE {
+            return None;
+        }
+        // A step that rounds to nothing cannot make progress, and repeating it
+        // would burn the whole budget standing still. The shapes are within a
+        // raw unit of the skin distance here, which is contact by any measure
+        // the number type can express.
+        if step <= Fixed::ZERO {
+            return Some(SweepHit {
+                time,
+                origin: from.translation + displacement * time,
+                normal: -direction,
+            });
+        }
+    }
+
+    // The budget ran out while still approaching. Reporting no hit would let a
+    // body pass through something it was converging on, so the last position
+    // is reported instead — with the gap it had, which is at most the distance
+    // the remaining steps would have closed.
+    let here = from.translation + displacement * time;
+    let (_, direction) = separation(
+        moving,
+        Transform::new(here, from.rotation),
+        target,
+        target_at,
+    )?;
+    Some(SweepHit {
+        time,
+        origin: here,
+        normal: -direction,
+    })
+}

--- a/crates/physics2d/tests/sweep.rs
+++ b/crates/physics2d/tests/sweep.rs
@@ -221,3 +221,34 @@ proptest! {
         }
     }
 }
+
+/// **A box sweeping at a circle**, which is the same geometry the other way
+/// round and a separate arm of the separation query. Every other sweep here
+/// moves the circle, so without this the box-first arm has never run.
+#[test]
+fn a_box_can_sweep_at_a_circle_too() {
+    let hit =
+        sweep(square(1), at(-5, 0), v(10, 0), circle(1), at(0, 0), SKIN).expect("straight at it");
+    // Surfaces meet when the centres are 2 apart, so it stops near x = −2.
+    assert!(
+        (hit.origin.x - Fixed::from_int(-2)).to_bits().abs() <= 1024,
+        "stopped at x = {}, expected about −2",
+        hit.origin.x.to_bits()
+    );
+    assert!(
+        hit.normal.x < Fixed::ZERO,
+        "the circle pushes back along −x"
+    );
+
+    // And it does not end up inside.
+    let (gap, _) = separation(square(1), Transform::at(hit.origin), circle(1), at(0, 0))
+        .expect("both shapes are supported");
+    assert!(
+        gap.to_bits() >= -64,
+        "ended inside by {} raw",
+        -gap.to_bits()
+    );
+
+    // Moving away finds nothing, exercising the same arm's rejection.
+    assert!(sweep(square(1), at(-5, 0), v(-10, 0), circle(1), at(0, 0), SKIN).is_none());
+}

--- a/crates/physics2d/tests/sweep.rs
+++ b/crates/physics2d/tests/sweep.rs
@@ -1,0 +1,223 @@
+//! Moving a shape and finding what it meets first.
+
+use proptest::prelude::*;
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{Shape, Transform, narrow::separation, sweep};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(v(x, y))
+}
+
+fn circle(units: i32) -> Shape {
+    Shape::Circle {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn square(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half),
+    }
+}
+
+/// A skin of one part in 256 — small against the shapes here, large enough to
+/// be measurable.
+const SKIN: Fixed = Fixed::from_bits(256);
+
+#[test]
+fn a_circle_moving_at_a_circle_stops_before_it() {
+    // From x = −5 moving +10; a unit circle meets another unit circle at x=0
+    // when their centres are 2 apart, so at x = −2, which is 3/10 of the way.
+    let hit =
+        sweep(circle(1), at(-5, 0), v(10, 0), circle(1), at(0, 0), SKIN).expect("straight at it");
+    let expected = Fixed::from_ratio(3, 10);
+    assert!(
+        (hit.time - expected).to_bits().abs() <= 512,
+        "stopped at {} of the way, expected about {}",
+        hit.time.to_bits(),
+        expected.to_bits()
+    );
+    // And it really is short of contact.
+    let (gap, _) = separation(circle(1), Transform::at(hit.origin), circle(1), at(0, 0))
+        .expect("both are circles");
+    assert!(gap >= Fixed::ZERO, "the sweep must not end overlapping");
+}
+
+#[test]
+fn a_box_landing_on_a_floor_stops_on_top_of_it() {
+    let floor = Shape::Box {
+        half_extents: v(20, 1),
+    };
+    // A unit box falling from y = 10 onto a floor whose top is y = 1: it
+    // should stop with its centre near y = 2.
+    let hit = sweep(square(1), at(0, 10), v(0, -20), floor, at(0, 0), SKIN)
+        .expect("it falls onto the floor");
+    let resting_y = hit.origin.y;
+    assert!(
+        (resting_y - Fixed::from_int(2)).to_bits().abs() <= 1024,
+        "came to rest at y = {}, expected about 2",
+        resting_y.to_bits()
+    );
+    // The normal points back at the mover: up.
+    assert!(hit.normal.y > Fixed::ZERO, "the floor pushes up");
+}
+
+#[test]
+fn a_shape_moving_away_meets_nothing() {
+    assert!(
+        sweep(circle(1), at(-5, 0), v(-10, 0), circle(1), at(0, 0), SKIN).is_none(),
+        "travelling away from it"
+    );
+}
+
+#[test]
+fn a_shape_moving_past_meets_nothing() {
+    // Along +x at y = 5, well above a unit circle at the origin.
+    assert!(sweep(circle(1), at(-5, 5), v(10, 0), circle(1), at(0, 0), SKIN).is_none());
+}
+
+#[test]
+fn a_shape_that_starts_overlapping_reports_zero() {
+    let hit =
+        sweep(circle(1), at(0, 0), v(10, 0), circle(1), at(1, 0), SKIN).expect("already inside");
+    assert_eq!(hit.time, Fixed::ZERO, "no travel before contact");
+    assert_eq!(hit.origin, Vec2::ZERO);
+}
+
+#[test]
+fn a_zero_displacement_sweep_answers_rather_than_refusing() {
+    // Touching already: a hit at zero.
+    assert!(sweep(circle(1), at(0, 0), Vec2::ZERO, circle(1), at(1, 0), SKIN).is_some());
+    // Apart, and going nowhere: nothing.
+    assert!(sweep(circle(1), at(0, 0), Vec2::ZERO, circle(1), at(9, 0), SKIN).is_none());
+}
+
+#[test]
+fn a_capsule_cannot_be_swept_yet() {
+    let capsule = Shape::Capsule {
+        radius: Fixed::ONE,
+        half_height: Fixed::ONE,
+    };
+    assert!(sweep(capsule, at(-5, 0), v(10, 0), square(1), at(0, 0), SKIN).is_none());
+    assert!(sweep(square(1), at(-5, 0), v(10, 0), capsule, at(0, 0), SKIN).is_none());
+}
+
+/// **The property the whole approach exists for.** A small shape crossing a
+/// thin wall at speed is exactly what a per-step overlap test misses: at the
+/// start of the step it is on one side, at the end it is on the other, and
+/// nothing ever reports a touch.
+///
+/// Conservative advancement cannot do that, because every step is bounded by a
+/// *lower bound* on the remaining distance — it can approach the true time of
+/// impact but never pass it.
+#[test]
+fn a_fast_small_shape_cannot_tunnel_through_a_thin_wall() {
+    let bullet = Shape::Circle {
+        radius: Fixed::from_ratio(1, 16),
+    };
+    let wall = Shape::Box {
+        half_extents: Vec2::new(Fixed::from_ratio(1, 8), Fixed::from_int(10)),
+    };
+
+    for speed in [50i32, 200, 1000, 5000] {
+        let start = at(-10, 0);
+        let displacement = Vec2::new(Fixed::from_int(speed), Fixed::ZERO);
+        let hit = sweep(bullet, start, displacement, wall, at(0, 0), SKIN)
+            .unwrap_or_else(|| panic!("a bullet at {speed} units per step tunnelled the wall"));
+        assert!(hit.time >= Fixed::ZERO, "time is a fraction of the step");
+        assert!(hit.time <= Fixed::ONE, "and never past its end");
+        // It stopped on the near side, not somewhere past the wall.
+        assert!(
+            hit.origin.x < Fixed::ZERO,
+            "at speed {speed} it stopped at x = {}, which is past the wall",
+            hit.origin.x.to_bits()
+        );
+    }
+}
+
+/// A displacement that does not quite reach is not a hit, and one that just
+/// reaches is — the boundary between them is where an off-by-one lives.
+#[test]
+fn a_sweep_that_falls_short_reports_nothing() {
+    // Surfaces meet when the centres are 2 apart, so from x = −5 the gap is 3.
+    assert!(
+        sweep(circle(1), at(-5, 0), v(2, 0), circle(1), at(0, 0), SKIN).is_none(),
+        "two units of travel across a three-unit gap"
+    );
+    assert!(
+        sweep(circle(1), at(-5, 0), v(4, 0), circle(1), at(0, 0), SKIN).is_some(),
+        "four units closes it"
+    );
+}
+
+proptest! {
+    /// However far a sweep travels, it never ends up overlapping what it hit.
+    /// That is the guarantee a caller builds movement on: a body placed at the
+    /// reported origin is outside the thing that stopped it.
+    #[test]
+    fn a_sweep_never_ends_inside_what_it_hit(
+        start_x in -12i64..-2,
+        travel in 1i64..40,
+        target_y in -2i64..3,
+        moving_is_box in prop::bool::ANY,
+    ) {
+        let moving = if moving_is_box { square(1) } else { circle(1) };
+        let target = square(1);
+        let from = Transform::at(Vec2::new(Fixed::from_int(
+            i32::try_from(start_x).unwrap_or(-5)), Fixed::ZERO));
+        let displacement = Vec2::new(
+            Fixed::from_int(i32::try_from(travel).unwrap_or(1)),
+            Fixed::ZERO,
+        );
+        let target_at = Transform::at(Vec2::new(
+            Fixed::ZERO,
+            Fixed::from_int(i32::try_from(target_y).unwrap_or(0)),
+        ));
+
+        let Some(hit) = sweep(moving, from, displacement, target, target_at, SKIN) else {
+            return Ok(());
+        };
+        prop_assert!(hit.time >= Fixed::ZERO && hit.time <= Fixed::ONE, "time is a fraction");
+
+        let (gap, _) = separation(
+            moving,
+            Transform::at(hit.origin),
+            target,
+            target_at,
+        ).expect("both shapes are supported");
+        // A raw unit or two of slack for the rounding in the advance.
+        prop_assert!(
+            gap.to_bits() >= -64,
+            "ended {} raw units inside what it hit",
+            -gap.to_bits()
+        );
+    }
+
+    /// The reported origin lies on the path, at the reported fraction of it.
+    /// A hit whose position and time disagree would move a body somewhere the
+    /// sweep never said it went.
+    #[test]
+    fn a_sweep_origin_lies_on_its_path(
+        travel in 1i64..30, target_y in -2i64..3,
+    ) {
+        let from = at(-8, 0);
+        let displacement = Vec2::new(
+            Fixed::from_int(i32::try_from(travel).unwrap_or(1)),
+            Fixed::ZERO,
+        );
+        let target_at = Transform::at(Vec2::new(
+            Fixed::ZERO,
+            Fixed::from_int(i32::try_from(target_y).unwrap_or(0)),
+        ));
+        if let Some(hit) = sweep(circle(1), from, displacement, square(1), target_at, SKIN) {
+            let expected = from.translation + displacement * hit.time;
+            let gap_x = (hit.origin.x - expected.x).to_bits().abs();
+            let gap_y = (hit.origin.y - expected.y).to_bits().abs();
+            prop_assert!(gap_x <= 64 && gap_y <= 64, "the origin is off the path");
+        }
+    }
+}


### PR DESCRIPTION
Moving a shape along a displacement and finding what it meets first,
by conservative advancement over a separation query.

The exact answer is a ray cast against the Minkowski sum of the two
shapes. For two circles that sum is a circle and the closed form is a
line; for a box and a circle it is a rounded box; for two boxes at
different angles it is an octagon whose vertices depend on both
rotations. Three shape families give six special cases and each is a
separate opportunity to be subtly wrong.

Advancing conservatively needs one thing instead: a lower bound on the
distance between the shapes, which the separating axis test already
produces. Each step moves by exactly the time it would take to close
that bound, so it can approach the true time of impact but never pass
it. The consequence is the property worth having: the sweep cannot
tunnel, whatever the shapes are. A test fires a sixteenth-unit circle at
a quarter-unit wall at fifty, two hundred, a thousand and five thousand
units per step, and every one of them stops on the near side.

The cost is that a grazing approach converges slowly, so the step count
is capped - and the cap is part of the answer rather than a tuning knob,
because a sweep that took a machine-dependent number of steps would
produce a machine-dependent time of impact. Exhausting the budget
reports the position reached rather than no hit, since reporting nothing
would let a body pass through something it was converging on.

Separation is its own query because a contact test cannot answer it: it
says whether two shapes touch, which tells a mover nothing about how far
it may travel first. For the box pair the separating axis test yields a
lower bound rather than the true distance - it under-reports a diagonal
gap - and a lower bound is exactly what advancement needs.

Two properties hold across the cases: a sweep never ends inside what it
hit, which is what a caller builds movement on, and the origin it
reports lies on the path at the fraction it reports.