### PR TITLE
feat(physics3d): ray casting and world queries in three dimensions

### DIFF
--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -43,6 +43,8 @@ pub mod bounds;
 pub mod broadphase;
 pub mod filter;
 pub mod narrow;
+pub mod query;
+pub mod ray;
 pub mod shape;
 pub mod world;
 
@@ -50,5 +52,7 @@ pub use bounds::Aabb;
 pub use broadphase::Broadphase;
 pub use filter::Filter;
 pub use narrow::{Contact, collide, separation};
+pub use query::{Counts, Exclude, Hit};
+pub use ray::{RayHit, cast};
 pub use shape::{Shape, Transform};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics3d/src/query.rs
+++ b/crates/physics3d/src/query.rs
@@ -1,0 +1,201 @@
+//! Asking the world what is where.
+
+use crate::narrow::collide;
+use crate::ray::cast;
+use crate::shape::{Shape, Transform};
+use crate::world::{Collider, World};
+use renew_ecs::Entity;
+use renew_fixed::{Fixed, Vec3};
+
+/// How much a query found, and how much it could write down.
+///
+/// **Both numbers, always.** A query that returned only what fitted would let
+/// a world quietly stop reporting under load — the same shape of failure as a
+/// gate that passes while measuring nothing. A caller that sees the two differ
+/// knows it lost information and can grow its buffer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Counts {
+    /// How many results were written into the caller's buffer.
+    pub written: usize,
+    /// How many existed. Never less than `written`.
+    pub existed: usize,
+}
+
+impl Counts {
+    /// Whether the buffer was too small.
+    #[must_use]
+    pub const fn truncated(self) -> bool {
+        self.existed > self.written
+    }
+}
+
+/// Bodies a query must ignore.
+///
+/// Names **bodies**, not colliders: excluding a body excludes all its shapes,
+/// because the reason to exclude one is almost always "this is me" and a body
+/// is what "me" means. A handle naming no body excludes nothing and the query
+/// answers — refusing there would collide with the legitimate empty answer.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Exclude<'a> {
+    handles: &'a [Entity],
+}
+
+impl<'a> Exclude<'a> {
+    /// Exclude nothing.
+    pub const NONE: Self = Self { handles: &[] };
+
+    /// Exclude these bodies.
+    #[must_use]
+    pub const fn bodies(handles: &'a [Entity]) -> Self {
+        Self { handles }
+    }
+
+    fn covers(self, handle: Entity) -> bool {
+        let mut index = 0;
+        while index < self.handles.len() {
+            if let Some(&excluded) = self.handles.get(index)
+                && excluded == handle
+            {
+                return true;
+            }
+            index += 1;
+        }
+        false
+    }
+}
+
+/// Where a world-space ray met something.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Hit {
+    /// What it met.
+    pub collider: Collider,
+    /// Distance along the direction.
+    pub distance: Fixed,
+    /// Where, in world space.
+    pub point: Vec3,
+    /// The surface normal, facing the ray.
+    pub normal: Vec3,
+}
+
+impl World {
+    /// Whether a collider is visible to a query with this mask and exclusion.
+    pub(crate) fn query_visible(
+        &self,
+        collider: Collider,
+        mask: u32,
+        exclude: Exclude<'_>,
+    ) -> Option<(Shape, Transform)> {
+        if exclude.covers(collider.handle) {
+            return None;
+        }
+        let (shape, _, filter) = self.shape(collider)?;
+        if !filter.visible_to_query(mask) {
+            return None;
+        }
+        Some((shape, self.world_transform(collider)?))
+    }
+
+    /// Every collider containing this point.
+    ///
+    /// Multi-valued: a point inside three overlapping shapes is inside three
+    /// of them, and picking one would be answering a different question.
+    pub fn point_query(
+        &self,
+        point: Vec3,
+        mask: u32,
+        exclude: Exclude<'_>,
+        out: &mut [Collider],
+    ) -> Counts {
+        let mut counts = Counts::default();
+        for collider in self.colliders() {
+            let Some((shape, at)) = self.query_visible(collider, mask, exclude) else {
+                continue;
+            };
+            // A point is a zero-radius sphere, and the geometry already knows
+            // how to answer that — one implementation rather than a second
+            // containment test that can disagree with the first.
+            let dot = Shape::Sphere {
+                radius: Fixed::ZERO,
+            };
+            if collide(dot, Transform::at(point), shape, at).is_none() {
+                continue;
+            }
+            if let Some(slot) = out.get_mut(counts.written) {
+                *slot = collider;
+                counts.written += 1;
+            }
+            counts.existed += 1;
+        }
+        counts
+    }
+
+    /// The nearest thing along a ray, or nothing.
+    ///
+    /// **Ties go to the lowest collider**, which matters more than it sounds:
+    /// in a tile-aligned world almost everything shares an edge, so a ray down
+    /// a seam meets two tiles at the same distance and "nearest" would
+    /// otherwise be whichever the iteration happened to reach first.
+    #[must_use]
+    pub fn ray_query(
+        &self,
+        origin: Vec3,
+        direction: Vec3,
+        max_distance: Fixed,
+        mask: u32,
+        exclude: Exclude<'_>,
+    ) -> Option<Hit> {
+        let mut best: Option<Hit> = None;
+        for collider in self.colliders() {
+            let Some((shape, at)) = self.query_visible(collider, mask, exclude) else {
+                continue;
+            };
+            let Some(hit) = cast(origin, direction, max_distance, shape, at) else {
+                continue;
+            };
+            // Strictly nearer, so an equal distance leaves the incumbent —
+            // and the incumbent is the lower collider, because `colliders()`
+            // ascends.
+            let nearer = best
+                .as_ref()
+                .is_none_or(|current| hit.distance < current.distance);
+            if nearer {
+                best = Some(Hit {
+                    collider,
+                    distance: hit.distance,
+                    point: hit.point,
+                    normal: hit.normal,
+                });
+            }
+        }
+        best
+    }
+
+    /// Every collider a shape placed here would intersect.
+    ///
+    /// Membership only. A caller wanting depth and normals is asking for a
+    /// contact, which is what the step produces.
+    pub fn overlap_query(
+        &self,
+        shape: Shape,
+        at: Transform,
+        mask: u32,
+        exclude: Exclude<'_>,
+        out: &mut [Collider],
+    ) -> Counts {
+        let mut counts = Counts::default();
+        for collider in self.colliders() {
+            let Some((other, other_at)) = self.query_visible(collider, mask, exclude) else {
+                continue;
+            };
+            if collide(shape, at, other, other_at).is_none() {
+                continue;
+            }
+            if let Some(slot) = out.get_mut(counts.written) {
+                *slot = collider;
+                counts.written += 1;
+            }
+            counts.existed += 1;
+        }
+        counts
+    }
+}

--- a/crates/physics3d/src/ray.rs
+++ b/crates/physics3d/src/ray.rs
@@ -1,0 +1,159 @@
+//! Casting a ray at a single shape.
+
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec3, Wide};
+
+/// Where a ray met a shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RayHit {
+    /// Distance along the ray's direction, never negative.
+    pub distance: Fixed,
+    /// Where it met, in world space.
+    pub point: Vec3,
+    /// The surface normal at that point, pointing back along the ray.
+    pub normal: Vec3,
+}
+
+/// Cast a ray at one shape.
+///
+/// `direction` must be unit length; `max_distance` bounds the search.
+///
+/// # A ray that starts inside
+///
+/// **Hits, at distance zero.** A ground check whose origin is already inside
+/// the floor should report the floor, not report nothing and let a character
+/// fall through what it is standing in. The normal there points back along the
+/// ray, since there is no surface crossing to take one from.
+#[must_use]
+pub fn cast(
+    origin: Vec3,
+    direction: Vec3,
+    max_distance: Fixed,
+    shape: Shape,
+    at: Transform,
+) -> Option<RayHit> {
+    match shape {
+        Shape::Sphere { radius } => sphere(origin, direction, max_distance, radius, at.translation),
+        Shape::Box { half_extents } => axis_aligned_box(
+            origin,
+            direction,
+            max_distance,
+            half_extents,
+            at.translation,
+        ),
+    }
+}
+
+/// Ray against sphere, in the form that keeps the arithmetic small.
+///
+/// With `direction` unit the quadratic's leading coefficient is one and the
+/// discriminant collapses to `m² − l² + r²`, where `m` is how far along the ray
+/// the centre projects. Three terms instead of a product of squares is what
+/// keeps this exact at world scale rather than merely deterministic.
+fn sphere(
+    origin: Vec3,
+    direction: Vec3,
+    max_distance: Fixed,
+    radius: Fixed,
+    centre: Vec3,
+) -> Option<RayHit> {
+    let to_centre = centre - origin;
+    let along = to_centre.dot(direction);
+    let discriminant =
+        along.wide_mul(along) - to_centre.length_squared_wide() + radius.wide_mul(radius);
+    if discriminant < Wide::ZERO {
+        return None;
+    }
+    let root = discriminant.sqrt();
+    let near = along - root;
+    let far = along + root;
+    if far < Fixed::ZERO {
+        return None; // wholly behind the origin
+    }
+    let distance = near.max(Fixed::ZERO);
+    if distance > max_distance {
+        return None;
+    }
+    let point = origin + direction * distance;
+    let normal = if near < Fixed::ZERO {
+        // Started inside: no crossing to take a normal from.
+        -direction
+    } else {
+        (point - centre).normalize().unwrap_or(-direction)
+    };
+    Some(RayHit {
+        distance,
+        point,
+        normal,
+    })
+}
+
+/// Ray against an axis-aligned box, by the slab test over three axes.
+fn axis_aligned_box(
+    origin: Vec3,
+    direction: Vec3,
+    max_distance: Fixed,
+    half: Vec3,
+    centre: Vec3,
+) -> Option<RayHit> {
+    let local = origin - centre;
+    let mut enter = Fixed::ZERO;
+    let mut exit = max_distance;
+    // Which axis the entry came from, and which way it faces. Starts on +x so
+    // a ray beginning inside — where no slab sets it — has a stated answer
+    // rather than an accidental one.
+    let mut entry_axis = 0u8;
+    let mut entry_sign = Fixed::ONE;
+
+    for axis in 0..3u8 {
+        let (start, step, extent) = match axis {
+            0 => (local.x, direction.x, half.x),
+            1 => (local.y, direction.y, half.y),
+            _ => (local.z, direction.z, half.z),
+        };
+        let Some(inverse) = Fixed::ONE.checked_div(step) else {
+            // Parallel to this slab: a ray outside it never enters, and one
+            // inside is unconstrained by it. A computed zero divisor is
+            // ordinary geometry, which is why the division is checked.
+            if start < -extent || start > extent {
+                return None;
+            }
+            continue;
+        };
+        let first = (-extent - start).saturating_mul(inverse);
+        let second = (extent - start).saturating_mul(inverse);
+        let (near, far) = if first <= second {
+            (first, second)
+        } else {
+            (second, first)
+        };
+        if near > enter {
+            enter = near;
+            entry_axis = axis;
+            entry_sign = if step < Fixed::ZERO {
+                Fixed::ONE
+            } else {
+                Fixed::from_int(-1)
+            };
+        }
+        exit = exit.min(far);
+        // One check rejects everything: a box behind the origin drives `exit`
+        // negative while `enter` sits at zero, and a box beyond the ray's
+        // reach drives `enter` past `max_distance`, which `exit` can never
+        // exceed. A second test after the loop would be unreachable.
+        if enter > exit {
+            return None;
+        }
+    }
+
+    let normal = match entry_axis {
+        0 => Vec3::new(entry_sign, Fixed::ZERO, Fixed::ZERO),
+        1 => Vec3::new(Fixed::ZERO, entry_sign, Fixed::ZERO),
+        _ => Vec3::new(Fixed::ZERO, Fixed::ZERO, entry_sign),
+    };
+    Some(RayHit {
+        distance: enter,
+        point: origin + direction * enter,
+        normal,
+    })
+}

--- a/crates/physics3d/tests/ray_and_query.rs
+++ b/crates/physics3d/tests/ray_and_query.rs
@@ -1,0 +1,315 @@
+//! Casting rays at shapes, and asking the world what is where.
+
+use proptest::prelude::*;
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{
+    BodyKind, Collider, Counts, Exclude, Filter, Shape, ShapeIndex, Transform, World, cast,
+};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+fn sphere(units: i32) -> Shape {
+    Shape::Sphere {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn cube(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half, half),
+    }
+}
+
+const RIGHT: Vec3 = Vec3::new(Fixed::ONE, Fixed::ZERO, Fixed::ZERO);
+const UP: Vec3 = Vec3::new(Fixed::ZERO, Fixed::ONE, Fixed::ZERO);
+const FORWARD: Vec3 = Vec3::new(Fixed::ZERO, Fixed::ZERO, Fixed::ONE);
+const FAR: Fixed = Fixed::from_bits(100 * 65536);
+const ANY: u32 = u32::MAX;
+const SLACK: i64 = 16;
+
+fn close(actual: Fixed, expected: Fixed, what: &str) {
+    let gap = (actual - expected).to_bits().abs();
+    assert!(
+        gap <= SLACK,
+        "{what}: got {} raw, expected {} raw",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}
+
+#[test]
+fn a_ray_meets_a_sphere_at_its_near_surface() {
+    let hit =
+        cast(v(-5, 0, 0), RIGHT, FAR, sphere(1), Transform::IDENTITY).expect("straight at it");
+    close(hit.distance, Fixed::from_int(4), "distance");
+    close(hit.point.x, Fixed::from_int(-1), "point");
+    close(hit.normal.x, Fixed::from_int(-1), "normal faces the ray");
+}
+
+#[test]
+fn a_ray_that_misses_a_sphere_reports_nothing() {
+    assert!(cast(v(-5, 2, 0), RIGHT, FAR, sphere(1), Transform::IDENTITY).is_none());
+    // And missing on the third axis is a miss too.
+    assert!(cast(v(-5, 0, 2), RIGHT, FAR, sphere(1), Transform::IDENTITY).is_none());
+}
+
+#[test]
+fn a_sphere_behind_the_origin_is_not_hit() {
+    assert!(cast(v(5, 0, 0), RIGHT, FAR, sphere(1), Transform::IDENTITY).is_none());
+}
+
+#[test]
+fn a_ray_stops_at_its_maximum_distance() {
+    let short = Fixed::from_int(3);
+    assert!(cast(v(-5, 0, 0), RIGHT, short, sphere(1), Transform::IDENTITY).is_none());
+    assert!(
+        cast(
+            v(-5, 0, 0),
+            RIGHT,
+            Fixed::from_int(5),
+            sphere(1),
+            Transform::IDENTITY
+        )
+        .is_some()
+    );
+}
+
+#[test]
+fn a_ray_starting_inside_a_sphere_hits_at_zero() {
+    let hit = cast(Vec3::ZERO, RIGHT, FAR, sphere(2), Transform::IDENTITY).expect("inside");
+    assert_eq!(hit.distance, Fixed::ZERO);
+    close(hit.normal.x, Fixed::from_int(-1), "normal points back");
+}
+
+/// A box is met on whichever axis the ray arrives along, and all six faces
+/// have to work — the other five are exactly what a careless lift leaves out.
+#[test]
+fn a_ray_meets_a_box_on_every_face() {
+    let cases = [
+        (v(-5, 0, 0), RIGHT, (-1, 0, 0)),
+        (v(0, -5, 0), UP, (0, -1, 0)),
+        (v(0, 0, -5), FORWARD, (0, 0, -1)),
+        (v(5, 0, 0), -RIGHT, (1, 0, 0)),
+        (v(0, 5, 0), -UP, (0, 1, 0)),
+        (v(0, 0, 5), -FORWARD, (0, 0, 1)),
+    ];
+    for (origin, direction, (nx, ny, nz)) in cases {
+        let hit = cast(origin, direction, FAR, cube(1), Transform::IDENTITY)
+            .expect("straight at the box");
+        close(hit.distance, Fixed::from_int(4), "distance");
+        close(hit.normal.x, Fixed::from_int(nx), "normal x");
+        close(hit.normal.y, Fixed::from_int(ny), "normal y");
+        close(hit.normal.z, Fixed::from_int(nz), "normal z");
+    }
+}
+
+#[test]
+fn a_ray_that_passes_beside_a_box_reports_nothing() {
+    assert!(cast(v(-5, 2, 0), RIGHT, FAR, cube(1), Transform::IDENTITY).is_none());
+    assert!(cast(v(-5, 0, 2), RIGHT, FAR, cube(1), Transform::IDENTITY).is_none());
+}
+
+/// A ray exactly parallel to a slab divides by zero in the naive test. Here it
+/// is checked and the case is decided by whether the origin lies within it.
+#[test]
+fn a_ray_parallel_to_a_face_is_decided_by_its_offset() {
+    assert!(cast(v(-5, 2, 0), RIGHT, FAR, cube(1), Transform::IDENTITY).is_none());
+    assert!(cast(v(-5, 0, 0), RIGHT, FAR, cube(1), Transform::IDENTITY).is_some());
+    assert!(
+        cast(v(-5, 1, 1), RIGHT, FAR, cube(1), Transform::IDENTITY).is_some(),
+        "exactly on two boundaries is still inside both"
+    );
+}
+
+#[test]
+fn a_ray_starting_inside_a_box_hits_at_zero() {
+    let hit = cast(Vec3::ZERO, RIGHT, FAR, cube(1), Transform::IDENTITY).expect("inside");
+    assert_eq!(hit.distance, Fixed::ZERO);
+}
+
+#[test]
+fn a_box_behind_the_origin_is_not_hit() {
+    assert!(cast(v(5, 0, 0), RIGHT, FAR, cube(1), Transform::IDENTITY).is_none());
+    assert!(cast(v(0, 5, 0), UP, FAR, cube(1), Transform::IDENTITY).is_none());
+    assert!(cast(v(0, 0, 5), FORWARD, FAR, cube(1), Transform::IDENTITY).is_none());
+}
+
+/// A zero-radius sphere is a point, and the vocabulary requires queries to
+/// answer for one rather than refuse.
+#[test]
+fn a_zero_radius_sphere_is_answerable() {
+    let dot = Shape::Sphere {
+        radius: Fixed::ZERO,
+    };
+    let hit = cast(v(-5, 0, 0), RIGHT, FAR, dot, Transform::IDENTITY).expect("a point is a target");
+    close(hit.distance, Fixed::from_int(5), "distance to the point");
+    // A hair to the side and it misses, which makes the hit above real.
+    assert!(
+        cast(
+            Vec3::new(Fixed::from_int(-5), Fixed::from_bits(64), Fixed::ZERO),
+            RIGHT,
+            FAR,
+            dot,
+            Transform::IDENTITY
+        )
+        .is_none()
+    );
+}
+
+/// A world of unit cubes at the given positions, all on layer 1.
+fn world_of(positions: &[(i32, i32, i32)]) -> (World, Vec<Entity>) {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let mut handles = Vec::new();
+    for &(x, y, z) in positions {
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Kinematic, at(x, y, z));
+        world.add_shape(handle, cube(1), Transform::IDENTITY, Filter::new(1, 1));
+        handles.push(handle);
+    }
+    (world, handles)
+}
+
+fn buffer(handle: Entity) -> [Collider; 8] {
+    [Collider {
+        handle,
+        index: ShapeIndex::from_raw(0),
+    }; 8]
+}
+
+#[test]
+fn a_point_finds_every_shape_containing_it() {
+    let (world, handles) = world_of(&[(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (9, 9, 9)]);
+    let mut found = buffer(handles[0]);
+    let counts = world.point_query(Vec3::ZERO, ANY, Exclude::NONE, &mut found);
+    assert_eq!(counts.existed, 4, "four cubes contain the origin");
+    assert_eq!(counts.written, 4);
+    for window in found[..4].windows(2) {
+        assert!(window[0] < window[1], "ascending, in collider order");
+    }
+}
+
+#[test]
+fn a_small_buffer_reports_what_it_could_not_write() {
+    let (world, handles) = world_of(&[(0, 0, 0), (1, 0, 0), (0, 0, 1)]);
+    let mut one = [Collider {
+        handle: handles[0],
+        index: ShapeIndex::from_raw(0),
+    }; 1];
+    let counts = world.point_query(Vec3::ZERO, ANY, Exclude::NONE, &mut one);
+    assert_eq!(counts.written, 1);
+    assert_eq!(counts.existed, 3);
+    assert!(counts.truncated());
+}
+
+#[test]
+fn a_ray_finds_the_nearest_body_and_ties_go_to_the_lower_collider() {
+    let (world, handles) = world_of(&[(0, 0, 0), (5, 0, 0), (10, 0, 0)]);
+    let hit = world
+        .ray_query(v(-5, 0, 0), RIGHT, FAR, ANY, Exclude::NONE)
+        .expect("three ahead");
+    assert_eq!(hit.collider.handle, handles[0], "the nearest one");
+
+    // Two bodies whose faces sit on the same plane, so the ray meets both at
+    // once — the tie has to go somewhere stated.
+    let (tied, tied_handles) = world_of(&[(0, 1, 0), (0, -1, 0)]);
+    let hit = tied
+        .ray_query(v(-5, 0, 0), RIGHT, FAR, ANY, Exclude::NONE)
+        .expect("both are on the line");
+    assert_eq!(hit.collider.handle, tied_handles[0], "the lower collider");
+}
+
+#[test]
+fn a_query_mask_and_an_exclusion_both_hide_things() {
+    let (mut world, handles) = world_of(&[(0, 0, 0), (5, 0, 0)]);
+    let mut found = buffer(handles[0]);
+
+    let wrong_layer = world.point_query(Vec3::ZERO, 0b10, Exclude::NONE, &mut found);
+    assert_eq!(wrong_layer.existed, 0, "nothing on that layer");
+
+    let excluded = world.ray_query(v(-5, 0, 0), RIGHT, FAR, ANY, Exclude::bodies(&[handles[0]]));
+    assert_eq!(
+        excluded.expect("the second is still there").collider.handle,
+        handles[1]
+    );
+
+    // A shape that collides with nothing is still findable by a cast, which is
+    // what makes triggers writable.
+    let trigger = handles[1];
+    world.set_filter(trigger, ShapeIndex::from_raw(0), Filter::new(0b10, 0b00));
+    let counts = world.overlap_query(cube(1), at(5, 0, 0), 0b10, Exclude::NONE, &mut found);
+    assert_eq!(counts.existed, 1, "a mask-zero shape is still castable");
+}
+
+#[test]
+fn an_overlap_finds_what_a_shape_would_touch() {
+    let (world, handles) = world_of(&[(0, 0, 0), (3, 0, 0), (9, 9, 9)]);
+    let mut found = buffer(handles[0]);
+    let wide = Shape::Box {
+        half_extents: v(2, 1, 1),
+    };
+    let counts = world.overlap_query(wide, at(1, 0, 0), ANY, Exclude::NONE, &mut found);
+    assert_eq!(counts.existed, 2, "the two near cubes, not the distant one");
+    assert_eq!(found[0].handle, handles[0]);
+    assert_eq!(found[1].handle, handles[1]);
+}
+
+#[test]
+fn queries_against_an_empty_world_answer_rather_than_refusing() {
+    let world = World::new();
+    let mut entities = Entities::new();
+    let mut found = buffer(entities.spawn());
+    assert_eq!(
+        world.point_query(Vec3::ZERO, ANY, Exclude::NONE, &mut found),
+        Counts::default()
+    );
+    assert_eq!(
+        world.overlap_query(cube(1), Transform::IDENTITY, ANY, Exclude::NONE, &mut found),
+        Counts::default()
+    );
+    assert!(
+        world
+            .ray_query(Vec3::ZERO, RIGHT, FAR, ANY, Exclude::NONE)
+            .is_none()
+    );
+}
+
+proptest! {
+    /// Whatever a ray hits, the point it reports lies on the ray at the
+    /// distance it reports, and the normal faces the ray.
+    #[test]
+    fn a_hit_is_self_consistent(
+        oy in -3i64..4, oz in -3i64..4, use_box in prop::bool::ANY,
+    ) {
+        let shape = if use_box { cube(1) } else { sphere(1) };
+        let origin = Vec3::new(
+            Fixed::from_int(-6),
+            Fixed::from_bits(oy * 32768),
+            Fixed::from_bits(oz * 32768),
+        );
+        if let Some(hit) = cast(origin, RIGHT, FAR, shape, Transform::IDENTITY) {
+            prop_assert!(hit.distance >= Fixed::ZERO && hit.distance <= FAR);
+            let expected = origin + RIGHT * hit.distance;
+            for (a, b) in [
+                (hit.point.x, expected.x),
+                (hit.point.y, expected.y),
+                (hit.point.z, expected.z),
+            ] {
+                prop_assert!((a - b).to_bits().abs() <= SLACK, "the point is off the ray");
+            }
+            let length_error = (hit.normal.length() - Fixed::ONE).to_bits().abs();
+            prop_assert!(length_error <= 64, "the normal is not unit");
+            prop_assert!(
+                hit.normal.dot(RIGHT) <= Fixed::ZERO,
+                "the normal must face the ray"
+            );
+        }
+    }
+}

--- a/crates/physics3d/tests/ray_and_query.rs
+++ b/crates/physics3d/tests/ray_and_query.rs
@@ -313,3 +313,32 @@ proptest! {
         }
     }
 }
+
+/// **A ray that passes some bodies and meets another.** Every other ray test
+/// puts every body on the line or leaves the world empty, so the path where a
+/// visible body is simply missed had never run — and a query that stopped at
+/// the first miss instead of continuing would report nothing at all.
+#[test]
+fn a_ray_walks_past_the_bodies_it_misses() {
+    // Three cubes off the line and one on it, the on-line one last so the
+    // walk has to get past all three misses to find it.
+    let (world, handles) = world_of(&[(0, 5, 0), (2, -5, 0), (4, 0, 5), (6, 0, 0)]);
+    let hit = world
+        .ray_query(v(-5, 0, 0), RIGHT, FAR, ANY, Exclude::NONE)
+        .expect("the fourth cube is on the line");
+    assert_eq!(hit.collider.handle, handles[3], "the only one it can meet");
+    close(
+        hit.distance,
+        Fixed::from_int(10),
+        "at x = 5, ten from the origin",
+    );
+
+    // And with that one gone there is nothing left to find, which proves the
+    // other three really are misses rather than silently accepted.
+    let (near_misses, _) = world_of(&[(0, 5, 0), (2, -5, 0), (4, 0, 5)]);
+    assert!(
+        near_misses
+            .ray_query(v(-5, 0, 0), RIGHT, FAR, ANY, Exclude::NONE)
+            .is_none()
+    );
+}


### PR DESCRIPTION
Casting a ray at a sphere or an axis-aligned box, and asking the world
for points, rays and overlaps with a filter mask and an exclusion.

A ray beginning inside a shape hits at distance zero, which is the rule
a ground check needs: a character already intersecting the floor must be
told about the floor, not told there is nothing beneath it.

The sphere test avoids the discriminant a naive quadratic builds from
three squared lengths. With the direction unit the leading coefficient
is one and the discriminant collapses to three terms rather than a
product of squares, which is what keeps it exact at world scale rather
than merely deterministic.

The box test is a slab test over three axes, and all six faces are
tested rather than one. Five of them are exactly what a two-dimensional
implementation lifted carelessly leaves out, and a ray that met the
right face with the wrong normal would send everything downstream in a
direction the geometry never reported. A ray exactly parallel to a slab
divides by zero, and a computed zero divisor is ordinary geometry here
rather than a mistake - so the division is checked and the case falls
back to whether the origin lies within that slab.

Queries report how much they found alongside how much they could write,
because a query that returned only what fitted would let a world quietly
stop reporting under load. Ray ties go to the lowest collider, which is
what stops nearest meaning whichever the iteration happened to reach
first - and in a voxel world, where every block face shares a plane with
its neighbours, ties are the common case rather than the corner one.