### PR TITLE
feat(samples): cube, a voxel world that walks, digs and places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -281,7 +281,7 @@ jobs:
       # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube-world --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -299,7 +299,7 @@ jobs:
       # workspace minus one leaf.
       - name: Build and test without three-dimensional collision
         run: |
-          sel="--workspace --exclude renew-physics3d"
+          sel="--workspace --exclude renew-physics3d --exclude renew-sample-cube-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics3d $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-cube-world"
+version = "0.1.0"
+dependencies = [
+ "renew-fixed",
+ "renew-frame",
+ "renew-physics3d",
+]
+
+[[package]]
 name = "renew-sample-glide"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube/world", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/cube/world/Cargo.toml
+++ b/samples/cube/world/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "renew-sample-cube-world"
+description = "The cube sample's simulation: a voxel world with a walking player, block breaking and placing, checked digest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "A voxel world's rules as a pure fixed-step function of per-tick input: a grid of blocks, a player swept against them, and the ray that decides which block is being looked at."
+maturity = "bootstrap"
+core = false
+simulation = true
+
+extension_points = []
+
+# Simulation only: the world may not reach an OS capability at any dependency
+# depth, and the structure check walks this list to prove it.
+[dependencies]
+renew-fixed = { path = "../../../crates/fixed" }
+renew-frame = { path = "../../../crates/frame" }
+renew-physics3d = { path = "../../../crates/physics3d" }
+
+[lints]
+workspace = true

--- a/samples/cube/world/clippy.toml
+++ b/samples/cube/world/clippy.toml
@@ -1,0 +1,34 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). The mechanical half of
+# this crate's determinism declaration: the world is a pure function of its
+# per-tick input, and everything below makes the ways that stops being true
+# unwritable rather than merely documented.
+#
+# One clock read inside `step` would destroy replay identity for every recorded
+# run, with no test failing until a digest diverged — and the digest would only
+# diverge on a machine other than the one that recorded it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
+    { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "the level arrives as an argument, never from a path this crate chose" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so a value derived from it differs between runs of the same binary on the same inputs" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same road to the same entropy: it is built from RandomState" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/samples/cube/world/src/grid.rs
+++ b/samples/cube/world/src/grid.rs
@@ -1,0 +1,221 @@
+//! The blocks, and where they are.
+
+use renew_fixed::{Fixed, Vec3};
+
+/// What occupies one cell.
+///
+/// A byte rather than an enum, because a voxel world's whole point is that
+/// there are many kinds and they arrive as data. Zero is air by convention and
+/// everything else is solid for now — the distinction a game makes between
+/// stone and glass belongs to the game.
+pub type Block = u8;
+
+/// Nothing there.
+pub const AIR: Block = 0;
+/// The one solid kind this sample has.
+pub const STONE: Block = 1;
+
+/// Integer coordinates of one cell.
+///
+/// **Signed, and that is deliberate.** A world that started at zero would need
+/// a translation between where a player is and which cell that is, and the
+/// translation is exactly where an off-by-one lives. Negative coordinates are
+/// ordinary here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Cell {
+    /// East.
+    pub x: i32,
+    /// Up.
+    pub y: i32,
+    /// North.
+    pub z: i32,
+}
+
+impl Cell {
+    /// A cell.
+    #[must_use]
+    pub const fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+
+    /// The centre of this cell in world space.
+    ///
+    /// A cell spans one unit, so cell zero covers −0.5 to +0.5 and its centre
+    /// is the origin. Centring on integers rather than cornering on them means
+    /// a block's half-extent is exactly one half and the arithmetic stays
+    /// exact.
+    #[must_use]
+    pub fn centre(self) -> Vec3 {
+        Vec3::new(
+            Fixed::from_int(self.x),
+            Fixed::from_int(self.y),
+            Fixed::from_int(self.z),
+        )
+    }
+
+    /// This cell offset by whole steps.
+    #[must_use]
+    pub const fn offset(self, x: i32, y: i32, z: i32) -> Self {
+        Self::new(
+            self.x.saturating_add(x),
+            self.y.saturating_add(y),
+            self.z.saturating_add(z),
+        )
+    }
+
+    /// Which cell a world position falls in.
+    ///
+    /// Rounds to nearest, which is what pairs with centring cells on integers.
+    /// A position exactly on a boundary goes to the higher cell, consistently,
+    /// so two players standing on the same seam agree about where they are.
+    #[must_use]
+    pub fn containing(position: Vec3) -> Self {
+        Self::new(
+            round_to_cell(position.x),
+            round_to_cell(position.y),
+            round_to_cell(position.z),
+        )
+    }
+}
+
+/// Round a coordinate to the cell that contains it.
+fn round_to_cell(value: Fixed) -> i32 {
+    // Adding half a unit and truncating toward negative infinity puts the
+    // boundary at the higher cell for both signs — `trunc_int` alone rounds
+    // toward zero, which would split the boundary rule between positive and
+    // negative coordinates.
+    let raised = value + Fixed::from_ratio(1, 2);
+    let floored = raised.to_bits().div_euclid(65536);
+    i32::try_from(floored).unwrap_or(0)
+}
+
+/// Half a block, which is every block's half-extent.
+#[must_use]
+pub fn block_half_extent() -> Vec3 {
+    let half = Fixed::from_ratio(1, 2);
+    Vec3::new(half, half, half)
+}
+
+/// A finite box of cells.
+///
+/// **Finite, and it says so at the edges.** A world that answered "air" for
+/// everything outside would let a player walk off it and fall forever with no
+/// way to tell that from a hole; one that answered "solid" would trap them at
+/// the boundary with no explanation. Asking is answered by [`Grid::get`],
+/// which returns nothing outside — so a caller decides.
+#[derive(Clone, Debug)]
+pub struct Grid {
+    blocks: Vec<Block>,
+    min: Cell,
+    size: (i32, i32, i32),
+}
+
+impl Grid {
+    /// An empty grid spanning `size` cells from `min`.
+    ///
+    /// A dimension of zero or less gives an empty grid rather than a refusal:
+    /// a world with no blocks is a legitimate thing to simulate, and it is
+    /// what a test that only cares about falling wants.
+    #[must_use]
+    pub fn new(min: Cell, size: (i32, i32, i32)) -> Self {
+        let count = size
+            .0
+            .max(0)
+            .saturating_mul(size.1.max(0))
+            .saturating_mul(size.2.max(0));
+        Self {
+            blocks: vec![AIR; usize::try_from(count).unwrap_or(0)],
+            min,
+            size: (size.0.max(0), size.1.max(0), size.2.max(0)),
+        }
+    }
+
+    /// The lowest cell this grid holds.
+    #[must_use]
+    pub const fn min(&self) -> Cell {
+        self.min
+    }
+
+    /// How many cells on each axis.
+    #[must_use]
+    pub const fn size(&self) -> (i32, i32, i32) {
+        self.size
+    }
+
+    fn index(&self, cell: Cell) -> Option<usize> {
+        let (x, y, z) = (
+            cell.x.checked_sub(self.min.x)?,
+            cell.y.checked_sub(self.min.y)?,
+            cell.z.checked_sub(self.min.z)?,
+        );
+        if x < 0 || y < 0 || z < 0 || x >= self.size.0 || y >= self.size.1 || z >= self.size.2 {
+            return None;
+        }
+        let flat = i64::from(x)
+            + i64::from(y) * i64::from(self.size.0)
+            + i64::from(z) * i64::from(self.size.0) * i64::from(self.size.1);
+        usize::try_from(flat).ok()
+    }
+
+    /// What is in a cell, or nothing if it is outside the grid.
+    #[must_use]
+    pub fn get(&self, cell: Cell) -> Option<Block> {
+        self.blocks.get(self.index(cell)?).copied()
+    }
+
+    /// Whether a cell blocks movement. **Outside the grid is not solid**, so a
+    /// player can leave — falling out of the world is a game's decision to
+    /// make, not the grid's.
+    #[must_use]
+    pub fn is_solid(&self, cell: Cell) -> bool {
+        self.get(cell).is_some_and(|block| block != AIR)
+    }
+
+    /// Put a block in a cell. `false` if the cell is outside the grid.
+    pub fn set(&mut self, cell: Cell, block: Block) -> bool {
+        let Some(index) = self.index(cell) else {
+            return false;
+        };
+        match self.blocks.get_mut(index) {
+            Some(slot) => {
+                *slot = block;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Fill a rectangular region, inclusive of both corners.
+    pub fn fill(&mut self, from: Cell, to: Cell, block: Block) {
+        for x in from.x.min(to.x)..=from.x.max(to.x) {
+            for y in from.y.min(to.y)..=from.y.max(to.y) {
+                for z in from.z.min(to.z)..=from.z.max(to.z) {
+                    self.set(Cell::new(x, y, z), block);
+                }
+            }
+        }
+    }
+
+    /// How many cells hold something.
+    #[must_use]
+    pub fn solid_count(&self) -> usize {
+        self.blocks.iter().filter(|&&block| block != AIR).count()
+    }
+
+    /// Every cell holding something, in a fixed order.
+    ///
+    /// The order is part of the contract rather than an accident: a digest
+    /// walks it, and a walk whose order depended on the representation would
+    /// hash two identical worlds differently.
+    pub fn solids(&self) -> impl Iterator<Item = (Cell, Block)> + '_ {
+        (0..self.size.2).flat_map(move |z| {
+            (0..self.size.1).flat_map(move |y| {
+                (0..self.size.0).filter_map(move |x| {
+                    let cell = Cell::new(self.min.x + x, self.min.y + y, self.min.z + z);
+                    let block = self.get(cell)?;
+                    (block != AIR).then_some((cell, block))
+                })
+            })
+        })
+    }
+}

--- a/samples/cube/world/src/grid.rs
+++ b/samples/cube/world/src/grid.rs
@@ -173,16 +173,13 @@ impl Grid {
 
     /// Put a block in a cell. `false` if the cell is outside the grid.
     pub fn set(&mut self, cell: Cell, block: Block) -> bool {
-        let Some(index) = self.index(cell) else {
+        // `index` already proved the cell is inside, so the slot is there. A
+        // second `None` arm would be a branch nothing could take.
+        let Some(slot) = self.index(cell).and_then(|at| self.blocks.get_mut(at)) else {
             return false;
         };
-        match self.blocks.get_mut(index) {
-            Some(slot) => {
-                *slot = block;
-                true
-            }
-            None => false,
-        }
+        *slot = block;
+        true
     }
 
     /// Fill a rectangular region, inclusive of both corners.

--- a/samples/cube/world/src/lib.rs
+++ b/samples/cube/world/src/lib.rs
@@ -219,7 +219,10 @@ impl Cube {
             if self.grid.set(picked.cell, AIR) {
                 self.broken += 1;
             }
-        } else if place {
+        } else {
+            // Placing, because the guard above established that one of the two
+            // is happening. Written as `else if place` this had a third path
+            // nothing could take, and dig wins a tick where both are pressed.
             // Against the face, not into the block — placing into the block
             // being looked at would replace it, which is what digging is for.
             let target = picked.neighbour();

--- a/samples/cube/world/src/lib.rs
+++ b/samples/cube/world/src/lib.rs
@@ -1,0 +1,431 @@
+//! A voxel world: blocks, a player who walks on them, and the ray that decides
+//! which one is being looked at.
+//!
+//! A pure fixed-step function of per-tick input. Everything is fixed-point and
+//! every value that can change future behaviour reaches the digest.
+//!
+//! # What this exists to prove
+//!
+//! The three-dimensional collision crate was written against a vocabulary, and
+//! a vocabulary cannot be run. This is the first thing that uses it the way a
+//! game does — a player who has to stand on blocks, stop at walls, and pick out
+//! the one block in front of them from thousands.
+//!
+//! # Why blocks are not physics bodies
+//!
+//! A chunk of sixteen cubed is four thousand cells. Creating a body per solid
+//! cell would make the collider set the largest thing in the world and the
+//! broadphase's cost a function of terrain rather than of moving things.
+//!
+//! So the grid stays the source of truth and movement asks it directly: gather
+//! the cells the swept path could touch, and sweep against each one's box with
+//! the collision crate's own geometry. The crate supplies the arithmetic; the
+//! world supplies the acceleration structure, which for a uniform grid is the
+//! grid itself.
+
+// The determinism rule in the language standard: a simulation crate performs
+// no floating-point arithmetic whose result can reach digested state.
+#![deny(clippy::float_arithmetic)]
+
+pub mod grid;
+pub mod ray;
+
+use renew_fixed::{Fixed, Vec3};
+use renew_frame::StateHash;
+use renew_physics3d::{Shape, Transform, sweep};
+
+pub use grid::{AIR, Block, Cell, Grid, STONE, block_half_extent};
+pub use ray::{Face, Pick, pick};
+
+/// What the player is asking for this tick.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Intent {
+    /// East–west, clamped to −1, 0 or +1.
+    pub walk_x: i32,
+    /// North–south, clamped the same way.
+    pub walk_z: i32,
+    /// Whether jump is held. Edge detection is the world's job.
+    pub jump: bool,
+    /// Break the block being looked at.
+    pub dig: bool,
+    /// Place a block against the face being looked at.
+    pub place: bool,
+}
+
+impl Intent {
+    /// Doing nothing.
+    pub const IDLE: Self = Self {
+        walk_x: 0,
+        walk_z: 0,
+        jump: false,
+        dig: false,
+        place: false,
+    };
+
+    /// Walking in a direction.
+    #[must_use]
+    pub const fn walking(x: i32, z: i32) -> Self {
+        Self {
+            walk_x: x,
+            walk_z: z,
+            ..Self::IDLE
+        }
+    }
+}
+
+/// The tuning a caller may not change mid-run.
+#[derive(Clone, Copy, Debug)]
+pub struct Tuning {
+    /// Downward acceleration per tick.
+    pub gravity: Fixed,
+    /// Horizontal speed while walking.
+    pub walk_speed: Fixed,
+    /// Upward speed applied at the moment of a jump.
+    pub jump_speed: Fixed,
+    /// Fastest the player may fall.
+    pub terminal_speed: Fixed,
+    /// How far short of a surface the player stops.
+    pub skin: Fixed,
+    /// How many sweep-and-slide iterations one move may take.
+    pub slide_iterations: u32,
+    /// How far the player can reach to break or place.
+    pub reach: Fixed,
+    /// Half the player's width and depth.
+    pub half_width: Fixed,
+    /// Half the player's height.
+    pub half_height: Fixed,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            gravity: Fixed::from_ratio(-1, 40),
+            walk_speed: Fixed::from_ratio(1, 5),
+            jump_speed: Fixed::from_ratio(1, 2),
+            terminal_speed: Fixed::from_int(-1),
+            skin: Fixed::from_bits(64),
+            slide_iterations: 3,
+            reach: Fixed::from_int(5),
+            half_width: Fixed::from_ratio(3, 10),
+            half_height: Fixed::from_ratio(9, 10),
+        }
+    }
+}
+
+/// A normal must lean this far toward vertical to count as ground.
+fn is_ground(normal: Vec3) -> bool {
+    normal.y >= Fixed::from_ratio(1, 2)
+}
+
+/// The world.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "three of the four are input latches — jump, dig and place each               need their own previous state for edge detection, and merging               any two of them would make a player who digs while jumping               behave differently from one who does not"
+)]
+pub struct Cube {
+    grid: Grid,
+    tuning: Tuning,
+    position: Vec3,
+    velocity: Vec3,
+    /// Which way the player is looking. Unit length.
+    look: Vec3,
+    grounded: bool,
+    jump_was_held: bool,
+    dig_was_held: bool,
+    place_was_held: bool,
+    tick: u64,
+    /// How many blocks have been broken and placed, so a test can tell a world
+    /// that did nothing from one that did the same amount of everything.
+    broken: u32,
+    placed: u32,
+}
+
+impl Cube {
+    /// A world with the given terrain and the player at `start`.
+    #[must_use]
+    pub fn new(tuning: Tuning, grid: Grid, start: Vec3) -> Self {
+        Self {
+            grid,
+            tuning,
+            position: start,
+            velocity: Vec3::ZERO,
+            look: Vec3::new(Fixed::ZERO, Fixed::ZERO, Fixed::ONE),
+            grounded: false,
+            jump_was_held: false,
+            dig_was_held: false,
+            place_was_held: false,
+            tick: 0,
+            broken: 0,
+            placed: 0,
+        }
+    }
+
+    /// Point the player somewhere. Ignored if the direction has no length,
+    /// since a zero direction names no block and would otherwise silently
+    /// leave the player looking along whatever they last chose.
+    pub fn look_at(&mut self, direction: Vec3) {
+        if let Some(unit) = direction.normalize() {
+            self.look = unit;
+        }
+    }
+
+    /// The player's shape.
+    fn body(&self) -> Shape {
+        Shape::Box {
+            half_extents: Vec3::new(
+                self.tuning.half_width,
+                self.tuning.half_height,
+                self.tuning.half_width,
+            ),
+        }
+    }
+
+    /// Advance one tick.
+    pub fn step(&mut self, intent: Intent) {
+        self.tick += 1;
+
+        self.act(intent);
+
+        let walk_x = Fixed::from_int(intent.walk_x.clamp(-1, 1)) * self.tuning.walk_speed;
+        let walk_z = Fixed::from_int(intent.walk_z.clamp(-1, 1)) * self.tuning.walk_speed;
+
+        let pressed = intent.jump && !self.jump_was_held;
+        let mut vertical = if pressed && self.grounded {
+            self.tuning.jump_speed
+        } else {
+            self.velocity.y + self.tuning.gravity
+        };
+        vertical = vertical.max(self.tuning.terminal_speed);
+        self.jump_was_held = intent.jump;
+
+        self.velocity = Vec3::new(walk_x, vertical, walk_z);
+        self.move_and_slide();
+    }
+
+    /// Break or place, on the tick the button goes down.
+    fn act(&mut self, intent: Intent) {
+        let dig = intent.dig && !self.dig_was_held;
+        let place = intent.place && !self.place_was_held;
+        self.dig_was_held = intent.dig;
+        self.place_was_held = intent.place;
+
+        if !dig && !place {
+            return;
+        }
+        let Some(picked) = pick(&self.grid, self.eye(), self.look, self.tuning.reach) else {
+            return;
+        };
+        if dig {
+            if self.grid.set(picked.cell, AIR) {
+                self.broken += 1;
+            }
+        } else if place {
+            // Against the face, not into the block — placing into the block
+            // being looked at would replace it, which is what digging is for.
+            let target = picked.neighbour();
+            // And never inside the player: a block placed where the body
+            // stands would trap it with no way out, and the check has to
+            // happen here because the grid does not know where anybody is.
+            if !self.body_overlaps(target) && self.grid.set(target, STONE) {
+                self.placed += 1;
+            }
+        }
+    }
+
+    /// Whether the player's box overlaps a cell.
+    fn body_overlaps(&self, cell: Cell) -> bool {
+        renew_physics3d::collide(
+            self.body(),
+            Transform::at(self.position),
+            Shape::Box {
+                half_extents: block_half_extent(),
+            },
+            Transform::at(cell.centre()),
+        )
+        .is_some()
+    }
+
+    /// Where the player is looking from.
+    #[must_use]
+    pub fn eye(&self) -> Vec3 {
+        // A little below the top of the head, which is where eyes are and,
+        // more usefully, means a player standing under a one-block ceiling can
+        // still look at it.
+        self.position
+            + Vec3::new(
+                Fixed::ZERO,
+                Fixed::from_bits(self.tuning.half_height.to_bits() / 2),
+                Fixed::ZERO,
+            )
+    }
+
+    /// Sweep the player through the world, sliding along what stops them.
+    fn move_and_slide(&mut self) {
+        let mut remaining = self.velocity;
+        let mut grounded = false;
+
+        for _ in 0..self.tuning.slide_iterations {
+            if remaining.length_squared().to_bits() <= 1 {
+                break;
+            }
+            let Some((time, normal)) = self.first_hit(remaining) else {
+                // Nothing in the way: spend what is left and finish.
+                self.position = self.position + remaining;
+                break;
+            };
+            if is_ground(normal) {
+                grounded = true;
+            }
+            self.position = self.position + remaining * time;
+            let unspent = remaining * (Fixed::ONE - time);
+            remaining = unspent.slide_along(normal);
+        }
+
+        // Landing kills downward speed and a ceiling kills upward, or gravity
+        // accumulates while standing still and the player launches on the next
+        // step off.
+        if grounded && self.velocity.y < Fixed::ZERO {
+            self.velocity = Vec3::new(self.velocity.x, Fixed::ZERO, self.velocity.z);
+        }
+        self.grounded = grounded;
+    }
+
+    /// The earliest block the player's box meets along a displacement.
+    ///
+    /// Candidates come from the grid rather than a broadphase: the cells a
+    /// swept box could touch are exactly the ones its bounding box covers, and
+    /// for a uniform grid that is a triple loop rather than a search.
+    fn first_hit(&self, displacement: Vec3) -> Option<(Fixed, Vec3)> {
+        let half = Vec3::new(
+            self.tuning.half_width,
+            self.tuning.half_height,
+            self.tuning.half_width,
+        );
+        let start = self.position;
+        let end = self.position + displacement;
+        let low = Cell::containing(Vec3::new(
+            start.x.min(end.x) - half.x,
+            start.y.min(end.y) - half.y,
+            start.z.min(end.z) - half.z,
+        ));
+        let high = Cell::containing(Vec3::new(
+            start.x.max(end.x) + half.x,
+            start.y.max(end.y) + half.y,
+            start.z.max(end.z) + half.z,
+        ));
+
+        let mut best: Option<(Fixed, Vec3, Cell)> = None;
+        for x in low.x..=high.x {
+            for y in low.y..=high.y {
+                for z in low.z..=high.z {
+                    let cell = Cell::new(x, y, z);
+                    if !self.grid.is_solid(cell) {
+                        continue;
+                    }
+                    let Some(hit) = sweep(
+                        self.body(),
+                        Transform::at(start),
+                        displacement,
+                        Shape::Box {
+                            half_extents: block_half_extent(),
+                        },
+                        Transform::at(cell.centre()),
+                        self.tuning.skin,
+                    ) else {
+                        continue;
+                    };
+                    // Earliest wins; a tie goes to the lower cell, so a player
+                    // meeting a seam between two blocks resolves the same way
+                    // on every machine.
+                    let earlier = best.as_ref().is_none_or(|(time, _, at)| {
+                        hit.time < *time || (hit.time == *time && cell < *at)
+                    });
+                    if earlier {
+                        best = Some((hit.time, hit.normal, cell));
+                    }
+                }
+            }
+        }
+        best.map(|(time, normal, _)| (time, normal))
+    }
+
+    /// Where the player is.
+    #[must_use]
+    pub const fn position(&self) -> Vec3 {
+        self.position
+    }
+
+    /// How fast they are moving.
+    #[must_use]
+    pub const fn velocity(&self) -> Vec3 {
+        self.velocity
+    }
+
+    /// Whether they are standing on something.
+    #[must_use]
+    pub const fn grounded(&self) -> bool {
+        self.grounded
+    }
+
+    /// The terrain.
+    #[must_use]
+    pub const fn grid(&self) -> &Grid {
+        &self.grid
+    }
+
+    /// Which block the player is looking at, if any is in reach.
+    #[must_use]
+    pub fn looking_at(&self) -> Option<Pick> {
+        pick(&self.grid, self.eye(), self.look, self.tuning.reach)
+    }
+
+    /// How many ticks have run.
+    #[must_use]
+    pub const fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    /// How many blocks have been broken, and how many placed.
+    #[must_use]
+    pub const fn edits(&self) -> (u32, u32) {
+        (self.broken, self.placed)
+    }
+
+    /// A hash over every value that can change future behaviour.
+    ///
+    /// **The terrain is in here**, walked in the grid's stated order, because
+    /// a world whose blocks differ plays differently from the next tick on.
+    /// So are the three input latches: two players standing in the same place
+    /// diverge immediately if one is holding a button and the other is not.
+    #[must_use]
+    pub fn digest(&self) -> u64 {
+        let mut hash = StateHash::new().absorb_u64(self.tick);
+        for (cell, block) in self.grid.solids() {
+            hash = hash
+                .absorb_u32(cell.x.cast_unsigned())
+                .absorb_u32(cell.y.cast_unsigned())
+                .absorb_u32(cell.z.cast_unsigned())
+                .absorb_u32(u32::from(block));
+        }
+        for value in [
+            self.position.x,
+            self.position.y,
+            self.position.z,
+            self.velocity.x,
+            self.velocity.y,
+            self.velocity.z,
+            self.look.x,
+            self.look.y,
+            self.look.z,
+        ] {
+            hash = hash.absorb_u64(value.to_bits().cast_unsigned());
+        }
+        hash.absorb_u32(u32::from(self.grounded))
+            .absorb_u32(u32::from(self.jump_was_held))
+            .absorb_u32(u32::from(self.dig_was_held))
+            .absorb_u32(u32::from(self.place_was_held))
+            .absorb_u32(self.broken)
+            .absorb_u32(self.placed)
+            .finish()
+    }
+}

--- a/samples/cube/world/src/ray.rs
+++ b/samples/cube/world/src/ray.rs
@@ -104,12 +104,10 @@ pub fn pick(grid: &Grid, origin: Vec3, direction: Vec3, reach: Fixed) -> Option<
             next[axis] = Fixed::MAX;
             continue;
         }
-        let Some(per_cell) = Fixed::ONE.checked_div(towards.abs()) else {
-            step[axis] = 0;
-            delta[axis] = Fixed::MAX;
-            next[axis] = Fixed::MAX;
-            continue;
-        };
+        // The zero case is handled above, so this cannot fail; falling back to
+        // a boundary infinitely far away keeps the arithmetic total without a
+        // branch nothing could take.
+        let per_cell = Fixed::ONE.checked_div(towards.abs()).unwrap_or(Fixed::MAX);
         delta[axis] = per_cell;
         // The cell spans half a unit either side of its centre, so the
         // distance to the boundary ahead depends on which way we are going.
@@ -132,7 +130,7 @@ pub fn pick(grid: &Grid, origin: Vec3, direction: Vec3, reach: Fixed) -> Option<
             cell,
             // Entered from nowhere; the face the ray is heading away from is
             // the useful answer, since that is where a block would go.
-            face: entry_face(0, -step[0].signum()).unwrap_or(Face::Top),
+            face: entry_face(0, step[0] < 0),
         });
     }
 
@@ -161,22 +159,26 @@ pub fn pick(grid: &Grid, origin: Vec3, direction: Vec3, reach: Fixed) -> Option<
         if grid.is_solid(cell) {
             return Some(Pick {
                 cell,
-                face: entry_face(axis, -step[axis])?,
+                face: entry_face(axis, step[axis] < 0),
             });
         }
     }
     None
 }
 
-/// The face a step of this direction on this axis enters through.
-fn entry_face(axis: usize, towards: i32) -> Option<Face> {
-    Some(match (axis, towards.signum()) {
-        (0, 1) => Face::East,
-        (0, -1) => Face::West,
-        (1, 1) => Face::Top,
-        (1, -1) => Face::Bottom,
-        (2, 1) => Face::North,
-        (2, -1) => Face::South,
-        _ => return None,
-    })
+/// The face a step enters through.
+///
+/// `backwards` is whether the ray is travelling in the negative direction on
+/// that axis — a ray heading east enters through the west face. Total by
+/// construction: six arms and no catch-all, so there is no impossible case to
+/// return nothing for.
+const fn entry_face(axis: usize, backwards: bool) -> Face {
+    match (axis, backwards) {
+        (0, false) => Face::West,
+        (0, true) => Face::East,
+        (1, false) => Face::Bottom,
+        (1, true) => Face::Top,
+        (_, false) => Face::South,
+        (_, true) => Face::North,
+    }
 }

--- a/samples/cube/world/src/ray.rs
+++ b/samples/cube/world/src/ray.rs
@@ -1,0 +1,182 @@
+//! Which block is being looked at.
+
+use crate::grid::{Cell, Grid};
+use renew_fixed::{Fixed, Vec3};
+
+/// Which side of a block a ray entered through.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Face {
+    /// Toward +x.
+    East,
+    /// Toward −x.
+    West,
+    /// Toward +y.
+    Top,
+    /// Toward −y.
+    Bottom,
+    /// Toward +z.
+    North,
+    /// Toward −z.
+    South,
+}
+
+impl Face {
+    /// The whole-step offset from a block to the cell on this side of it.
+    #[must_use]
+    pub const fn step(self) -> (i32, i32, i32) {
+        match self {
+            Self::East => (1, 0, 0),
+            Self::West => (-1, 0, 0),
+            Self::Top => (0, 1, 0),
+            Self::Bottom => (0, -1, 0),
+            Self::North => (0, 0, 1),
+            Self::South => (0, 0, -1),
+        }
+    }
+}
+
+/// A block a ray met, and which way it came in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Pick {
+    /// The block.
+    pub cell: Cell,
+    /// The face entered through.
+    pub face: Face,
+}
+
+impl Pick {
+    /// The empty cell on the near side of the face.
+    ///
+    /// **Where a placed block goes.** Placing into the picked cell would
+    /// replace the block being looked at, which is what digging does — a
+    /// distinction every player expects and every implementation has to make
+    /// explicitly.
+    #[must_use]
+    pub const fn neighbour(self) -> Cell {
+        let (x, y, z) = self.face.step();
+        self.cell.offset(x, y, z)
+    }
+}
+
+/// How many cells a pick may step through before giving up.
+///
+/// The reach bounds it in world units and this bounds it in work: a ray very
+/// nearly parallel to an axis crosses many cells per unit travelled, and a
+/// grid the ray never leaves would otherwise walk until the reach ran out one
+/// tiny step at a time. Fixed rather than tuned, because a pick that visited a
+/// machine-dependent number of cells would pick machine-dependent blocks.
+pub const MAX_STEPS: u32 = 256;
+
+/// The first solid block along a ray, within `reach`.
+///
+/// # How
+///
+/// Grid traversal rather than a shape query: step from cell to cell along the
+/// ray, always crossing whichever axis boundary comes first. That visits every
+/// cell the ray actually passes through, in order, and stops at the first
+/// solid one — where testing every block in reach would be thousands of tests
+/// to answer a question about a handful.
+///
+/// The alternative worth naming is sampling the ray at fixed intervals, which
+/// is simpler and wrong: a step longer than a cell skips blocks, and a step
+/// short enough not to visits the same cell many times over.
+#[must_use]
+pub fn pick(grid: &Grid, origin: Vec3, direction: Vec3, reach: Fixed) -> Option<Pick> {
+    let mut cell = Cell::containing(origin);
+
+    // Per axis: which way we step, how far along the ray one whole cell is,
+    // and how far along the ray the next boundary is.
+    let mut step = [0i32; 3];
+    let mut delta = [Fixed::ZERO; 3];
+    let mut next = [Fixed::ZERO; 3];
+    let components = [direction.x, direction.y, direction.z];
+    let positions = [origin.x, origin.y, origin.z];
+    let cells = [cell.x, cell.y, cell.z];
+
+    for axis in 0..3 {
+        let towards = components[axis];
+        if towards == Fixed::ZERO {
+            // Parallel to this axis: never crosses one of its boundaries. A
+            // boundary infinitely far away is the honest encoding, and it
+            // keeps the comparison below uniform instead of special-casing.
+            step[axis] = 0;
+            delta[axis] = Fixed::MAX;
+            next[axis] = Fixed::MAX;
+            continue;
+        }
+        let Some(per_cell) = Fixed::ONE.checked_div(towards.abs()) else {
+            step[axis] = 0;
+            delta[axis] = Fixed::MAX;
+            next[axis] = Fixed::MAX;
+            continue;
+        };
+        delta[axis] = per_cell;
+        // The cell spans half a unit either side of its centre, so the
+        // distance to the boundary ahead depends on which way we are going.
+        let centre = Fixed::from_int(cells[axis]);
+        let boundary = if towards > Fixed::ZERO {
+            step[axis] = 1;
+            centre + Fixed::from_ratio(1, 2)
+        } else {
+            step[axis] = -1;
+            centre - Fixed::from_ratio(1, 2)
+        };
+        let gap = (boundary - positions[axis]).abs();
+        next[axis] = gap.saturating_mul(per_cell);
+    }
+
+    // The origin itself may be inside a block, which a player standing in one
+    // should be told about rather than having the ray start beyond it.
+    if grid.is_solid(cell) {
+        return Some(Pick {
+            cell,
+            // Entered from nowhere; the face the ray is heading away from is
+            // the useful answer, since that is where a block would go.
+            face: entry_face(0, -step[0].signum()).unwrap_or(Face::Top),
+        });
+    }
+
+    for _ in 0..MAX_STEPS {
+        // Whichever boundary comes first. Ties go to the lower axis, so a ray
+        // through a corner enters through a stated face rather than one that
+        // depends on comparison order.
+        let mut axis = 0;
+        for candidate in 1..3 {
+            if next[candidate] < next[axis] {
+                axis = candidate;
+            }
+        }
+        if next[axis] > reach {
+            return None;
+        }
+
+        let (dx, dy, dz) = match axis {
+            0 => (step[0], 0, 0),
+            1 => (0, step[1], 0),
+            _ => (0, 0, step[2]),
+        };
+        cell = cell.offset(dx, dy, dz);
+        next[axis] = next[axis] + delta[axis];
+
+        if grid.is_solid(cell) {
+            return Some(Pick {
+                cell,
+                face: entry_face(axis, -step[axis])?,
+            });
+        }
+    }
+    None
+}
+
+/// The face a step of this direction on this axis enters through.
+fn entry_face(axis: usize, towards: i32) -> Option<Face> {
+    Some(match (axis, towards.signum()) {
+        (0, 1) => Face::East,
+        (0, -1) => Face::West,
+        (1, 1) => Face::Top,
+        (1, -1) => Face::Bottom,
+        (2, 1) => Face::North,
+        (2, -1) => Face::South,
+        _ => return None,
+    })
+}

--- a/samples/cube/world/tests/voxel.rs
+++ b/samples/cube/world/tests/voxel.rs
@@ -443,3 +443,67 @@ fn the_player_never_ends_a_tick_inside_a_block() {
         );
     }
 }
+
+/// A ray beginning inside a block reports that block rather than starting past
+/// it — which is what a player standing in one needs to be told.
+#[test]
+fn a_ray_starting_inside_a_block_reports_it() {
+    let mut grid = Grid::new(Cell::new(-4, -4, -4), (9, 9, 9));
+    grid.set(Cell::new(0, 0, 0), STONE);
+    let picked = pick(
+        &grid,
+        Vec3::ZERO,
+        Vec3::new(Fixed::ONE, Fixed::ZERO, Fixed::ZERO),
+        Fixed::from_int(10),
+    )
+    .expect("the origin is inside a block");
+    assert_eq!(picked.cell, Cell::new(0, 0, 0));
+    // Heading east, so it is treated as having come in through the west face —
+    // which puts a placed block on the side the ray came from.
+    assert_eq!(picked.face, Face::West);
+}
+
+/// **A ray that never leaves the grid still stops.** The reach bounds it in
+/// world units and the step budget bounds it in work; without the second, a
+/// ray very nearly parallel to an axis walks one tiny step at a time.
+#[test]
+fn a_ray_with_a_huge_reach_stops_at_its_step_budget() {
+    // A big empty grid and a reach far beyond what the budget can cover.
+    let grid = Grid::new(Cell::new(-500, -500, -500), (1001, 1001, 1001));
+    assert!(
+        pick(
+            &grid,
+            Vec3::ZERO,
+            Vec3::new(Fixed::ONE, Fixed::ZERO, Fixed::ZERO),
+            Fixed::from_int(10_000)
+        )
+        .is_none(),
+        "nothing to find, and it must give up rather than walk forever"
+    );
+}
+
+/// Placing at the edge of the world is refused rather than silently dropped
+/// somewhere else, and the counter does not move.
+#[test]
+fn placing_outside_the_grid_is_refused() {
+    // A one-block grid holding one block: every neighbour is outside.
+    let mut grid = Grid::new(Cell::new(0, 0, 0), (1, 1, 1));
+    grid.set(Cell::new(0, 0, 0), STONE);
+    let mut world = Cube::new(Tuning::default(), grid, v(0, 4, 0));
+    world.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+
+    let picked = world.looking_at().expect("the block is below");
+    assert_eq!(picked.cell, Cell::new(0, 0, 0));
+    assert_eq!(picked.neighbour(), Cell::new(0, 1, 0), "outside the grid");
+
+    world.step(Intent {
+        place: true,
+        ..Intent::IDLE
+    });
+    assert_eq!(
+        world.edits(),
+        (0, 0),
+        "a refused placement must not be counted"
+    );
+    assert_eq!(world.grid().solid_count(), 1, "and must not appear");
+}

--- a/samples/cube/world/tests/voxel.rs
+++ b/samples/cube/world/tests/voxel.rs
@@ -1,0 +1,445 @@
+//! The behaviours a voxel game is judged on.
+
+use renew_fixed::{Fixed, Vec3};
+use renew_sample_cube_world::{AIR, Cell, Cube, Face, Grid, Intent, STONE, Tuning, pick};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+/// A walled arena: a stone floor with a wall around its edge.
+///
+/// **Walled rather than open, and that is not decoration.** Outside the grid
+/// is not solid, so a player who walks off the floor falls — correctly, and
+/// forever. A test that then asserts something about their position is really
+/// asserting that they did not wander, which is not what it says it checks.
+/// The first version of these tests was open, and two of them failed for
+/// exactly that reason.
+fn flat_world() -> Grid {
+    let mut grid = Grid::new(Cell::new(-20, -2, -20), (41, 14, 41));
+    grid.fill(Cell::new(-20, 0, -20), Cell::new(20, 0, 20), STONE);
+    // Four walls, three blocks high.
+    grid.fill(Cell::new(-20, 1, -20), Cell::new(-20, 3, 20), STONE);
+    grid.fill(Cell::new(20, 1, -20), Cell::new(20, 3, 20), STONE);
+    grid.fill(Cell::new(-20, 1, -20), Cell::new(20, 3, -20), STONE);
+    grid.fill(Cell::new(-20, 1, 20), Cell::new(20, 3, 20), STONE);
+    grid
+}
+
+fn staged() -> Cube {
+    Cube::new(Tuning::default(), flat_world(), v(0, 4, 0))
+}
+
+fn run(world: &mut Cube, ticks: u32, intent: Intent) {
+    for _ in 0..ticks {
+        world.step(intent);
+    }
+}
+
+#[test]
+fn a_cell_and_a_position_agree_about_where_things_are() {
+    assert_eq!(Cell::containing(Vec3::ZERO), Cell::new(0, 0, 0));
+    assert_eq!(Cell::containing(v(3, -2, 5)), Cell::new(3, -2, 5));
+    // A cell spans half a unit either side of its centre.
+    let just_inside = Vec3::new(Fixed::from_ratio(49, 100), Fixed::ZERO, Fixed::ZERO);
+    assert_eq!(Cell::containing(just_inside), Cell::new(0, 0, 0));
+    let just_over = Vec3::new(Fixed::from_ratio(51, 100), Fixed::ZERO, Fixed::ZERO);
+    assert_eq!(Cell::containing(just_over), Cell::new(1, 0, 0));
+
+    // **The boundary rule is the same on both sides of zero**, which is what
+    // rounding toward zero would get wrong.
+    let below = Vec3::new(-Fixed::from_ratio(51, 100), Fixed::ZERO, Fixed::ZERO);
+    assert_eq!(Cell::containing(below), Cell::new(-1, 0, 0));
+    assert_eq!(Cell::new(3, 4, 5).centre(), v(3, 4, 5));
+}
+
+#[test]
+fn a_grid_answers_inside_and_declines_outside() {
+    let mut grid = Grid::new(Cell::new(0, 0, 0), (4, 4, 4));
+    assert_eq!(grid.get(Cell::new(0, 0, 0)), Some(AIR));
+    assert_eq!(grid.get(Cell::new(3, 3, 3)), Some(AIR));
+    assert_eq!(grid.get(Cell::new(4, 0, 0)), None, "past the far edge");
+    assert_eq!(grid.get(Cell::new(-1, 0, 0)), None, "before the near edge");
+
+    assert!(grid.set(Cell::new(1, 2, 3), STONE));
+    assert_eq!(grid.get(Cell::new(1, 2, 3)), Some(STONE));
+    assert!(grid.is_solid(Cell::new(1, 2, 3)));
+    assert!(!grid.set(Cell::new(9, 9, 9), STONE), "outside is refused");
+
+    // **Outside is not solid**, so a player can leave the world rather than
+    // being trapped at its edge with no explanation.
+    assert!(!grid.is_solid(Cell::new(-1, 0, 0)));
+    assert_eq!(grid.solid_count(), 1);
+}
+
+/// A grid with a dimension of zero is empty rather than an error: a world with
+/// no blocks is a legitimate thing to simulate.
+#[test]
+fn a_degenerate_grid_is_empty_rather_than_refused() {
+    let grid = Grid::new(Cell::new(0, 0, 0), (0, 5, 5));
+    assert_eq!(grid.solid_count(), 0);
+    assert_eq!(grid.get(Cell::new(0, 0, 0)), None);
+    assert_eq!(grid.size(), (0, 5, 5));
+    assert_eq!(grid.min(), Cell::new(0, 0, 0));
+
+    let negative = Grid::new(Cell::new(0, 0, 0), (-3, 5, 5));
+    assert_eq!(negative.size(), (0, 5, 5), "a negative size clamps to none");
+}
+
+#[test]
+fn a_player_falls_and_lands_on_the_ground() {
+    let mut world = staged();
+    assert!(!world.grounded(), "it starts in the air");
+    run(&mut world, 120, Intent::IDLE);
+
+    assert!(world.grounded(), "it should have landed");
+    // The floor's top is y = 0.5 and the player's half-height is 0.9, so the
+    // centre rests near 1.4.
+    let resting = world.position().y;
+    assert!(
+        (resting - Fixed::from_ratio(14, 10)).to_bits().abs() <= 8192,
+        "rested at y = {}, expected about 1.4",
+        resting.to_bits()
+    );
+    assert!(
+        world.velocity().y.to_bits().abs() <= 4096,
+        "landing must kill the downward speed"
+    );
+}
+
+#[test]
+fn a_grounded_player_jumps_and_comes_back_down() {
+    let mut world = staged();
+    run(&mut world, 120, Intent::IDLE);
+    let ground = world.position().y;
+
+    world.step(Intent {
+        jump: true,
+        ..Intent::IDLE
+    });
+    assert!(world.velocity().y > Fixed::ZERO, "the jump pushed it up");
+    run(&mut world, 8, Intent::IDLE);
+    assert!(world.position().y > ground, "it went up");
+
+    run(&mut world, 120, Intent::IDLE);
+    assert!(world.grounded(), "and came back down");
+}
+
+#[test]
+fn a_player_walks_on_the_ground() {
+    let mut world = staged();
+    run(&mut world, 120, Intent::IDLE);
+    let start = world.position();
+
+    run(&mut world, 20, Intent::walking(1, 0));
+    assert!(world.position().x > start.x, "moved east");
+    assert!(world.grounded(), "and stayed on the ground");
+
+    run(&mut world, 20, Intent::walking(0, 1));
+    assert!(world.position().z > start.z, "and north");
+}
+
+/// **A wall stops the player and lets them slide along it**, which is the
+/// three-dimensional case: the two components that are not into the wall both
+/// survive.
+#[test]
+fn a_player_walking_into_a_wall_slides_along_it() {
+    let mut grid = flat_world();
+    // A wall three blocks high at x = 3, spanning the arena.
+    grid.fill(Cell::new(3, 1, -20), Cell::new(3, 3, 20), STONE);
+    let mut world = Cube::new(Tuning::default(), grid, v(0, 4, 0));
+    run(&mut world, 120, Intent::IDLE);
+
+    run(&mut world, 200, Intent::walking(1, 1));
+    // The wall's near face is x = 2.5 and the player is 0.3 wide, so the
+    // centre cannot pass 2.2.
+    assert!(
+        world.position().x < Fixed::from_ratio(23, 10),
+        "walked into the wall, reaching x = {}",
+        world.position().x.to_bits()
+    );
+    // And kept going north the whole time.
+    assert!(
+        world.position().z > Fixed::from_int(3),
+        "should have slid along the wall, reached z = {}",
+        world.position().z.to_bits()
+    );
+}
+
+#[test]
+fn a_ray_picks_the_first_solid_block_and_names_the_face() {
+    let grid = flat_world();
+    // Looking straight down from above the floor.
+    let picked = pick(
+        &grid,
+        v(0, 4, 0),
+        Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO),
+        Fixed::from_int(10),
+    )
+    .expect("the floor is below");
+    assert_eq!(picked.cell, Cell::new(0, 0, 0));
+    assert_eq!(picked.face, Face::Top, "entered through the top");
+    assert_eq!(
+        picked.neighbour(),
+        Cell::new(0, 1, 0),
+        "a block placed here goes above the one looked at"
+    );
+}
+
+#[test]
+fn a_ray_names_the_face_it_came_in_through_on_every_side() {
+    let mut grid = Grid::new(Cell::new(-4, -4, -4), (9, 9, 9));
+    grid.set(Cell::new(0, 0, 0), STONE);
+    let reach = Fixed::from_int(10);
+    let cases = [
+        (v(-4, 0, 0), v(1, 0, 0), Face::West),
+        (v(4, 0, 0), v(-1, 0, 0), Face::East),
+        (v(0, -4, 0), v(0, 1, 0), Face::Bottom),
+        (v(0, 4, 0), v(0, -1, 0), Face::Top),
+        (v(0, 0, -4), v(0, 0, 1), Face::South),
+        (v(0, 0, 4), v(0, 0, -1), Face::North),
+    ];
+    for (origin, direction, expected) in cases {
+        let picked = pick(&grid, origin, direction, reach).expect("the block is on the line");
+        assert_eq!(picked.cell, Cell::new(0, 0, 0));
+        assert_eq!(picked.face, expected, "from {origin:?} along {direction:?}");
+        // The neighbour is always back toward where the ray came from.
+        let (dx, dy, dz) = expected.step();
+        assert_eq!(picked.neighbour(), Cell::new(dx, dy, dz));
+    }
+}
+
+#[test]
+fn a_ray_past_its_reach_finds_nothing() {
+    let grid = flat_world();
+    let down = Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO);
+    assert!(
+        pick(&grid, v(0, 40, 0), down, Fixed::from_int(5)).is_none(),
+        "the floor is forty below and the reach is five"
+    );
+    assert!(
+        pick(&grid, v(0, 40, 0), down, Fixed::from_int(50)).is_some(),
+        "and fifty reaches it"
+    );
+}
+
+#[test]
+fn a_ray_into_empty_space_finds_nothing() {
+    let grid = Grid::new(Cell::new(-4, -4, -4), (9, 9, 9));
+    assert!(
+        pick(
+            &grid,
+            v(0, 0, 0),
+            Vec3::new(Fixed::ONE, Fixed::ZERO, Fixed::ZERO),
+            Fixed::from_int(100)
+        )
+        .is_none()
+    );
+}
+
+/// Breaking removes the block being looked at; placing puts one against its
+/// face rather than inside it.
+#[test]
+fn digging_and_placing_do_what_a_player_expects() {
+    let mut world = staged();
+    run(&mut world, 120, Intent::IDLE);
+    world.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+
+    let target = world.looking_at().expect("standing on the floor").cell;
+    assert!(world.grid().is_solid(target));
+
+    world.step(Intent {
+        dig: true,
+        ..Intent::IDLE
+    });
+    assert!(!world.grid().is_solid(target), "the block is gone");
+    assert_eq!(world.edits(), (1, 0));
+
+    // Holding the button does not keep digging, which is why the latch exists.
+    let before = world.grid().solid_count();
+    run(
+        &mut world,
+        5,
+        Intent {
+            dig: true,
+            ..Intent::IDLE
+        },
+    );
+    assert_eq!(
+        world.grid().solid_count(),
+        before,
+        "a held button digs once"
+    );
+}
+
+#[test]
+fn a_placed_block_goes_against_the_face_and_never_inside_the_player() {
+    let mut world = staged();
+    run(&mut world, 120, Intent::IDLE);
+
+    // Look at a floor block a little away, so the space above it is free.
+    world.look_at(Vec3::new(
+        Fixed::from_int(2),
+        Fixed::from_int(-2),
+        Fixed::ZERO,
+    ));
+    let picked = world.looking_at().expect("looking at the floor");
+    let target = picked.neighbour();
+    assert!(!world.grid().is_solid(target), "the space is free first");
+
+    world.step(Intent {
+        place: true,
+        ..Intent::IDLE
+    });
+    assert!(world.grid().is_solid(target), "a block appeared beside it");
+    assert_eq!(world.edits(), (0, 1));
+
+    // And straight down, where the block would land inside the player's feet,
+    // nothing is placed — a block there would trap them with no way out.
+    world.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+    let before = world.grid().solid_count();
+    world.step(Intent {
+        place: true,
+        ..Intent::IDLE
+    });
+    assert_eq!(
+        world.grid().solid_count(),
+        before,
+        "a block must not be placed inside the player"
+    );
+}
+
+/// **The property that makes a replay an assertion.** The same inputs give the
+/// same digest, and a digest that ignored an input would not be an oracle.
+#[test]
+fn the_same_inputs_give_the_same_digest() {
+    let script: Vec<Intent> = (0..200)
+        .map(|tick: u32| match tick % 13 {
+            0..=3 => Intent::walking(1, 0),
+            4 => Intent {
+                jump: true,
+                ..Intent::IDLE
+            },
+            5..=7 => Intent::walking(0, 1),
+            8 => Intent {
+                dig: true,
+                ..Intent::IDLE
+            },
+            9 => Intent {
+                place: true,
+                ..Intent::IDLE
+            },
+            _ => Intent::IDLE,
+        })
+        .collect();
+
+    let digest_of = |script: &[Intent]| {
+        let mut world = staged();
+        world.look_at(Vec3::new(
+            Fixed::ONE,
+            Fixed::from_int(-1),
+            Fixed::from_ratio(1, 2),
+        ));
+        for &intent in script {
+            world.step(intent);
+        }
+        world.digest()
+    };
+
+    let first = digest_of(&script);
+    assert_eq!(first, digest_of(&script), "the same run digests the same");
+
+    // A walk, not a dig: the dig at that tick might find nothing in reach or
+    // a block already broken, and a negative control that can silently do
+    // nothing proves nothing. A step in a different direction always moves.
+    let mut altered = script.clone();
+    altered[100] = Intent::walking(-1, -1);
+    assert_ne!(
+        digest_of(&altered),
+        first,
+        "a digest that ignores an input is not an oracle"
+    );
+}
+
+/// The terrain is part of the state, so a world where a block was broken
+/// hashes differently from one where it was not — even if the player is in
+/// exactly the same place.
+#[test]
+fn the_digest_covers_the_terrain() {
+    let mut untouched = staged();
+    let mut edited = staged();
+    run(&mut untouched, 120, Intent::IDLE);
+    run(&mut edited, 120, Intent::IDLE);
+    assert_eq!(untouched.digest(), edited.digest(), "identical so far");
+
+    edited.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+    untouched.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+    edited.step(Intent {
+        dig: true,
+        ..Intent::IDLE
+    });
+    untouched.step(Intent::IDLE);
+    assert_ne!(
+        untouched.digest(),
+        edited.digest(),
+        "one of them has a hole in the floor"
+    );
+}
+
+/// Looking nowhere is ignored rather than silently repointing the player, and
+/// the tick counter counts.
+#[test]
+fn a_zero_look_direction_is_ignored_and_ticks_are_counted() {
+    let mut world = staged();
+    run(&mut world, 120, Intent::IDLE);
+    world.look_at(Vec3::new(Fixed::ZERO, Fixed::from_int(-1), Fixed::ZERO));
+    let before = world.looking_at();
+
+    world.look_at(Vec3::ZERO);
+    assert_eq!(
+        world.looking_at(),
+        before,
+        "a zero direction changes nothing"
+    );
+
+    let ticks = world.tick();
+    world.step(Intent::IDLE);
+    assert_eq!(world.tick(), ticks + 1);
+}
+
+/// The player never ends a tick inside the terrain, over a long run of walking
+/// and jumping around a world with obstacles.
+#[test]
+fn the_player_never_ends_a_tick_inside_a_block() {
+    let mut grid = flat_world();
+    grid.fill(Cell::new(3, 1, -20), Cell::new(3, 2, 20), STONE);
+    grid.fill(Cell::new(-20, 1, 3), Cell::new(20, 2, 3), STONE);
+    let mut world = Cube::new(Tuning::default(), grid, v(0, 4, 0));
+
+    for tick in 0..500u32 {
+        let intent = match tick % 19 {
+            0..=5 => Intent::walking(1, 0),
+            6 => Intent {
+                jump: true,
+                ..Intent::IDLE
+            },
+            7..=12 => Intent::walking(0, 1),
+            13..=16 => Intent::walking(-1, -1),
+            _ => Intent::IDLE,
+        };
+        world.step(intent);
+
+        let at = world.position();
+        let cell = Cell::containing(at);
+        assert!(
+            !world.grid().is_solid(cell),
+            "tick {tick}: the player's centre is inside block {cell:?}"
+        );
+        // And never below the floor, whose top is y = 0.5.
+        assert!(
+            at.y > Fixed::ZERO,
+            "tick {tick}: sank to y = {}, through the floor",
+            at.y.to_bits()
+        );
+    }
+}


### PR DESCRIPTION
A grid of blocks, a player swept through it, and the ray that decides
which block is being looked at. Break one, place one against its face,
and never place one inside yourself.

Blocks are not physics bodies, and that is the design. A chunk of
sixteen cubed is four thousand cells; a body per solid cell would make
the collider set the largest thing in the world and the broadphase's
cost a function of terrain rather than of moving things. So the grid
stays the source of truth and movement asks it directly - gather the
cells a swept path could touch, sweep against each one's box with the
collision crate's geometry. The crate supplies the arithmetic; the world
supplies the acceleration structure, which for a uniform grid is the
grid itself.

Picking a block is grid traversal rather than a shape query: step from
cell to cell along the ray, always crossing whichever axis boundary
comes first, and stop at the first solid one. That visits every cell the
ray actually passes through, in order. The alternative worth naming is
sampling at fixed intervals, which is simpler and wrong - a step longer
than a cell skips blocks and a shorter one visits the same cell many
times.

Cells are centred on integers rather than cornered on them, so a block's
half-extent is exactly one half and the arithmetic stays exact. The
rounding that pairs with it puts a boundary position in the higher cell
on both sides of zero, which rounding toward zero would get wrong for
negative coordinates - and a voxel world has those.

Placing goes against the face rather than into the block, because
placing into it is what digging is for. And never inside the player: a
block placed where the body stands would trap it with no way out, and
the check has to live in the world because the grid does not know where
anybody is.

Two of these tests failed on their first run and the fixture now records
why. The world is finite and outside it is not solid, so a player who
walks off the floor falls - correctly, and forever. A test that then
asserts something about their position is really asserting that they did
not wander. The arena is walled now, which is both more honest and more
like a game.