### PR TITLE
feat(samples): chess, checked against the one oracle the game has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-chess-rules"
+version = "0.1.0"
+dependencies = [
+ "renew-frame",
+]
+
+[[package]]
 name = "renew-sample-glide"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/chess/rules/Cargo.toml
+++ b/samples/chess/rules/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "renew-sample-chess-rules"
+description = "The chess sample's rules: legal move generation, checked against published perft counts"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Chess as a pure function of position and move: generation, legality, castling, en passant, promotion, and a digest over every value that can change future play."
+maturity = "bootstrap"
+core = false
+simulation = true
+
+extension_points = []
+
+# Simulation only: the rules may not reach an OS capability at any dependency
+# depth, and the structure check walks this list to prove it.
+[dependencies]
+renew-frame = { path = "../../../crates/frame" }
+
+[lints]
+workspace = true

--- a/samples/chess/rules/clippy.toml
+++ b/samples/chess/rules/clippy.toml
@@ -1,0 +1,33 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). The mechanical half of
+# this crate's determinism declaration: the rules are a pure function of
+# position and move, and everything below makes the ways that stops being true
+# unwritable rather than merely documented.
+#
+# One clock read inside move generation would make a recorded game unreplayable,
+# with no test failing until a position hashed differently on another machine.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "the rules advance by moves the caller plays, never by a clock they read" },
+    { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "a position arrives as text the caller supplies, never from a path this crate chose" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/samples/chess/rules/src/board.rs
+++ b/samples/chess/rules/src/board.rs
@@ -1,0 +1,494 @@
+//! The position, and the vocabulary it is written in.
+
+use renew_frame::StateHash;
+
+/// Which side.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Colour {
+    /// Moves first.
+    White,
+    /// Moves second.
+    Black,
+}
+
+impl Colour {
+    /// The other one.
+    #[must_use]
+    pub const fn other(self) -> Self {
+        match self {
+            Self::White => Self::Black,
+            Self::Black => Self::White,
+        }
+    }
+
+    /// Which way this side's pawns move, in ranks.
+    const fn pawn_step(self) -> i32 {
+        match self {
+            Self::White => 1,
+            Self::Black => -1,
+        }
+    }
+
+    /// The rank this side's pawns start on.
+    const fn pawn_home_rank(self) -> i32 {
+        match self {
+            Self::White => 1,
+            Self::Black => 6,
+        }
+    }
+
+    /// The rank this side's pawns promote on.
+    const fn promotion_rank(self) -> i32 {
+        match self {
+            Self::White => 7,
+            Self::Black => 0,
+        }
+    }
+
+    /// The rank this side's king and rooks start on.
+    const fn back_rank(self) -> i32 {
+        match self {
+            Self::White => 0,
+            Self::Black => 7,
+        }
+    }
+}
+
+/// What a piece is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Kind {
+    /// Moves forward, captures diagonally, and is the reason this game has
+    /// three special rules.
+    Pawn,
+    /// The only piece that jumps.
+    Knight,
+    /// Diagonals.
+    Bishop,
+    /// Ranks and files.
+    Rook,
+    /// Both.
+    Queen,
+    /// One square, and the whole point.
+    King,
+}
+
+impl Kind {
+    /// The letter used in algebraic notation, lower case.
+    #[must_use]
+    pub const fn letter(self) -> char {
+        match self {
+            Self::Pawn => 'p',
+            Self::Knight => 'n',
+            Self::Bishop => 'b',
+            Self::Rook => 'r',
+            Self::Queen => 'q',
+            Self::King => 'k',
+        }
+    }
+
+    /// A stable small number, so a digest does not depend on the enum's
+    /// declaration order surviving an edit.
+    const fn code(self) -> u32 {
+        match self {
+            Self::Pawn => 1,
+            Self::Knight => 2,
+            Self::Bishop => 3,
+            Self::Rook => 4,
+            Self::Queen => 5,
+            Self::King => 6,
+        }
+    }
+}
+
+/// A piece on the board.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Piece {
+    /// Whose.
+    pub colour: Colour,
+    /// What.
+    pub kind: Kind,
+}
+
+impl Piece {
+    /// A piece.
+    #[must_use]
+    pub const fn new(colour: Colour, kind: Kind) -> Self {
+        Self { colour, kind }
+    }
+
+    const fn code(self) -> u32 {
+        match self.colour {
+            Colour::White => self.kind.code(),
+            Colour::Black => self.kind.code() + 8,
+        }
+    }
+}
+
+/// A square, 0 = a1 through 63 = h8.
+///
+/// One number rather than a file and a rank, because every table below is
+/// indexed by it and a pair would need unpacking at each use. The file and
+/// rank accessors are where the geometry lives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Square(u8);
+
+impl Square {
+    /// From a file and a rank, both 0..8, or nothing if either is off the
+    /// board.
+    ///
+    /// **Returning an option rather than wrapping is the whole of the
+    /// board-edge handling.** A knight on a1 offset by (−1, 2) lands on a
+    /// file of −1, and an implementation that added to a square index instead
+    /// would land on h2 — a legal-looking move that teleports across the
+    /// board. Every offset in this crate goes through here.
+    #[must_use]
+    pub const fn at(file: i32, rank: i32) -> Option<Self> {
+        if file < 0 || file > 7 || rank < 0 || rank > 7 {
+            None
+        } else {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "the bounds check above puts the result in 0..64"
+            )]
+            let index = (rank * 8 + file) as u8;
+            Some(Self(index))
+        }
+    }
+
+    /// From a raw index, or nothing if past the board.
+    #[must_use]
+    pub const fn from_index(index: u8) -> Option<Self> {
+        if index < 64 { Some(Self(index)) } else { None }
+    }
+
+    /// The raw index.
+    #[must_use]
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+
+    /// 0 for the a-file through 7 for the h-file.
+    #[must_use]
+    pub const fn file(self) -> i32 {
+        (self.0 % 8) as i32
+    }
+
+    /// 0 for rank 1 through 7 for rank 8.
+    #[must_use]
+    pub const fn rank(self) -> i32 {
+        (self.0 / 8) as i32
+    }
+
+    /// This square offset by a file and rank delta, if it stays on the board.
+    #[must_use]
+    pub const fn offset(self, files: i32, ranks: i32) -> Option<Self> {
+        Self::at(self.file() + files, self.rank() + ranks)
+    }
+
+    /// The two-character name, like `e4`.
+    #[must_use]
+    pub fn name(self) -> [char; 2] {
+        let file = char::from(b'a' + u8::try_from(self.file()).unwrap_or(0));
+        let rank = char::from(b'1' + u8::try_from(self.rank()).unwrap_or(0));
+        [file, rank]
+    }
+}
+
+/// Who may still castle where.
+///
+/// Four independent bits rather than a per-side pair: a rook that moves loses
+/// that side's right alone, and a king that moves loses both. Collapsing them
+/// makes the first case unrepresentable.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "the four rights are genuinely independent — a rook that moves loses one, a               king that moves loses two — and any packing into a smaller type would make               the single-right case harder to read rather than easier"
+)]
+pub struct Castling {
+    /// White may castle toward the h-file.
+    pub white_king_side: bool,
+    /// White may castle toward the a-file.
+    pub white_queen_side: bool,
+    /// Black may castle toward the h-file.
+    pub black_king_side: bool,
+    /// Black may castle toward the a-file.
+    pub black_queen_side: bool,
+}
+
+impl Castling {
+    /// Everything still available, as at the start of a game.
+    pub const ALL: Self = Self {
+        white_king_side: true,
+        white_queen_side: true,
+        black_king_side: true,
+        black_queen_side: true,
+    };
+
+    /// Nothing available.
+    pub const NONE: Self = Self {
+        white_king_side: false,
+        white_queen_side: false,
+        black_king_side: false,
+        black_queen_side: false,
+    };
+
+    const fn code(self) -> u32 {
+        (self.white_king_side as u32)
+            | ((self.white_queen_side as u32) << 1)
+            | ((self.black_king_side as u32) << 2)
+            | ((self.black_queen_side as u32) << 3)
+    }
+}
+
+/// A position.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Board {
+    squares: [Option<Piece>; 64],
+    /// Whose turn.
+    pub to_move: Colour,
+    /// Who may still castle where.
+    pub castling: Castling,
+    /// The square a pawn just skipped over, capturable in passing.
+    ///
+    /// **The skipped square, not the pawn's.** That is what the capturing
+    /// move's destination is, so storing the pawn instead would need a
+    /// conversion at every use and would get it wrong once.
+    pub en_passant: Option<Square>,
+    /// Half-moves since the last capture or pawn move.
+    pub halfmove_clock: u32,
+    /// Full moves, from one, incremented after Black plays.
+    pub fullmove_number: u32,
+}
+
+impl Board {
+    /// An empty board with White to move and no rights.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            squares: [None; 64],
+            to_move: Colour::White,
+            castling: Castling::NONE,
+            en_passant: None,
+            halfmove_clock: 0,
+            fullmove_number: 1,
+        }
+    }
+
+    /// The starting position.
+    #[must_use]
+    pub fn initial() -> Self {
+        use Kind::{Bishop, King, Knight, Pawn, Queen, Rook};
+        let back = [Rook, Knight, Bishop, Queen, King, Bishop, Knight, Rook];
+        let mut board = Self::empty();
+        for (file, kind) in back.into_iter().enumerate() {
+            let file = i32::try_from(file).unwrap_or(0);
+            board.put(Square::at(file, 0), Some(Piece::new(Colour::White, kind)));
+            board.put(Square::at(file, 1), Some(Piece::new(Colour::White, Pawn)));
+            board.put(Square::at(file, 6), Some(Piece::new(Colour::Black, Pawn)));
+            board.put(Square::at(file, 7), Some(Piece::new(Colour::Black, kind)));
+        }
+        board.castling = Castling::ALL;
+        board
+    }
+
+    /// What is on a square.
+    #[must_use]
+    pub fn piece_at(&self, square: Square) -> Option<Piece> {
+        self.squares.get(square.index()).copied().flatten()
+    }
+
+    /// Put a piece on a square, or clear it. A square off the board is
+    /// ignored, which only arises from a caller passing `None`.
+    pub fn put(&mut self, square: Option<Square>, piece: Option<Piece>) {
+        if let Some(square) = square
+            && let Some(slot) = self.squares.get_mut(square.index())
+        {
+            *slot = piece;
+        }
+    }
+
+    /// Where a side's king stands, if it has one.
+    ///
+    /// Optional because positions without kings are useful for testing a
+    /// single piece's movement, and refusing to represent one would mean every
+    /// such test had to build a legal game around it.
+    #[must_use]
+    pub fn king_square(&self, colour: Colour) -> Option<Square> {
+        for index in 0..64u8 {
+            let square = Square::from_index(index)?;
+            if self.piece_at(square) == Some(Piece::new(colour, Kind::King)) {
+                return Some(square);
+            }
+        }
+        None
+    }
+
+    /// Every square, in ascending index order.
+    ///
+    /// The order is part of the contract rather than an accident: move
+    /// generation walks it, and the order moves come out in is observable to
+    /// anything that takes the first legal move.
+    pub fn squares(&self) -> impl Iterator<Item = (Square, Option<Piece>)> + '_ {
+        (0..64u8).filter_map(move |index| {
+            let square = Square::from_index(index)?;
+            Some((square, self.piece_at(square)))
+        })
+    }
+
+    /// A hash over everything that can change future play.
+    ///
+    /// **Castling rights and the en-passant square are in here**, and leaving
+    /// either out is the classic way to make two positions that look identical
+    /// behave differently. The move clocks are in too: the fifty-move rule
+    /// makes the halfmove clock decide a game.
+    #[must_use]
+    pub fn digest(&self) -> u64 {
+        let mut hash = StateHash::new();
+        for (_, piece) in self.squares() {
+            hash = hash.absorb_u32(piece.map_or(0, Piece::code));
+        }
+        hash.absorb_u32(match self.to_move {
+            Colour::White => 1,
+            Colour::Black => 2,
+        })
+        .absorb_u32(self.castling.code())
+        .absorb_u32(
+            self.en_passant
+                .map_or(64, |square| u32::try_from(square.index()).unwrap_or(64)),
+        )
+        .absorb_u32(self.halfmove_clock)
+        .absorb_u32(self.fullmove_number)
+        .finish()
+    }
+}
+
+impl Colour {
+    pub(crate) const fn forward(self) -> i32 {
+        self.pawn_step()
+    }
+    pub(crate) const fn home_rank(self) -> i32 {
+        self.pawn_home_rank()
+    }
+    pub(crate) const fn last_rank(self) -> i32 {
+        self.promotion_rank()
+    }
+    pub(crate) const fn castle_rank(self) -> i32 {
+        self.back_rank()
+    }
+}
+
+/// Why a position could not be read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FenError {
+    /// Fewer than four space-separated fields.
+    TooFewFields,
+    /// The piece placement did not describe eight ranks.
+    WrongRankCount,
+    /// A rank described more or fewer than eight files.
+    WrongFileCount,
+    /// A character that is not a piece or a digit.
+    UnknownPiece,
+    /// The side to move was not `w` or `b`.
+    UnknownSideToMove,
+    /// The en-passant field was neither `-` nor a square.
+    UnknownSquare,
+    /// A move counter was not a number.
+    UnknownNumber,
+}
+
+impl Board {
+    /// Read a position in Forsyth–Edwards notation.
+    ///
+    /// **The reason this exists is the test suite, not the user interface.**
+    /// The published perft positions are distributed as FEN, and a rules crate
+    /// that cannot read them cannot be checked against the one oracle chess
+    /// has. Everything else it enables is a bonus.
+    ///
+    /// # Errors
+    ///
+    /// Returns why the text is not a position. Malformed input is an ordinary
+    /// outcome here — the text usually comes from outside — so it is a result
+    /// rather than an assertion.
+    pub fn from_fen(text: &str) -> Result<Self, FenError> {
+        let mut fields = text.split_whitespace();
+        let placement = fields.next().ok_or(FenError::TooFewFields)?;
+        let side = fields.next().ok_or(FenError::TooFewFields)?;
+        let rights = fields.next().ok_or(FenError::TooFewFields)?;
+        let passant = fields.next().ok_or(FenError::TooFewFields)?;
+        // The clocks are optional: many published positions omit them, and
+        // refusing those would make the oracle unreachable over a detail that
+        // does not affect move generation.
+        let halfmove = fields.next().unwrap_or("0");
+        let fullmove = fields.next().unwrap_or("1");
+
+        let mut board = Self::empty();
+        let ranks: Vec<&str> = placement.split('/').collect();
+        if ranks.len() != 8 {
+            return Err(FenError::WrongRankCount);
+        }
+        // FEN lists rank 8 first, and this crate numbers rank 1 as zero.
+        for (offset, row) in ranks.iter().enumerate() {
+            let rank = 7 - i32::try_from(offset).unwrap_or(0);
+            let mut file = 0;
+            for symbol in row.chars() {
+                if let Some(skip) = symbol.to_digit(10) {
+                    file += i32::try_from(skip).unwrap_or(0);
+                    continue;
+                }
+                let colour = if symbol.is_ascii_uppercase() {
+                    Colour::White
+                } else {
+                    Colour::Black
+                };
+                let kind = match symbol.to_ascii_lowercase() {
+                    'p' => Kind::Pawn,
+                    'n' => Kind::Knight,
+                    'b' => Kind::Bishop,
+                    'r' => Kind::Rook,
+                    'q' => Kind::Queen,
+                    'k' => Kind::King,
+                    _ => return Err(FenError::UnknownPiece),
+                };
+                board.put(Square::at(file, rank), Some(Piece::new(colour, kind)));
+                file += 1;
+            }
+            if file != 8 {
+                return Err(FenError::WrongFileCount);
+            }
+        }
+
+        board.to_move = match side {
+            "w" => Colour::White,
+            "b" => Colour::Black,
+            _ => return Err(FenError::UnknownSideToMove),
+        };
+        board.castling = Castling {
+            white_king_side: rights.contains('K'),
+            white_queen_side: rights.contains('Q'),
+            black_king_side: rights.contains('k'),
+            black_queen_side: rights.contains('q'),
+        };
+        board.en_passant = if passant == "-" {
+            None
+        } else {
+            Some(parse_square(passant).ok_or(FenError::UnknownSquare)?)
+        };
+        board.halfmove_clock = halfmove.parse().map_err(|_| FenError::UnknownNumber)?;
+        board.fullmove_number = fullmove.parse().map_err(|_| FenError::UnknownNumber)?;
+        Ok(board)
+    }
+}
+
+/// A square from its name, like `e4`.
+fn parse_square(text: &str) -> Option<Square> {
+    let mut characters = text.chars();
+    let file = characters.next()?;
+    let rank = characters.next()?;
+    if characters.next().is_some() {
+        return None;
+    }
+    let file = i32::from(u8::try_from(file).ok()?) - i32::from(b'a');
+    let rank = i32::from(u8::try_from(rank).ok()?) - i32::from(b'1');
+    Square::at(file, rank)
+}

--- a/samples/chess/rules/src/lib.rs
+++ b/samples/chess/rules/src/lib.rs
@@ -1,0 +1,42 @@
+//! Chess, as a pure function of position and move.
+//!
+//! # Why this is here
+//!
+//! It is a second consumer for the engine, deliberately unlike the first. The
+//! platformer is continuous, swept and geometric; this is discrete, exact and
+//! combinatorial. Nothing in it is approximate, and nothing in it is a matter
+//! of taste — a move is legal or it is not.
+//!
+//! # The oracle
+//!
+//! Chess has something most software does not: **published, independently
+//! verified counts** of how many positions exist at each depth from a set of
+//! standard starting points. A single missing en-passant case, an off-by-one
+//! in castling rights, or a promotion that generates three pieces instead of
+//! four shows up as a wrong number rather than as a game that feels slightly
+//! odd.
+//!
+//! That is worth more than any amount of careful reading, and it is the whole
+//! reason the rules are written as a separate crate with no rendering in it:
+//! the thing that can be checked against an oracle is kept where the oracle
+//! can reach it.
+//!
+//! ```
+//! use renew_sample_chess_rules::{Board, perft};
+//! assert_eq!(perft(&Board::initial(), 3), 8_902);
+//! ```
+
+// A rules crate is simulation: a game must replay identically from its move
+// list, and a value that varied between runs would break that. The lint covers
+// operators only, so it is necessary and not sufficient — but there is no
+// floating point here at all, and this is what keeps that true under edits.
+#![deny(clippy::float_arithmetic)]
+
+pub mod board;
+pub mod moves;
+
+pub use board::{Board, Castling, Colour, FenError, Kind, Piece, Square};
+pub use moves::{
+    MAX_MOVES, Move, MoveList, Outcome, apply, in_check, is_attacked, legal, outcome, perft,
+    pseudo_legal,
+};

--- a/samples/chess/rules/src/moves.rs
+++ b/samples/chess/rules/src/moves.rs
@@ -1,0 +1,545 @@
+//! Which moves exist, which are legal, and what playing one does.
+
+use crate::board::{Board, Castling, Colour, Kind, Piece, Square};
+
+/// The most moves any legal chess position offers.
+///
+/// The known maximum is 218; 256 leaves room and keeps the list a power of
+/// two. Fixed rather than grown, because generation runs inside a search and
+/// a heap allocation per node is the difference between a usable perft and an
+/// unusable one.
+pub const MAX_MOVES: usize = 256;
+
+/// A move: where from, where to, and what a pawn became.
+///
+/// **Castling, en passant and the double push are not tagged here.** They are
+/// derivable from the position and the move — a king moving two files is a
+/// castle, a pawn moving diagonally to an empty square is an en-passant
+/// capture — and a tag would be a second source of truth that can disagree
+/// with the first. A caller building a move by hand cannot get the tag wrong
+/// if there is no tag.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Move {
+    /// Where the piece started.
+    pub from: Square,
+    /// Where it ended.
+    pub to: Square,
+    /// What a pawn reaching the last rank became.
+    pub promotion: Option<Kind>,
+}
+
+impl Move {
+    /// A move with no promotion.
+    #[must_use]
+    pub const fn new(from: Square, to: Square) -> Self {
+        Self {
+            from,
+            to,
+            promotion: None,
+        }
+    }
+
+    /// A pawn promotion.
+    #[must_use]
+    pub const fn promoting(from: Square, to: Square, kind: Kind) -> Self {
+        Self {
+            from,
+            to,
+            promotion: Some(kind),
+        }
+    }
+
+    /// Long algebraic notation, like `e2e4` or `a7a8q`.
+    #[must_use]
+    pub fn notation(self) -> String {
+        let from = self.from.name();
+        let to = self.to.name();
+        let mut text = String::with_capacity(5);
+        text.push(from[0]);
+        text.push(from[1]);
+        text.push(to[0]);
+        text.push(to[1]);
+        if let Some(kind) = self.promotion {
+            text.push(kind.letter());
+        }
+        text
+    }
+}
+
+/// A fixed-capacity list of moves.
+#[derive(Clone, Copy, Debug)]
+pub struct MoveList {
+    moves: [Move; MAX_MOVES],
+    count: usize,
+}
+
+impl MoveList {
+    /// Empty.
+    #[must_use]
+    pub fn new() -> Self {
+        let filler = Move::new(
+            Square::from_index(0).unwrap_or_else(|| unreachable!("zero is on the board")),
+            Square::from_index(0).unwrap_or_else(|| unreachable!("zero is on the board")),
+        );
+        Self {
+            moves: [filler; MAX_MOVES],
+            count: 0,
+        }
+    }
+
+    /// Add a move. Silently ignored past capacity, which no legal position
+    /// reaches — the known maximum is 218 against a capacity of 256.
+    pub fn push(&mut self, candidate: Move) {
+        if let Some(slot) = self.moves.get_mut(self.count) {
+            *slot = candidate;
+            self.count += 1;
+        }
+    }
+
+    /// The moves.
+    #[must_use]
+    pub fn as_slice(&self) -> &[Move] {
+        self.moves.split_at(self.count.min(MAX_MOVES)).0
+    }
+
+    /// How many.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.count
+    }
+
+    /// Whether there are none — which for legal moves means the game is over.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+}
+
+impl Default for MoveList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The eight squares a knight reaches.
+const KNIGHT_STEPS: [(i32, i32); 8] = [
+    (1, 2),
+    (2, 1),
+    (2, -1),
+    (1, -2),
+    (-1, -2),
+    (-2, -1),
+    (-2, 1),
+    (-1, 2),
+];
+
+/// The eight squares a king reaches, and the eight directions a queen slides.
+const KING_STEPS: [(i32, i32); 8] = [
+    (0, 1),
+    (1, 1),
+    (1, 0),
+    (1, -1),
+    (0, -1),
+    (-1, -1),
+    (-1, 0),
+    (-1, 1),
+];
+
+const ROOK_STEPS: [(i32, i32); 4] = [(0, 1), (1, 0), (0, -1), (-1, 0)];
+const BISHOP_STEPS: [(i32, i32); 4] = [(1, 1), (1, -1), (-1, -1), (-1, 1)];
+
+/// Is `square` attacked by any piece of `by`?
+///
+/// Asked of the square a king stands on, this is the whole of check detection.
+/// It walks outward from the square rather than over every enemy piece, which
+/// is the same answer for a fraction of the work.
+#[must_use]
+pub fn is_attacked(board: &Board, square: Square, by: Colour) -> bool {
+    // Pawns attack diagonally *forward*, so a square is attacked by a pawn
+    // sitting diagonally *backward* from it — the direction is inverted here
+    // and getting that wrong is the classic check-detection bug.
+    let back = -by.forward();
+    for files in [-1, 1] {
+        if let Some(origin) = square.offset(files, back)
+            && board.piece_at(origin) == Some(Piece::new(by, Kind::Pawn))
+        {
+            return true;
+        }
+    }
+
+    for (files, ranks) in KNIGHT_STEPS {
+        if let Some(origin) = square.offset(files, ranks)
+            && board.piece_at(origin) == Some(Piece::new(by, Kind::Knight))
+        {
+            return true;
+        }
+    }
+
+    for (files, ranks) in KING_STEPS {
+        if let Some(origin) = square.offset(files, ranks)
+            && board.piece_at(origin) == Some(Piece::new(by, Kind::King))
+        {
+            return true;
+        }
+    }
+
+    for (steps, sliders) in [
+        (ROOK_STEPS.as_slice(), [Kind::Rook, Kind::Queen]),
+        (BISHOP_STEPS.as_slice(), [Kind::Bishop, Kind::Queen]),
+    ] {
+        for &(files, ranks) in steps {
+            let mut at = square;
+            while let Some(next) = at.offset(files, ranks) {
+                at = next;
+                if let Some(piece) = board.piece_at(at) {
+                    if piece.colour == by && sliders.contains(&piece.kind) {
+                        return true;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Every move the side to move could make ignoring whether it leaves its own
+/// king attacked.
+#[must_use]
+pub fn pseudo_legal(board: &Board) -> MoveList {
+    let mut list = MoveList::new();
+    let us = board.to_move;
+    for (from, occupant) in board.squares() {
+        let Some(piece) = occupant else { continue };
+        if piece.colour != us {
+            continue;
+        }
+        match piece.kind {
+            Kind::Pawn => pawn_moves(board, from, us, &mut list),
+            Kind::Knight => step_moves(board, from, us, &KNIGHT_STEPS, &mut list),
+            Kind::King => {
+                step_moves(board, from, us, &KING_STEPS, &mut list);
+                castles(board, from, us, &mut list);
+            }
+            Kind::Bishop => slide_moves(board, from, us, &BISHOP_STEPS, &mut list),
+            Kind::Rook => slide_moves(board, from, us, &ROOK_STEPS, &mut list),
+            Kind::Queen => {
+                slide_moves(board, from, us, &ROOK_STEPS, &mut list);
+                slide_moves(board, from, us, &BISHOP_STEPS, &mut list);
+            }
+        }
+    }
+    list
+}
+
+fn pawn_moves(board: &Board, from: Square, us: Colour, list: &mut MoveList) {
+    let ahead = us.forward();
+
+    // One forward, onto an empty square.
+    if let Some(one) = from.offset(0, ahead)
+        && board.piece_at(one).is_none()
+    {
+        push_pawn(from, one, us, list);
+        // Two forward, only from home and only through an empty square.
+        if from.rank() == us.home_rank()
+            && let Some(two) = from.offset(0, ahead * 2)
+            && board.piece_at(two).is_none()
+        {
+            list.push(Move::new(from, two));
+        }
+    }
+
+    // Captures, including in passing.
+    for files in [-1, 1] {
+        let Some(target) = from.offset(files, ahead) else {
+            continue;
+        };
+        let occupied_by_enemy = board
+            .piece_at(target)
+            .is_some_and(|piece| piece.colour != us);
+        if occupied_by_enemy || board.en_passant == Some(target) {
+            push_pawn(from, target, us, list);
+        }
+    }
+}
+
+/// Add a pawn move, expanding it into four if it reaches the last rank.
+fn push_pawn(from: Square, to: Square, us: Colour, list: &mut MoveList) {
+    if to.rank() == us.last_rank() {
+        // The order is part of the contract: a caller taking the first move
+        // gets a queen, which is what anybody means by "promote".
+        for kind in [Kind::Queen, Kind::Rook, Kind::Bishop, Kind::Knight] {
+            list.push(Move::promoting(from, to, kind));
+        }
+    } else {
+        list.push(Move::new(from, to));
+    }
+}
+
+fn step_moves(board: &Board, from: Square, us: Colour, steps: &[(i32, i32)], list: &mut MoveList) {
+    for &(files, ranks) in steps {
+        let Some(to) = from.offset(files, ranks) else {
+            continue;
+        };
+        if board.piece_at(to).is_none_or(|piece| piece.colour != us) {
+            list.push(Move::new(from, to));
+        }
+    }
+}
+
+fn slide_moves(board: &Board, from: Square, us: Colour, steps: &[(i32, i32)], list: &mut MoveList) {
+    for &(files, ranks) in steps {
+        let mut at = from;
+        while let Some(to) = at.offset(files, ranks) {
+            at = to;
+            match board.piece_at(to) {
+                None => list.push(Move::new(from, to)),
+                Some(piece) => {
+                    if piece.colour != us {
+                        list.push(Move::new(from, to));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Castling, with all four of its conditions.
+///
+/// The one people forget is the third: the king may not pass *through* an
+/// attacked square, which is a different test from the two either side of it.
+fn castles(board: &Board, from: Square, us: Colour, list: &mut MoveList) {
+    let rank = us.castle_rank();
+    if from.file() != 4 || from.rank() != rank {
+        return;
+    }
+    // A king already in check may not castle out of it.
+    if is_attacked(board, from, us.other()) {
+        return;
+    }
+
+    let (king_side, queen_side) = match us {
+        Colour::White => (
+            board.castling.white_king_side,
+            board.castling.white_queen_side,
+        ),
+        Colour::Black => (
+            board.castling.black_king_side,
+            board.castling.black_queen_side,
+        ),
+    };
+
+    // (right, squares that must be empty, the square the king crosses, where
+    // the king lands)
+    let plans: [(bool, &[i32], i32, i32); 2] =
+        [(king_side, &[5, 6], 5, 6), (queen_side, &[1, 2, 3], 3, 2)];
+
+    for (allowed, empty_files, crossed, landing) in plans {
+        if !allowed {
+            continue;
+        }
+        if empty_files
+            .iter()
+            .any(|&file| Square::at(file, rank).is_some_and(|sq| board.piece_at(sq).is_some()))
+        {
+            continue;
+        }
+        let Some(crossed_square) = Square::at(crossed, rank) else {
+            continue;
+        };
+        // Through check. The landing square is checked by the ordinary
+        // legality filter, so it is deliberately not repeated here.
+        if is_attacked(board, crossed_square, us.other()) {
+            continue;
+        }
+        if let Some(to) = Square::at(landing, rank) {
+            list.push(Move::new(from, to));
+        }
+    }
+}
+
+/// Play a move, returning the position it leads to.
+///
+/// Copy-and-play rather than make-and-unmake: a position is 72 bytes, copying
+/// one is cheaper than the bookkeeping an undo needs, and a function that
+/// cannot corrupt the position it was given is worth more here than the
+/// difference.
+#[must_use]
+pub fn apply(board: &Board, played: Move) -> Board {
+    let mut next = *board;
+    let us = board.to_move;
+    let Some(piece) = board.piece_at(played.from) else {
+        // Nothing to move. Returning the position unchanged except for the
+        // turn would invent a null move, so the position is returned exactly
+        // as given and the caller's own generation is what stops this arising.
+        return next;
+    };
+
+    let captured = board.piece_at(played.to);
+    let is_pawn = piece.kind == Kind::Pawn;
+
+    // In passing: a pawn moving diagonally onto an empty square takes the
+    // pawn beside it rather than the one it lands on.
+    if is_pawn && played.from.file() != played.to.file() && captured.is_none() {
+        let victim = Square::at(played.to.file(), played.from.rank());
+        next.put(victim, None);
+    }
+
+    // Castling: the king has moved two files, so the rook jumps over it.
+    if piece.kind == Kind::King && (played.to.file() - played.from.file()).abs() == 2 {
+        let rank = played.from.rank();
+        let (rook_from, rook_to) = if played.to.file() == 6 {
+            (7, 5)
+        } else {
+            (0, 3)
+        };
+        let rook = Square::at(rook_from, rank).and_then(|sq| board.piece_at(sq));
+        next.put(Square::at(rook_from, rank), None);
+        next.put(Square::at(rook_to, rank), rook);
+    }
+
+    next.put(Some(played.from), None);
+    next.put(
+        Some(played.to),
+        Some(Piece::new(us, played.promotion.unwrap_or(piece.kind))),
+    );
+
+    // A double push leaves a square capturable in passing, and only for one
+    // move — which is why it is set from scratch every time rather than
+    // cleared conditionally.
+    next.en_passant = if is_pawn && (played.to.rank() - played.from.rank()).abs() == 2 {
+        Square::at(
+            played.from.file(),
+            played.from.rank().midpoint(played.to.rank()),
+        )
+    } else {
+        None
+    };
+
+    next.castling = rights_after(board.castling, played, piece);
+
+    // The fifty-move rule counts half-moves since the last capture or pawn
+    // move, so both reset it.
+    next.halfmove_clock = if is_pawn || captured.is_some() {
+        0
+    } else {
+        board.halfmove_clock.saturating_add(1)
+    };
+    if us == Colour::Black {
+        next.fullmove_number = board.fullmove_number.saturating_add(1);
+    }
+    next.to_move = us.other();
+    next
+}
+
+/// Castling rights after a move.
+///
+/// Three ways to lose one, and the third is the one that gets missed: a rook
+/// **captured on its home square** ends that side's right even though neither
+/// the king nor the rook moved of its own accord.
+fn rights_after(mut rights: Castling, played: Move, piece: Piece) -> Castling {
+    if piece.kind == Kind::King {
+        match piece.colour {
+            Colour::White => {
+                rights.white_king_side = false;
+                rights.white_queen_side = false;
+            }
+            Colour::Black => {
+                rights.black_king_side = false;
+                rights.black_queen_side = false;
+            }
+        }
+    }
+    for square in [played.from, played.to] {
+        match (square.file(), square.rank()) {
+            (0, 0) => rights.white_queen_side = false,
+            (7, 0) => rights.white_king_side = false,
+            (0, 7) => rights.black_queen_side = false,
+            (7, 7) => rights.black_king_side = false,
+            _ => {}
+        }
+    }
+    rights
+}
+
+/// Every move the side to move may legally make.
+#[must_use]
+pub fn legal(board: &Board) -> MoveList {
+    let mut list = MoveList::new();
+    let us = board.to_move;
+    for &candidate in pseudo_legal(board).as_slice() {
+        let after = apply(board, candidate);
+        // A move is legal exactly when it does not leave one's own king
+        // attacked — which covers pins, moving into check, and failing to
+        // address an existing check, without any of them being a special case.
+        let safe = after
+            .king_square(us)
+            .is_none_or(|king| !is_attacked(&after, king, us.other()));
+        if safe {
+            list.push(candidate);
+        }
+    }
+    list
+}
+
+/// Whether the side to move is in check.
+#[must_use]
+pub fn in_check(board: &Board) -> bool {
+    board
+        .king_square(board.to_move)
+        .is_some_and(|king| is_attacked(board, king, board.to_move.other()))
+}
+
+/// How a game ended, if it has.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// The side to move is checkmated.
+    Checkmate,
+    /// The side to move has no legal move and is not in check.
+    Stalemate,
+    /// Fifty moves by each side without a capture or a pawn move.
+    FiftyMove,
+    /// Still playing.
+    Ongoing,
+}
+
+/// Whether the game is over, and how.
+#[must_use]
+pub fn outcome(board: &Board) -> Outcome {
+    if legal(board).is_empty() {
+        if in_check(board) {
+            Outcome::Checkmate
+        } else {
+            Outcome::Stalemate
+        }
+    } else if board.halfmove_clock >= 100 {
+        Outcome::FiftyMove
+    } else {
+        Outcome::Ongoing
+    }
+}
+
+/// Count the leaf nodes of the legal-move tree at a given depth.
+///
+/// **This is the oracle chess has and most software does not.** The counts
+/// from the standard positions are published, independently verified, and
+/// unforgiving: a single missing en-passant case, an off-by-one in castling
+/// rights, or a promotion that generates three pieces instead of four shows up
+/// as a wrong number rather than as a game that feels slightly odd.
+#[must_use]
+pub fn perft(board: &Board, depth: u32) -> u64 {
+    if depth == 0 {
+        return 1;
+    }
+    let moves = legal(board);
+    if depth == 1 {
+        return moves.len() as u64;
+    }
+    let mut nodes = 0;
+    for &candidate in moves.as_slice() {
+        nodes += perft(&apply(board, candidate), depth - 1);
+    }
+    nodes
+}

--- a/samples/chess/rules/src/moves.rs
+++ b/samples/chess/rules/src/moves.rs
@@ -346,17 +346,19 @@ fn castles(board: &Board, from: Square, us: Colour, list: &mut MoveList) {
         {
             continue;
         }
-        let Some(crossed_square) = Square::at(crossed, rank) else {
-            continue;
-        };
+        // The crossed file is 3 or 5 and the rank is 0 or 7, so this is on the
+        // board by construction — a `continue` here would be a branch nothing
+        // could take.
+        let crossed_square = Square::at(crossed, rank)
+            .unwrap_or_else(|| unreachable!("a castling path stays on the board"));
         // Through check. The landing square is checked by the ordinary
         // legality filter, so it is deliberately not repeated here.
         if is_attacked(board, crossed_square, us.other()) {
             continue;
         }
-        if let Some(to) = Square::at(landing, rank) {
-            list.push(Move::new(from, to));
-        }
+        let to = Square::at(landing, rank)
+            .unwrap_or_else(|| unreachable!("a castling destination stays on the board"));
+        list.push(Move::new(from, to));
     }
 }
 

--- a/samples/chess/rules/tests/perft.rs
+++ b/samples/chess/rules/tests/perft.rs
@@ -1,0 +1,108 @@
+//! The one oracle chess has.
+//!
+//! These counts are published and independently verified: from a given
+//! position, the number of distinct legal games of a given length is a fact
+//! about chess, not about this implementation. A missing en-passant case, an
+//! off-by-one in castling rights, a promotion that generates three pieces
+//! instead of four, a check-evasion that misses a pin — each shows up as a
+//! wrong number rather than as a game that feels slightly odd.
+//!
+//! The positions below are the standard set, chosen because between them they
+//! exercise every rule that is easy to get wrong. Position 3 is almost empty
+//! and is about pawns and rooks; position 4 is dense with promotions;
+//! Kiwipete is the classic castling-and-en-passant torture test.
+
+use renew_sample_chess_rules::{Board, perft};
+
+/// The starting position.
+#[test]
+fn perft_from_the_initial_position() {
+    let board = Board::initial();
+    assert_eq!(perft(&board, 0), 1, "depth zero is the position itself");
+    assert_eq!(perft(&board, 1), 20);
+    assert_eq!(perft(&board, 2), 400);
+    assert_eq!(perft(&board, 3), 8_902);
+    assert_eq!(perft(&board, 4), 197_281);
+}
+
+/// **Kiwipete**, the standard torture test: castling both ways for both sides,
+/// pins, and a position where a careless generator invents moves.
+#[test]
+fn perft_from_kiwipete() {
+    let board =
+        Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1")
+            .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 48);
+    assert_eq!(perft(&board, 2), 2_039);
+    assert_eq!(perft(&board, 3), 97_862);
+}
+
+/// A sparse endgame: pawns, rooks and a king on each side. This is the
+/// position that catches en passant discovering a check along a rank — the
+/// capture removes two pawns from the same rank at once, which a legality
+/// filter that only re-checks the moved piece will miss.
+#[test]
+fn perft_from_the_sparse_endgame() {
+    let board = Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1")
+        .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 14);
+    assert_eq!(perft(&board, 2), 191);
+    assert_eq!(perft(&board, 3), 2_812);
+    assert_eq!(perft(&board, 4), 43_238);
+    assert_eq!(perft(&board, 5), 674_624);
+}
+
+/// Dense with promotions, including under-promotions that matter: a generator
+/// producing only queens gets this badly wrong.
+#[test]
+fn perft_from_the_promotion_position() {
+    let board = Board::from_fen("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1")
+        .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 6);
+    assert_eq!(perft(&board, 2), 264);
+    assert_eq!(perft(&board, 3), 9_467);
+    assert_eq!(perft(&board, 4), 422_333);
+}
+
+/// The mirror of the promotion position, with Black to move. A generator with
+/// a colour-dependent bug passes one of these and fails the other.
+#[test]
+fn perft_from_the_mirrored_promotion_position() {
+    let board = Board::from_fen("r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1")
+        .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 6);
+    assert_eq!(perft(&board, 2), 264);
+    assert_eq!(perft(&board, 3), 9_467);
+}
+
+/// A middlegame with no castling rights left, which isolates ordinary piece
+/// movement from the special cases.
+#[test]
+fn perft_from_a_quiet_middlegame() {
+    let board = Board::from_fen("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8")
+        .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 44);
+    assert_eq!(perft(&board, 2), 1_486);
+    assert_eq!(perft(&board, 3), 62_379);
+}
+
+/// One more, from a symmetric position, because a bug that cancels itself in
+/// symmetric play still shows up in the counts.
+#[test]
+fn perft_from_a_symmetric_position() {
+    let board =
+        Board::from_fen("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10")
+            .expect("a well-formed position");
+    assert_eq!(perft(&board, 1), 46);
+    assert_eq!(perft(&board, 2), 2_079);
+    assert_eq!(perft(&board, 3), 89_890);
+}
+
+/// Depth five from the start is four and a half million positions. Too slow
+/// for every run, and worth having: it is the depth at which the counts stop
+/// being reachable by accident.
+#[test]
+#[ignore = "four and a half million positions; run with --ignored"]
+fn perft_five_from_the_initial_position() {
+    assert_eq!(perft(&Board::initial(), 5), 4_865_609);
+}

--- a/samples/chess/rules/tests/rules.rs
+++ b/samples/chess/rules/tests/rules.rs
@@ -1,0 +1,326 @@
+//! The rules perft cannot see: how a game ends, and what a position hashes to.
+//!
+//! Perft counts positions, so it proves move generation exhaustively and says
+//! nothing about whether the game knows it is over. These are the parts a
+//! player notices.
+
+use renew_sample_chess_rules::{
+    Board, Castling, Colour, Kind, Move, Outcome, Piece, Square, apply, in_check, legal, outcome,
+};
+
+/// A square from a name like `e4`.
+///
+/// The allowance is explicit because the crate's lint configuration exempts
+/// `#[test]` bodies and this is a free helper beside them. Failing loudly on a
+/// mistyped name is exactly what a fixture should do: a helper that quietly
+/// returned a1 instead would make a test pass while checking the wrong square.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture, and a mistyped square must fail rather than default"
+)]
+fn square(name: &str) -> Square {
+    let bytes = name.as_bytes();
+    let file = i32::from(bytes[0]) - i32::from(b'a');
+    let rank = i32::from(bytes[1]) - i32::from(b'1');
+    Square::at(file, rank).expect("a name on the board")
+}
+
+fn play(board: &Board, from: &str, to: &str) -> Board {
+    apply(board, Move::new(square(from), square(to)))
+}
+
+#[test]
+fn the_initial_position_is_what_everyone_agrees_it_is() {
+    let board = Board::initial();
+    assert_eq!(board.to_move, Colour::White);
+    assert_eq!(board.castling, Castling::ALL);
+    assert_eq!(board.en_passant, None);
+    assert_eq!(board.fullmove_number, 1);
+    assert_eq!(
+        board.piece_at(square("e1")),
+        Some(Piece::new(Colour::White, Kind::King))
+    );
+    assert_eq!(
+        board.piece_at(square("d8")),
+        Some(Piece::new(Colour::Black, Kind::Queen))
+    );
+    assert_eq!(board.piece_at(square("e4")), None);
+    assert_eq!(outcome(&board), Outcome::Ongoing);
+    assert!(!in_check(&board));
+}
+
+/// The shortest possible checkmate, played move by move.
+#[test]
+fn the_shortest_checkmate_is_recognised() {
+    let mut board = Board::initial();
+    for (from, to) in [("f2", "f3"), ("e7", "e5"), ("g2", "g4"), ("d8", "h4")] {
+        board = play(&board, from, to);
+    }
+    assert!(in_check(&board), "the king is attacked");
+    assert!(legal(&board).is_empty(), "and cannot answer it");
+    assert_eq!(outcome(&board), Outcome::Checkmate);
+}
+
+/// No legal move and no check is a draw, not a loss — the distinction the
+/// outcome exists to make.
+#[test]
+fn a_king_with_nowhere_to_go_is_stalemate_not_checkmate() {
+    let board = Board::from_fen("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1").expect("well-formed");
+    assert!(!in_check(&board), "not attacked");
+    assert!(legal(&board).is_empty(), "and with nowhere to go");
+    assert_eq!(outcome(&board), Outcome::Stalemate);
+}
+
+#[test]
+fn castling_moves_the_rook_too() {
+    let board = Board::from_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1").expect("well-formed");
+
+    let short = play(&board, "e1", "g1");
+    assert_eq!(
+        short.piece_at(square("f1")),
+        Some(Piece::new(Colour::White, Kind::Rook)),
+        "the rook jumped to f1"
+    );
+    assert_eq!(short.piece_at(square("h1")), None, "and left h1");
+    assert!(!short.castling.white_king_side, "the right is spent");
+    assert!(!short.castling.white_queen_side, "and so is the other");
+
+    let long = play(&board, "e1", "c1");
+    assert_eq!(
+        long.piece_at(square("d1")),
+        Some(Piece::new(Colour::White, Kind::Rook))
+    );
+    assert_eq!(long.piece_at(square("a1")), None);
+}
+
+/// **The condition people forget**: a king may not pass through an attacked
+/// square, which is a different test from the squares either side of it.
+#[test]
+fn a_king_may_not_castle_through_check() {
+    // A black rook on f8 attacks f1, the square the white king crosses.
+    let board = Board::from_fen("5r2/8/8/8/8/8/8/R3K2R w KQ - 0 1").expect("well-formed");
+    let castles: Vec<String> = legal(&board)
+        .as_slice()
+        .iter()
+        .filter(|m| m.from == square("e1") && (m.to == square("g1") || m.to == square("c1")))
+        .map(|m| m.notation())
+        .collect();
+    assert_eq!(
+        castles,
+        vec!["e1c1".to_string()],
+        "only the queen-side castle survives"
+    );
+}
+
+#[test]
+fn a_king_in_check_may_not_castle_out_of_it() {
+    // A black rook on e8 gives check down the e-file.
+    let board = Board::from_fen("4r3/8/8/8/8/8/8/R3K2R w KQ - 0 1").expect("well-formed");
+    assert!(in_check(&board));
+    let castles = legal(&board)
+        .as_slice()
+        .iter()
+        .filter(|m| m.from == square("e1") && (m.to.file() - 4).abs() == 2)
+        .count();
+    assert_eq!(castles, 0, "castling out of check is never legal");
+}
+
+/// A rook captured on its home square ends that side's right, even though
+/// neither the king nor the rook moved of its own accord.
+#[test]
+fn capturing_a_rook_on_its_home_square_ends_that_right() {
+    let board = Board::from_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1").expect("well-formed");
+    let after = play(&board, "a1", "a8");
+    assert!(
+        !after.castling.black_queen_side,
+        "black lost the queen-side right with the rook"
+    );
+    assert!(
+        after.castling.black_king_side,
+        "and kept the other one, which is the point of four bits"
+    );
+    assert!(
+        !after.castling.white_queen_side,
+        "the mover lost its own too"
+    );
+}
+
+#[test]
+fn a_double_push_offers_an_en_passant_square_for_exactly_one_move() {
+    let board = Board::initial();
+    let after = play(&board, "e2", "e4");
+    assert_eq!(
+        after.en_passant,
+        Some(square("e3")),
+        "the square skipped over, not the pawn's"
+    );
+
+    let later = play(&after, "b8", "c6");
+    assert_eq!(later.en_passant, None, "the chance lasts one move");
+}
+
+#[test]
+fn an_en_passant_capture_removes_the_pawn_beside_it() {
+    let board = Board::from_fen("4k3/3p4/8/4P3/8/8/8/4K3 b - - 0 1").expect("well-formed");
+    let pushed = play(&board, "d7", "d5");
+    assert_eq!(pushed.en_passant, Some(square("d6")));
+
+    let captured = play(&pushed, "e5", "d6");
+    assert_eq!(
+        captured.piece_at(square("d6")),
+        Some(Piece::new(Colour::White, Kind::Pawn)),
+        "the capturer landed behind it"
+    );
+    assert_eq!(
+        captured.piece_at(square("d5")),
+        None,
+        "and the pawn it passed is gone"
+    );
+}
+
+#[test]
+fn a_pawn_reaching_the_last_rank_may_become_any_of_four_pieces() {
+    let board = Board::from_fen("4k3/P7/8/8/8/8/8/4K3 w - - 0 1").expect("well-formed");
+    let promotions: Vec<Option<Kind>> = legal(&board)
+        .as_slice()
+        .iter()
+        .filter(|m| m.from == square("a7"))
+        .map(|m| m.promotion)
+        .collect();
+    assert_eq!(promotions.len(), 4, "queen, rook, bishop, knight");
+    assert_eq!(
+        promotions.first().copied().flatten(),
+        Some(Kind::Queen),
+        "the queen comes first, so taking the first move promotes to one"
+    );
+    assert!(
+        promotions.contains(&Some(Kind::Knight)),
+        "and the knight is there"
+    );
+
+    let under = apply(
+        &board,
+        Move::promoting(square("a7"), square("a8"), Kind::Knight),
+    );
+    assert_eq!(
+        under.piece_at(square("a8")),
+        Some(Piece::new(Colour::White, Kind::Knight)),
+        "under-promotion is honoured"
+    );
+}
+
+/// A pinned piece has no moves, and this falls out of the legality filter
+/// rather than being a special case anywhere.
+#[test]
+fn a_pinned_piece_cannot_move() {
+    // White knight on e2 pinned to the king on e1 by a black rook on e8.
+    let board = Board::from_fen("4r3/8/8/8/8/8/4N3/4K3 w - - 0 1").expect("well-formed");
+    let knight_moves = legal(&board)
+        .as_slice()
+        .iter()
+        .filter(|m| m.from == square("e2"))
+        .count();
+    assert_eq!(knight_moves, 0, "moving it would expose the king");
+}
+
+/// The fifty-move rule counts half-moves since the last capture or pawn move,
+/// and both reset it.
+#[test]
+fn the_halfmove_clock_resets_on_a_capture_or_a_pawn_move() {
+    let board = Board::from_fen("4k3/8/8/3p4/4P3/8/8/4K3 w - - 40 60").expect("well-formed");
+    let quiet = play(&board, "e1", "d1");
+    assert_eq!(quiet.halfmove_clock, 41, "a quiet move advances it");
+
+    let pawn = play(&board, "e4", "e5");
+    assert_eq!(pawn.halfmove_clock, 0, "a pawn move resets it");
+
+    let capture = play(&board, "e4", "d5");
+    assert_eq!(capture.halfmove_clock, 0, "and so does a capture");
+}
+
+#[test]
+fn a_hundred_half_moves_without_progress_ends_the_game() {
+    let board = Board::from_fen("4k3/8/8/8/8/8/8/4K2R w - - 100 60").expect("well-formed");
+    assert_eq!(outcome(&board), Outcome::FiftyMove);
+}
+
+/// **Two positions that look identical must not hash the same when they play
+/// differently.** Castling rights and the en-passant square are the classic
+/// pair to forget, and both change what is legal next.
+#[test]
+fn the_digest_separates_positions_that_play_differently() {
+    let base = Board::from_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1").expect("well-formed");
+
+    let mut fewer_rights = base;
+    fewer_rights.castling = Castling {
+        white_king_side: false,
+        ..base.castling
+    };
+    assert_ne!(
+        base.digest(),
+        fewer_rights.digest(),
+        "the same pieces with different rights are different positions"
+    );
+
+    let mut passant = base;
+    passant.en_passant = Some(square("e3"));
+    assert_ne!(base.digest(), passant.digest());
+
+    let mut later = base;
+    later.halfmove_clock = 99;
+    assert_ne!(
+        base.digest(),
+        later.digest(),
+        "the fifty-move clock decides games, so it is state"
+    );
+
+    // And the same position hashes the same, or none of the above means
+    // anything.
+    let twin = Board::from_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1").expect("well-formed");
+    assert_eq!(base.digest(), twin.digest());
+}
+
+#[test]
+fn a_malformed_position_is_refused_rather_than_guessed() {
+    assert!(Board::from_fen("").is_err());
+    assert!(
+        Board::from_fen("8/8/8/8 w - -").is_err(),
+        "four ranks is not eight"
+    );
+    assert!(
+        Board::from_fen("8/8/8/8/8/8/8/9 w - -").is_err(),
+        "nine files is not eight"
+    );
+    assert!(
+        Board::from_fen("8/8/8/8/8/8/8/X7 w - -").is_err(),
+        "X is not a piece"
+    );
+    assert!(
+        Board::from_fen("8/8/8/8/8/8/8/8 x - -").is_err(),
+        "x is not a side"
+    );
+    assert!(
+        Board::from_fen("8/8/8/8/8/8/8/8 w - z9").is_err(),
+        "z9 is not a square"
+    );
+    // And the clocks are optional, because published positions often omit them.
+    assert!(Board::from_fen("8/8/8/8/8/8/8/8 w - -").is_ok());
+}
+
+/// Notation round-trips through the move list, which is what a recorded game
+/// is written in.
+#[test]
+fn moves_have_readable_names() {
+    let board = Board::initial();
+    let names: Vec<String> = legal(&board)
+        .as_slice()
+        .iter()
+        .map(|m| m.notation())
+        .collect();
+    assert_eq!(names.len(), 20);
+    assert!(names.contains(&"e2e4".to_string()));
+    assert!(names.contains(&"g1f3".to_string()));
+
+    let promotion = Move::promoting(square("a7"), square("a8"), Kind::Knight);
+    assert_eq!(promotion.notation(), "a7a8n");
+}

--- a/samples/chess/rules/tests/rules.rs
+++ b/samples/chess/rules/tests/rules.rs
@@ -324,3 +324,85 @@ fn moves_have_readable_names() {
     let promotion = Move::promoting(square("a7"), square("a8"), Kind::Knight);
     assert_eq!(promotion.notation(), "a7a8n");
 }
+
+/// Every piece has a letter and a digest code, and both have to be distinct
+/// per kind or two different positions hash the same.
+#[test]
+fn every_kind_has_its_own_letter_and_its_own_code() {
+    use Kind::{Bishop, King, Knight, Pawn, Queen, Rook};
+    let kinds = [Pawn, Knight, Bishop, Rook, Queen, King];
+
+    let letters: Vec<char> = kinds.iter().map(|kind| kind.letter()).collect();
+    assert_eq!(letters, vec!['p', 'n', 'b', 'r', 'q', 'k']);
+
+    // Distinctness, in both colours, through the digest: a board with one
+    // piece on one square must hash differently for each of the twelve.
+    let mut seen = Vec::new();
+    for colour in [Colour::White, Colour::Black] {
+        for kind in kinds {
+            let mut board = Board::empty();
+            board.put(Some(square("d4")), Some(Piece::new(colour, kind)));
+            let digest = board.digest();
+            assert!(
+                !seen.contains(&digest),
+                "{colour:?} {kind:?} hashes the same as something else"
+            );
+            seen.push(digest);
+        }
+    }
+    assert_eq!(seen.len(), 12);
+}
+
+/// The side to move is part of the position: the same pieces with the other
+/// player to move is a different position and usually a different game.
+#[test]
+fn the_side_to_move_reaches_the_digest() {
+    let mut white = Board::from_fen("4k3/8/8/8/8/8/8/4K3 w - - 0 1").expect("well-formed");
+    let black = Board::from_fen("4k3/8/8/8/8/8/8/4K3 b - - 0 1").expect("well-formed");
+    assert_ne!(white.digest(), black.digest());
+    white.to_move = Colour::Black;
+    assert_eq!(white.digest(), black.digest(), "and nothing else differs");
+}
+
+/// A board with no king is representable, because testing one piece's movement
+/// should not require building a legal game around it.
+#[test]
+fn a_board_without_a_king_has_no_king_square() {
+    let board = Board::from_fen("8/8/8/3Q4/8/8/8/8 w - - 0 1").expect("well-formed");
+    assert_eq!(board.king_square(Colour::White), None);
+    assert_eq!(board.king_square(Colour::Black), None);
+    // And its legal moves are still generated, since legality only asks
+    // whether a king it can find is attacked.
+    assert!(!legal(&board).is_empty(), "the queen can still move");
+}
+
+/// A move from an empty square changes nothing rather than inventing a null
+/// move that hands the turn over.
+#[test]
+fn a_move_from_an_empty_square_does_nothing() {
+    let board = Board::initial();
+    let after = apply(&board, Move::new(square("e4"), square("e5")));
+    assert_eq!(after, board, "the position is returned exactly as given");
+    assert_eq!(after.to_move, Colour::White, "and the turn did not pass");
+}
+
+/// An en-passant field longer than a square name is malformed, not a square
+/// with something after it.
+#[test]
+fn an_over_long_square_name_is_refused() {
+    assert!(Board::from_fen("8/8/8/8/8/8/8/8 w - e33").is_err());
+    assert!(Board::from_fen("8/8/8/8/8/8/8/8 w - e").is_err());
+}
+
+/// An empty move list reports itself as empty, which is how a caller learns a
+/// game is over without asking twice.
+#[test]
+fn an_empty_move_list_says_so() {
+    let list = renew_sample_chess_rules::MoveList::default();
+    assert!(list.is_empty());
+    assert_eq!(list.len(), 0);
+    assert!(list.as_slice().is_empty());
+
+    // And a position with moves does not.
+    assert!(!legal(&Board::initial()).is_empty());
+}


### PR DESCRIPTION
Legal move generation, castling, en passant, promotion, check,
checkmate, stalemate and the fifty-move rule, as a pure function of
position and move.

The reason this is worth having is not that chess is fun to implement.
It is that chess has published, independently verified counts of how
many distinct legal games of a given length exist from a set of standard
positions - a fact about the rules rather than about anybody's code. A
missing en-passant case, an off-by-one in castling rights, a promotion
that generates three pieces instead of four, a check evasion that misses
a pin: each shows up as a wrong number rather than as a game that feels
slightly odd.

Seven positions and twenty-six counts, all matching, including the four
and a half million at depth five from the start. The positions are the
standard set because between them they exercise every rule that is easy
to get wrong: one is almost empty and catches an en-passant capture that
discovers a check along a rank, because it removes two pawns from the
same rank at once; one is dense with under-promotions; one is the
classic castling torture test; and one is the mirror of another, so a
colour-dependent bug passes one and fails the other.

It is also a deliberately different second consumer for the engine. The
platformer is continuous, swept and geometric, and its correctness is a
matter of tolerances. This is discrete and exact: a move is legal or it
is not, and there is no floating point anywhere in it.

Two design choices are worth naming. Special moves carry no tag - a king
moving two files is a castle, a pawn moving diagonally onto an empty
square is an en-passant capture - because a tag would be a second source
of truth that can disagree with the position. And castling rights are
four independent bits rather than a per-side pair, since a rook that
moves loses one right while a king that moves loses two; collapsing them
makes the first case unrepresentable, and a rook captured on its home
square is exactly that case.

Square construction returns an option rather than wrapping, which is the
whole of the board-edge handling. A knight on a1 offset by minus one
file lands off the board; an implementation adding to an index instead
would land on h2, a legal-looking move that teleports across the board.