### PR TITLE
feat(physics3d): the collider set, lifted to three dimensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -281,7 +281,7 @@ jobs:
       # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -292,6 +292,15 @@ jobs:
         run: |
           sel="--workspace --exclude renew-physics2d --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics2d $sel
+          cargo build $sel
+          cargo test $sel
+      # Three-dimensional collision. No consumers yet -- the voxel sandbox
+      # that will drive it is not written -- so the cell is the whole
+      # workspace minus one leaf.
+      - name: Build and test without three-dimensional collision
+        run: |
+          sel="--workspace --exclude renew-physics3d"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics3d $sel
           cargo build $sel
           cargo test $sel
       # The audio stack. The game is excluded alongside it because the
@@ -329,7 +338,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d; do
+          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,6 +1690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-physics3d"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-ecs",
+ "renew-fixed",
+]
+
+[[package]]
 name = "renew-platform"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/physics3d/Cargo.toml
+++ b/crates/physics3d/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "renew-physics3d"
+description = "Three-dimensional collision detection for simulation code that must reproduce bit-for-bit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Bodies, shapes, filtering and collision queries in fixed-point 3D: the collider set, its lifecycle, and the orders that make contacts reproducible."
+maturity = "bootstrap"
+core = false
+extension_points = []
+# Collision state must reproduce, so this crate carries the simulation
+# obligations: the float closure walk and the cross-target digest comparison.
+simulation = true
+
+[dependencies]
+renew-ecs = { path = "../ecs" }
+renew-fixed = { path = "../fixed" }
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/physics3d/clippy.toml
+++ b/crates/physics3d/clippy.toml
@@ -1,0 +1,34 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate is simulation-designated: its state is the collider set, and a
+# contact array it produces reaches a state hash directly. Every tripwire
+# below closes a route by which something outside the inputs could reach that
+# hash — a clock, a thread, a file, or a hasher that seeds itself.
+#
+# The float deny is at the crate root, beside the sentence explaining it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
+    { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "geometry arrives through the caller's operations, never from a path this crate chose" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, and nothing behind a reproducibility contract may" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same reason as RandomState: self-seeding entropy has no place here" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary — and iteration order here is contact order" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/physics3d/src/bounds.rs
+++ b/crates/physics3d/src/bounds.rs
@@ -1,0 +1,178 @@
+//! World-space extents: how far a shape reaches along each axis.
+
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec3};
+
+/// An axis-aligned box in world space, given by its lowest and highest corner.
+///
+/// Touching counts as overlapping in every dimension: a body whose maximum
+/// equals another's minimum *is* touching, and the broadphase proposes the
+/// pair so narrowphase can decide. Under-reporting loses a contact silently;
+/// over-reporting costs one narrowphase test.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Aabb {
+    /// Lowest corner.
+    pub min: Vec3,
+    /// Highest corner.
+    pub max: Vec3,
+}
+
+impl Aabb {
+    /// The box containing exactly this point.
+    #[must_use]
+    pub const fn point(at: Vec3) -> Self {
+        Self { min: at, max: at }
+    }
+
+    /// Grown by `margin` in every direction.
+    #[must_use]
+    pub fn expanded(self, margin: Fixed) -> Self {
+        let by = Vec3::new(margin, margin, margin);
+        Self {
+            min: self.min - by,
+            max: self.max + by,
+        }
+    }
+
+    /// Whether two boxes share any point, touching included.
+    ///
+    /// **Three axes, and all three must overlap.** A two-dimensional test
+    /// lifted by forgetting one is the classic way to make a 3D broadphase
+    /// propose everything in a column, which is correct and useless.
+    #[must_use]
+    pub fn overlaps(self, other: Self) -> bool {
+        self.min.x <= other.max.x
+            && other.min.x <= self.max.x
+            && self.min.y <= other.max.y
+            && other.min.y <= self.max.y
+            && self.min.z <= other.max.z
+            && other.min.z <= self.max.z
+    }
+
+    /// Whether a point is inside or on the boundary.
+    #[must_use]
+    pub fn contains(self, point: Vec3) -> bool {
+        self.min.x <= point.x
+            && point.x <= self.max.x
+            && self.min.y <= point.y
+            && point.y <= self.max.y
+            && self.min.z <= point.z
+            && point.z <= self.max.z
+    }
+}
+
+impl Shape {
+    /// The world-space box this shape occupies under `transform`.
+    ///
+    /// Exact, and with no rotation to account for it is also trivial — which
+    /// is a fair share of why the axis-aligned case is worth having on its own
+    /// rather than waiting for an orientation type.
+    #[must_use]
+    pub fn world_bounds(self, transform: Transform) -> Aabb {
+        let reach = match self {
+            Self::Sphere { radius } => Vec3::new(radius, radius, radius),
+            Self::Box { half_extents } => half_extents,
+        };
+        Aabb {
+            min: transform.translation - reach,
+            max: transform.translation + reach,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Aabb;
+    use crate::shape::{Shape, Transform};
+    use renew_fixed::{Fixed, Vec3};
+
+    fn v(x: i32, y: i32, z: i32) -> Vec3 {
+        Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+    }
+
+    #[test]
+    fn a_box_bounds_exactly_its_half_extents() {
+        let bounds = Shape::Box {
+            half_extents: v(1, 2, 3),
+        }
+        .world_bounds(Transform::at(v(10, 20, 30)));
+        assert_eq!(bounds.min, v(9, 18, 27));
+        assert_eq!(bounds.max, v(11, 22, 33));
+    }
+
+    #[test]
+    fn a_sphere_bounds_its_radius_on_every_axis() {
+        let bounds = Shape::Sphere {
+            radius: Fixed::from_int(2),
+        }
+        .world_bounds(Transform::at(v(0, 0, 5)));
+        assert_eq!(bounds.min, v(-2, -2, 3));
+        assert_eq!(bounds.max, v(2, 2, 7));
+    }
+
+    /// **Separation on any one axis is separation.** A test that checks two
+    /// and forgets the third proposes every pair in a column — correct, and
+    /// useless.
+    #[test]
+    fn separation_on_any_single_axis_is_enough() {
+        let here = Aabb {
+            min: v(0, 0, 0),
+            max: v(1, 1, 1),
+        };
+        for offset in [v(3, 0, 0), v(0, 3, 0), v(0, 0, 3)] {
+            let there = Aabb {
+                min: offset,
+                max: offset + v(1, 1, 1),
+            };
+            assert!(
+                !here.overlaps(there),
+                "separated along one axis is separated"
+            );
+            assert!(!there.overlaps(here), "and symmetrically so");
+        }
+    }
+
+    #[test]
+    fn boxes_that_merely_touch_overlap() {
+        let here = Aabb {
+            min: v(0, 0, 0),
+            max: v(1, 1, 1),
+        };
+        let touching = Aabb {
+            min: v(1, 0, 0),
+            max: v(2, 1, 1),
+        };
+        assert!(here.overlaps(touching));
+        assert!(touching.overlaps(here));
+    }
+
+    #[test]
+    fn expanding_makes_near_misses_into_candidates() {
+        let here = Aabb {
+            min: v(0, 0, 0),
+            max: v(1, 1, 1),
+        };
+        let apart = Aabb {
+            min: v(0, 0, 2),
+            max: v(1, 1, 3),
+        };
+        assert!(!here.overlaps(apart));
+        assert!(here.expanded(Fixed::ONE).overlaps(apart));
+    }
+
+    #[test]
+    fn a_point_box_contains_only_itself_and_a_bigger_one_contains_more() {
+        let dot = Aabb::point(v(3, 4, 5));
+        assert!(dot.contains(v(3, 4, 5)));
+        assert!(!dot.contains(v(3, 4, 6)));
+        assert!(dot.overlaps(dot));
+
+        let around = Aabb {
+            min: v(0, 0, 0),
+            max: v(9, 9, 9),
+        };
+        assert!(around.contains(v(3, 4, 5)));
+        assert!(around.contains(v(0, 0, 0)), "the boundary is inside");
+        assert!(!around.contains(v(3, 4, 10)), "and past it is not");
+    }
+}

--- a/crates/physics3d/src/filter.rs
+++ b/crates/physics3d/src/filter.rs
@@ -1,0 +1,116 @@
+//! Which pairs are allowed to collide, and which shapes a query can see.
+
+/// A bit set naming what a shape *is*, and what it *cares about*.
+///
+/// # Why both halves, and why per shape
+///
+/// The body-kind matrix decides only static/kinematic/dynamic, and two
+/// kinematic bodies always collide by it. A game needs them not to: the
+/// character ignores pickups but collides with boxes, a bullet ignores
+/// whatever fired it, the ground query ignores the character. None of that
+/// is expressible without a filter, and no game can be written without all
+/// three.
+///
+/// It lives on the shape rather than the body because a body may own several
+/// — a one-way platform is one body whose top and volume filter differently,
+/// and one filter per body pushes the caller back into splitting it into two
+/// bodies it must then keep in step by hand.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Filter {
+    /// What this shape is.
+    pub layer: u32,
+    /// What this shape collides with.
+    pub mask: u32,
+}
+
+impl Filter {
+    /// A shape on every layer that collides with everything.
+    pub const ALL: Self = Self {
+        layer: u32::MAX,
+        mask: u32::MAX,
+    };
+
+    /// A shape on no layer that collides with nothing — invisible to pair
+    /// tests, and still visible to a query whose mask names its layer, which
+    /// is `NONE`'s point of difference from simply not existing.
+    pub const NONE: Self = Self { layer: 0, mask: 0 };
+
+    /// Layer and mask, in that order.
+    #[must_use]
+    pub const fn new(layer: u32, mask: u32) -> Self {
+        Self { layer, mask }
+    }
+
+    /// Whether two shapes are eligible to collide.
+    ///
+    /// **Symmetric by construction**, so a pair cannot be eligible in one
+    /// direction only — which would make the answer depend on which of the
+    /// two the broadphase happened to visit first, and that is precisely the
+    /// class of storage-order dependence the ordering rules exist to remove.
+    #[must_use]
+    pub const fn eligible(self, other: Self) -> bool {
+        (self.layer & other.mask) != 0 && (other.layer & self.mask) != 0
+    }
+
+    /// Whether a query carrying `mask` can see this shape.
+    ///
+    /// **One-sided, and deliberately.** A query has no layer, so the
+    /// symmetric rule cannot be evaluated for one at all. Consulting the
+    /// shape's own mask instead would make a trigger configured with an empty
+    /// mask — the ordinary way to write "collides with nothing" — invisible
+    /// to a ray, and casting against triggers is a large part of why rays
+    /// exist.
+    #[must_use]
+    pub const fn visible_to_query(self, mask: u32) -> bool {
+        (self.layer & mask) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Filter;
+
+    #[test]
+    fn eligibility_is_symmetric() {
+        let character = Filter::new(0b0001, 0b0010);
+        let wall = Filter::new(0b0010, 0b0001);
+        assert!(character.eligible(wall));
+        assert!(wall.eligible(character));
+    }
+
+    #[test]
+    fn one_sided_interest_is_not_enough() {
+        // The character wants to collide with the pickup; the pickup does not
+        // want to collide with anything. No contact, in either direction.
+        let character = Filter::new(0b0001, 0b1111);
+        let pickup = Filter::new(0b0100, 0b0000);
+        assert!(!character.eligible(pickup));
+        assert!(!pickup.eligible(character));
+    }
+
+    /// The case the one-sided query rule exists for: a shape that collides
+    /// with nothing must still be findable by a cast, or triggers cannot be
+    /// implemented.
+    #[test]
+    fn a_shape_that_collides_with_nothing_is_still_visible_to_a_query() {
+        let trigger = Filter::new(0b0100, 0b0000);
+        assert!(!trigger.eligible(Filter::ALL), "it blocks nothing");
+        assert!(
+            trigger.visible_to_query(0b0100),
+            "and a query naming its layer still finds it"
+        );
+        assert!(
+            !trigger.visible_to_query(0b1011),
+            "while a query not naming its layer does not"
+        );
+    }
+
+    #[test]
+    fn the_constants_mean_what_they_say() {
+        assert!(Filter::ALL.eligible(Filter::ALL));
+        assert!(!Filter::NONE.eligible(Filter::ALL));
+        assert!(!Filter::NONE.eligible(Filter::NONE));
+        assert!(Filter::ALL.visible_to_query(1));
+        assert!(!Filter::NONE.visible_to_query(u32::MAX));
+    }
+}

--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -1,0 +1,50 @@
+//! Three-dimensional collision detection that reproduces bit-for-bit.
+//!
+//! # What this is, and what it is not yet
+//!
+//! The collider set and the operations that change it, in fixed-point
+//! arithmetic with no floating point anywhere. **Axis-aligned only**: a
+//! placement here is a translation, because rotating in three dimensions needs
+//! a fixed-point orientation representation — a quaternion or a matrix — and
+//! that decision has not been taken.
+//!
+//! That is a restriction with a named unblocker rather than a shape of the
+//! world. It is also enough to be useful now: a voxel world never asks for a
+//! rotated collider, which is why it is the right thing to build first.
+//!
+//! # Why this is a second implementation rather than a generic one
+//!
+//! The shared thing between the two dimensions is the *vocabulary* — what a
+//! body is, what a contact reports, what order pairs come out in — not the
+//! code. A dimension-generic version was considered and rejected: the generic
+//! bounds infect every signature, and the result is an API nobody can read for
+//! a saving that is mostly in files that differ anyway. The broadphase
+//! structure, the narrowphase algorithms and the storage layout are all
+//! expected to diverge; the meanings are not.
+//!
+//! # The decisions worth knowing before reading the code
+//!
+//! - **A shape index is stable for the life of its body.** Removing a shape
+//!   leaves a hole; the next one fills the lowest free hole.
+//! - **A handle is an ECS entity, stored whole**, because `Entity`'s
+//!   constructor is crate-private and this crate can neither mint one nor
+//!   rebuild one from its parts.
+//! - **A stale handle is refused, a foreign one is undetectable.**
+//! - **Incarnation counters** advance when a collider is rebuilt at an
+//!   identity it already used.
+
+#![forbid(unsafe_code)]
+// A float that reached a contact would make the world a function of the
+// compiler's instruction selection, and this crate's whole obligation is that
+// it is not. There is no `allow` below.
+#![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
+
+pub mod bounds;
+pub mod filter;
+pub mod shape;
+pub mod world;
+
+pub use bounds::Aabb;
+pub use filter::Filter;
+pub use shape::{Shape, Transform};
+pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics3d/src/shape.rs
+++ b/crates/physics3d/src/shape.rs
@@ -1,0 +1,174 @@
+//! What a collider is shaped like, and where it sits on its body.
+
+use renew_fixed::{Fixed, Vec3};
+
+/// A placement in three dimensions.
+///
+/// **A translation, and nothing else.** Rotating in three dimensions needs a
+/// fixed-point *orientation representation* — a quaternion or a matrix — and
+/// that is a decision with its own review that has not been taken. The two
+/// dimensional crate rotates because a rotation there is one scalar; here it
+/// would be four, with a normalisation rule and a composition order to fix.
+///
+/// This is a restriction with a named unblocker rather than a shape of the
+/// world: the vocabulary defines rotated shapes and this crate cannot yet
+/// express one. A voxel world never asks for one, which is why it is the right
+/// place to start.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Transform {
+    /// Position.
+    pub translation: Vec3,
+}
+
+impl Transform {
+    /// At the origin.
+    pub const IDENTITY: Self = Self {
+        translation: Vec3::ZERO,
+    };
+
+    /// At a position.
+    #[must_use]
+    pub const fn at(translation: Vec3) -> Self {
+        Self { translation }
+    }
+
+    /// This placement applied on top of another.
+    ///
+    /// Addition, while there is no rotation. It is a named operation rather
+    /// than a bare `+` because the moment an orientation type exists this is
+    /// the one call site that has to change, and a search for `compose` finds
+    /// it where a search for `+` finds everything.
+    #[must_use]
+    pub fn compose(self, outer: Self) -> Self {
+        Self {
+            translation: outer.translation + self.translation,
+        }
+    }
+}
+
+/// The shape families.
+///
+/// Each is defined in body space. With no rotation the box's axes are the
+/// world's, which is exactly what a voxel world wants and is the reason this
+/// crate is useful before the orientation decision is taken.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Shape {
+    /// Half-extents from the shape's local origin.
+    Box { half_extents: Vec3 },
+    /// Radius about the shape's local origin.
+    Sphere { radius: Fixed },
+}
+
+impl Shape {
+    /// The furthest any point of this shape lies from its local origin.
+    #[must_use]
+    pub fn bounding_radius(self) -> Fixed {
+        match self {
+            Self::Box { half_extents } => half_extents.length(),
+            Self::Sphere { radius } => radius,
+        }
+    }
+
+    /// Whether the operands describe a shape at all.
+    ///
+    /// Zero extents are legal — the query vocabulary requires a zero-radius
+    /// sphere to be answerable rather than refused — but negative ones are
+    /// not, and they are what a caller produces by subtracting in the wrong
+    /// order.
+    #[must_use]
+    pub fn is_valid(self) -> bool {
+        match self {
+            Self::Box { half_extents } => {
+                half_extents.x >= Fixed::ZERO
+                    && half_extents.y >= Fixed::ZERO
+                    && half_extents.z >= Fixed::ZERO
+            }
+            Self::Sphere { radius } => radius >= Fixed::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Shape, Transform};
+    use renew_fixed::{Fixed, Vec3};
+
+    fn v(x: i32, y: i32, z: i32) -> Vec3 {
+        Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+    }
+
+    #[test]
+    fn composing_with_the_identity_changes_nothing() {
+        let placed = Transform::at(v(3, 4, 5));
+        assert_eq!(placed.compose(Transform::IDENTITY), placed);
+        assert_eq!(Transform::IDENTITY.compose(placed), placed);
+    }
+
+    #[test]
+    fn composing_adds_the_placements() {
+        let local = Transform::at(v(1, 2, 3));
+        let body = Transform::at(v(10, 20, 30));
+        assert_eq!(local.compose(body).translation, v(11, 22, 33));
+    }
+
+    #[test]
+    fn a_bounding_radius_covers_the_shape() {
+        assert_eq!(
+            Shape::Sphere {
+                radius: Fixed::from_int(3)
+            }
+            .bounding_radius(),
+            Fixed::from_int(3)
+        );
+        // A 1-2-2 box reaches its corner at 3.
+        assert_eq!(
+            Shape::Box {
+                half_extents: v(1, 2, 2)
+            }
+            .bounding_radius(),
+            Fixed::from_int(3)
+        );
+    }
+
+    #[test]
+    fn zero_sized_shapes_are_valid_and_negative_ones_are_not() {
+        assert!(
+            Shape::Sphere {
+                radius: Fixed::ZERO
+            }
+            .is_valid()
+        );
+        assert!(
+            Shape::Box {
+                half_extents: Vec3::ZERO
+            }
+            .is_valid()
+        );
+        assert!(
+            !Shape::Sphere {
+                radius: Fixed::from_int(-1)
+            }
+            .is_valid()
+        );
+        // Every axis is checked, not just the first — a negative on z is as
+        // wrong as one on x and easier to miss.
+        assert!(
+            !Shape::Box {
+                half_extents: v(-1, 1, 1)
+            }
+            .is_valid()
+        );
+        assert!(
+            !Shape::Box {
+                half_extents: v(1, -1, 1)
+            }
+            .is_valid()
+        );
+        assert!(
+            !Shape::Box {
+                half_extents: v(1, 1, -1)
+            }
+            .is_valid()
+        );
+    }
+}

--- a/crates/physics3d/src/world.rs
+++ b/crates/physics3d/src/world.rs
@@ -1,0 +1,472 @@
+//! The collider set: what is in the world, and every operation that changes it.
+
+use crate::filter::Filter;
+use crate::shape::{Shape, Transform};
+use renew_ecs::Entity;
+
+/// How a body moves, and what it collides with.
+///
+/// `Dynamic` is named and refused. v0 has no solver, so accepting a dynamic
+/// body would mean accepting it and doing something surprising; naming it
+/// keeps the word stable for the implementation that grows one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum BodyKind {
+    /// Never moves.
+    Static,
+    /// Moved by the caller, unaffected by contacts.
+    Kinematic,
+    /// Moved by the simulation. **Refused in v0.**
+    Dynamic,
+}
+
+impl BodyKind {
+    /// Whether two kinds may produce a contact at all.
+    ///
+    /// Static-versus-static is the only pair that cannot: neither ever moves,
+    /// so a contact between them can never change, and reporting it every step
+    /// is noise a caller has to filter out forever.
+    #[must_use]
+    pub const fn collides_with(self, other: Self) -> bool {
+        !matches!((self, other), (Self::Static, Self::Static))
+    }
+}
+
+/// A shape's position in its body's list.
+///
+/// **Stable for the life of the body.** Removing a shape leaves a hole rather
+/// than renumbering, because this index is half of every collider identity,
+/// part of the broadphase sort key, and the order overlaps resolve in — and
+/// shift-down, swap-remove and tombstone each give a different contact order
+/// for the same removal history.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShapeIndex(u32);
+
+impl ShapeIndex {
+    /// The raw position.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+
+    /// An index from a raw position.
+    ///
+    /// Needed because a shape index is *saved* state: it is half of every
+    /// collider identity, so a caller restoring a world has to be able to
+    /// name the same collider it named before. An index that names nothing is
+    /// not an error — every operation refuses it the same way it refuses a
+    /// hole.
+    #[must_use]
+    pub const fn from_raw(position: u32) -> Self {
+        Self(position)
+    }
+}
+
+/// What identifies a collider: a body and one of its shapes.
+///
+/// Ordered lexicographically, handle first, and total because both components
+/// are — which is what every emitted ordering in this crate rests on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Collider {
+    /// The body.
+    pub handle: Entity,
+    /// Which of its shapes.
+    pub index: ShapeIndex,
+}
+
+/// How many times a collider has been rebuilt at the same identity.
+///
+/// A contact identifier derived from a collider pair must not survive either
+/// collider's destruction. Purity alone does not give that: a shape removed
+/// and re-added takes the same index back by the lowest-free-hole rule, and a
+/// body destroyed and recreated against a still-live entity takes the same
+/// handle back. Both would make a rebuilt collider bit-identical to the one it
+/// replaced, and a caller's one-shot impact sound would not fire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Incarnation(u32);
+
+impl Incarnation {
+    /// The raw count.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// One shape on a body.
+#[derive(Clone, Copy, Debug)]
+struct Slot {
+    shape: Shape,
+    local: Transform,
+    filter: Filter,
+}
+
+/// One position in a body's shape list, occupied or not.
+///
+/// The incarnation lives on the *cell* rather than on the shape, so it
+/// survives a removal — which is the point of it.
+#[derive(Clone, Copy, Debug, Default)]
+struct Cell {
+    occupied: Option<Slot>,
+    incarnation: u32,
+}
+
+/// One body and its shapes.
+#[derive(Clone, Debug)]
+struct Body {
+    /// **The entity as issued, not its parts.** `Entity`'s constructor is
+    /// crate-private to the ECS, so physics cannot mint or rebuild a handle:
+    /// keeping the whole thing is the only way to hand one back. This is what
+    /// makes body identity saved state rather than something derivable.
+    entity: Entity,
+    live: bool,
+    kind: BodyKind,
+    transform: Transform,
+    /// Holes are unoccupied cells. Never compacted.
+    shapes: Vec<Cell>,
+    incarnation: u32,
+}
+
+/// What this world can say about a handle.
+///
+/// Named rather than folded into an `Option` because the cases are not equally
+/// answerable, and pretending they are is how a specification comes to demand
+/// an assertion on something undetectable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandleState {
+    /// A body exists here at exactly this generation.
+    Live,
+    /// This world knows the index at a different generation — the entity was
+    /// despawned and its slot reused by the allocator.
+    Stale,
+    /// This world has no body for the handle, either because it never had one
+    /// or because the body was destroyed.
+    Unknown,
+}
+
+/// The bodies, their shapes, and nothing else.
+///
+/// Holds no global state, so a caller may hold several worlds and they do not
+/// interact. Owns the transforms: a caller that also stores one for rendering
+/// copies it out.
+#[derive(Debug, Default)]
+pub struct World {
+    /// Indexed by entity index. The vector only grows, so iteration is in
+    /// ascending index order — a function of the collider set rather than of
+    /// insertion order.
+    bodies: Vec<Option<Body>>,
+    live: usize,
+}
+
+impl World {
+    /// An empty world.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// How many bodies are live.
+    #[must_use]
+    pub const fn body_count(&self) -> usize {
+        self.live
+    }
+
+    /// What this world can say about a handle.
+    ///
+    /// **There is no `Foreign` answer, and that is not an omission.** Two
+    /// entity allocators hand out identical handles by construction — both
+    /// start at index 0, generation 0 — so a handle from another world that
+    /// collides with a live local body is indistinguishable from a correct
+    /// one. It is a caller warrant, and a contract cannot require an
+    /// implementation to detect what it cannot see.
+    #[must_use]
+    pub fn handle_state(&self, handle: Entity) -> HandleState {
+        let Some(body) = self
+            .bodies
+            .get(handle.index() as usize)
+            .and_then(Option::as_ref)
+        else {
+            return HandleState::Unknown;
+        };
+        if body.entity.generation() == handle.generation() {
+            // A destroyed body leaves a tombstone at the same generation. The
+            // world has no body for the handle either way, so it answers
+            // Unknown rather than inventing a fourth case.
+            if body.live {
+                HandleState::Live
+            } else {
+                HandleState::Unknown
+            }
+        } else {
+            HandleState::Stale
+        }
+    }
+
+    fn body(&self, handle: Entity) -> Option<&Body> {
+        self.bodies
+            .get(handle.index() as usize)?
+            .as_ref()
+            .filter(|body| body.live && body.entity == handle)
+    }
+
+    fn body_mut(&mut self, handle: Entity) -> Option<&mut Body> {
+        self.bodies
+            .get_mut(handle.index() as usize)?
+            .as_mut()
+            .filter(|body| body.live && body.entity == handle)
+    }
+
+    // ---- structural mutation: between steps only ----
+
+    /// Create a body against a caller-supplied entity.
+    ///
+    /// `None` if the entity already owns a live body here, or if the kind is
+    /// `Dynamic`. **At most one body per entity** is what keeps collider order
+    /// total: two bodies sharing a handle would compare equal on (handle,
+    /// shape index), and every emitted ordering rests on that being impossible.
+    pub fn create_body(
+        &mut self,
+        entity: Entity,
+        kind: BodyKind,
+        transform: Transform,
+    ) -> Option<Entity> {
+        if kind == BodyKind::Dynamic {
+            return None;
+        }
+        let slot = entity.index() as usize;
+        if self.bodies.len() <= slot {
+            self.bodies.resize(slot + 1, None);
+        }
+        let entry = self.bodies.get_mut(slot)?;
+        let carried = match entry.as_ref() {
+            Some(body) if body.live && body.entity == entity => return None,
+            Some(body) => body.incarnation,
+            None => 0,
+        };
+        *entry = Some(Body {
+            entity,
+            live: true,
+            kind,
+            transform,
+            shapes: Vec::new(),
+            incarnation: carried.wrapping_add(1),
+        });
+        self.live = self.live.saturating_add(1);
+        Some(entity)
+    }
+
+    /// Remove a body and all its shapes. `false` if the handle named none.
+    ///
+    /// The record is kept as a tombstone rather than dropped, because the
+    /// incarnation has to outlive the body: a later body created against the
+    /// same entity must not inherit its identity.
+    pub fn destroy_body(&mut self, handle: Entity) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        body.live = false;
+        body.shapes.clear();
+        self.live = self.live.saturating_sub(1);
+        true
+    }
+
+    /// Add a shape, filling the **lowest free hole**. `None` if the handle
+    /// named no body, or the operands are not a shape.
+    pub fn add_shape(
+        &mut self,
+        handle: Entity,
+        shape: Shape,
+        local: Transform,
+        filter: Filter,
+    ) -> Option<ShapeIndex> {
+        if !shape.is_valid() {
+            return None;
+        }
+        let body = self.body_mut(handle)?;
+        // The lowest free hole, or a new cell at the end. Never a swap, never
+        // a shift: the index is identity.
+        let index = if let Some(hole) = body.shapes.iter().position(|cell| cell.occupied.is_none())
+        {
+            hole
+        } else {
+            body.shapes.push(Cell::default());
+            body.shapes.len() - 1
+        };
+        let cell = body.shapes.get_mut(index)?;
+        cell.occupied = Some(Slot {
+            shape,
+            local,
+            filter,
+        });
+        cell.incarnation = cell.incarnation.wrapping_add(1);
+        u32::try_from(index).ok().map(ShapeIndex)
+    }
+
+    /// Remove a shape, leaving a hole that keeps its index. `false` if there
+    /// was nothing there.
+    pub fn remove_shape(&mut self, handle: Entity, index: ShapeIndex) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        if cell.occupied.is_none() {
+            return false;
+        }
+        cell.occupied = None;
+        true
+    }
+
+    /// Replace a shape in place, keeping its index and advancing its
+    /// incarnation. `false` if there was nothing there.
+    pub fn replace_shape(
+        &mut self,
+        handle: Entity,
+        index: ShapeIndex,
+        shape: Shape,
+        local: Transform,
+    ) -> bool {
+        if !shape.is_valid() {
+            return false;
+        }
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        let Some(slot) = cell.occupied.as_mut() else {
+            return false;
+        };
+        slot.shape = shape;
+        slot.local = local;
+        cell.incarnation = cell.incarnation.wrapping_add(1);
+        true
+    }
+
+    /// Change a shape's filter. `false` if there was nothing there.
+    ///
+    /// Does **not** advance the incarnation: the collider is the same one it
+    /// was, and a contact that persists across a filter change is a persisting
+    /// contact.
+    pub fn set_filter(&mut self, handle: Entity, index: ShapeIndex, filter: Filter) -> bool {
+        let Some(body) = self.body_mut(handle) else {
+            return false;
+        };
+        let Some(cell) = body.shapes.get_mut(index.get() as usize) else {
+            return false;
+        };
+        match cell.occupied.as_mut() {
+            Some(slot) => {
+                slot.filter = filter;
+                true
+            }
+            None => false,
+        }
+    }
+
+    // ---- movement: legal during the caller's phase, effective immediately ----
+
+    /// Place a body. **Teleports; does not sweep.**
+    ///
+    /// A body moved this way passes through anything between where it was and
+    /// where it lands. That is the caller's choice, and the swept operation is
+    /// the other one — a placement that quietly swept would make the cheap
+    /// operation expensive and leave the expensive one unavailable.
+    pub fn set_transform(&mut self, handle: Entity, transform: Transform) -> bool {
+        match self.body_mut(handle) {
+            Some(body) => {
+                body.transform = transform;
+                true
+            }
+            None => false,
+        }
+    }
+
+    // ---- reading ----
+
+    /// A body's transform.
+    #[must_use]
+    pub fn transform(&self, handle: Entity) -> Option<Transform> {
+        self.body(handle).map(|body| body.transform)
+    }
+
+    /// A body's kind.
+    #[must_use]
+    pub fn kind(&self, handle: Entity) -> Option<BodyKind> {
+        self.body(handle).map(|body| body.kind)
+    }
+
+    /// One shape, in body-local terms.
+    #[must_use]
+    pub fn shape(&self, collider: Collider) -> Option<(Shape, Transform, Filter)> {
+        let slot = self.cell(collider)?.occupied.as_ref()?;
+        Some((slot.shape, slot.local, slot.filter))
+    }
+
+    /// A shape's world transform — its local placement composed onto its
+    /// body's.
+    #[must_use]
+    pub fn world_transform(&self, collider: Collider) -> Option<Transform> {
+        let body = self.body(collider.handle)?;
+        let slot = body
+            .shapes
+            .get(collider.index.get() as usize)?
+            .occupied
+            .as_ref()?;
+        Some(slot.local.compose(body.transform))
+    }
+
+    /// How many times this collider has been rebuilt at the same identity.
+    #[must_use]
+    pub fn incarnation(&self, collider: Collider) -> Option<Incarnation> {
+        let body = self.body(collider.handle)?;
+        let cell = body.shapes.get(collider.index.get() as usize)?;
+        cell.occupied.as_ref()?;
+        Some(Incarnation(
+            body.incarnation
+                .wrapping_mul(31)
+                .wrapping_add(cell.incarnation),
+        ))
+    }
+
+    fn cell(&self, collider: Collider) -> Option<&Cell> {
+        self.body(collider.handle)?
+            .shapes
+            .get(collider.index.get() as usize)
+    }
+
+    /// The highest occupied index plus one — **not** the number of live
+    /// shapes, because holes keep their place.
+    #[must_use]
+    pub fn shape_extent(&self, handle: Entity) -> Option<u32> {
+        let shapes = &self.body(handle)?.shapes;
+        let highest = shapes.iter().rposition(|cell| cell.occupied.is_some());
+        Some(highest.map_or(0, |index| u32::try_from(index).unwrap_or(u32::MAX) + 1))
+    }
+
+    /// Every live collider, **in ascending (handle, shape index) order**.
+    ///
+    /// The order is part of the contract rather than an accident of the
+    /// representation: it is a function of the collider set, so two worlds
+    /// built by different insertion sequences iterate identically.
+    pub fn colliders(&self) -> impl Iterator<Item = Collider> + '_ {
+        self.bodies
+            .iter()
+            .filter_map(Option::as_ref)
+            .filter(|body| body.live)
+            .flat_map(|body| {
+                let handle = body.entity;
+                body.shapes
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(position, cell)| {
+                        cell.occupied.as_ref()?;
+                        Some(Collider {
+                            handle,
+                            index: ShapeIndex(u32::try_from(position).unwrap_or(u32::MAX)),
+                        })
+                    })
+            })
+    }
+}

--- a/crates/physics3d/tests/lifecycle.rs
+++ b/crates/physics3d/tests/lifecycle.rs
@@ -1,0 +1,385 @@
+//! The identity and ordering rules, lifted to three dimensions.
+//!
+//! These are the same properties the two-dimensional crate holds, and they are
+//! tested again rather than assumed to carry over: the vocabulary is shared,
+//! the implementation is not, and "it worked in 2D" is not evidence about code
+//! that was written separately.
+
+use proptest::prelude::*;
+use renew_ecs::Entities;
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{
+    BodyKind, Collider, Filter, HandleState, Shape, ShapeIndex, Transform, World,
+};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+fn sphere(units: i32) -> Shape {
+    Shape::Sphere {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn cube(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half, half),
+    }
+}
+
+/// A removed shape leaves a hole, and the shapes after it keep their indices.
+#[test]
+fn removing_a_shape_does_not_renumber_the_others() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Kinematic, Transform::IDENTITY)
+        .expect("a fresh entity has no body");
+
+    let indices: Vec<_> = (1..=3)
+        .map(|units| {
+            world
+                .add_shape(body, sphere(units), Transform::IDENTITY, Filter::ALL)
+                .expect("live body")
+        })
+        .collect();
+    assert_eq!(indices[2].get(), 2);
+
+    assert!(world.remove_shape(body, indices[1]));
+
+    let (shape, _, _) = world
+        .shape(Collider {
+            handle: body,
+            index: indices[2],
+        })
+        .expect("the third shape kept its index");
+    assert_eq!(shape, sphere(3));
+    assert!(
+        world
+            .shape(Collider {
+                handle: body,
+                index: indices[1]
+            })
+            .is_none(),
+        "index one must be a hole, not a shifted-down neighbour"
+    );
+    assert_eq!(
+        world.shape_extent(body),
+        Some(3),
+        "the hole keeps its place"
+    );
+}
+
+#[test]
+fn a_new_shape_fills_the_lowest_free_hole() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Static, Transform::IDENTITY)
+        .expect("fresh");
+
+    let indices: Vec<_> = (0..5)
+        .map(|_| {
+            world
+                .add_shape(body, cube(1), Transform::IDENTITY, Filter::ALL)
+                .expect("live")
+        })
+        .collect();
+
+    // Free the higher hole first, so "lowest" is about ordering rather than
+    // recency.
+    assert!(world.remove_shape(body, indices[3]));
+    assert!(world.remove_shape(body, indices[1]));
+
+    let first = world
+        .add_shape(body, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    assert_eq!(first, indices[1], "the lowest free hole, not the newest");
+    let second = world
+        .add_shape(body, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    assert_eq!(second, indices[3], "then the next one up");
+}
+
+#[test]
+fn a_handle_is_live_stale_or_unknown() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+
+    let handle = entities.spawn();
+    assert_eq!(world.handle_state(handle), HandleState::Unknown);
+
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    assert_eq!(world.handle_state(handle), HandleState::Live);
+
+    entities.despawn(handle);
+    let recycled = entities.spawn();
+    assert_eq!(recycled.index(), handle.index(), "the slot was reused");
+    assert_eq!(
+        world.handle_state(recycled),
+        HandleState::Stale,
+        "a reused index must not reach another body's data"
+    );
+    assert!(!world.set_transform(recycled, at(5, 5, 5)));
+    assert!(world.transform(recycled).is_none());
+
+    // The original still works: nothing about the ECS despawn reached here.
+    assert!(world.set_transform(handle, at(5, 5, 5)));
+}
+
+#[test]
+fn one_entity_gets_at_most_one_body() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    assert!(
+        world
+            .create_body(handle, BodyKind::Static, Transform::IDENTITY)
+            .is_some()
+    );
+    assert!(
+        world
+            .create_body(handle, BodyKind::Static, Transform::IDENTITY)
+            .is_none(),
+        "a second body against the same entity must be refused"
+    );
+    assert_eq!(world.body_count(), 1);
+}
+
+#[test]
+fn a_dynamic_body_is_refused_rather_than_silently_reinterpreted() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    assert!(
+        world
+            .create_body(entities.spawn(), BodyKind::Dynamic, Transform::IDENTITY)
+            .is_none()
+    );
+    assert_eq!(world.body_count(), 0);
+}
+
+#[test]
+fn a_rebuilt_collider_is_not_the_one_it_replaced() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, sphere(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    let collider = Collider { handle, index };
+    let before = world.incarnation(collider).expect("occupied");
+
+    assert!(world.remove_shape(handle, index));
+    let again = world
+        .add_shape(handle, sphere(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    assert_eq!(again, index, "the identity is reused, which is the problem");
+    assert_ne!(
+        world.incarnation(collider).expect("occupied"),
+        before,
+        "and the incarnation is what distinguishes them"
+    );
+}
+
+/// A shape's placement is added to its body's, which is what lets one body own
+/// several in different places — a chunk of terrain, or a door and its frame.
+#[test]
+fn a_shape_sits_where_its_local_transform_puts_it() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, at(10, 0, -5));
+    let index = world
+        .add_shape(handle, cube(1), at(0, 3, 2), Filter::ALL)
+        .expect("live");
+    let placed = world
+        .world_transform(Collider { handle, index })
+        .expect("occupied");
+    assert_eq!(placed.translation, v(10, 3, -3));
+}
+
+#[test]
+fn every_operation_refuses_a_handle_this_world_never_saw() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let stranger = entities.spawn();
+
+    assert_eq!(world.handle_state(stranger), HandleState::Unknown);
+    assert!(!world.destroy_body(stranger));
+    assert!(!world.set_transform(stranger, at(1, 1, 1)));
+    assert!(
+        world
+            .add_shape(stranger, cube(1), Transform::IDENTITY, Filter::ALL)
+            .is_none()
+    );
+    assert!(!world.remove_shape(stranger, ShapeIndex::from_raw(0)));
+    assert!(!world.replace_shape(
+        stranger,
+        ShapeIndex::from_raw(0),
+        cube(1),
+        Transform::IDENTITY
+    ));
+    assert!(!world.set_filter(stranger, ShapeIndex::from_raw(0), Filter::ALL));
+    assert!(world.kind(stranger).is_none());
+    assert!(world.shape_extent(stranger).is_none());
+}
+
+#[test]
+fn destroying_a_body_takes_its_shapes_and_stops_answering() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, at(1, 2, 3));
+    let index = world
+        .add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+
+    assert_eq!(world.kind(handle), Some(BodyKind::Kinematic));
+    assert!(world.destroy_body(handle));
+    assert_eq!(world.body_count(), 0);
+    assert_eq!(world.handle_state(handle), HandleState::Unknown);
+    assert!(world.shape(Collider { handle, index }).is_none());
+    assert!(world.world_transform(Collider { handle, index }).is_none());
+    assert_eq!(world.colliders().count(), 0);
+    assert!(!world.destroy_body(handle), "twice is a no-op");
+}
+
+#[test]
+fn replacing_and_refiltering_a_shape_behave_as_they_do_in_two_dimensions() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, sphere(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    let collider = Collider { handle, index };
+    let before = world.incarnation(collider).expect("occupied");
+
+    assert!(world.replace_shape(handle, index, cube(2), at(1, 1, 1)));
+    let (shape, local, _) = world.shape(collider).expect("still occupied");
+    assert_eq!(shape, cube(2));
+    assert_eq!(local.translation, v(1, 1, 1));
+    assert_ne!(world.incarnation(collider).expect("occupied"), before);
+
+    // A filter change is not a rebuild.
+    let after_replace = world.incarnation(collider).expect("occupied");
+    assert!(world.set_filter(handle, index, Filter::NONE));
+    assert_eq!(
+        world.incarnation(collider).expect("occupied"),
+        after_replace
+    );
+    let (_, _, filter) = world.shape(collider).expect("occupied");
+    assert_eq!(filter, Filter::NONE);
+
+    // Refusals.
+    assert!(!world.replace_shape(handle, index, cube(-1), Transform::IDENTITY));
+    assert!(!world.replace_shape(
+        handle,
+        ShapeIndex::from_raw(9),
+        cube(1),
+        Transform::IDENTITY
+    ));
+    assert!(!world.set_filter(handle, ShapeIndex::from_raw(9), Filter::ALL));
+    assert!(world.remove_shape(handle, index));
+    assert!(!world.remove_shape(handle, index));
+    assert!(!world.set_filter(handle, index, Filter::ALL));
+}
+
+#[test]
+fn a_shape_with_a_negative_extent_is_refused() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = world
+        .create_body(entities.spawn(), BodyKind::Static, Transform::IDENTITY)
+        .expect("fresh");
+    assert!(
+        world
+            .add_shape(body, cube(-1), Transform::IDENTITY, Filter::ALL)
+            .is_none()
+    );
+    assert_eq!(world.shape_extent(body), Some(0), "and nothing was stored");
+}
+
+/// Bodies live against entity indices, and a sparse index space must not
+/// invent bodies in the gaps or lose the order between them.
+#[test]
+fn a_sparse_index_space_does_not_invent_bodies() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let first = entities.spawn();
+    for _ in 0..5 {
+        let _ = entities.spawn();
+    }
+    let distant = entities.spawn();
+
+    world.create_body(first, BodyKind::Static, Transform::IDENTITY);
+    world.create_body(distant, BodyKind::Static, Transform::IDENTITY);
+    world.add_shape(first, cube(1), Transform::IDENTITY, Filter::ALL);
+    world.add_shape(distant, cube(1), Transform::IDENTITY, Filter::ALL);
+
+    assert_eq!(world.body_count(), 2);
+    let seen: Vec<_> = world.colliders().collect();
+    assert_eq!(seen.len(), 2, "the gap contributed nothing");
+    assert!(seen[0] < seen[1], "and they came out in index order");
+}
+
+proptest! {
+    /// Collider order is a function of the collider set, not of the order it
+    /// was built in — which is what makes a contact array reproducible across
+    /// machines that reached the same state by different routes.
+    #[test]
+    fn collider_order_does_not_depend_on_insertion_order(
+        permutation in Just((0usize..6).collect::<Vec<_>>()).prop_shuffle()
+    ) {
+        let build = |order: &[usize]| {
+            let mut entities = Entities::new();
+            let handles: Vec<_> = (0..6).map(|_| entities.spawn()).collect();
+            let mut world = World::new();
+            for &which in order {
+                let handle = handles[which];
+                world.create_body(handle, BodyKind::Static, Transform::IDENTITY);
+                world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+            }
+            world.colliders().collect::<Vec<_>>()
+        };
+        let ascending: Vec<usize> = (0..6).collect();
+        prop_assert_eq!(build(&ascending), build(&permutation));
+    }
+
+    /// However a body's shapes are added and removed, every live one keeps a
+    /// distinct index and collider order stays strictly ascending.
+    #[test]
+    fn collider_order_is_strictly_ascending_under_any_history(
+        operations in prop::collection::vec(prop::bool::ANY, 0..24)
+    ) {
+        let mut entities = Entities::new();
+        let mut world = World::new();
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+
+        let mut added: Vec<ShapeIndex> = Vec::new();
+        for add in operations {
+            if add || added.is_empty() {
+                if let Some(index) = world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL) {
+                    added.push(index);
+                }
+            } else {
+                let victim = added.remove(added.len() / 2);
+                world.remove_shape(handle, victim);
+            }
+        }
+
+        let seen: Vec<Collider> = world.colliders().collect();
+        for pair in seen.windows(2) {
+            prop_assert!(pair[0] < pair[1], "collider order must be strictly ascending");
+        }
+        prop_assert_eq!(seen.len(), added.len(), "every live shape appears exactly once");
+    }
+}

--- a/crates/physics3d/tests/lifecycle.rs
+++ b/crates/physics3d/tests/lifecycle.rs
@@ -454,3 +454,37 @@ fn an_index_past_the_end_of_a_body_is_refused() {
     assert!(!world.set_filter(handle, past, Filter::ALL));
     assert_eq!(world.shape_extent(handle), Some(1), "the list did not grow");
 }
+
+/// **A hole is not a shape to replace.** Replacing at a freed index must be
+/// refused rather than quietly refilling it, because a caller that meant to
+/// change an existing collider and got a new one at the same identity has a
+/// contact history that lies.
+#[test]
+fn replacing_at_a_hole_is_refused_rather_than_refilling_it() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    assert!(world.remove_shape(handle, index));
+
+    // A perfectly valid shape at a freed index. The refusal is about the hole,
+    // not about the operands — which is why the shape here is a good one.
+    assert!(
+        !world.replace_shape(handle, index, sphere(2), Transform::IDENTITY),
+        "a hole is not a shape to replace"
+    );
+    assert!(
+        world.shape(Collider { handle, index }).is_none(),
+        "and nothing was put there"
+    );
+
+    // Adding is how a freed index comes back, and that path still works.
+    let refilled = world
+        .add_shape(handle, sphere(2), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    assert_eq!(refilled, index);
+    assert!(world.replace_shape(handle, index, cube(3), Transform::IDENTITY));
+}

--- a/crates/physics3d/tests/lifecycle.rs
+++ b/crates/physics3d/tests/lifecycle.rs
@@ -383,3 +383,74 @@ proptest! {
         prop_assert_eq!(seen.len(), added.len(), "every live shape appears exactly once");
     }
 }
+
+/// Two static bodies never move, so a contact between them can never change.
+/// The rest of the matrix must still collide, or the only movable kind in v0
+/// collides with nothing.
+#[test]
+fn only_two_static_bodies_cannot_produce_a_contact() {
+    use BodyKind::{Dynamic, Kinematic, Static};
+    assert!(!Static.collides_with(Static));
+    assert!(Static.collides_with(Kinematic));
+    assert!(Kinematic.collides_with(Static));
+    assert!(Kinematic.collides_with(Kinematic));
+    assert!(Dynamic.collides_with(Static));
+    assert!(Dynamic.collides_with(Dynamic));
+}
+
+/// A body created against an entity whose slot was reused inherits nothing
+/// from the body that used to be there — including its incarnation, which is
+/// what stops a rebuilt collider passing for the old one.
+#[test]
+fn a_body_at_a_recycled_slot_carries_a_fresh_incarnation() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let first = entities.spawn();
+    world.create_body(first, BodyKind::Kinematic, Transform::IDENTITY);
+    let index = world
+        .add_shape(first, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    let before = world
+        .incarnation(Collider {
+            handle: first,
+            index,
+        })
+        .expect("occupied")
+        .get();
+
+    entities.despawn(first);
+    let recycled = entities.spawn();
+    world.create_body(recycled, BodyKind::Kinematic, Transform::IDENTITY);
+    let again = world
+        .add_shape(recycled, cube(1), Transform::IDENTITY, Filter::ALL)
+        .expect("live");
+    let after = world
+        .incarnation(Collider {
+            handle: recycled,
+            index: again,
+        })
+        .expect("occupied")
+        .get();
+
+    assert_ne!(
+        after, before,
+        "the new body must not inherit the old one's identity"
+    );
+}
+
+/// Removing, replacing or refiltering a shape index past the end of a body's
+/// list is a no-op rather than a panic or a silent extension.
+#[test]
+fn an_index_past_the_end_of_a_body_is_refused() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+
+    let past = ShapeIndex::from_raw(99);
+    assert!(!world.remove_shape(handle, past));
+    assert!(!world.replace_shape(handle, past, cube(1), Transform::IDENTITY));
+    assert!(!world.set_filter(handle, past, Filter::ALL));
+    assert_eq!(world.shape_extent(handle), Some(1), "the list did not grow");
+}


### PR DESCRIPTION
Bodies, shapes, filtering and the operations that change them, in
axis-aligned three-dimensional space.

Axis-aligned is the point rather than a shortcut. Rotating in three
dimensions needs a fixed-point orientation representation - a quaternion
or a matrix - with a normalisation rule and a composition order, and
that decision has its own review and has not been taken. A placement
here is a translation, which is a restriction with a named unblocker
rather than a shape of the world. It is also enough to be useful now: a
voxel world never asks for a rotated collider, which is why it is the
right thing to build first.

A second implementation rather than a generic one, which is the ruling
this follows. What the two dimensions share is the vocabulary - what a
body is, what order colliders come out in, what a stale handle does -
not the code. A dimension-generic version infects every signature with
generic bounds for a saving that is mostly in files expected to diverge
anyway: the broadphase structure, the narrowphase algorithms and the
storage layout are all meant to differ.

The properties are tested again rather than assumed to carry over.
It worked in two dimensions is not evidence about code written
separately, so shape-index stability, the lowest-free-hole rule, the
handle protocol's three cases, one body per entity, incarnation
counters, sparse index spaces and both ordering properties all have
their own tests here.

One test is specific to the extra axis and worth naming: separation
along any single axis is separation. An overlap test that checks two and
forgets the third proposes every pair in a column, which is correct and
useless - and it is the mistake a two-dimensional test lifted carelessly
would make.