### PR TITLE
feat(physics3d): candidate pairs and contacts in three dimensions

### DIFF
--- a/crates/physics3d/src/broadphase.rs
+++ b/crates/physics3d/src/broadphase.rs
@@ -1,0 +1,201 @@
+//! Which pairs are worth testing, in an order that is a function of the world.
+
+use crate::bounds::Aabb;
+use crate::filter::Filter;
+use crate::world::{BodyKind, Collider, World};
+use renew_fixed::Fixed;
+
+/// One collider's contribution to the sweep.
+#[derive(Clone, Copy, Debug)]
+struct Record {
+    collider: Collider,
+    bounds: Aabb,
+    kind: BodyKind,
+    filter: Filter,
+}
+
+/// One end of one interval on the swept axis.
+///
+/// The `begin` flag is not decoration: a zero-extent shape — a zero-radius
+/// sphere, which the query vocabulary requires to be answerable — has its two
+/// endpoints at the same coordinate, and nothing else in the key separates
+/// them. Without it their relative order is whatever the sort happens to do.
+#[derive(Clone, Copy, Debug)]
+struct Endpoint {
+    coordinate: Fixed,
+    begin: bool,
+    record: usize,
+}
+
+/// Candidate pairs, and the storage that produces them.
+///
+/// Owned by the caller and reused: the vectors are cleared rather than
+/// dropped, so a warm broadphase allocates nothing. The first rebuild after a
+/// world grows is the only one that can.
+#[derive(Debug, Default)]
+pub struct Broadphase {
+    records: Vec<Record>,
+    endpoints: Vec<Endpoint>,
+    active: Vec<usize>,
+    pairs: Vec<(Collider, Collider)>,
+}
+
+impl Broadphase {
+    /// Empty, with no storage yet.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Rebuild from the world as it currently stands.
+    ///
+    /// **One axis is swept and all three are tested.** Sweeping *x* prunes the
+    /// pairs that cannot touch along it; the overlap test that follows still
+    /// checks *y* and *z*, because separation along any single axis is
+    /// separation. A three-dimensional broadphase that forgot the third would
+    /// propose every pair in a column — correct, and useless.
+    ///
+    /// **Rebuilt rather than maintained**, and that is the determinism
+    /// argument rather than a simplification. An incrementally-maintained
+    /// structure carries the order of the mutations that built it, and two
+    /// worlds that reached the same state by different routes would sweep
+    /// differently. Rebuilding makes the result a function of the collider set
+    /// and nothing else.
+    pub fn rebuild(&mut self, world: &World, tolerance: Fixed) {
+        self.records.clear();
+        self.endpoints.clear();
+        self.active.clear();
+        self.pairs.clear();
+
+        for collider in world.colliders() {
+            // `colliders()` yields only live colliders, so each lookup below
+            // succeeds by construction. Written as a `let ... else` that
+            // panics rather than one that skips, because a skip here would
+            // silently drop a collider out of the broadphase and the world
+            // would quietly stop colliding — a defensive `continue` cannot be
+            // reached and would hide the bug that reached it.
+            let (shape, _, filter) = world
+                .shape(collider)
+                .unwrap_or_else(|| unreachable!("a live collider has a shape"));
+            let transform = world
+                .world_transform(collider)
+                .unwrap_or_else(|| unreachable!("a live collider has a transform"));
+            let kind = world
+                .kind(collider.handle)
+                .unwrap_or_else(|| unreachable!("a live collider has a body"));
+            // Inflated by the contact tolerance, so a pair separated by less
+            // than it still reaches narrowphase — a contact at depth zero is
+            // one the vocabulary requires, and it cannot be generated from a
+            // pair the broadphase never proposed.
+            let bounds = shape.world_bounds(transform).expanded(tolerance);
+            let record = self.records.len();
+            self.records.push(Record {
+                collider,
+                bounds,
+                kind,
+                filter,
+            });
+            self.endpoints.push(Endpoint {
+                coordinate: bounds.min.x,
+                begin: true,
+                record,
+            });
+            self.endpoints.push(Endpoint {
+                coordinate: bounds.max.x,
+                begin: false,
+                record,
+            });
+        }
+
+        // The key is total, which is the whole point: equal coordinates are
+        // the common case in a tile-aligned world, not a corner one. Begins
+        // sort before ends so that colliders which merely touch are proposed.
+        self.endpoints.sort_unstable_by(|a, b| {
+            let left = self.records.get(a.record).map(|r| r.collider);
+            let right = self.records.get(b.record).map(|r| r.collider);
+            a.coordinate
+                .cmp(&b.coordinate)
+                .then_with(|| b.begin.cmp(&a.begin))
+                .then_with(|| left.cmp(&right))
+        });
+
+        // Four disjoint field borrows, which is why this is a free function
+        // rather than a method: it lets the sweep read the records and write
+        // the pairs without an index dance whose bounds checks could never
+        // fail and could never be tested either.
+        sweep(
+            &self.records,
+            &self.endpoints,
+            &mut self.active,
+            &mut self.pairs,
+        );
+
+        // **Emitted order is over the pair, not over the sweep.** Stating the
+        // obligation this way is what lets a different structure — a grid, a
+        // tree, three swept axes — produce the same output, and what stops the
+        // swept axis leaking into a contact array.
+        self.pairs.sort_unstable();
+    }
+
+    /// The candidate pairs, lower collider first, in ascending pair order.
+    #[must_use]
+    pub fn pairs(&self) -> &[(Collider, Collider)] {
+        &self.pairs
+    }
+
+    /// How many colliders the last rebuild saw.
+    #[must_use]
+    pub fn collider_count(&self) -> usize {
+        self.records.len()
+    }
+}
+
+/// Walk the sorted endpoints, proposing a pair for every overlapping resident
+/// as each interval opens.
+fn sweep(
+    records: &[Record],
+    endpoints: &[Endpoint],
+    active: &mut Vec<usize>,
+    pairs: &mut Vec<(Collider, Collider)>,
+) {
+    for endpoint in endpoints {
+        let entering = records[endpoint.record];
+        if endpoint.begin {
+            for &other in active.iter() {
+                let resident = records[other];
+                if eligible(entering, resident) && entering.bounds.overlaps(resident.bounds) {
+                    // Canonical order, lower collider first, so a pair reads
+                    // the same however the sweep happened to reach it.
+                    pairs.push(if entering.collider < resident.collider {
+                        (entering.collider, resident.collider)
+                    } else {
+                        (resident.collider, entering.collider)
+                    });
+                }
+            }
+            active.push(endpoint.record);
+        } else if let Some(position) = active
+            .iter()
+            .position(|&candidate| candidate == endpoint.record)
+        {
+            // The active set is unordered — the pairs it produces are a set,
+            // and they are sorted afterwards — so removing cheaply here costs
+            // nothing observable.
+            active.swap_remove(position);
+        }
+    }
+}
+
+/// Whether a pair is worth a narrowphase test at all.
+///
+/// Rejections here mean the pair **never existed** rather than existed and was
+/// dropped — which is why the rule lives in one place: two implementations
+/// disagreeing about it would report different totals for the same world.
+fn eligible(a: Record, b: Record) -> bool {
+    // A body does not collide with itself. Its shapes are parts of one object,
+    // and an articulated thing whose parts must collide is several bodies.
+    if a.collider.handle == b.collider.handle {
+        return false;
+    }
+    a.kind.collides_with(b.kind) && a.filter.eligible(b.filter)
+}

--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -40,11 +40,15 @@
 #![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
 
 pub mod bounds;
+pub mod broadphase;
 pub mod filter;
+pub mod narrow;
 pub mod shape;
 pub mod world;
 
 pub use bounds::Aabb;
+pub use broadphase::Broadphase;
 pub use filter::Filter;
+pub use narrow::{Contact, collide, separation};
 pub use shape::{Shape, Transform};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics3d/src/narrow.rs
+++ b/crates/physics3d/src/narrow.rs
@@ -1,0 +1,297 @@
+//! Whether two shapes actually touch, and where.
+
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec3};
+
+/// The direction taken when two shapes are exactly coincident and no
+/// separating direction exists.
+///
+/// Arbitrary, and that is the point: two implementations must choose the same
+/// arbitrary thing, and a reader must be able to predict which.
+const COINCIDENT_FALLBACK: Vec3 = Vec3::new(Fixed::ONE, Fixed::ZERO, Fixed::ZERO);
+
+/// A touch between two shapes.
+///
+/// **One point rather than a manifold, and that is a real limitation.** Two
+/// axis-aligned boxes meeting face to face touch across a rectangle, and the
+/// full contact is its corners — up to four of them. A single representative
+/// point is how a box resting on a floor starts to rock.
+///
+/// It is enough for a voxel world, where a body meets a face at a time and the
+/// caller resolves by axis, and it is not enough for a solver. Named here so
+/// the gap is visible rather than discovered.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Contact {
+    /// From the first shape toward the second — the direction the first would
+    /// move to separate.
+    pub normal: Vec3,
+    /// Where, in world space.
+    pub point: Vec3,
+    /// How far they interpenetrate along the normal. Never negative.
+    pub depth: Fixed,
+}
+
+/// Do these two shapes touch, and if so how?
+///
+/// `None` means apart; a touch at exactly zero separation is a contact with
+/// depth zero rather than a miss, because a caller cannot act on a contact it
+/// never receives.
+///
+/// # Antisymmetry, and the one case that breaks it
+///
+/// Swapping the arguments negates the normal — except when the two centres
+/// coincide exactly, where the direction carries no information and both
+/// orders take the stated fallback. Inherent rather than a defect: with
+/// identical inputs there is nothing antisymmetric left to derive a direction
+/// from. The pipeline never depends on it, because the broadphase emits every
+/// pair with its lower collider first.
+#[must_use]
+pub fn collide(a: Shape, a_at: Transform, b: Shape, b_at: Transform) -> Option<Contact> {
+    match (a, b) {
+        (Shape::Sphere { radius: ra }, Shape::Sphere { radius: rb }) => {
+            sphere_sphere(a_at.translation, ra, b_at.translation, rb)
+        }
+        (Shape::Sphere { radius }, Shape::Box { half_extents }) => {
+            sphere_box(a_at.translation, radius, half_extents, b_at.translation)
+        }
+        (Shape::Box { half_extents }, Shape::Sphere { radius }) => {
+            // Solved the other way and reversed, so there is one
+            // implementation of this geometry rather than two that can drift.
+            sphere_box(b_at.translation, radius, half_extents, a_at.translation).map(reverse)
+        }
+        (Shape::Box { half_extents: ha }, Shape::Box { half_extents: hb }) => {
+            box_box(a_at.translation, ha, b_at.translation, hb)
+        }
+    }
+}
+
+fn reverse(contact: Contact) -> Contact {
+    Contact {
+        normal: -contact.normal,
+        point: contact.point,
+        depth: contact.depth,
+    }
+}
+
+/// Two spheres: exact, and the only case with no ambiguity anywhere.
+fn sphere_sphere(a: Vec3, ra: Fixed, b: Vec3, rb: Fixed) -> Option<Contact> {
+    let delta = b - a;
+    let reach = ra + rb;
+    // Compared wide, so the test is exact at every scale a world reaches.
+    if delta.length_squared_wide() > reach.wide_mul(reach) {
+        return None;
+    }
+    let distance = delta.length();
+    let normal = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+    let depth = (reach - distance).max(Fixed::ZERO);
+    // The middle of the overlapped span, so the point does not jump between
+    // the two surfaces as the depth changes.
+    let point = a + normal * (ra - Fixed::from_bits(depth.to_bits() / 2));
+    Some(Contact {
+        normal,
+        point,
+        depth,
+    })
+}
+
+/// A sphere against an axis-aligned box: clamp the centre into the box, and
+/// the rest follows.
+fn sphere_box(centre: Vec3, radius: Fixed, half: Vec3, box_at: Vec3) -> Option<Contact> {
+    let local = centre - box_at;
+    let clamped = Vec3::new(
+        local.x.clamp(-half.x, half.x),
+        local.y.clamp(-half.y, half.y),
+        local.z.clamp(-half.z, half.z),
+    );
+    let surface = box_at + clamped;
+
+    if clamped == local {
+        // The centre is inside, so the shortest way out is through the nearest
+        // face — and all six are candidates, which is why the choice compares
+        // distances rather than testing a sign.
+        let reaches = [
+            (half.x - local.x.abs(), 0u8),
+            (half.y - local.y.abs(), 1),
+            (half.z - local.z.abs(), 2),
+        ];
+        let mut nearest = reaches[0];
+        for candidate in reaches {
+            // Strictly nearer, so a tie leaves the earlier axis and two
+            // machines choose the same one.
+            if candidate.0 < nearest.0 {
+                nearest = candidate;
+            }
+        }
+        let (to_face, axis) = nearest;
+        let sign = |value: Fixed| {
+            if value < Fixed::ZERO {
+                Fixed::from_int(-1)
+            } else {
+                Fixed::ONE
+            }
+        };
+        let out = match axis {
+            0 => Vec3::new(sign(local.x), Fixed::ZERO, Fixed::ZERO),
+            1 => Vec3::new(Fixed::ZERO, sign(local.y), Fixed::ZERO),
+            _ => Vec3::new(Fixed::ZERO, Fixed::ZERO, sign(local.z)),
+        };
+        return Some(Contact {
+            // From the sphere toward the box.
+            normal: -out,
+            point: surface,
+            depth: to_face + radius,
+        });
+    }
+
+    let delta = local - clamped;
+    if delta.length_squared_wide() > radius.wide_mul(radius) {
+        return None;
+    }
+    let distance = delta.length();
+    let out = delta.normalize().unwrap_or(COINCIDENT_FALLBACK);
+    Some(Contact {
+        normal: -out,
+        point: surface,
+        depth: (radius - distance).max(Fixed::ZERO),
+    })
+}
+
+/// Two axis-aligned boxes: the overlap on each axis, and the shallowest wins.
+///
+/// With no rotation this is the whole separating-axis test — the three world
+/// axes are the only candidates, and one with no overlap is a proof of no
+/// contact.
+fn box_box(a: Vec3, ha: Vec3, b: Vec3, hb: Vec3) -> Option<Contact> {
+    let delta = b - a;
+    let reach = ha + hb;
+    let overlaps = [
+        (reach.x - delta.x.abs(), 0u8),
+        (reach.y - delta.y.abs(), 1),
+        (reach.z - delta.z.abs(), 2),
+    ];
+    for (overlap, _) in overlaps {
+        if overlap < Fixed::ZERO {
+            return None;
+        }
+    }
+
+    // Shallowest wins; a tie leaves the earlier axis, so x beats y beats z and
+    // two machines agree on a symmetric overlap.
+    let mut best = overlaps[0];
+    for candidate in overlaps {
+        if candidate.0 < best.0 {
+            best = candidate;
+        }
+    }
+    let (depth, axis) = best;
+    let along = match axis {
+        0 => delta.x,
+        1 => delta.y,
+        _ => delta.z,
+    };
+    let sign = if along < Fixed::ZERO {
+        Fixed::from_int(-1)
+    } else {
+        Fixed::ONE
+    };
+    let normal = match axis {
+        0 => Vec3::new(sign, Fixed::ZERO, Fixed::ZERO),
+        1 => Vec3::new(Fixed::ZERO, sign, Fixed::ZERO),
+        _ => Vec3::new(Fixed::ZERO, Fixed::ZERO, sign),
+    };
+    // The middle of the overlapped region on the winning axis, clamped to the
+    // shared extent on the other two.
+    let point = Vec3::new(
+        midpoint(a.x, ha.x, b.x, hb.x),
+        midpoint(a.y, ha.y, b.y, hb.y),
+        midpoint(a.z, ha.z, b.z, hb.z),
+    );
+    Some(Contact {
+        normal,
+        point,
+        depth,
+    })
+}
+
+/// The centre of the shared span on one axis.
+fn midpoint(a: Fixed, ha: Fixed, b: Fixed, hb: Fixed) -> Fixed {
+    let low = (a - ha).max(b - hb);
+    let high = (a + ha).min(b + hb);
+    Fixed::from_bits(low.to_bits().midpoint(high.to_bits()))
+}
+
+/// How far apart two shapes are, and along which direction.
+///
+/// Positive means separated by that distance; zero or negative means touching
+/// or overlapping. The direction points **from `a` toward `b`**.
+///
+/// A sweep needs this and a contact test cannot give it: "do they touch" says
+/// nothing about how far a body may travel before they do.
+#[must_use]
+pub fn separation(a: Shape, a_at: Transform, b: Shape, b_at: Transform) -> (Fixed, Vec3) {
+    match (a, b) {
+        (Shape::Sphere { radius: ra }, Shape::Sphere { radius: rb }) => {
+            let delta = b_at.translation - a_at.translation;
+            (
+                delta.length() - ra - rb,
+                delta.normalize().unwrap_or(COINCIDENT_FALLBACK),
+            )
+        }
+        (Shape::Sphere { radius }, Shape::Box { half_extents }) => {
+            sphere_box_separation(a_at.translation, radius, half_extents, b_at.translation)
+        }
+        (Shape::Box { half_extents }, Shape::Sphere { radius }) => {
+            let (distance, direction) =
+                sphere_box_separation(b_at.translation, radius, half_extents, a_at.translation);
+            (distance, -direction)
+        }
+        (Shape::Box { half_extents: ha }, Shape::Box { half_extents: hb }) => {
+            box_box_separation(a_at.translation, ha, b_at.translation, hb)
+        }
+    }
+}
+
+fn sphere_box_separation(centre: Vec3, radius: Fixed, half: Vec3, box_at: Vec3) -> (Fixed, Vec3) {
+    let local = centre - box_at;
+    let clamped = Vec3::new(
+        local.x.clamp(-half.x, half.x),
+        local.y.clamp(-half.y, half.y),
+        local.z.clamp(-half.z, half.z),
+    );
+    let delta = clamped - local;
+    (
+        delta.length() - radius,
+        delta.normalize().unwrap_or(COINCIDENT_FALLBACK),
+    )
+}
+
+/// The widest gap over the three axes — a lower bound on the true distance,
+/// which is what conservative advancement is built on. It under-reports a
+/// diagonal gap, and a lower bound is exactly what is wanted.
+fn box_box_separation(a: Vec3, ha: Vec3, b: Vec3, hb: Vec3) -> (Fixed, Vec3) {
+    let delta = b - a;
+    let reach = ha + hb;
+    let gaps = [
+        (delta.x.abs() - reach.x, delta.x, 0u8),
+        (delta.y.abs() - reach.y, delta.y, 1),
+        (delta.z.abs() - reach.z, delta.z, 2),
+    ];
+    let mut best = gaps[0];
+    for candidate in gaps {
+        if candidate.0 > best.0 {
+            best = candidate;
+        }
+    }
+    let (gap, along, axis) = best;
+    let sign = if along < Fixed::ZERO {
+        Fixed::from_int(-1)
+    } else {
+        Fixed::ONE
+    };
+    let direction = match axis {
+        0 => Vec3::new(sign, Fixed::ZERO, Fixed::ZERO),
+        1 => Vec3::new(Fixed::ZERO, sign, Fixed::ZERO),
+        _ => Vec3::new(Fixed::ZERO, Fixed::ZERO, sign),
+    };
+    (gap, direction)
+}

--- a/crates/physics3d/tests/broadphase.rs
+++ b/crates/physics3d/tests/broadphase.rs
@@ -1,0 +1,256 @@
+//! What the three-dimensional broadphase proposes, and in what order.
+
+use proptest::prelude::*;
+use renew_ecs::Entities;
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{BodyKind, Broadphase, Collider, Filter, Shape, Transform, World};
+
+const NO_TOLERANCE: Fixed = Fixed::ZERO;
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+fn cube(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half, half),
+    }
+}
+
+fn pairs_for(positions: &[(i32, i32, i32)], order: &[usize]) -> Vec<(Collider, Collider)> {
+    let mut entities = Entities::new();
+    let handles: Vec<_> = (0..positions.len()).map(|_| entities.spawn()).collect();
+    let mut world = World::new();
+    for &which in order {
+        let handle = handles[which];
+        let (x, y, z) = positions[which];
+        world.create_body(handle, BodyKind::Kinematic, at(x, y, z));
+        world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+    }
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    broadphase.pairs().to_vec()
+}
+
+#[test]
+fn overlapping_cubes_are_proposed_and_distant_ones_are_not() {
+    assert_eq!(pairs_for(&[(0, 0, 0), (1, 0, 0)], &[0, 1]).len(), 1);
+    assert!(pairs_for(&[(0, 0, 0), (5, 0, 0)], &[0, 1]).is_empty());
+}
+
+/// **The mistake a lifted two-dimensional sweep makes.** Sweeping *x* alone
+/// prunes nothing between bodies stacked in *y* or *z*, so the overlap test
+/// that follows has to check all three — otherwise every pair in a column is
+/// proposed.
+#[test]
+fn a_column_of_cubes_is_not_proposed_as_every_pair() {
+    // Six cubes stacked on the y axis, two apart: each touches its neighbour
+    // and nothing else. They share every x and z coordinate, so the swept axis
+    // separates none of them.
+    let column: Vec<(i32, i32, i32)> = (0..6).map(|i| (0, i * 2, 0)).collect();
+    let order: Vec<usize> = (0..6).collect();
+    let pairs = pairs_for(&column, &order);
+    assert_eq!(
+        pairs.len(),
+        5,
+        "only neighbours, not the fifteen a single-axis test would give"
+    );
+    for window in pairs.windows(2) {
+        assert!(window[0] < window[1], "pairs must ascend");
+    }
+}
+
+/// The same, along the swept axis itself, so the sweep is doing its job too.
+#[test]
+fn a_row_along_the_swept_axis_proposes_only_neighbours() {
+    let row: Vec<(i32, i32, i32)> = (0..6).map(|i| (i * 2, 0, 0)).collect();
+    let order: Vec<usize> = (0..6).collect();
+    assert_eq!(pairs_for(&row, &order).len(), 5);
+}
+
+#[test]
+fn a_body_never_pairs_with_itself() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let handle = entities.spawn();
+    world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+    world.add_shape(handle, cube(1), at(1, 0, 0), Filter::ALL);
+
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert_eq!(broadphase.collider_count(), 2, "both shapes were swept");
+    assert!(
+        broadphase.pairs().is_empty(),
+        "and neither blocks the other"
+    );
+}
+
+#[test]
+fn two_static_bodies_are_not_proposed_and_a_kinematic_one_is() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    for _ in 0..2 {
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Static, Transform::IDENTITY);
+        world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+    }
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert!(broadphase.pairs().is_empty());
+
+    let moving = entities.spawn();
+    world.create_body(moving, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(moving, cube(1), Transform::IDENTITY, Filter::ALL);
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert_eq!(broadphase.pairs().len(), 2, "one against each static body");
+}
+
+#[test]
+fn a_filtered_pair_never_existed() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let a = entities.spawn();
+    let b = entities.spawn();
+    world.create_body(a, BodyKind::Kinematic, Transform::IDENTITY);
+    world.create_body(b, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(a, cube(1), Transform::IDENTITY, Filter::new(0b01, 0b10));
+    let shape_b = world
+        .add_shape(b, cube(1), Transform::IDENTITY, Filter::new(0b10, 0b01))
+        .expect("live");
+
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert_eq!(broadphase.pairs().len(), 1);
+
+    world.set_filter(b, shape_b, Filter::new(0b10, 0b00));
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert!(broadphase.pairs().is_empty(), "the rule is symmetric");
+    assert_eq!(
+        broadphase.collider_count(),
+        2,
+        "both were still swept — the pair is what vanished"
+    );
+}
+
+#[test]
+fn the_tolerance_makes_near_misses_into_candidates() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    for z in [0, 3] {
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Kinematic, at(0, 0, z));
+        world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+    }
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert!(broadphase.pairs().is_empty(), "one unit apart on z");
+
+    broadphase.rebuild(&world, Fixed::from_ratio(1, 2));
+    assert_eq!(
+        broadphase.pairs().len(),
+        1,
+        "and the tolerance closes it, on an axis that is not the swept one"
+    );
+}
+
+#[test]
+fn rebuilding_twice_gives_the_same_answer() {
+    let positions: Vec<(i32, i32, i32)> = (0..6).map(|i| (i, i % 2, i % 3)).collect();
+    let order: Vec<usize> = (0..6).collect();
+    let first = pairs_for(&positions, &order);
+    let second = pairs_for(&positions, &order);
+    assert_eq!(first, second, "a rebuild is a pure function");
+}
+
+#[test]
+fn zero_extent_shapes_do_not_confuse_the_sweep() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    for _ in 0..3 {
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Kinematic, Transform::IDENTITY);
+        world.add_shape(
+            handle,
+            Shape::Sphere {
+                radius: Fixed::ZERO,
+            },
+            Transform::IDENTITY,
+            Filter::ALL,
+        );
+    }
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert_eq!(broadphase.pairs().len(), 3, "three coincident points");
+    for window in broadphase.pairs().windows(2) {
+        assert!(window[0] < window[1]);
+    }
+}
+
+/// Every other test lays bodies out in the same order as their handles, so the
+/// collider opening an interval always outranks the ones already active. A
+/// world laid out backwards reaches the other side of the pair ordering.
+#[test]
+fn a_pair_names_its_lower_collider_first_whichever_arrives_last() {
+    let mut entities = Entities::new();
+    let handles: Vec<_> = (0..3).map(|_| entities.spawn()).collect();
+    let mut world = World::new();
+    for (step, &handle) in handles.iter().enumerate() {
+        let x = 4 - 2 * i32::try_from(step).unwrap_or(0);
+        world.create_body(handle, BodyKind::Kinematic, at(x, 0, 0));
+        world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::ALL);
+    }
+    let mut broadphase = Broadphase::new();
+    broadphase.rebuild(&world, NO_TOLERANCE);
+    assert_eq!(broadphase.pairs().len(), 2);
+    for &(low, high) in broadphase.pairs() {
+        assert!(low < high, "a pair names its lower collider first");
+    }
+}
+
+proptest! {
+    /// Two worlds holding the same colliders propose the same pairs in the
+    /// same order, however they were assembled.
+    #[test]
+    fn proposed_pairs_do_not_depend_on_insertion_order(
+        order in Just((0usize..7).collect::<Vec<_>>()).prop_shuffle(),
+        heights in prop::collection::vec(-2i32..3, 7),
+    ) {
+        let positions: Vec<(i32, i32, i32)> = heights
+            .iter()
+            .enumerate()
+            .map(|(i, &y)| (i32::try_from(i).unwrap_or(0), y, y % 2))
+            .collect();
+        let ascending: Vec<usize> = (0..7).collect();
+        prop_assert_eq!(pairs_for(&positions, &ascending), pairs_for(&positions, &order));
+    }
+
+    /// Whatever the world holds, pairs ascend, name their lower collider
+    /// first, and none is proposed twice.
+    #[test]
+    fn emitted_pairs_are_ordered_and_unique(
+        heights in prop::collection::vec(-2i32..3, 1..8),
+    ) {
+        let positions: Vec<(i32, i32, i32)> = heights
+            .iter()
+            .enumerate()
+            .map(|(i, &y)| (i32::try_from(i).unwrap_or(0), y, 0))
+            .collect();
+        let order: Vec<usize> = (0..positions.len()).collect();
+        let pairs = pairs_for(&positions, &order);
+
+        for &(low, high) in &pairs {
+            prop_assert!(low < high);
+        }
+        for window in pairs.windows(2) {
+            prop_assert!(window[0] <= window[1]);
+        }
+        let mut seen = pairs.clone();
+        seen.dedup();
+        prop_assert_eq!(seen.len(), pairs.len(), "a pair was proposed twice");
+    }
+}

--- a/crates/physics3d/tests/narrow.rs
+++ b/crates/physics3d/tests/narrow.rs
@@ -308,3 +308,38 @@ proptest! {
         }
     }
 }
+
+/// Separation in the negative direction, and with the sphere named first.
+///
+/// The other separation test only ever puts the second shape on the positive
+/// side and only ever names the box first, which leaves the sign branch and
+/// one whole arm unexercised — both of which would report a direction pointing
+/// the wrong way, and a sweep built on that walks into what it meant to avoid.
+#[test]
+fn separation_points_the_right_way_from_either_side() {
+    // Boxes, with the second one behind the first on each axis in turn.
+    for (offset, axis) in [(v(-5, 0, 0), 0), (v(0, -5, 0), 1), (v(0, 0, -5), 2)] {
+        let (gap, direction) = separation(cube(1), at(0, 0, 0), cube(1), Transform::at(offset));
+        close(gap, Fixed::from_int(3), "gap");
+        let component = match axis {
+            0 => direction.x,
+            1 => direction.y,
+            _ => direction.z,
+        };
+        close(
+            component,
+            Fixed::from_int(-1),
+            "the direction follows the second shape",
+        );
+    }
+
+    // A sphere named first against a box, which is its own arm.
+    let (gap, direction) = separation(sphere(1), at(0, 0, 0), cube(1), at(5, 0, 0));
+    close(gap, Fixed::from_int(3), "gap");
+    close(direction.x, Fixed::ONE, "pointing at the box");
+
+    // And behind it, so that arm's sign is exercised too.
+    let (gap, direction) = separation(sphere(1), at(0, 0, 0), cube(1), at(-5, 0, 0));
+    close(gap, Fixed::from_int(3), "gap");
+    close(direction.x, Fixed::from_int(-1), "pointing behind");
+}

--- a/crates/physics3d/tests/narrow.rs
+++ b/crates/physics3d/tests/narrow.rs
@@ -1,0 +1,310 @@
+//! Whether two shapes touch in three dimensions, where, and which way.
+
+use proptest::prelude::*;
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{Shape, Transform, collide, narrow::separation};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+fn sphere(units: i32) -> Shape {
+    Shape::Sphere {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn cube(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half, half),
+    }
+}
+
+const SLACK: i64 = 8;
+
+fn close(actual: Fixed, expected: Fixed, what: &str) {
+    let gap = (actual - expected).to_bits().abs();
+    assert!(
+        gap <= SLACK,
+        "{what}: got {} raw, expected {} raw",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}
+
+#[test]
+fn spheres_apart_do_not_touch() {
+    assert!(collide(sphere(1), at(0, 0, 0), sphere(1), at(5, 0, 0)).is_none());
+    assert!(collide(sphere(1), at(0, 0, 0), sphere(1), at(0, 0, 5)).is_none());
+}
+
+#[test]
+fn overlapping_spheres_report_the_overlap_along_the_line_of_centres() {
+    let contact =
+        collide(sphere(2), at(0, 0, 0), sphere(2), at(0, 0, 3)).expect("they overlap by one");
+    close(contact.depth, Fixed::ONE, "depth");
+    close(
+        contact.normal.z,
+        Fixed::ONE,
+        "the normal points at the second",
+    );
+    close(contact.normal.x, Fixed::ZERO, "and nowhere else");
+    close(contact.normal.y, Fixed::ZERO, "and nowhere else");
+}
+
+#[test]
+fn coincident_spheres_take_the_stated_fallback_direction() {
+    let contact =
+        collide(sphere(1), at(0, 0, 0), sphere(1), at(0, 0, 0)).expect("fully overlapped");
+    assert_eq!(contact.normal, v(1, 0, 0), "the stated arbitrary direction");
+    close(contact.depth, Fixed::from_int(2), "fully overlapped");
+}
+
+/// **Separation on any single axis is separation.** This is the test a
+/// two-dimensional implementation lifted carelessly fails.
+#[test]
+fn boxes_separated_on_any_one_axis_do_not_touch() {
+    for offset in [v(3, 0, 0), v(0, 3, 0), v(0, 0, 3)] {
+        assert!(
+            collide(cube(1), at(0, 0, 0), cube(1), Transform::at(offset)).is_none(),
+            "separated along {offset:?} and still reported touching"
+        );
+    }
+    // Diagonally apart, where a bounding-sphere test would wrongly report a hit.
+    assert!(collide(cube(1), at(0, 0, 0), cube(1), at(3, 3, 3)).is_none());
+}
+
+#[test]
+fn boxes_that_merely_touch_report_depth_zero() {
+    let contact = collide(cube(1), at(0, 0, 0), cube(1), at(2, 0, 0)).expect("touching");
+    close(contact.depth, Fixed::ZERO, "depth");
+    close(
+        contact.normal.x,
+        Fixed::ONE,
+        "the normal points at the second",
+    );
+}
+
+/// The shallowest axis wins, which is what makes a body land on a floor rather
+/// than being pushed sideways off it.
+#[test]
+fn the_shallowest_axis_decides_the_normal() {
+    // Deeply overlapped on x and z, barely on y: the answer is y.
+    let contact = collide(
+        Shape::Box {
+            half_extents: v(4, 1, 4),
+        },
+        at(0, 0, 0),
+        Shape::Box {
+            half_extents: v(4, 1, 4),
+        },
+        Transform::at(Vec3::new(
+            Fixed::ZERO,
+            Fixed::from_ratio(15, 8),
+            Fixed::ZERO,
+        )),
+    )
+    .expect("overlapping");
+    close(contact.normal.y, Fixed::ONE, "pushed along y");
+    close(contact.normal.x, Fixed::ZERO, "not x");
+    close(contact.normal.z, Fixed::ZERO, "not z");
+    close(
+        contact.depth,
+        Fixed::from_ratio(1, 8),
+        "the shallow overlap",
+    );
+}
+
+#[test]
+fn a_sphere_beside_a_box_touches_its_face() {
+    // A unit box at the origin, a unit sphere centred at z = 1.5.
+    let contact = collide(
+        sphere(1),
+        Transform::at(Vec3::new(Fixed::ZERO, Fixed::ZERO, Fixed::from_ratio(3, 2))),
+        cube(1),
+        at(0, 0, 0),
+    )
+    .expect("overlapping");
+    close(contact.depth, Fixed::from_ratio(1, 2), "depth");
+    close(
+        contact.normal.z,
+        Fixed::from_int(-1),
+        "from the sphere toward the box",
+    );
+}
+
+#[test]
+fn a_sphere_past_a_box_corner_does_not_touch() {
+    let far = Transform::at(Vec3::new(
+        Fixed::from_ratio(5, 2),
+        Fixed::from_ratio(5, 2),
+        Fixed::from_ratio(5, 2),
+    ));
+    assert!(collide(sphere(1), far, cube(1), at(0, 0, 0)).is_none());
+
+    let near = Transform::at(Vec3::new(
+        Fixed::from_ratio(3, 2),
+        Fixed::from_ratio(3, 2),
+        Fixed::from_ratio(3, 2),
+    ));
+    let contact = collide(sphere(1), near, cube(1), at(0, 0, 0)).expect("corner contact");
+    assert!(contact.depth > Fixed::ZERO);
+}
+
+/// A sphere whose centre is inside the box has no closest surface point, so
+/// the direction comes from the nearest of the six faces.
+#[test]
+fn a_sphere_inside_a_box_leaves_through_the_nearest_face() {
+    let small = Shape::Sphere {
+        radius: Fixed::from_ratio(1, 4),
+    };
+    // Nearest face, and the outward normal from the sphere toward the box.
+    let cases = [
+        (
+            v(0, 0, 0) + Vec3::new(Fixed::from_ratio(4, 5), Fixed::ZERO, Fixed::ZERO),
+            (-1, 0, 0),
+        ),
+        (
+            Vec3::new(-Fixed::from_ratio(4, 5), Fixed::ZERO, Fixed::ZERO),
+            (1, 0, 0),
+        ),
+        (
+            Vec3::new(Fixed::ZERO, Fixed::from_ratio(4, 5), Fixed::ZERO),
+            (0, -1, 0),
+        ),
+        (
+            Vec3::new(Fixed::ZERO, -Fixed::from_ratio(4, 5), Fixed::ZERO),
+            (0, 1, 0),
+        ),
+        (
+            Vec3::new(Fixed::ZERO, Fixed::ZERO, Fixed::from_ratio(4, 5)),
+            (0, 0, -1),
+        ),
+        (
+            Vec3::new(Fixed::ZERO, Fixed::ZERO, -Fixed::from_ratio(4, 5)),
+            (0, 0, 1),
+        ),
+    ];
+    for (centre, (nx, ny, nz)) in cases {
+        let contact =
+            collide(small, Transform::at(centre), cube(1), at(0, 0, 0)).expect("inside the box");
+        close(contact.normal.x, Fixed::from_int(nx), "normal x");
+        close(contact.normal.y, Fixed::from_int(ny), "normal y");
+        close(contact.normal.z, Fixed::from_int(nz), "normal z");
+        assert!(contact.depth > Fixed::ZERO, "inside means penetrating");
+    }
+}
+
+/// A box first and a sphere second is the same geometry reversed, and a
+/// separate arm — so without this the box-first path never runs.
+#[test]
+fn a_box_against_a_sphere_is_the_reverse_of_the_other_order() {
+    let sphere_at = Transform::at(Vec3::new(Fixed::from_ratio(3, 2), Fixed::ZERO, Fixed::ZERO));
+    let forward = collide(sphere(1), sphere_at, cube(1), at(0, 0, 0)).expect("overlapping");
+    let reversed = collide(cube(1), at(0, 0, 0), sphere(1), sphere_at).expect("overlapping");
+
+    close(
+        forward.normal.x + reversed.normal.x,
+        Fixed::ZERO,
+        "normals oppose",
+    );
+    close(forward.depth, reversed.depth, "same depth either way");
+    close(
+        reversed.normal.x,
+        Fixed::ONE,
+        "the box points at the sphere",
+    );
+}
+
+#[test]
+fn separation_measures_the_gap_and_the_direction() {
+    // Two unit spheres five apart: three units of clear air.
+    let (gap, direction) = separation(sphere(1), at(0, 0, 0), sphere(1), at(5, 0, 0));
+    close(gap, Fixed::from_int(3), "gap");
+    close(direction.x, Fixed::ONE, "pointing at the second");
+
+    // Overlapping is a negative gap.
+    let (overlapped, _) = separation(sphere(2), at(0, 0, 0), sphere(2), at(3, 0, 0));
+    assert!(overlapped < Fixed::ZERO, "overlap is a negative gap");
+
+    // Boxes, on each axis in turn.
+    for (offset, axis) in [(v(5, 0, 0), 0), (v(0, 5, 0), 1), (v(0, 0, 5), 2)] {
+        let (gap, direction) = separation(cube(1), at(0, 0, 0), cube(1), Transform::at(offset));
+        close(gap, Fixed::from_int(3), "box gap");
+        let component = match axis {
+            0 => direction.x,
+            1 => direction.y,
+            _ => direction.z,
+        };
+        close(
+            component,
+            Fixed::ONE,
+            "the widest axis is the separating one",
+        );
+    }
+
+    // And the box-first-sphere-second arm, which is its own path.
+    let (gap, direction) = separation(cube(1), at(0, 0, 0), sphere(1), at(5, 0, 0));
+    close(gap, Fixed::from_int(3), "gap");
+    close(direction.x, Fixed::ONE, "pointing at the sphere");
+}
+
+proptest! {
+    /// Swapping the arguments negates the normal and keeps the depth, except
+    /// where the centres coincide exactly — which carries no direction and is
+    /// pinned by its own test.
+    #[test]
+    fn colliding_is_symmetric(
+        bx in -4i64..5, by in -4i64..5, bz in -4i64..5, use_box in prop::bool::ANY,
+    ) {
+        prop_assume!((bx, by, bz) != (0, 0, 0));
+        let second = if use_box { cube(1) } else { sphere(1) };
+        let b_at = Transform::at(Vec3::new(
+            Fixed::from_bits(bx * 32768),
+            Fixed::from_bits(by * 32768),
+            Fixed::from_bits(bz * 32768),
+        ));
+
+        match (
+            collide(cube(1), at(0, 0, 0), second, b_at),
+            collide(second, b_at, cube(1), at(0, 0, 0)),
+        ) {
+            (Some(forward), Some(backward)) => {
+                for (a, b) in [
+                    (forward.normal.x, backward.normal.x),
+                    (forward.normal.y, backward.normal.y),
+                    (forward.normal.z, backward.normal.z),
+                ] {
+                    prop_assert!((a + b).to_bits().abs() <= SLACK, "normals must oppose");
+                }
+                let gap = (forward.depth - backward.depth).to_bits().abs();
+                prop_assert!(gap <= SLACK, "depth must not depend on argument order");
+            }
+            (None, None) => {}
+            _ => prop_assert!(false, "one order found a contact and the other did not"),
+        }
+    }
+
+    /// A reported depth is never negative, and a reported normal is a
+    /// direction: a caller pushing along a zero vector moves nowhere and one
+    /// pushing along a long vector overshoots.
+    #[test]
+    fn every_contact_is_usable(
+        bx in -3i64..4, by in -3i64..4, bz in -3i64..4,
+    ) {
+        let b_at = Transform::at(Vec3::new(
+            Fixed::from_bits(bx * 32768),
+            Fixed::from_bits(by * 32768),
+            Fixed::from_bits(bz * 32768),
+        ));
+        if let Some(contact) = collide(cube(1), at(0, 0, 0), cube(1), b_at) {
+            prop_assert!(contact.depth >= Fixed::ZERO, "depth is never negative");
+            let error = (contact.normal.length() - Fixed::ONE).to_bits().abs();
+            prop_assert!(error <= 64, "the normal is not unit");
+        }
+    }
+}


### PR DESCRIPTION
Sorted sweep-and-prune over exact world-space extents, and a narrowphase
for the three axis-aligned pairs: sphere against sphere, sphere against
box, box against box.

One axis is swept and all three are tested, and the distinction is the
whole of what lifting a two-dimensional broadphase gets wrong.
Sweeping x prunes the pairs that cannot touch along it and prunes
nothing between bodies stacked in y or z, so the overlap test that
follows still checks all three. A column of six cubes shares every x and
z coordinate; a test that forgot the third axis would propose all
fifteen pairs instead of the five that touch. That column is a test.

Without rotation the separating axis test is the three world axes and
nothing else, so a box pair is three overlaps and the shallowest wins.
That is not just simpler - it is what makes a body land on a floor
rather than being pushed sideways off it, and a case with a deep overlap
on two axes and a shallow one on the third pins it.

A sphere whose centre is inside a box leaves through the nearest of six
faces, chosen by comparing distances rather than testing a sign, with
ties going to the earlier axis so two machines agree. All six directions
are tested, because five of them are exactly what a careless lift
leaves out.

The contact is one point rather than a manifold, and the limitation is
named in the type's documentation rather than left to be discovered. Two
axis-aligned boxes meet across a rectangle whose full contact is up to
four corners; one representative point is how a box resting on a floor
starts to rock. It is enough for a voxel world, where a body meets a
face at a time and the caller resolves by axis, and it is not enough for
a solver.