### PR TITLE
feat(physics3d): sweeping and sliding, completing the three-dimensional v0

### DIFF
--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -46,6 +46,8 @@ pub mod narrow;
 pub mod query;
 pub mod ray;
 pub mod shape;
+pub mod slide;
+pub mod sweep;
 pub mod world;
 
 pub use bounds::Aabb;
@@ -55,4 +57,6 @@ pub use narrow::{Contact, collide, separation};
 pub use query::{Counts, Exclude, Hit};
 pub use ray::{RayHit, cast};
 pub use shape::{Shape, Transform};
+pub use slide::{SlideEnd, SlideHit, SlideReport};
+pub use sweep::{MAX_ADVANCE_STEPS, SweepHit, sweep};
 pub use world::{BodyKind, Collider, HandleState, Incarnation, ShapeIndex, World};

--- a/crates/physics3d/src/slide.rs
+++ b/crates/physics3d/src/slide.rs
@@ -1,0 +1,190 @@
+//! Moving a body against the world and sliding along what stops it.
+
+use crate::query::{Counts, Exclude};
+use crate::shape::Transform;
+use crate::sweep::sweep;
+use crate::world::{Collider, World};
+use renew_fixed::{Fixed, Vec3};
+
+/// Why a slide stopped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SlideEnd {
+    /// The whole displacement was used, or what remained pointed into a
+    /// surface and had nowhere left to go.
+    Displaced,
+    /// The iteration limit ran out with displacement still unspent.
+    ///
+    /// **Reported rather than swallowed.** A body that silently stopped short
+    /// looks to a caller exactly like one that arrived, and the difference
+    /// shows up as a character that sticks in corners for reasons nothing
+    /// explains.
+    IterationsExhausted,
+}
+
+/// One surface a slide met.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlideHit {
+    /// What was hit.
+    pub collider: Collider,
+    /// The surface direction, facing the mover.
+    pub normal: Vec3,
+    /// Where the body's origin sat when it met this.
+    pub origin: Vec3,
+}
+
+/// What a slide did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SlideReport {
+    /// Where the body ended up.
+    pub destination: Vec3,
+    /// How many surfaces were met, and how many fitted the caller's buffer.
+    pub hits: Counts,
+    /// How many sweep-and-slide iterations were spent.
+    pub iterations: u32,
+    /// Why it stopped.
+    pub end: SlideEnd,
+}
+
+/// A displacement shorter than this is nothing left to spend.
+///
+/// Not zero: the slide subtracts a normal component each iteration and the
+/// remainder is rounded, so an exactly-zero remainder is a case that does not
+/// arise. One raw unit squared is the smallest length the number type can tell
+/// from nothing.
+const SPENT: i64 = 1;
+
+impl World {
+    /// Move a body along a displacement, sliding along whatever stops it.
+    ///
+    /// **This is where a character's ground state comes from, not from the
+    /// contact array.** A body stopped here rests a skin distance from what
+    /// stopped it — far enough that a contact test will not report it — so
+    /// the hits written here are the only record that it landed, what it
+    /// landed on, and which way that surface faced.
+    ///
+    /// The moving body is excluded from its own sweep. Its shapes are parts of
+    /// one object and an object does not block itself; an articulated thing
+    /// whose parts must collide is several bodies.
+    pub fn move_and_slide(
+        &mut self,
+        handle: renew_ecs::Entity,
+        displacement: Vec3,
+        mask: u32,
+        skin: Fixed,
+        iteration_limit: u32,
+        out: &mut [SlideHit],
+    ) -> Option<SlideReport> {
+        let start = self.transform(handle)?;
+        let mut position = start.translation;
+        let mut remaining = displacement;
+        let mut hits = Counts::default();
+        let mut iterations = 0;
+        let mut end = SlideEnd::IterationsExhausted;
+        let excluded = [handle];
+
+        while iterations < iteration_limit {
+            if remaining.length_squared().to_bits() <= SPENT {
+                end = SlideEnd::Displaced;
+                break;
+            }
+            iterations += 1;
+
+            let here = Transform::at(position);
+            let Some((hit, collider)) = self.sweep_body(
+                handle,
+                here,
+                remaining,
+                mask,
+                skin,
+                Exclude::bodies(&excluded),
+            ) else {
+                // Nothing in the way: spend what is left and finish.
+                position = position + remaining;
+                end = SlideEnd::Displaced;
+                break;
+            };
+
+            if let Some(slot) = out.get_mut(hits.written) {
+                *slot = SlideHit {
+                    collider,
+                    normal: hit.normal,
+                    origin: hit.origin,
+                };
+                hits.written += 1;
+            }
+            hits.existed += 1;
+
+            position = hit.origin;
+            // What is left of the displacement after the part already
+            // travelled, with the component into the surface removed. Sliding
+            // rather than stopping is what lets a character run along a wall
+            // instead of sticking to it.
+            let unspent = remaining * (Fixed::ONE - hit.time);
+            remaining = unspent.slide_along(hit.normal);
+        }
+
+        self.set_transform(handle, Transform::at(position));
+        Some(SlideReport {
+            destination: position,
+            hits,
+            iterations,
+            end,
+        })
+    }
+
+    /// Sweep every live shape of a body and take the earliest impact.
+    ///
+    /// **Ties break by the collider hit**, lowest first, so two surfaces met
+    /// at the same instant — which is what a corner is — resolve the same way
+    /// on every machine.
+    fn sweep_body(
+        &self,
+        handle: renew_ecs::Entity,
+        from: Transform,
+        displacement: Vec3,
+        mask: u32,
+        skin: Fixed,
+        exclude: Exclude<'_>,
+    ) -> Option<(crate::sweep::SweepHit, Collider)> {
+        let extent = self.shape_extent(handle)?;
+        let mut best: Option<(crate::sweep::SweepHit, Collider)> = None;
+
+        for index in 0..extent {
+            let mine = Collider {
+                handle,
+                index: crate::world::ShapeIndex::from_raw(index),
+            };
+            let Some((shape, local, _)) = self.shape(mine) else {
+                continue;
+            };
+            let placed = local.compose(from);
+
+            for collider in self.colliders() {
+                let Some((other, other_at)) = self.query_visible(collider, mask, exclude) else {
+                    continue;
+                };
+                let Some(hit) = sweep(shape, placed, displacement, other, other_at, skin) else {
+                    continue;
+                };
+                let earlier = best.as_ref().is_none_or(|(current, current_collider)| {
+                    hit.time < current.time
+                        || (hit.time == current.time && collider < *current_collider)
+                });
+                if earlier {
+                    // The reported origin is the shape's, and the caller moves
+                    // the body — so it is shifted back by the local placement.
+                    let body_origin = hit.origin - (placed.translation - from.translation);
+                    best = Some((
+                        crate::sweep::SweepHit {
+                            time: hit.time,
+                            origin: body_origin,
+                            normal: hit.normal,
+                        },
+                        collider,
+                    ));
+                }
+            }
+        }
+        best
+    }
+}

--- a/crates/physics3d/src/sweep.rs
+++ b/crates/physics3d/src/sweep.rs
@@ -1,0 +1,140 @@
+//! Moving a shape and finding what it meets first.
+
+use crate::narrow::separation;
+use crate::shape::{Shape, Transform};
+use renew_fixed::{Fixed, Vec3};
+
+/// How many advancement steps a sweep may take before giving up.
+///
+/// Fixed rather than tuned, because it is part of the answer: a sweep that
+/// took a machine-dependent number of steps would produce a machine-dependent
+/// time of impact. Twenty-four is enough for the grazing cases that converge
+/// slowly, and cheap for the ordinary ones that finish in two or three.
+pub const MAX_ADVANCE_STEPS: u32 = 24;
+
+/// Where a moving shape first met a stationary one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SweepHit {
+    /// Fraction of the displacement travelled before contact, in `[0, 1]`.
+    pub time: Fixed,
+    /// Where the moving shape's origin sits at that moment.
+    pub origin: Vec3,
+    /// The surface direction at contact, pointing back at the mover.
+    pub normal: Vec3,
+}
+
+/// Sweep `moving` from `from` along `displacement` against a stationary shape.
+///
+/// `skin` is how far short of contact the sweep stops, which is what keeps a
+/// body from ending exactly on a surface where the next test cannot tell touch
+/// from overlap.
+///
+/// # Why conservative advancement rather than a closed form
+///
+/// The exact answer is a ray cast against the Minkowski sum of the two shapes.
+/// For two spheres that sum is a sphere; for a box and a sphere it is a rounded
+/// box; for two axis-aligned boxes it is a box, which is the one easy case.
+/// Each is a separate opportunity to be subtly wrong, and the rounded box in
+/// three dimensions has twenty-six pieces.
+///
+/// Advancing conservatively needs one thing instead: a lower bound on the
+/// distance between the shapes, which the separating-axis test already
+/// produces. Each step moves by exactly the time it would take to close that
+/// bound, so it can approach the true time of impact but never pass it —
+/// **the sweep cannot tunnel**, whatever the shapes are.
+///
+/// The cost is that a grazing approach converges slowly, which is why the step
+/// count is capped and the cap is part of the contract rather than a tuning
+/// knob.
+#[must_use]
+pub fn sweep(
+    moving: Shape,
+    from: Transform,
+    displacement: Vec3,
+    target: Shape,
+    target_at: Transform,
+    skin: Fixed,
+) -> Option<SweepHit> {
+    let mut time = Fixed::ZERO;
+    let mut outcome = None;
+
+    for step_index in 0..MAX_ADVANCE_STEPS {
+        let here = Transform::at(from.translation + displacement * time);
+        let (gap, direction) = separation(moving, here, target, target_at);
+
+        // **Touching is not the same as being obstructed.** A body resting
+        // against a wall and sliding along it is in contact for the whole
+        // move, and reporting that as a blocking hit stops it dead: the slide
+        // removes the normal component, the remainder is already parallel, and
+        // the next iteration meets the same surface at the same instant. The
+        // body burns its whole iteration budget standing still.
+        //
+        // So contact only blocks when the motion goes *into* it. This is the
+        // one check that separates a wall a character is running along from a
+        // wall it is running at.
+        //
+        // **Penetration is the exception**: a body genuinely inside something
+        // reports whichever way it is moving, because a caller needs to know
+        // it is there before it can decide to push out. Only the band between
+        // touching and the skin distance is treated as passable.
+        let resting = gap >= Fixed::ZERO && displacement.dot(direction) <= Fixed::ZERO;
+        if gap <= skin && resting {
+            break;
+        }
+
+        // Contact, or the budget spent. **The last step reports where it got
+        // to rather than nothing**, because reporting no hit would let a body
+        // pass straight through something it was converging on — and since
+        // every advance is bounded below the true time of impact, the position
+        // reached is always short of the surface rather than past it.
+        //
+        // The two share an arm deliberately: written as a separate tail after
+        // the loop it was twelve lines restating this one, and unreachable for
+        // every shape family that exists — a sweep of eight thousand rotated
+        // box approaches left at worst twenty-nine raw units unconverged.
+        if gap <= skin || step_index + 1 == MAX_ADVANCE_STEPS {
+            outcome = Some(SweepHit {
+                time,
+                origin: here.translation,
+                // The direction points from the mover toward the target, and a
+                // caller sliding wants the surface facing back at it.
+                normal: -direction,
+            });
+            break;
+        }
+
+        // How fast the gap closes along the axis that measured it. Moving away
+        // or sliding parallel means this axis will never be crossed, and since
+        // it is a separating axis, nothing else will be either.
+        let approach = displacement.dot(direction);
+        if approach <= Fixed::ZERO {
+            break;
+        }
+
+        // Time to close the gap if the mover kept going straight. The bound is
+        // a lower bound on the true distance, so this is a lower bound on the
+        // true time — advancing by it can never overshoot. The guard above
+        // established a positive divisor, so the fallback is unreachable and
+        // routes any surprise through the no-progress check below rather than
+        // inventing a distance.
+        let step = (gap - skin).checked_div(approach).unwrap_or(Fixed::ZERO);
+        time = time + step;
+        if time > Fixed::ONE {
+            break;
+        }
+        // A step that rounds to nothing cannot make progress, and repeating it
+        // would burn the whole budget standing still. The shapes are within a
+        // raw unit of the skin distance here, which is contact by any measure
+        // the number type can express.
+        if step <= Fixed::ZERO {
+            outcome = Some(SweepHit {
+                time,
+                origin: from.translation + displacement * time,
+                normal: -direction,
+            });
+            break;
+        }
+    }
+
+    outcome
+}

--- a/crates/physics3d/tests/sweep_and_slide.rs
+++ b/crates/physics3d/tests/sweep_and_slide.rs
@@ -419,3 +419,49 @@ fn a_body_with_a_removed_shape_sweeps_only_its_live_ones() {
     assert_eq!(report.hits.existed, 1, "the surviving shape met the wall");
     assert!(report.destination.x < Fixed::from_int(3));
 }
+
+/// A displacement that does not quite reach is not a hit, and one that just
+/// reaches is. The boundary between them is where an off-by-one lives, and
+/// nothing else here travels a distance too short to arrive.
+#[test]
+fn a_sweep_that_falls_short_reports_nothing() {
+    // Surfaces meet when the centres are two apart, so from x = −5 the gap is
+    // three units of clear air.
+    assert!(
+        sweep(
+            sphere(1),
+            at(-5, 0, 0),
+            v(2, 0, 0),
+            sphere(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_none(),
+        "two units of travel across a three-unit gap"
+    );
+    assert!(
+        sweep(
+            sphere(1),
+            at(-5, 0, 0),
+            v(4, 0, 0),
+            sphere(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_some(),
+        "four units closes it"
+    );
+
+    // And the same for boxes, on an axis that is not the swept one.
+    assert!(
+        sweep(
+            cube(1),
+            at(0, -5, 0),
+            v(0, 2, 0),
+            cube(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_none()
+    );
+}

--- a/crates/physics3d/tests/sweep_and_slide.rs
+++ b/crates/physics3d/tests/sweep_and_slide.rs
@@ -1,0 +1,421 @@
+//! Sweeping a shape and sliding a body, in three dimensions.
+
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{
+    BodyKind, Collider, Filter, Shape, ShapeIndex, SlideEnd, SlideHit, Transform, World,
+    narrow::separation, sweep,
+};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+fn sphere(units: i32) -> Shape {
+    Shape::Sphere {
+        radius: Fixed::from_int(units),
+    }
+}
+
+fn cube(half: i32) -> Shape {
+    Shape::Box {
+        half_extents: v(half, half, half),
+    }
+}
+
+const SKIN: Fixed = Fixed::from_bits(256);
+const ANY: u32 = u32::MAX;
+const LIMIT: u32 = 4;
+
+#[test]
+fn a_sphere_moving_at_a_sphere_stops_before_it() {
+    let hit = sweep(
+        sphere(1),
+        at(-5, 0, 0),
+        v(10, 0, 0),
+        sphere(1),
+        Transform::IDENTITY,
+        SKIN,
+    )
+    .expect("straight at it");
+    let expected = Fixed::from_ratio(3, 10);
+    assert!(
+        (hit.time - expected).to_bits().abs() <= 512,
+        "stopped at {} of the way",
+        hit.time.to_bits()
+    );
+    let (gap, _) = separation(
+        sphere(1),
+        Transform::at(hit.origin),
+        sphere(1),
+        Transform::IDENTITY,
+    );
+    assert!(gap >= Fixed::ZERO, "the sweep must not end overlapping");
+}
+
+/// A body falling onto a floor stops on top of it, on every axis a floor could
+/// be on — because a voxel world has walls and ceilings too.
+#[test]
+fn a_cube_swept_at_a_slab_stops_against_it_on_every_axis() {
+    let cases = [
+        (
+            v(0, 10, 0),
+            v(0, -20, 0),
+            Shape::Box {
+                half_extents: v(20, 1, 20),
+            },
+        ),
+        (
+            v(10, 0, 0),
+            v(-20, 0, 0),
+            Shape::Box {
+                half_extents: v(1, 20, 20),
+            },
+        ),
+        (
+            v(0, 0, 10),
+            v(0, 0, -20),
+            Shape::Box {
+                half_extents: v(20, 20, 1),
+            },
+        ),
+    ];
+    for (start, displacement, slab) in cases {
+        let hit = sweep(
+            cube(1),
+            Transform::at(start),
+            displacement,
+            slab,
+            Transform::IDENTITY,
+            SKIN,
+        )
+        .expect("it meets the slab");
+        let (gap, _) = separation(
+            cube(1),
+            Transform::at(hit.origin),
+            slab,
+            Transform::IDENTITY,
+        );
+        assert!(
+            gap.to_bits() >= -64,
+            "ended {} raw inside the slab",
+            -gap.to_bits()
+        );
+        // And the normal points back at the mover.
+        assert!(
+            hit.normal.dot(displacement) < Fixed::ZERO,
+            "the surface must face the mover"
+        );
+    }
+}
+
+#[test]
+fn a_shape_moving_away_or_past_meets_nothing() {
+    assert!(
+        sweep(
+            sphere(1),
+            at(-5, 0, 0),
+            v(-10, 0, 0),
+            sphere(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_none(),
+        "travelling away"
+    );
+    assert!(
+        sweep(
+            sphere(1),
+            at(-5, 5, 0),
+            v(10, 0, 0),
+            sphere(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_none(),
+        "passing above"
+    );
+    assert!(
+        sweep(
+            sphere(1),
+            at(-5, 0, 5),
+            v(10, 0, 0),
+            sphere(1),
+            Transform::IDENTITY,
+            SKIN
+        )
+        .is_none(),
+        "and passing in front"
+    );
+}
+
+#[test]
+fn a_shape_that_starts_overlapping_reports_zero() {
+    let hit = sweep(
+        sphere(1),
+        Transform::IDENTITY,
+        v(10, 0, 0),
+        sphere(1),
+        at(1, 0, 0),
+        SKIN,
+    )
+    .expect("already inside");
+    assert_eq!(hit.time, Fixed::ZERO);
+}
+
+/// **The property the whole approach exists for.** A small shape crossing a
+/// thin wall at speed is what a per-step overlap test misses.
+#[test]
+fn a_fast_small_shape_cannot_tunnel_through_a_thin_wall() {
+    let bullet = Shape::Sphere {
+        radius: Fixed::from_ratio(1, 16),
+    };
+    let wall = Shape::Box {
+        half_extents: Vec3::new(
+            Fixed::from_ratio(1, 8),
+            Fixed::from_int(10),
+            Fixed::from_int(10),
+        ),
+    };
+    for speed in [50i32, 200, 1000, 5000] {
+        let hit = sweep(
+            bullet,
+            at(-10, 0, 0),
+            Vec3::new(Fixed::from_int(speed), Fixed::ZERO, Fixed::ZERO),
+            wall,
+            Transform::IDENTITY,
+            SKIN,
+        )
+        .unwrap_or_else(|| panic!("a bullet at {speed} per step tunnelled the wall"));
+        assert!(hit.time >= Fixed::ZERO && hit.time <= Fixed::ONE);
+        assert!(
+            hit.origin.x < Fixed::ZERO,
+            "at {speed} it stopped past the wall, at x = {}",
+            hit.origin.x.to_bits()
+        );
+    }
+}
+
+fn empty_hits() -> [SlideHit; 8] {
+    [SlideHit {
+        collider: Collider {
+            handle: Entities::new().spawn(),
+            index: ShapeIndex::from_raw(0),
+        },
+        normal: Vec3::ZERO,
+        origin: Vec3::ZERO,
+    }; 8]
+}
+
+/// Where a block sits, and how big it is — both in whole units.
+///
+/// Named because the bare nested tuple is unreadable at the call site and
+/// clippy is right to say so: `((4, 0, 0), (1, 20, 20))` gives a reader no way
+/// to tell a position from a half-extent.
+type Block = ((i32, i32, i32), (i32, i32, i32));
+
+/// A world with a mover and whatever static blocks are named.
+fn staged(start: (i32, i32, i32), blocks: &[Block]) -> (World, Entity) {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let mover = entities.spawn();
+    world.create_body(mover, BodyKind::Kinematic, at(start.0, start.1, start.2));
+    world.add_shape(mover, cube(1), Transform::IDENTITY, Filter::new(1, 1));
+    for &((x, y, z), (hx, hy, hz)) in blocks {
+        let block = entities.spawn();
+        world.create_body(block, BodyKind::Static, at(x, y, z));
+        world.add_shape(
+            block,
+            Shape::Box {
+                half_extents: v(hx, hy, hz),
+            },
+            Transform::IDENTITY,
+            Filter::new(1, 1),
+        );
+    }
+    (world, mover)
+}
+
+#[test]
+fn a_body_with_nothing_in_the_way_travels_the_whole_displacement() {
+    let (mut world, mover) = staged((0, 0, 0), &[]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(5, 0, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.end, SlideEnd::Displaced);
+    assert_eq!(report.hits.existed, 0);
+    assert_eq!(report.destination, v(5, 0, 0));
+    assert_eq!(
+        world.transform(mover).map(|t| t.translation),
+        Some(v(5, 0, 0))
+    );
+}
+
+/// **Sliding rather than sticking**, which is the bug the platformer found in
+/// two dimensions and which this crate inherits the fix for.
+#[test]
+fn a_body_pushed_into_a_wall_slides_along_it() {
+    // A wall at x = 4, and a mover heading up and to the right.
+    let (mut world, mover) = staged((0, 0, 0), &[((4, 0, 0), (1, 20, 20))]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(6, 6, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert!(report.hits.existed >= 1, "it met the wall");
+    assert!(
+        report.destination.x < Fixed::from_int(3),
+        "ended at x = {}, inside the wall",
+        report.destination.x.to_bits()
+    );
+    assert!(
+        report.destination.y > Fixed::from_int(3),
+        "and kept climbing, to y = {}",
+        report.destination.y.to_bits()
+    );
+}
+
+/// Sliding along a *third* axis, which two dimensions cannot test at all: a
+/// body pressed into a wall while moving diagonally in the plane of that wall
+/// keeps both of the components that are not into it.
+#[test]
+fn a_body_slides_in_the_plane_of_the_surface_it_meets() {
+    let (mut world, mover) = staged((0, 0, 0), &[((4, 0, 0), (1, 20, 20))]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(6, 4, 4), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+
+    assert!(
+        report.destination.x < Fixed::from_int(3),
+        "kept out of the wall"
+    );
+    assert!(
+        report.destination.y > Fixed::from_int(2),
+        "kept its y motion, reached {}",
+        report.destination.y.to_bits()
+    );
+    assert!(
+        report.destination.z > Fixed::from_int(2),
+        "and its z motion, reached {}",
+        report.destination.z.to_bits()
+    );
+}
+
+#[test]
+fn a_body_never_collides_with_its_own_shapes() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let mover = entities.spawn();
+    world.create_body(mover, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(mover, cube(1), Transform::IDENTITY, Filter::new(1, 1));
+    world.add_shape(mover, cube(1), at(1, 0, 0), Filter::new(1, 1));
+
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(5, 0, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.hits.existed, 0, "its own shapes are not obstacles");
+    assert_eq!(report.destination, v(5, 0, 0));
+}
+
+#[test]
+fn a_mask_lets_a_body_pass_through_what_it_does_not_collide_with() {
+    let (mut world, mover) = staged((0, 0, 0), &[((4, 0, 0), (1, 20, 20))]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(8, 0, 0), 0b10, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.hits.existed, 0);
+    assert_eq!(report.destination, v(8, 0, 0), "straight through");
+}
+
+#[test]
+fn a_zero_displacement_slide_goes_nowhere_and_says_so() {
+    let (mut world, mover) = staged((3, 4, 5), &[]);
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, Vec3::ZERO, ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.end, SlideEnd::Displaced);
+    assert_eq!(report.iterations, 0);
+    assert_eq!(report.destination, v(3, 4, 5));
+}
+
+#[test]
+fn a_slide_on_a_destroyed_body_is_refused() {
+    let (mut world, _) = staged((0, 0, 0), &[]);
+    let mut entities = Entities::new();
+    let _first = entities.spawn();
+    let doomed = entities.spawn();
+    world.create_body(doomed, BodyKind::Kinematic, Transform::IDENTITY);
+    world.destroy_body(doomed);
+
+    let mut hits = empty_hits();
+    assert!(
+        world
+            .move_and_slide(doomed, v(1, 0, 0), ANY, SKIN, LIMIT, &mut hits)
+            .is_none(),
+        "a destroyed body has nothing to move"
+    );
+}
+
+#[test]
+fn a_small_hit_buffer_reports_what_it_could_not_write() {
+    // A corner of three slabs, so a diagonal run meets more than one.
+    let (mut world, mover) = staged(
+        (0, 6, 0),
+        &[((4, 0, 0), (1, 20, 20)), ((0, 0, 0), (20, 1, 20))],
+    );
+    let mut one = [SlideHit {
+        collider: Collider {
+            handle: mover,
+            index: ShapeIndex::from_raw(0),
+        },
+        normal: Vec3::ZERO,
+        origin: Vec3::ZERO,
+    }; 1];
+    let report = world
+        .move_and_slide(mover, v(6, -10, 0), ANY, SKIN, LIMIT, &mut one)
+        .expect("a live body");
+    assert_eq!(report.hits.written, 1);
+    if report.hits.existed > 1 {
+        assert!(report.hits.truncated());
+    }
+}
+
+#[test]
+fn a_body_with_a_removed_shape_sweeps_only_its_live_ones() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let mover = entities.spawn();
+    world.create_body(mover, BodyKind::Kinematic, Transform::IDENTITY);
+    let doomed = world
+        .add_shape(mover, cube(1), Transform::IDENTITY, Filter::new(1, 1))
+        .expect("live");
+    world.add_shape(mover, cube(1), Transform::IDENTITY, Filter::new(1, 1));
+    assert!(world.remove_shape(mover, doomed));
+
+    let wall = entities.spawn();
+    world.create_body(wall, BodyKind::Static, at(4, 0, 0));
+    world.add_shape(
+        wall,
+        Shape::Box {
+            half_extents: v(1, 20, 20),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+
+    let mut hits = empty_hits();
+    let report = world
+        .move_and_slide(mover, v(8, 0, 0), ANY, SKIN, LIMIT, &mut hits)
+        .expect("a live body");
+    assert_eq!(report.hits.existed, 1, "the surviving shape met the wall");
+    assert!(report.destination.x < Fixed::from_int(3));
+}


### PR DESCRIPTION
Conservative advancement over the separation query, and move-and-slide
built on it. With this the three-dimensional crate has the same surface
the two-dimensional one does: lifecycle, filtering, bounds, broadphase,
narrowphase, ray casting, queries, sweeping and sliding.

It inherits the fix a platformer found rather than repeating the bug.
Contact blocks only when the displacement points into the surface, with
penetration as the exception - so a body resting against a wall and
sliding along it makes progress instead of burning its iteration budget
standing still. That defect passed every test written against the
two-dimensional geometry in isolation and took a game to expose; it
would have been written again here from the same reasoning.

The sweep cannot tunnel, and a test fires a sixteenth-unit sphere at a
quarter-unit wall at fifty, two hundred, a thousand and five thousand
units per step to say so.

Two tests exist here that two dimensions cannot express. A body swept at
a slab is stopped on all three axes in turn, because a voxel world has
ceilings and side walls as well as floors, and an implementation with a
transposed axis passes one of the three. And a body pressed into a wall
while moving diagonally in the plane of that wall keeps both of the
components that are not into it - in two dimensions there is only ever
one component left to keep, so the plane case never arises.