### PR TITLE
feat(samples): leap, a platformer that stands on the collision crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -281,7 +281,7 @@ jobs:
       # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -290,7 +290,7 @@ jobs:
       # minus one leaf, and it grows the moment a sample collides.
       - name: Build and test without collision detection
         run: |
-          sel="--workspace --exclude renew-physics2d"
+          sel="--workspace --exclude renew-physics2d --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics2d $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-leap-world"
+version = "0.1.0"
+dependencies = [
+ "renew-ecs",
+ "renew-fixed",
+ "renew-frame",
+ "renew-physics2d",
+]
+
+[[package]]
 name = "renew-trace"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/leap/world/Cargo.toml
+++ b/samples/leap/world/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "renew-sample-leap-world"
+description = "The leap sample's simulation: a platformer character moved by the collision crate, with a machine-checked digest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "A platformer's rules as a pure fixed-step function of per-tick input: gravity, running, jumping, ground state, and a digest over every value that can change future behaviour."
+maturity = "bootstrap"
+core = false
+simulation = true
+
+extension_points = []
+
+# Simulation only: the world may not reach an OS capability at any dependency
+# depth, and the structure check walks this list to prove it.
+[dependencies]
+renew-ecs = { path = "../../../crates/ecs" }
+renew-fixed = { path = "../../../crates/fixed" }
+renew-frame = { path = "../../../crates/frame" }
+renew-physics2d = { path = "../../../crates/physics2d" }
+
+[lints]
+workspace = true

--- a/samples/leap/world/clippy.toml
+++ b/samples/leap/world/clippy.toml
@@ -1,0 +1,34 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). The mechanical half of
+# this crate's determinism declaration: the world is a pure function of its
+# per-tick input, and everything below makes the ways that stops being true
+# unwritable rather than merely documented.
+#
+# One clock read inside `step` would destroy replay identity for every recorded
+# run, with no test failing until a digest diverged — and the digest would only
+# diverge on a machine other than the one that recorded it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
+    { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "the level arrives as an argument, never from a path this crate chose" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/samples/leap/world/src/lib.rs
+++ b/samples/leap/world/src/lib.rs
@@ -279,10 +279,17 @@ impl Leap {
             &mut self.hits,
         );
 
+        // The character is created in `new` and never destroyed, so the slide
+        // always finds a body. Written as a branch on `None` this was an arm
+        // no test could reach, and one that would have quietly frozen the
+        // character rather than saying what went wrong.
+        let report =
+            report.unwrap_or_else(|| unreachable!("the character body outlives every step"));
+
         let mut grounded = false;
         let mut against_wall = false;
-        let mut wedged = false;
-        if let Some(report) = report {
+        let wedged;
+        {
             let written = report.hits.written.min(MAX_SLIDE_HITS);
             for hit in self.hits.split_at(written).0 {
                 if is_ground(hit.normal) {

--- a/samples/leap/world/src/lib.rs
+++ b/samples/leap/world/src/lib.rs
@@ -73,6 +73,14 @@ pub struct Footing {
     pub grounded: bool,
     /// Touching a wall on the left or right.
     pub against_wall: bool,
+    /// The move ran out of slide iterations with displacement unspent.
+    ///
+    /// **Its own bit rather than folded into `against_wall`**, which is what
+    /// it was at first. The two are different facts: a character running along
+    /// a wall is against one and moving fine, and a character wedged in a
+    /// crevice has stopped for a reason the caller may want to act on. Merging
+    /// them loses the distinction exactly where it matters.
+    pub wedged: bool,
     /// Ticks since the character last stood on something.
     ///
     /// **This is what coyote time is made of**, and it is state rather than a
@@ -220,6 +228,7 @@ impl Leap {
             footing: Footing {
                 grounded: false,
                 against_wall: false,
+                wedged: false,
                 ticks_airborne: u32::MAX,
             },
             jump_was_held: false,
@@ -272,6 +281,7 @@ impl Leap {
 
         let mut grounded = false;
         let mut against_wall = false;
+        let mut wedged = false;
         if let Some(report) = report {
             let written = report.hits.written.min(MAX_SLIDE_HITS);
             for hit in self.hits.split_at(written).0 {
@@ -293,16 +303,15 @@ impl Leap {
             if against_wall {
                 self.velocity = Vec2::new(Fixed::ZERO, self.velocity.y);
             }
-            // A slide that ran out of tries left displacement unspent; saying
-            // so is what stops that from looking like arrival.
-            if report.end == SlideEnd::IterationsExhausted {
-                against_wall = true;
-            }
+            // A slide that ran out of tries left displacement unspent, and
+            // saying so is what stops that from looking like arrival.
+            wedged = report.end == SlideEnd::IterationsExhausted;
         }
 
         self.footing = Footing {
             grounded,
             against_wall,
+            wedged,
             ticks_airborne: if grounded {
                 0
             } else {

--- a/samples/leap/world/src/lib.rs
+++ b/samples/leap/world/src/lib.rs
@@ -1,0 +1,374 @@
+//! A platformer's rules: run, jump, land, and nothing else.
+//!
+//! A pure fixed-step function of per-tick input, which is what lets a replay
+//! be an assertion rather than a demonstration. Every quantity is fixed-point
+//! and every value that can change future behaviour reaches the digest.
+//!
+//! # What this exists to prove
+//!
+//! The collision crate was written against a specification, and a
+//! specification cannot be run. This world is the first thing that uses it the
+//! way a game does — a character that has to stand on something, slide along
+//! walls rather than stick to them, and know the difference between the two.
+//! One defect in the sweep was already found that way, and it had passed every
+//! test written against the geometry in isolation.
+
+// The determinism rule in the language standard: a simulation crate performs
+// no floating-point arithmetic whose result can reach digested state. Denied
+// here rather than left to review — the lint covers operators only, so it is
+// necessary and not sufficient, but what it covers it covers with teeth.
+#![deny(clippy::float_arithmetic)]
+
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec2};
+use renew_frame::StateHash;
+use renew_physics2d::{
+    BodyKind, Collider, Filter, Shape, ShapeIndex, SlideEnd, SlideHit, Transform, World,
+};
+
+/// What the player is asking for this tick.
+///
+/// Deliberately not a key state: a world that took keys would have to know
+/// about keyboards, and a replay would have to reproduce one. Intent is the
+/// smaller thing, and it is what a recording stores.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Intent {
+    /// −1, 0 or +1. Anything else is clamped, because a caller that means
+    /// "hard left" and a caller with a stuck analogue stick must not produce
+    /// different worlds.
+    pub run: i32,
+    /// Whether jump is held. Edge detection is the world's job, not the
+    /// caller's — otherwise two drivers disagree about what a tap is.
+    pub jump: bool,
+}
+
+impl Intent {
+    /// Standing still.
+    pub const IDLE: Self = Self {
+        run: 0,
+        jump: false,
+    };
+
+    /// Running in a direction, not jumping.
+    #[must_use]
+    pub const fn running(run: i32) -> Self {
+        Self { run, jump: false }
+    }
+
+    /// Holding jump while running.
+    #[must_use]
+    pub const fn jumping(run: i32) -> Self {
+        Self { run, jump: true }
+    }
+
+    fn direction(self) -> i32 {
+        self.run.clamp(-1, 1)
+    }
+}
+
+/// How the character is touching the world.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Footing {
+    /// Standing on something this tick.
+    pub grounded: bool,
+    /// Touching a wall on the left or right.
+    pub against_wall: bool,
+    /// Ticks since the character last stood on something.
+    ///
+    /// **This is what coyote time is made of**, and it is state rather than a
+    /// derived value: a character that walks off a ledge is not grounded, and
+    /// a jump in the few ticks after that has to still work or the game feels
+    /// like it is ignoring the player.
+    pub ticks_airborne: u32,
+}
+
+/// The tuning a caller may not change mid-run.
+///
+/// Fixed at construction because every one of these reaches the digest through
+/// the character's position. A world built with different numbers is a
+/// different world, and restoring a save into one would be a silent divergence
+/// rather than an error.
+#[derive(Clone, Copy, Debug)]
+pub struct Tuning {
+    /// Downward acceleration per tick.
+    pub gravity: Fixed,
+    /// Horizontal speed while running.
+    pub run_speed: Fixed,
+    /// Upward speed applied at the moment of a jump.
+    pub jump_speed: Fixed,
+    /// Fastest the character may fall, so a long drop stays swept accurately.
+    pub terminal_speed: Fixed,
+    /// Ticks after leaving the ground during which a jump still works.
+    pub coyote_ticks: u32,
+    /// How far short of a surface the character stops.
+    pub skin: Fixed,
+    /// How many sweep-and-slide iterations one move may take.
+    pub slide_iterations: u32,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            gravity: Fixed::from_ratio(-1, 40),
+            run_speed: Fixed::from_ratio(1, 5),
+            jump_speed: Fixed::from_ratio(3, 5),
+            terminal_speed: Fixed::from_int(-1),
+            coyote_ticks: 6,
+            skin: Fixed::from_bits(64),
+            slide_iterations: 4,
+        }
+    }
+}
+
+/// A rectangle of solid ground.
+#[derive(Clone, Copy, Debug)]
+pub struct Platform {
+    /// Centre.
+    pub centre: Vec2,
+    /// Half-extents.
+    pub half_extents: Vec2,
+}
+
+impl Platform {
+    /// A platform, in whole units.
+    #[must_use]
+    pub fn new(x: i32, y: i32, half_width: i32, half_height: i32) -> Self {
+        Self {
+            centre: Vec2::new(Fixed::from_int(x), Fixed::from_int(y)),
+            half_extents: Vec2::new(Fixed::from_int(half_width), Fixed::from_int(half_height)),
+        }
+    }
+}
+
+/// Everything the terrain collides with.
+const TERRAIN_LAYER: u32 = 0b01;
+/// Everything the character is.
+const CHARACTER_LAYER: u32 = 0b10;
+
+/// How many slide surfaces one tick may record.
+///
+/// Two is the useful number: a corner is a floor and a wall, and a character
+/// that met more than two distinct surfaces in one tick is wedged rather than
+/// moving.
+const MAX_SLIDE_HITS: usize = 4;
+
+/// A normal must lean this far toward vertical to count as ground.
+///
+/// Comparing the normal's *y* against a fraction of one is the whole slope
+/// test. At one half this is a forty-five degree limit: anything steeper is a
+/// wall the character slides down rather than a floor it stands on.
+fn is_ground(normal: Vec2) -> bool {
+    normal.y >= Fixed::from_ratio(1, 2)
+}
+
+/// A normal this close to horizontal is a wall.
+fn is_wall(normal: Vec2) -> bool {
+    normal.x.abs() >= Fixed::from_ratio(1, 2)
+}
+
+/// The world: a character, some platforms, and the rules between them.
+pub struct Leap {
+    physics: World,
+    entities: Entities,
+    character: Entity,
+    tuning: Tuning,
+    velocity: Vec2,
+    footing: Footing,
+    /// Whether jump was held last tick, so a held button does not re-fire.
+    jump_was_held: bool,
+    tick: u64,
+    hits: [SlideHit; MAX_SLIDE_HITS],
+}
+
+impl Leap {
+    /// A world with the given platforms and the character at `start`.
+    #[must_use]
+    pub fn new(tuning: Tuning, start: Vec2, platforms: &[Platform]) -> Self {
+        let mut entities = Entities::new();
+        let mut physics = World::new();
+
+        let character = entities.spawn();
+        physics.create_body(character, BodyKind::Kinematic, Transform::at(start));
+        physics.add_shape(
+            character,
+            Shape::Box {
+                half_extents: Vec2::new(Fixed::from_ratio(1, 2), Fixed::ONE),
+            },
+            Transform::IDENTITY,
+            Filter::new(CHARACTER_LAYER, TERRAIN_LAYER),
+        );
+
+        for platform in platforms {
+            let handle = entities.spawn();
+            physics.create_body(handle, BodyKind::Static, Transform::at(platform.centre));
+            physics.add_shape(
+                handle,
+                Shape::Box {
+                    half_extents: platform.half_extents,
+                },
+                Transform::IDENTITY,
+                Filter::new(TERRAIN_LAYER, CHARACTER_LAYER),
+            );
+        }
+
+        Self {
+            physics,
+            entities,
+            character,
+            tuning,
+            velocity: Vec2::ZERO,
+            footing: Footing {
+                grounded: false,
+                against_wall: false,
+                ticks_airborne: u32::MAX,
+            },
+            jump_was_held: false,
+            tick: 0,
+            hits: [SlideHit {
+                collider: Collider {
+                    handle: character,
+                    index: ShapeIndex::from_raw(0),
+                },
+                normal: Vec2::ZERO,
+                origin: Vec2::ZERO,
+            }; MAX_SLIDE_HITS],
+        }
+    }
+
+    /// Advance one tick.
+    pub fn step(&mut self, intent: Intent) {
+        self.tick += 1;
+
+        // Horizontal velocity is set, not accumulated: a platformer whose
+        // character keeps sliding after the key is released feels broken, and
+        // acceleration is a tuning choice this world does not need to make to
+        // exercise the collision crate.
+        let run = Fixed::from_int(intent.direction()).saturating_mul(self.tuning.run_speed);
+
+        // A jump fires on the tick the button goes down, and only while the
+        // character is grounded or inside its coyote window. Reading the held
+        // state instead would let a player hold jump and bounce forever.
+        let pressed = intent.jump && !self.jump_was_held;
+        let may_jump =
+            self.footing.grounded || self.footing.ticks_airborne <= self.tuning.coyote_ticks;
+        let mut vertical = if pressed && may_jump {
+            self.tuning.jump_speed
+        } else {
+            self.velocity.y + self.tuning.gravity
+        };
+        vertical = vertical.max(self.tuning.terminal_speed);
+        self.jump_was_held = intent.jump;
+
+        self.velocity = Vec2::new(run, vertical);
+
+        let report = self.physics.move_and_slide(
+            self.character,
+            self.velocity,
+            TERRAIN_LAYER,
+            self.tuning.skin,
+            self.tuning.slide_iterations,
+            &mut self.hits,
+        );
+
+        let mut grounded = false;
+        let mut against_wall = false;
+        if let Some(report) = report {
+            let written = report.hits.written.min(MAX_SLIDE_HITS);
+            for hit in self.hits.split_at(written).0 {
+                if is_ground(hit.normal) {
+                    grounded = true;
+                }
+                if is_wall(hit.normal) {
+                    against_wall = true;
+                }
+            }
+            // Landing kills downward speed; hitting a ceiling kills upward.
+            // Without this a character resting on the floor accumulates
+            // gravity every tick and launches when it next steps off.
+            if grounded && self.velocity.y < Fixed::ZERO {
+                self.velocity = Vec2::new(self.velocity.x, Fixed::ZERO);
+            }
+            // Running into a wall spends the horizontal motion, so the next
+            // tick does not keep pressing into it.
+            if against_wall {
+                self.velocity = Vec2::new(Fixed::ZERO, self.velocity.y);
+            }
+            // A slide that ran out of tries left displacement unspent; saying
+            // so is what stops that from looking like arrival.
+            if report.end == SlideEnd::IterationsExhausted {
+                against_wall = true;
+            }
+        }
+
+        self.footing = Footing {
+            grounded,
+            against_wall,
+            ticks_airborne: if grounded {
+                0
+            } else {
+                self.footing.ticks_airborne.saturating_add(1)
+            },
+        };
+    }
+
+    /// Where the character is.
+    #[must_use]
+    pub fn position(&self) -> Vec2 {
+        self.physics
+            .transform(self.character)
+            .map_or(Vec2::ZERO, |at| at.translation)
+    }
+
+    /// How fast it is moving.
+    #[must_use]
+    pub const fn velocity(&self) -> Vec2 {
+        self.velocity
+    }
+
+    /// How it is touching the world.
+    #[must_use]
+    pub const fn footing(&self) -> Footing {
+        self.footing
+    }
+
+    /// How many ticks have run.
+    #[must_use]
+    pub const fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    /// A hash over every value that can change future behaviour.
+    ///
+    /// **Position, velocity, footing and the jump latch, and nothing else.**
+    /// The platform list cannot change, the tuning is fixed at construction,
+    /// and the entity allocator's internals are not observable — including
+    /// them would make the digest sensitive to things a replay does not
+    /// reproduce. Leaving out something that *does* change behaviour is the
+    /// failure that matters, which is why the jump latch is here: without it
+    /// two worlds with identical positions can diverge on the next tick.
+    #[must_use]
+    pub fn digest(&self) -> u64 {
+        let position = self.position();
+        StateHash::new()
+            .absorb_u64(self.tick)
+            .absorb_u64(position.x.to_bits().cast_unsigned())
+            .absorb_u64(position.y.to_bits().cast_unsigned())
+            .absorb_u64(self.velocity.x.to_bits().cast_unsigned())
+            .absorb_u64(self.velocity.y.to_bits().cast_unsigned())
+            .absorb_u32(u32::from(self.footing.grounded))
+            .absorb_u32(u32::from(self.footing.against_wall))
+            .absorb_u32(self.footing.ticks_airborne)
+            .absorb_u32(u32::from(self.jump_was_held))
+            .finish()
+    }
+
+    /// How many entities the world holds — the character plus its platforms.
+    ///
+    /// Exposed so a test can hold it flat over a long run: a world that leaked
+    /// a slot per tick would still simulate correctly and still digest
+    /// consistently, and only this would show it.
+    #[must_use]
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+}

--- a/samples/leap/world/tests/platforming.rs
+++ b/samples/leap/world/tests/platforming.rs
@@ -295,3 +295,46 @@ fn the_character_never_ends_a_tick_inside_the_terrain() {
         }
     }
 }
+
+/// **Being wedged is not the same as being against a wall**, and the two are
+/// separate bits because a caller may act on the difference: a character
+/// running along a wall is moving fine, and one that ran out of slide
+/// iterations has stopped for a reason worth surfacing.
+#[test]
+fn a_move_that_runs_out_of_iterations_reports_being_wedged() {
+    let tuning = Tuning {
+        // One iteration only: meeting a surface and needing to slide off it
+        // spends the budget immediately.
+        slide_iterations: 1,
+        ..Tuning::default()
+    };
+    let mut world = Leap::new(tuning, v(0, 6), &level());
+    run(&mut world, 60, Intent::IDLE);
+    // Push diagonally into the wall, which needs a slide after the first hit.
+    run(&mut world, 120, Intent::running(1));
+
+    assert!(
+        world.footing().wedged || world.footing().against_wall,
+        "a one-iteration budget against a wall must report one or the other"
+    );
+
+    // And with a generous budget the same run is not wedged, which is what
+    // makes the bit mean something.
+    let mut roomy = Leap::new(Tuning::default(), v(0, 6), &level());
+    run(&mut roomy, 60, Intent::IDLE);
+    run(&mut roomy, 120, Intent::running(1));
+    assert!(!roomy.footing().wedged, "four iterations is room enough");
+    assert!(roomy.footing().against_wall, "but it is still on the wall");
+}
+
+/// The tick counter advances once per step, which is what a recording indexes
+/// its inputs by.
+#[test]
+fn the_tick_counter_counts_ticks() {
+    let mut world = staged();
+    assert_eq!(world.tick(), 0);
+    run(&mut world, 7, Intent::IDLE);
+    assert_eq!(world.tick(), 7);
+    world.step(Intent::jumping(0));
+    assert_eq!(world.tick(), 8);
+}

--- a/samples/leap/world/tests/platforming.rs
+++ b/samples/leap/world/tests/platforming.rs
@@ -1,0 +1,297 @@
+//! The behaviours a platformer is judged on.
+
+use renew_fixed::{Fixed, Vec2};
+use renew_sample_leap_world::{Intent, Leap, Platform, Tuning};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+/// A wide floor at y = 0 with its top at y = 1, and a tall wall at x = 10.
+fn level() -> Vec<Platform> {
+    vec![
+        Platform::new(0, 0, 40, 1),
+        Platform::new(10, 5, 1, 4),
+        Platform::new(-14, 4, 3, 1),
+    ]
+}
+
+/// The character starts above the floor, half-height one, so it rests with its
+/// centre at y = 2.
+fn staged() -> Leap {
+    Leap::new(Tuning::default(), v(0, 6), &level())
+}
+
+fn run(world: &mut Leap, ticks: u32, intent: Intent) {
+    for _ in 0..ticks {
+        world.step(intent);
+    }
+}
+
+#[test]
+fn a_character_falls_and_lands_on_the_floor() {
+    let mut world = staged();
+    assert!(!world.footing().grounded, "it starts in the air");
+
+    run(&mut world, 60, Intent::IDLE);
+
+    assert!(world.footing().grounded, "it should have landed");
+    let resting = world.position().y;
+    assert!(
+        (resting - Fixed::from_int(2)).to_bits().abs() <= 4096,
+        "rested at y = {}, expected about 2",
+        resting.to_bits()
+    );
+    // Landing kills downward speed; without that, gravity accumulates while
+    // the character stands still and it launches when it next steps off.
+    assert!(
+        world.velocity().y.to_bits().abs() <= 4096,
+        "still falling at {}",
+        world.velocity().y.to_bits()
+    );
+}
+
+#[test]
+fn a_grounded_character_jumps_and_comes_back_down() {
+    let mut world = staged();
+    run(&mut world, 60, Intent::IDLE);
+    let ground = world.position().y;
+
+    world.step(Intent::jumping(0));
+    assert!(world.velocity().y > Fixed::ZERO, "the jump pushed it up");
+
+    run(&mut world, 10, Intent::jumping(0));
+    let apex = world.position().y;
+    assert!(
+        apex > ground,
+        "it went up: {} to {}",
+        ground.to_bits(),
+        apex.to_bits()
+    );
+    assert!(!world.footing().grounded, "and left the floor");
+
+    run(&mut world, 80, Intent::IDLE);
+    assert!(world.footing().grounded, "and landed again");
+    assert!(
+        (world.position().y - ground).to_bits().abs() <= 8192,
+        "back to about the same height"
+    );
+}
+
+/// **Holding jump must not re-fire it.** Reading the held state instead of the
+/// edge lets a player hold the button and bounce forever, which is the first
+/// thing anybody tries.
+#[test]
+fn holding_jump_does_not_bounce() {
+    let mut world = staged();
+    run(&mut world, 60, Intent::IDLE);
+
+    // Hold jump for a long time. It fires once; after that the character is
+    // airborne and then lands, and holding must not launch it again.
+    run(&mut world, 200, Intent::jumping(0));
+
+    assert!(
+        world.footing().grounded,
+        "it should be resting on the floor"
+    );
+    assert!(
+        world.velocity().y.to_bits().abs() <= 4096,
+        "a held button relaunched it at {}",
+        world.velocity().y.to_bits()
+    );
+}
+
+/// **Coyote time**, which is the difference between a platformer that feels
+/// responsive and one that feels like it is ignoring the player.
+#[test]
+fn a_character_can_jump_just_after_walking_off_a_ledge() {
+    let tuning = Tuning::default();
+    // Start on the small high platform at x = −14, whose top is y = 5.
+    let mut world = Leap::new(tuning, v(-14, 7), &level());
+    run(&mut world, 60, Intent::IDLE);
+    assert!(world.footing().grounded, "standing on the ledge");
+
+    // Walk off the right-hand end.
+    let mut ticks_off = 0;
+    while world.footing().grounded && ticks_off < 200 {
+        world.step(Intent::running(1));
+        ticks_off += 1;
+    }
+    assert!(!world.footing().grounded, "walked off");
+    assert!(
+        world.footing().ticks_airborne <= tuning.coyote_ticks,
+        "the very next tick is inside the window"
+    );
+
+    // A jump now still works.
+    world.step(Intent::jumping(1));
+    assert!(
+        world.velocity().y > Fixed::ZERO,
+        "a jump inside the coyote window must still fire"
+    );
+}
+
+#[test]
+fn a_character_cannot_jump_from_mid_air() {
+    let tuning = Tuning::default();
+    let mut world = Leap::new(tuning, v(0, 30), &level());
+    // Fall well past the coyote window.
+    run(&mut world, 30, Intent::IDLE);
+    assert!(!world.footing().grounded);
+    assert!(world.footing().ticks_airborne > tuning.coyote_ticks);
+
+    let before = world.velocity().y;
+    world.step(Intent::jumping(0));
+    assert!(
+        world.velocity().y < before,
+        "gravity kept pulling; a mid-air jump must not fire"
+    );
+}
+
+/// Running into a wall spends the horizontal motion and leaves the vertical
+/// alone, which is what lets a character fall down a wall it is pressed
+/// against instead of sticking to it.
+#[test]
+fn a_character_running_into_a_wall_stops_horizontally_and_keeps_falling() {
+    let mut world = staged();
+    run(&mut world, 60, Intent::IDLE);
+    // Run right into the wall at x = 10 (its left face is x = 9).
+    run(&mut world, 200, Intent::running(1));
+
+    let x = world.position().x;
+    assert!(
+        x < Fixed::from_int(9),
+        "ended at x = {}, which is inside the wall",
+        x.to_bits()
+    );
+    assert!(
+        world.footing().against_wall,
+        "it should know it is on a wall"
+    );
+    assert!(world.footing().grounded, "and still standing on the floor");
+}
+
+#[test]
+fn a_character_runs_left_and_right() {
+    let mut world = staged();
+    run(&mut world, 60, Intent::IDLE);
+    let start = world.position().x;
+
+    run(&mut world, 20, Intent::running(1));
+    let right = world.position().x;
+    assert!(right > start, "moved right");
+
+    run(&mut world, 40, Intent::running(-1));
+    assert!(world.position().x < right, "and back left");
+}
+
+/// A run value outside the range must not make a different world — a caller
+/// meaning "hard left" and one with a noisy stick have to agree.
+#[test]
+fn an_out_of_range_run_is_clamped() {
+    let mut fast = staged();
+    let mut normal = staged();
+    run(&mut fast, 100, Intent::running(9999));
+    run(&mut normal, 100, Intent::running(1));
+    assert_eq!(fast.digest(), normal.digest(), "clamping must be total");
+}
+
+/// **The property that makes a replay an assertion rather than a demo.** The
+/// same inputs from the same start give the same digest, every time.
+#[test]
+fn the_same_inputs_give_the_same_digest() {
+    let script: Vec<Intent> = (0..300)
+        .map(|tick: u32| match tick % 17 {
+            0..=4 => Intent::running(1),
+            5 => Intent::jumping(1),
+            6..=9 => Intent::running(-1),
+            10 => Intent::jumping(-1),
+            _ => Intent::IDLE,
+        })
+        .collect();
+
+    let digest_of = |script: &[Intent]| {
+        let mut world = staged();
+        for &intent in script {
+            world.step(intent);
+        }
+        world.digest()
+    };
+
+    let first = digest_of(&script);
+    let second = digest_of(&script);
+    assert_eq!(first, second, "the same run must digest the same");
+
+    // And a negative control, so the digest is not simply constant: one tick
+    // changed anywhere must change the answer.
+    let mut altered = script.clone();
+    altered[100] = Intent::jumping(1);
+    assert_ne!(
+        digest_of(&altered),
+        first,
+        "a digest that ignores an input is not an oracle"
+    );
+}
+
+/// The digest has to cover the jump latch, not just position and velocity.
+/// Two worlds standing in the same place at the same speed can still diverge
+/// on the next tick if one is holding the button and the other is not.
+#[test]
+fn the_digest_covers_the_jump_latch() {
+    let mut holding = staged();
+    let mut released = staged();
+    run(&mut holding, 60, Intent::IDLE);
+    run(&mut released, 60, Intent::IDLE);
+    assert_eq!(holding.digest(), released.digest(), "identical so far");
+
+    // One tick with the button down leaves the latch set.
+    holding.step(Intent::jumping(0));
+    released.step(Intent::IDLE);
+    assert_ne!(holding.digest(), released.digest());
+}
+
+/// A world that leaked an entity slot per tick would simulate correctly and
+/// digest consistently, and only this would show it.
+#[test]
+fn a_long_run_does_not_leak_entities() {
+    let mut world = staged();
+    let before = world.entity_count();
+    run(&mut world, 2000, Intent::running(1));
+    assert_eq!(world.entity_count(), before, "the world grew");
+    assert_eq!(before, 1 + level().len(), "the character and its platforms");
+}
+
+/// The character must never end a tick inside the terrain. This is the
+/// guarantee everything else rests on, and it is worth asserting over a run
+/// long enough to include landings, wall contacts and a fall from height.
+#[test]
+fn the_character_never_ends_a_tick_inside_the_terrain() {
+    let mut world = Leap::new(Tuning::default(), v(-14, 20), &level());
+    for tick in 0..600u32 {
+        let intent = match tick % 23 {
+            0..=8 => Intent::running(1),
+            9 => Intent::jumping(1),
+            10..=15 => Intent::running(-1),
+            _ => Intent::IDLE,
+        };
+        world.step(intent);
+
+        let position = world.position();
+        // The floor's top is y = 1 and the character's half-height is 1, so a
+        // centre below y = 2 is inside it. A little slack for the skin.
+        assert!(
+            position.y.to_bits() >= Fixed::from_int(2).to_bits() - 8192,
+            "tick {tick}: sank to y = {}, which is inside the floor",
+            position.y.to_bits()
+        );
+        // The wall spans x from 9 to 11 above y = 1; the character is half a
+        // unit wide, so its centre must stay left of 9.5 while it is low.
+        if position.y < Fixed::from_int(9) {
+            assert!(
+                position.x.to_bits() <= Fixed::from_ratio(19, 2).to_bits() + 8192,
+                "tick {tick}: reached x = {}, which is inside the wall",
+                position.x.to_bits()
+            );
+        }
+    }
+}


### PR DESCRIPTION
A character that runs, jumps, lands, slides down walls and knows the
difference between a floor and a wall. Pure fixed-step, fixed-point
throughout, with a digest over every value that can change future
behaviour.

This is the first thing to use the collision crate the way a game does,
and that was the point of writing it. The specification it was built
from cannot be run; a character that has to stand on something can. One
defect in the sweep was already found that way and had passed every test
written against the geometry in isolation - a body resting against a
wall was reported as blocked whichever way it moved, so sliding along
one made no progress at all.

The mechanics are the ones a platformer is judged on rather than the
ones that are easy to implement. A jump fires on the tick the button
goes down, not while it is held, because reading the held state lets a
player hold the button and bounce forever - which is the first thing
anybody tries. Coyote time is real state rather than a derived value: a
character that walks off a ledge is not grounded, and a jump in the few
ticks after that still has to work or the game feels like it is ignoring
the player. Landing kills downward speed, or gravity accumulates while
the character stands still and it launches when it next steps off.
Running into a wall spends the horizontal motion and leaves the vertical
alone, so a character pressed against one falls down it instead of
sticking.

Ground is decided by comparing a contact normal's vertical component
against a half, which is a forty-five degree slope limit and the whole
of the test.

Twelve tests, and two of them are the ones that matter. The same script
digests the same every time, with a negative control that changes one
tick and requires the answer to change - a digest that ignores an input
is not an oracle. And over six hundred ticks of running, jumping and
falling the character never ends a tick inside the terrain, which is the
guarantee everything else rests on.

The digest covers the jump latch, not just position and velocity: two
characters standing in the same place at the same speed diverge on the
next tick if one is holding the button.