### PR TITLE
feat(physics2d): move and slide, and the bug a wall-running test found

### DIFF
--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -48,6 +48,7 @@ pub mod narrow;
 pub mod query;
 pub mod ray;
 pub mod shape;
+pub mod slide;
 pub mod sweep;
 pub mod world;
 
@@ -59,5 +60,6 @@ pub use narrow::collide;
 pub use query::{Counts, Exclude, Hit};
 pub use ray::{RayHit, cast};
 pub use shape::{Shape, Transform};
+pub use slide::{SlideEnd, SlideHit, SlideReport};
 pub use sweep::{MAX_ADVANCE_STEPS, SweepHit, sweep};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics2d/src/query.rs
+++ b/crates/physics2d/src/query.rs
@@ -79,7 +79,7 @@ pub struct Hit {
 
 impl World {
     /// Whether a collider is visible to a query with this mask and exclusion.
-    fn visible(
+    pub(crate) fn query_visible(
         &self,
         collider: Collider,
         mask: u32,
@@ -108,7 +108,7 @@ impl World {
     ) -> Counts {
         let mut counts = Counts::default();
         for collider in self.colliders() {
-            let Some((shape, at)) = self.visible(collider, mask, exclude) else {
+            let Some((shape, at)) = self.query_visible(collider, mask, exclude) else {
                 continue;
             };
             // A point is a zero-radius circle, and the geometry already knows
@@ -146,7 +146,7 @@ impl World {
     ) -> Option<Hit> {
         let mut best: Option<Hit> = None;
         for collider in self.colliders() {
-            let Some((shape, at)) = self.visible(collider, mask, exclude) else {
+            let Some((shape, at)) = self.query_visible(collider, mask, exclude) else {
                 continue;
             };
             let Some(hit) = cast(origin, direction, max_distance, shape, at) else {
@@ -184,7 +184,7 @@ impl World {
     ) -> Counts {
         let mut counts = Counts::default();
         for collider in self.colliders() {
-            let Some((other, other_at)) = self.visible(collider, mask, exclude) else {
+            let Some((other, other_at)) = self.query_visible(collider, mask, exclude) else {
                 continue;
             };
             if collide(shape, at, other, other_at).is_none() {

--- a/crates/physics2d/src/slide.rs
+++ b/crates/physics2d/src/slide.rs
@@ -1,0 +1,190 @@
+//! Moving a body against the world and sliding along what stops it.
+
+use crate::query::{Counts, Exclude};
+use crate::shape::Transform;
+use crate::sweep::sweep;
+use crate::world::{Collider, World};
+use renew_fixed::{Fixed, Vec2};
+
+/// Why a slide stopped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SlideEnd {
+    /// The whole displacement was used, or what remained pointed into a
+    /// surface and had nowhere left to go.
+    Displaced,
+    /// The iteration limit ran out with displacement still unspent.
+    ///
+    /// **Reported rather than swallowed.** A body that silently stopped short
+    /// looks to a caller exactly like one that arrived, and the difference
+    /// shows up as a character that sticks in corners for reasons nothing
+    /// explains.
+    IterationsExhausted,
+}
+
+/// One surface a slide met.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlideHit {
+    /// What was hit.
+    pub collider: Collider,
+    /// The surface direction, facing the mover.
+    pub normal: Vec2,
+    /// Where the body's origin sat when it met this.
+    pub origin: Vec2,
+}
+
+/// What a slide did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlideReport {
+    /// Where the body ended up.
+    pub destination: Vec2,
+    /// How many surfaces were met, and how many fitted the caller's buffer.
+    pub hits: Counts,
+    /// How many sweep-and-slide iterations were spent.
+    pub iterations: u32,
+    /// Why it stopped.
+    pub end: SlideEnd,
+}
+
+/// A displacement shorter than this is nothing left to spend.
+///
+/// Not zero: the slide subtracts a normal component each iteration and the
+/// remainder is rounded, so an exactly-zero remainder is a case that does not
+/// arise. One raw unit squared is the smallest length the number type can tell
+/// from nothing.
+const SPENT: i64 = 1;
+
+impl World {
+    /// Move a body along a displacement, sliding along whatever stops it.
+    ///
+    /// **This is where a character's ground state comes from, not from the
+    /// contact array.** A body stopped here rests a skin distance from what
+    /// stopped it — far enough that a contact test will not report it — so
+    /// the hits written here are the only record that it landed, what it
+    /// landed on, and which way that surface faced.
+    ///
+    /// The moving body is excluded from its own sweep. Its shapes are parts of
+    /// one object and an object does not block itself; an articulated thing
+    /// whose parts must collide is several bodies.
+    pub fn move_and_slide(
+        &mut self,
+        handle: renew_ecs::Entity,
+        displacement: Vec2,
+        mask: u32,
+        skin: Fixed,
+        iteration_limit: u32,
+        out: &mut [SlideHit],
+    ) -> Option<SlideReport> {
+        let start = self.transform(handle)?;
+        let mut position = start.translation;
+        let mut remaining = displacement;
+        let mut hits = Counts::default();
+        let mut iterations = 0;
+        let mut end = SlideEnd::IterationsExhausted;
+        let excluded = [handle];
+
+        while iterations < iteration_limit {
+            if remaining.length_squared().to_bits() <= SPENT {
+                end = SlideEnd::Displaced;
+                break;
+            }
+            iterations += 1;
+
+            let here = Transform::new(position, start.rotation);
+            let Some((hit, collider)) = self.sweep_body(
+                handle,
+                here,
+                remaining,
+                mask,
+                skin,
+                Exclude::bodies(&excluded),
+            ) else {
+                // Nothing in the way: spend what is left and finish.
+                position = position + remaining;
+                end = SlideEnd::Displaced;
+                break;
+            };
+
+            if let Some(slot) = out.get_mut(hits.written) {
+                *slot = SlideHit {
+                    collider,
+                    normal: hit.normal,
+                    origin: hit.origin,
+                };
+                hits.written += 1;
+            }
+            hits.existed += 1;
+
+            position = hit.origin;
+            // What is left of the displacement after the part already
+            // travelled, with the component into the surface removed. Sliding
+            // rather than stopping is what lets a character run along a wall
+            // instead of sticking to it.
+            let unspent = remaining * (Fixed::ONE - hit.time);
+            remaining = unspent.slide_along(hit.normal);
+        }
+
+        self.set_transform(handle, Transform::new(position, start.rotation));
+        Some(SlideReport {
+            destination: position,
+            hits,
+            iterations,
+            end,
+        })
+    }
+
+    /// Sweep every live shape of a body and take the earliest impact.
+    ///
+    /// **Ties break by the collider hit**, lowest first, so two surfaces met
+    /// at the same instant — which is what a corner is — resolve the same way
+    /// on every machine.
+    fn sweep_body(
+        &self,
+        handle: renew_ecs::Entity,
+        from: Transform,
+        displacement: Vec2,
+        mask: u32,
+        skin: Fixed,
+        exclude: Exclude<'_>,
+    ) -> Option<(crate::sweep::SweepHit, Collider)> {
+        let extent = self.shape_extent(handle)?;
+        let mut best: Option<(crate::sweep::SweepHit, Collider)> = None;
+
+        for index in 0..extent {
+            let mine = Collider {
+                handle,
+                index: crate::world::ShapeIndex::from_raw(index),
+            };
+            let Some((shape, local, _)) = self.shape(mine) else {
+                continue;
+            };
+            let placed = local.compose(from);
+
+            for collider in self.colliders() {
+                let Some((other, other_at)) = self.query_visible(collider, mask, exclude) else {
+                    continue;
+                };
+                let Some(hit) = sweep(shape, placed, displacement, other, other_at, skin) else {
+                    continue;
+                };
+                let earlier = best.as_ref().is_none_or(|(current, current_collider)| {
+                    hit.time < current.time
+                        || (hit.time == current.time && collider < *current_collider)
+                });
+                if earlier {
+                    // The reported origin is the shape's, and the caller moves
+                    // the body — so it is shifted back by the local placement.
+                    let body_origin = hit.origin - (placed.translation - from.translation);
+                    best = Some((
+                        crate::sweep::SweepHit {
+                            time: hit.time,
+                            origin: body_origin,
+                            normal: hit.normal,
+                        },
+                        collider,
+                    ));
+                }
+            }
+        }
+        best
+    }
+}

--- a/crates/physics2d/src/sweep.rs
+++ b/crates/physics2d/src/sweep.rs
@@ -62,6 +62,26 @@ pub fn sweep(
         let here = Transform::new(from.translation + displacement * time, from.rotation);
         let (gap, direction) = separation(moving, here, target, target_at)?;
 
+        // **Touching is not the same as being obstructed.** A body resting
+        // against a wall and sliding along it is in contact for the whole
+        // move, and reporting that as a blocking hit stops it dead: the slide
+        // removes the normal component, the remainder is already parallel, and
+        // the next iteration meets the same surface at the same instant. The
+        // body burns its whole iteration budget standing still.
+        //
+        // So contact only blocks when the motion goes *into* it. This is the
+        // one check that separates a wall a character is running along from a
+        // wall it is running at.
+        //
+        // **Penetration is the exception**: a body genuinely inside something
+        // reports whichever way it is moving, because a caller needs to know
+        // it is there before it can decide to push out. Only the band between
+        // touching and the skin distance is treated as passable.
+        let resting = gap >= Fixed::ZERO && displacement.dot(direction) <= Fixed::ZERO;
+        if gap <= skin && resting {
+            break;
+        }
+
         // Contact, or the budget spent. **The last step reports where it got
         // to rather than nothing**, because reporting no hit would let a body
         // pass straight through something it was converging on — and since

--- a/crates/physics2d/tests/slide.rs
+++ b/crates/physics2d/tests/slide.rs
@@ -286,3 +286,54 @@ fn exhausting_the_iteration_limit_is_reported() {
         assert_eq!(report.iterations, 1);
     }
 }
+
+/// **A body whose shape list has a hole still moves correctly.** Removing a
+/// shape leaves its index occupied by nothing, and the sweep walks indices up
+/// to the highest occupied one — so it has to step over the gap rather than
+/// treat it as a collider with no geometry.
+#[test]
+fn a_body_with_a_removed_shape_sweeps_only_its_live_ones() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let character = entities.spawn();
+    world.create_body(character, BodyKind::Kinematic, at(0, 0));
+
+    // Two shapes; the first is removed, leaving index 0 a hole and index 1
+    // live. The extent stays at two, which is what walks over the hole.
+    let doomed = world
+        .add_shape(character, square(1), Transform::IDENTITY, Filter::new(1, 1))
+        .expect("live body");
+    world
+        .add_shape(character, square(1), Transform::IDENTITY, Filter::new(1, 1))
+        .expect("live body");
+    assert!(world.remove_shape(character, doomed));
+    assert_eq!(
+        world.shape_extent(character),
+        Some(2),
+        "the hole keeps its place"
+    );
+
+    // A wall at x = 4, so the surviving shape still stops the body.
+    let wall = entities.spawn();
+    world.create_body(wall, BodyKind::Static, at(4, 0));
+    world.add_shape(
+        wall,
+        Shape::Box {
+            half_extents: v(1, 20),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(8, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert_eq!(report.hits.existed, 1, "the surviving shape met the wall");
+    assert!(
+        report.destination.x < Fixed::from_int(3),
+        "stopped at x = {}, which is inside the wall",
+        report.destination.x.to_bits()
+    );
+}

--- a/crates/physics2d/tests/slide.rs
+++ b/crates/physics2d/tests/slide.rs
@@ -1,0 +1,277 @@
+//! Moving a body against the world and sliding along what stops it.
+
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{
+    BodyKind, Collider, Filter, Shape, ShapeIndex, SlideEnd, SlideHit, Transform, World,
+};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(v(x, y))
+}
+
+fn square(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half),
+    }
+}
+
+const SKIN: Fixed = Fixed::from_bits(64);
+const ANY: u32 = u32::MAX;
+const LIMIT: u32 = 4;
+
+fn empty_hits() -> [SlideHit; 8] {
+    [SlideHit {
+        collider: Collider {
+            handle: Entities::new().spawn(),
+            index: ShapeIndex::from_raw(0),
+        },
+        normal: Vec2::ZERO,
+        origin: Vec2::ZERO,
+    }; 8]
+}
+
+/// A world with a character and whatever static boxes are named.
+fn staged(character_at: (i32, i32), walls: &[(i32, i32, i32, i32)]) -> (World, Entity) {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let character = entities.spawn();
+    world.create_body(
+        character,
+        BodyKind::Kinematic,
+        at(character_at.0, character_at.1),
+    );
+    world.add_shape(character, square(1), Transform::IDENTITY, Filter::new(1, 1));
+    for &(x, y, hx, hy) in walls {
+        let wall = entities.spawn();
+        world.create_body(wall, BodyKind::Static, at(x, y));
+        world.add_shape(
+            wall,
+            Shape::Box {
+                half_extents: v(hx, hy),
+            },
+            Transform::IDENTITY,
+            Filter::new(1, 1),
+        );
+    }
+    (world, character)
+}
+
+#[test]
+fn a_body_with_nothing_in_the_way_travels_the_whole_displacement() {
+    let (mut world, character) = staged((0, 0), &[]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(5, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert_eq!(report.end, SlideEnd::Displaced);
+    assert_eq!(report.hits.existed, 0, "nothing was met");
+    assert_eq!(report.destination, v(5, 0));
+    // The world was actually moved, not just told about it.
+    assert_eq!(
+        world.transform(character).map(|t| t.translation),
+        Some(v(5, 0))
+    );
+}
+
+/// **The landing case, which is what a platformer is built out of.** The body
+/// stops on the floor and the hit list is the record that it did — a contact
+/// test will not report it, because it rests a skin distance clear.
+#[test]
+fn a_body_falling_onto_a_floor_stops_on_it_and_reports_the_surface() {
+    let (mut world, character) = staged((0, 6), &[(0, 0, 20, 1)]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(0, -10), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert_eq!(report.end, SlideEnd::Displaced);
+    assert!(report.hits.existed >= 1, "it met the floor");
+    // Resting with its centre about one unit above the floor's top at y = 1.
+    let resting = report.destination.y;
+    assert!(
+        (resting - Fixed::from_int(2)).to_bits().abs() <= 2048,
+        "came to rest at y = {}, expected about 2",
+        resting.to_bits()
+    );
+    // The surface faces up, which is what tells a character it is grounded.
+    assert!(
+        hits[0].normal.y > Fixed::ZERO,
+        "the floor's normal must point up, got {}",
+        hits[0].normal.y.to_bits()
+    );
+}
+
+/// **Sliding rather than sticking.** A body pushed diagonally into a wall
+/// keeps the part of its motion along the wall — without that a character
+/// stops dead the moment it touches anything.
+#[test]
+fn a_body_pushed_into_a_wall_slides_along_it() {
+    // A tall wall at x = 4, and a character moving up and to the right.
+    let (mut world, character) = staged((0, 0), &[(4, 0, 1, 20)]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(6, 6), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert!(report.hits.existed >= 1, "it met the wall");
+    // Stopped short of the wall's face at x = 3.
+    assert!(
+        report.destination.x < Fixed::from_int(3),
+        "ended at x = {}, which is inside the wall",
+        report.destination.x.to_bits()
+    );
+    // And kept climbing: the vertical part of the motion survived.
+    assert!(
+        report.destination.y > Fixed::from_int(3),
+        "slid to y = {}, expected most of the six",
+        report.destination.y.to_bits()
+    );
+}
+
+/// A body driven straight at a wall keeps none of its motion, and that is
+/// slide working rather than failing: the whole displacement was normal to the
+/// surface, so removing the normal component leaves nothing.
+#[test]
+fn a_body_driven_straight_at_a_wall_stops() {
+    let (mut world, character) = staged((0, 0), &[(4, 0, 1, 20)]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(6, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert_eq!(
+        report.end,
+        SlideEnd::Displaced,
+        "it ran out of motion, not of tries"
+    );
+    assert!(report.destination.x < Fixed::from_int(3));
+    assert!(
+        report.destination.y.to_bits().abs() <= 64,
+        "it did not drift sideways"
+    );
+}
+
+/// A corner meets two surfaces, and the hit list records both.
+#[test]
+fn a_body_wedged_into_a_corner_reports_both_surfaces() {
+    // A wall on the right and a floor below, meeting at a corner.
+    let (mut world, character) = staged((0, 6), &[(4, 0, 1, 20), (0, 0, 20, 1)]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(6, -10), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert!(
+        report.hits.existed >= 2,
+        "a corner is two surfaces, got {}",
+        report.hits.existed
+    );
+    assert!(
+        report.destination.x < Fixed::from_int(3),
+        "kept out of the wall"
+    );
+    assert!(
+        report.destination.y > Fixed::from_int(1),
+        "kept out of the floor"
+    );
+}
+
+#[test]
+fn a_body_never_collides_with_its_own_shapes() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let character = entities.spawn();
+    world.create_body(character, BodyKind::Kinematic, at(0, 0));
+    // Two shapes on the one body, overlapping.
+    world.add_shape(character, square(1), Transform::IDENTITY, Filter::new(1, 1));
+    world.add_shape(character, square(1), at(1, 0), Filter::new(1, 1));
+
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(5, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.hits.existed, 0, "its own shapes are not obstacles");
+    assert_eq!(report.destination, v(5, 0));
+}
+
+#[test]
+fn a_mask_lets_a_body_pass_through_what_it_does_not_collide_with() {
+    let (mut world, character) = staged((0, 0), &[(4, 0, 1, 20)]);
+    let mut hits = empty_hits();
+    // The wall is on layer 1; a slide masked to layer 2 does not see it.
+    let report = world
+        .move_and_slide(character, v(8, 0), 0b10, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.hits.existed, 0);
+    assert_eq!(report.destination, v(8, 0), "straight through");
+}
+
+#[test]
+fn a_zero_displacement_slide_goes_nowhere_and_says_so() {
+    let (mut world, character) = staged((3, 4), &[]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, Vec2::ZERO, ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.end, SlideEnd::Displaced);
+    assert_eq!(report.iterations, 0, "nothing to do");
+    assert_eq!(report.destination, v(3, 4));
+}
+
+#[test]
+fn a_slide_on_a_handle_naming_no_body_is_refused() {
+    let (mut world, _) = staged((0, 0), &[]);
+    let stranger = Entities::new().spawn();
+    let mut hits = empty_hits();
+    // A fresh allocator's first entity shares an index with the character but
+    // the world checks the whole handle.
+    let refused = world.move_and_slide(stranger, v(1, 0), ANY, SKIN, LIMIT, &mut hits);
+    assert!(refused.is_none() || refused.is_some_and(|r| r.hits.existed == 0));
+}
+
+/// **A full hit buffer is reported, never silently truncated.** A caller that
+/// asked for one surface and met three has to be able to tell.
+#[test]
+fn a_small_hit_buffer_reports_what_it_could_not_write() {
+    let (mut world, character) = staged((0, 6), &[(4, 0, 1, 20), (0, 0, 20, 1)]);
+    let mut one: [SlideHit; 1] = [SlideHit {
+        collider: Collider {
+            handle: character,
+            index: ShapeIndex::from_raw(0),
+        },
+        normal: Vec2::ZERO,
+        origin: Vec2::ZERO,
+    }; 1];
+    let report = world
+        .move_and_slide(character, v(6, -10), ANY, SKIN, LIMIT, &mut one)
+        .expect("a live body");
+    assert_eq!(report.hits.written, 1);
+    assert!(report.hits.existed >= 2);
+    assert!(report.hits.truncated());
+}
+
+/// The iteration limit is reported rather than swallowed. A body that silently
+/// stopped short looks to a caller exactly like one that arrived.
+#[test]
+fn exhausting_the_iteration_limit_is_reported() {
+    // A narrow channel: walls above and below, so each slide meets another.
+    let (mut world, character) = staged(
+        (0, 0),
+        &[(4, 3, 1, 1), (4, -3, 1, 1), (6, 0, 1, 1), (8, 3, 1, 1)],
+    );
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(character, v(20, 1), ANY, SKIN, 1, &mut hits)
+        .expect("a live body");
+    // One iteration only, and it met something, so it cannot have finished.
+    if report.hits.existed > 0 {
+        assert_eq!(report.end, SlideEnd::IterationsExhausted);
+        assert_eq!(report.iterations, 1);
+    }
+}

--- a/crates/physics2d/tests/slide.rs
+++ b/crates/physics2d/tests/slide.rs
@@ -227,12 +227,23 @@ fn a_zero_displacement_slide_goes_nowhere_and_says_so() {
 #[test]
 fn a_slide_on_a_handle_naming_no_body_is_refused() {
     let (mut world, _) = staged((0, 0), &[]);
-    let stranger = Entities::new().spawn();
     let mut hits = empty_hits();
-    // A fresh allocator's first entity shares an index with the character but
-    // the world checks the whole handle.
-    let refused = world.move_and_slide(stranger, v(1, 0), ANY, SKIN, LIMIT, &mut hits);
-    assert!(refused.is_none() || refused.is_some_and(|r| r.hits.existed == 0));
+    // A body that existed and does not any more. Using a fresh allocator's
+    // first entity would not do: it is index zero generation zero, the very
+    // handle the character already has, so the world would find a live body
+    // and the test would pass while checking nothing.
+    let mut entities = Entities::new();
+    let _first = entities.spawn();
+    let doomed = entities.spawn();
+    world.create_body(doomed, BodyKind::Kinematic, at(0, 0));
+    world.destroy_body(doomed);
+
+    assert!(
+        world
+            .move_and_slide(doomed, v(1, 0), ANY, SKIN, LIMIT, &mut hits)
+            .is_none(),
+        "a destroyed body has nothing to move"
+    );
 }
 
 /// **A full hit buffer is reported, never silently truncated.** A caller that


### PR DESCRIPTION
Sweep the body, move to just short of what stops it, remove the part of
the motion that went into the surface, repeat. This is what a character
moves with, and the hits it records are where ground state comes from -
a body stopped here rests a skin distance clear of what stopped it, so a
contact test will not report it and the hit list is the only record that
it landed, on what, and which way that surface faced.

Writing the wall-sliding test found a real defect in the sweep. Contact
was reported from the gap alone, without asking whether the motion went
into the surface - so a body resting against a wall and sliding along it
got a blocking hit at time zero, the slide removed a normal component
that was already absent, and the next iteration met the same surface at
the same instant. The character burned its whole iteration budget
standing still. In isolation the sweep looked right; it took a test
shaped like a game to show otherwise.

Contact now blocks only when the displacement points into it, with
penetration as the exception: a body genuinely inside something reports
whichever way it is moving, because a caller needs to know it is there
before it can decide to push out. Only the band between touching and the
skin distance is treated as passable, which is precisely the band a body
sits in after a previous slide put it there.

A body sweep is the earliest impact over all of the body's live shapes,
ties broken by the collider hit so that a corner - two surfaces met at
the same instant - resolves the same way everywhere. The body is
excluded from its own sweep, since its shapes are parts of one object.

Exhausting the iteration limit is reported rather than swallowed. A body
that silently stopped short looks to a caller exactly like one that
arrived, and the difference shows up as a character sticking in corners
for reasons nothing explains.