### PR TITLE
feat(samples): a command-line face for the voxel world

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -281,7 +281,7 @@ jobs:
       # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube-world --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -299,7 +299,7 @@ jobs:
       # workspace minus one leaf.
       - name: Build and test without three-dimensional collision
         run: |
-          sel="--workspace --exclude renew-physics3d --exclude renew-sample-cube-world"
+          sel="--workspace --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics3d $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,6 +1756,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-cube"
+version = "0.1.0"
+dependencies = [
+ "renew-fixed",
+ "renew-sample-cube-world",
+]
+
+[[package]]
 name = "renew-sample-cube-world"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube/world", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/cube/Cargo.toml
+++ b/samples/cube/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "renew-sample-cube"
+description = "The cube sample's driver: runs the voxel world headless from a named script and answers with a digest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The voxel game's command-line face: parses a script name and a tick count, runs the world headless, and prints the digest as text and as JSON."
+maturity = "bootstrap"
+core = false
+simulation = false
+
+extension_points = []
+
+[[bin]]
+name = "cube"
+path = "src/main.rs"
+
+[dependencies]
+renew-fixed = { path = "../../crates/fixed" }
+renew-sample-cube-world = { path = "world" }
+
+[lints]
+workspace = true

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -1,0 +1,285 @@
+//! The voxel game's command-line face.
+//!
+//! # Why a driver at all, when the world is already testable
+//!
+//! The world is a pure function and its tests assert its digest, which proves
+//! it reproduces **on one machine**. The determinism obligation is across
+//! machines, and the lane that checks that runs binaries: it needs something
+//! it can execute on three platforms and compare the output of.
+//!
+//! So this is small on purpose. It parses a script name and a tick count, runs
+//! the world headless, and prints one line. Everything interesting is in the
+//! world; everything here is the seam that lets a machine ask it a question.
+
+use renew_fixed::{Fixed, Vec3};
+use renew_sample_cube_world::{Cell, Cube, Grid, Intent, STONE, Tuning};
+
+/// How a run can fail to start.
+///
+/// Malformed input is an ordinary outcome — it comes from a command line — so
+/// it is a value rather than an assertion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CliError {
+    /// A flag nobody knows.
+    UnknownFlag(String),
+    /// A flag that needs a value and did not get one.
+    MissingValue(&'static str),
+    /// A value that is not a number.
+    NotANumber(String),
+    /// A script name that names no script.
+    UnknownScript(String),
+}
+
+impl CliError {
+    /// What went wrong, for a person.
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::UnknownFlag(flag) => format!("unknown flag `{flag}`; try --help"),
+            Self::MissingValue(flag) => format!("`{flag}` needs a value"),
+            Self::NotANumber(text) => format!("`{text}` is not a number"),
+            Self::UnknownScript(name) => {
+                format!("no script called `{name}`; try {}", script_names())
+            }
+        }
+    }
+}
+
+/// What to run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Options {
+    /// Which built-in script drives the player.
+    pub script: Script,
+    /// How many ticks to run.
+    pub ticks: u32,
+    /// Print the answer as JSON rather than as a sentence.
+    pub json: bool,
+    /// Print usage and stop.
+    pub help: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            script: Script::Stand,
+            ticks: 600,
+            json: false,
+            help: false,
+        }
+    }
+}
+
+/// A built-in input script.
+///
+/// **Named rather than supplied as a file**, because the point of this binary
+/// is to be run identically on three platforms and compared. A file is one
+/// more thing that can differ between them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Script {
+    /// Do nothing but fall and land.
+    Stand,
+    /// Walk a loop around the arena.
+    Patrol,
+    /// Walk, jump, dig and place.
+    Build,
+}
+
+impl Script {
+    /// What the player asks for on a given tick.
+    #[must_use]
+    pub fn intent(self, tick: u32) -> Intent {
+        match self {
+            Self::Stand => Intent::IDLE,
+            Self::Patrol => match (tick / 40) % 4 {
+                0 => Intent::walking(1, 0),
+                1 => Intent::walking(0, 1),
+                2 => Intent::walking(-1, 0),
+                _ => Intent::walking(0, -1),
+            },
+            Self::Build => match tick % 17 {
+                0..=4 => Intent::walking(1, 0),
+                5 => Intent {
+                    jump: true,
+                    ..Intent::IDLE
+                },
+                6..=9 => Intent::walking(0, 1),
+                10 => Intent {
+                    dig: true,
+                    ..Intent::IDLE
+                },
+                11 => Intent {
+                    place: true,
+                    ..Intent::IDLE
+                },
+                _ => Intent::IDLE,
+            },
+        }
+    }
+
+    /// The name this script is asked for by.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Stand => "stand",
+            Self::Patrol => "patrol",
+            Self::Build => "build",
+        }
+    }
+
+    /// A script from its name.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "stand" => Some(Self::Stand),
+            "patrol" => Some(Self::Patrol),
+            "build" => Some(Self::Build),
+            _ => None,
+        }
+    }
+}
+
+/// Every script's name, for a message.
+fn script_names() -> String {
+    "stand, patrol, build".to_string()
+}
+
+/// What the run answers with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Report {
+    /// Which script ran.
+    pub script: Script,
+    /// How many ticks it ran for.
+    pub ticks: u64,
+    /// The world's hash at the end.
+    pub digest: u64,
+    /// How many blocks are left.
+    pub solids: usize,
+    /// Broken and placed.
+    pub edits: (u32, u32),
+    /// Whether the player finished standing on something.
+    pub grounded: bool,
+}
+
+/// The usage text.
+///
+/// **Every flag the parser accepts appears here**, which the repository checks
+/// mechanically — a flag a reader cannot discover is a flag that does not
+/// exist as far as anyone but its author is concerned.
+#[must_use]
+pub fn usage() -> &'static str {
+    "cube — run the voxel world headless and answer with a digest\n\
+     \n\
+     Usage: cube [--script NAME] [--ticks N] [--json] [--help]\n\
+     \n\
+     --script NAME   which built-in script drives the player: stand, patrol, build\n\
+     --ticks N       how many ticks to run (default 600)\n\
+     --json          print the answer as JSON rather than as a sentence\n\
+     --help          print this and stop\n"
+}
+
+/// Parse a command line.
+///
+/// # Errors
+///
+/// Returns what was wrong with it.
+pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, CliError> {
+    let mut options = Options::default();
+    let mut arguments = arguments.into_iter();
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--help" | "-h" => options.help = true,
+            "--json" => options.json = true,
+            "--script" => {
+                let name = arguments.next().ok_or(CliError::MissingValue("--script"))?;
+                options.script =
+                    Script::from_name(&name).ok_or(CliError::UnknownScript(name.clone()))?;
+            }
+            "--ticks" => {
+                let text = arguments.next().ok_or(CliError::MissingValue("--ticks"))?;
+                options.ticks = text
+                    .parse()
+                    .map_err(|_| CliError::NotANumber(text.clone()))?;
+            }
+            other => return Err(CliError::UnknownFlag(other.to_string())),
+        }
+    }
+    Ok(options)
+}
+
+/// The arena every script runs in.
+///
+/// Walled, because outside the grid is not solid and a player who walks off
+/// the floor falls forever — which would make `patrol` answer with a digest
+/// about falling rather than about walking.
+#[must_use]
+pub fn arena() -> Grid {
+    let mut grid = Grid::new(Cell::new(-20, -2, -20), (41, 14, 41));
+    grid.fill(Cell::new(-20, 0, -20), Cell::new(20, 0, 20), STONE);
+    grid.fill(Cell::new(-20, 1, -20), Cell::new(-20, 3, 20), STONE);
+    grid.fill(Cell::new(20, 1, -20), Cell::new(20, 3, 20), STONE);
+    grid.fill(Cell::new(-20, 1, -20), Cell::new(20, 3, -20), STONE);
+    grid.fill(Cell::new(-20, 1, 20), Cell::new(20, 3, 20), STONE);
+    grid
+}
+
+/// Run a script and answer.
+#[must_use]
+pub fn run(options: &Options) -> Report {
+    let start = Vec3::new(Fixed::ZERO, Fixed::from_int(4), Fixed::ZERO);
+    let mut world = Cube::new(Tuning::default(), arena(), start);
+    // Looking down and forward, so `build` has something to dig at.
+    world.look_at(Vec3::new(
+        Fixed::ONE,
+        Fixed::from_int(-1),
+        Fixed::from_ratio(1, 2),
+    ));
+
+    for tick in 0..options.ticks {
+        world.step(options.script.intent(tick));
+    }
+
+    Report {
+        script: options.script,
+        ticks: world.tick(),
+        digest: world.digest(),
+        solids: world.grid().solid_count(),
+        edits: world.edits(),
+        grounded: world.grounded(),
+    }
+}
+
+/// The one line a run answers with.
+#[must_use]
+pub fn describe(report: &Report) -> String {
+    let (broken, placed) = report.edits;
+    format!(
+        "cube script={} ticks={} digest={:016x} solids={} broken={} placed={} grounded={}",
+        report.script.name(),
+        report.ticks,
+        report.digest,
+        report.solids,
+        broken,
+        placed,
+        report.grounded
+    )
+}
+
+/// The same answer, machine-readable.
+///
+/// Carries a `schema_version` from its first release, so a consumer can tell a
+/// shape it understands from one it does not.
+#[must_use]
+pub fn describe_json(report: &Report) -> String {
+    let (broken, placed) = report.edits;
+    format!(
+        "{{\"schema_version\":1,\"sample\":\"cube\",\"script\":\"{}\",\"ticks\":{},\
+         \"digest\":\"{:016x}\",\"solids\":{},\"broken\":{},\"placed\":{},\"grounded\":{}}}",
+        report.script.name(),
+        report.ticks,
+        report.digest,
+        report.solids,
+        broken,
+        placed,
+        report.grounded
+    )
+}

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -283,3 +283,30 @@ pub fn describe_json(report: &Report) -> String {
         report.grounded
     )
 }
+
+/// Parse, run, print, and answer with an exit code.
+///
+/// **The whole binary, in the library.** A process shell that did any of this
+/// itself would be a piece of the program no test could drive without spawning
+/// one — and the parts most worth testing, the refusals, are exactly the parts
+/// a spawned process makes hardest to inspect.
+pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    let options = match parse(arguments) {
+        Ok(options) => options,
+        Err(error) => {
+            eprintln!("cube: {}", error.message());
+            return 1;
+        }
+    };
+    if options.help {
+        print!("{}", usage());
+        return 0;
+    }
+    let report = run(&options);
+    if options.json {
+        println!("{}", describe_json(&report));
+    } else {
+        println!("{}", describe(&report));
+    }
+    0
+}

--- a/samples/cube/src/main.rs
+++ b/samples/cube/src/main.rs
@@ -1,24 +1,6 @@
-//! The `cube` binary.
-
-use renew_sample_cube::{describe, describe_json, parse, run, usage};
+//! Process shell: argument strings in, exit code out. Everything else lives in
+//! the library so tests can drive it without a process.
 
 fn main() -> std::process::ExitCode {
-    let options = match parse(std::env::args().skip(1)) {
-        Ok(options) => options,
-        Err(error) => {
-            eprintln!("cube: {}", error.message());
-            return std::process::ExitCode::FAILURE;
-        }
-    };
-    if options.help {
-        print!("{}", usage());
-        return std::process::ExitCode::SUCCESS;
-    }
-    let report = run(&options);
-    if options.json {
-        println!("{}", describe_json(&report));
-    } else {
-        println!("{}", describe(&report));
-    }
-    std::process::ExitCode::SUCCESS
+    std::process::ExitCode::from(renew_sample_cube::run_cli(std::env::args().skip(1)))
 }

--- a/samples/cube/src/main.rs
+++ b/samples/cube/src/main.rs
@@ -1,0 +1,24 @@
+//! The `cube` binary.
+
+use renew_sample_cube::{describe, describe_json, parse, run, usage};
+
+fn main() -> std::process::ExitCode {
+    let options = match parse(std::env::args().skip(1)) {
+        Ok(options) => options,
+        Err(error) => {
+            eprintln!("cube: {}", error.message());
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+    if options.help {
+        print!("{}", usage());
+        return std::process::ExitCode::SUCCESS;
+    }
+    let report = run(&options);
+    if options.json {
+        println!("{}", describe_json(&report));
+    } else {
+        println!("{}", describe(&report));
+    }
+    std::process::ExitCode::SUCCESS
+}

--- a/samples/cube/tests/binary.rs
+++ b/samples/cube/tests/binary.rs
@@ -1,0 +1,83 @@
+//! The binary, run as a binary.
+//!
+//! Everything else here drives the library directly, which is faster and says
+//! nothing about whether the executable works. This spawns it — the same way
+//! the determinism lane does on three platforms — so the process shell, the
+//! argument plumbing and the exit codes are exercised as a caller meets them.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_cube");
+
+/// Run it, and give back what it said and whether it succeeded.
+///
+/// The allowance is explicit because the crate's lint configuration exempts
+/// test bodies and this is a free helper beside them. A binary cargo has just
+/// built and cannot run is not a condition worth encoding a recovery for.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn invoke(arguments: &[&str]) -> (bool, String, String) {
+    let output = Command::new(BINARY)
+        .args(arguments)
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn the_binary_runs_a_script_and_prints_a_digest() {
+    let (ok, out, _) = invoke(&["--script", "patrol", "--ticks", "120"]);
+    assert!(ok, "a well-formed run should succeed");
+    assert!(out.starts_with("cube script=patrol"), "got: {out}");
+    assert!(out.contains("ticks=120"), "got: {out}");
+    assert!(out.contains("digest="), "got: {out}");
+}
+
+/// **The property the lane exists for**: the same command answers the same,
+/// which is what makes comparing three platforms' output meaningful.
+#[test]
+fn the_binary_answers_the_same_twice() {
+    let first = invoke(&["--script", "build", "--ticks", "150"]).1;
+    let second = invoke(&["--script", "build", "--ticks", "150"]).1;
+    assert_eq!(first, second, "the same command must answer the same");
+    assert!(!first.trim().is_empty(), "and must answer at all");
+}
+
+#[test]
+fn the_binary_prints_json_when_asked() {
+    let (ok, out, _) = invoke(&["--script", "stand", "--ticks", "60", "--json"]);
+    assert!(ok);
+    let line = out.trim();
+    assert!(line.starts_with('{') && line.ends_with('}'), "got: {line}");
+    assert!(line.contains("\"schema_version\":1"), "got: {line}");
+    assert!(line.contains("\"sample\":\"cube\""), "got: {line}");
+}
+
+#[test]
+fn the_binary_prints_usage_and_stops() {
+    let (ok, out, _) = invoke(&["--help"]);
+    assert!(ok, "help is not a failure");
+    assert!(out.contains("--script"), "got: {out}");
+    assert!(!out.contains("digest="), "and it did not run anything");
+}
+
+/// A refusal goes to the error stream and sets a failing status, so a script
+/// calling this can tell without parsing anything.
+#[test]
+fn the_binary_refuses_a_bad_command_line_on_the_error_stream() {
+    let (ok, out, err) = invoke(&["--wat"]);
+    assert!(!ok, "an unknown flag must fail");
+    assert!(out.is_empty(), "and print nothing to the output stream");
+    assert!(err.contains("--wat"), "while naming the flag: {err}");
+
+    let (ok, _, err) = invoke(&["--script", "fly"]);
+    assert!(!ok);
+    assert!(err.contains("fly"), "got: {err}");
+}

--- a/samples/cube/tests/cli.rs
+++ b/samples/cube/tests/cli.rs
@@ -192,3 +192,20 @@ fn a_run_of_no_ticks_answers() {
     assert!(!report.grounded, "it has not fallen yet");
     assert!(report.solids > 0);
 }
+
+/// The whole binary, driven without spawning one.
+#[test]
+fn the_command_line_answers_with_an_exit_code() {
+    use renew_sample_cube::run_cli;
+
+    assert_eq!(run_cli(args("--ticks 30")), 0, "a good run succeeds");
+    assert_eq!(run_cli(args("--ticks 30 --json")), 0);
+    assert_eq!(run_cli(args("--help")), 0, "help is not a failure");
+    assert_eq!(run_cli(args("--wat")), 1, "an unknown flag fails");
+    assert_eq!(
+        run_cli(args("--script fly")),
+        1,
+        "so does an unknown script"
+    );
+    assert_eq!(run_cli(args("--ticks lots")), 1);
+}

--- a/samples/cube/tests/cli.rs
+++ b/samples/cube/tests/cli.rs
@@ -1,0 +1,194 @@
+//! The command line, and the line a run answers with.
+
+use renew_sample_cube::{CliError, Options, Script, describe, describe_json, parse, run, usage};
+
+fn args(text: &str) -> Vec<String> {
+    text.split_whitespace().map(str::to_string).collect()
+}
+
+#[test]
+fn no_arguments_gives_the_defaults() {
+    let options = parse(Vec::new()).expect("nothing to object to");
+    assert_eq!(options, Options::default());
+    assert_eq!(options.script, Script::Stand);
+    assert_eq!(options.ticks, 600);
+    assert!(!options.json);
+    assert!(!options.help);
+}
+
+#[test]
+fn every_flag_parses() {
+    let options = parse(args("--script build --ticks 42 --json")).expect("well formed");
+    assert_eq!(options.script, Script::Build);
+    assert_eq!(options.ticks, 42);
+    assert!(options.json);
+
+    assert!(parse(args("--help")).expect("well formed").help);
+    assert!(parse(args("-h")).expect("well formed").help);
+    assert_eq!(
+        parse(args("--script patrol")).expect("well formed").script,
+        Script::Patrol
+    );
+}
+
+/// A malformed command line is refused with a reason rather than guessed at,
+/// and every message names what to do about it.
+#[test]
+fn a_malformed_command_line_is_refused_with_a_reason() {
+    assert_eq!(
+        parse(args("--wat")),
+        Err(CliError::UnknownFlag("--wat".to_string()))
+    );
+    assert_eq!(
+        parse(args("--script")),
+        Err(CliError::MissingValue("--script"))
+    );
+    assert_eq!(
+        parse(args("--ticks")),
+        Err(CliError::MissingValue("--ticks"))
+    );
+    assert_eq!(
+        parse(args("--ticks lots")),
+        Err(CliError::NotANumber("lots".to_string()))
+    );
+    assert_eq!(
+        parse(args("--script fly")),
+        Err(CliError::UnknownScript("fly".to_string()))
+    );
+
+    // Every refusal names the thing at fault, so a reader can find it without
+    // re-reading their own command line character by character.
+    for (error, subject) in [
+        (CliError::UnknownFlag("--wat".to_string()), "--wat"),
+        (CliError::MissingValue("--ticks"), "--ticks"),
+        (CliError::NotANumber("lots".to_string()), "lots"),
+        (CliError::UnknownScript("fly".to_string()), "fly"),
+    ] {
+        let message = error.message();
+        assert!(
+            message.contains(subject),
+            "the refusal does not name `{subject}`: {message}"
+        );
+    }
+    // And the one that can suggest an alternative does.
+    assert!(
+        CliError::UnknownScript("fly".to_string())
+            .message()
+            .contains("patrol"),
+        "an unknown script should say what the real ones are"
+    );
+}
+
+/// **Every flag the parser accepts appears in the usage text.** A flag a
+/// reader cannot discover is a flag that does not exist as far as anyone but
+/// its author is concerned.
+#[test]
+fn the_usage_text_documents_every_flag() {
+    let text = usage();
+    for flag in ["--script", "--ticks", "--json", "--help"] {
+        assert!(text.contains(flag), "usage does not mention {flag}");
+    }
+    for name in ["stand", "patrol", "build"] {
+        assert!(
+            text.contains(name),
+            "usage does not mention the {name} script"
+        );
+    }
+}
+
+#[test]
+fn every_script_has_a_name_that_round_trips() {
+    for script in [Script::Stand, Script::Patrol, Script::Build] {
+        assert_eq!(Script::from_name(script.name()), Some(script));
+    }
+    assert_eq!(Script::from_name("nope"), None);
+}
+
+/// **The point of the binary**: the same run answers the same, which is what
+/// lets three platforms compare one line.
+#[test]
+fn a_run_is_reproducible() {
+    let options = Options {
+        script: Script::Build,
+        ticks: 300,
+        json: false,
+        help: false,
+    };
+    let first = run(&options);
+    let second = run(&options);
+    assert_eq!(first, second, "the same run must answer the same");
+
+    // And a different script answers differently, or the digest is not
+    // watching the thing it claims to.
+    let other = run(&Options {
+        script: Script::Patrol,
+        ..options
+    });
+    assert_ne!(first.digest, other.digest);
+
+    // As does a different length.
+    let longer = run(&Options {
+        ticks: 301,
+        ..options
+    });
+    assert_ne!(first.digest, longer.digest);
+}
+
+#[test]
+fn standing_still_lands_and_builds_edits_the_world() {
+    let stood = run(&Options {
+        script: Script::Stand,
+        ticks: 300,
+        ..Options::default()
+    });
+    assert!(stood.grounded, "it falls onto the floor and stays there");
+    assert_eq!(stood.edits, (0, 0), "and touches nothing");
+    assert!(stood.solids > 0, "the arena is not empty");
+
+    let built = run(&Options {
+        script: Script::Build,
+        ticks: 300,
+        ..Options::default()
+    });
+    let (broken, placed) = built.edits;
+    assert!(broken > 0, "building digs");
+    assert!(placed > 0, "and places");
+}
+
+#[test]
+fn the_answer_reads_and_parses() {
+    let report = run(&Options {
+        script: Script::Patrol,
+        ticks: 120,
+        ..Options::default()
+    });
+
+    let line = describe(&report);
+    assert!(line.starts_with("cube script=patrol"));
+    assert!(line.contains("ticks=120"));
+    assert!(line.contains(&format!("digest={:016x}", report.digest)));
+
+    let json = describe_json(&report);
+    assert!(
+        json.contains("\"schema_version\":1"),
+        "a machine-readable output carries its version from the first release"
+    );
+    assert!(json.contains("\"sample\":\"cube\""));
+    assert!(json.contains("\"script\":\"patrol\""));
+    assert!(json.contains("\"ticks\":120"));
+    assert!(json.contains(&format!("\"digest\":\"{:016x}\"", report.digest)));
+    assert!(json.starts_with('{') && json.ends_with('}'));
+}
+
+/// A zero-tick run is answerable rather than a special case: it is the world
+/// as constructed, which is a legitimate thing to ask for a digest of.
+#[test]
+fn a_run_of_no_ticks_answers() {
+    let report = run(&Options {
+        ticks: 0,
+        ..Options::default()
+    });
+    assert_eq!(report.ticks, 0);
+    assert!(!report.grounded, "it has not fallen yet");
+    assert!(report.solids > 0);
+}


### PR DESCRIPTION
The world is a pure function and its tests assert its digest, which
proves it reproduces on one machine. The obligation is across machines,
and the lane that checks that runs binaries - it needs something it can
execute on three platforms and compare the output of.

So this is small on purpose: a script name, a tick count, and one line
out. Three built-in scripts drive the player - stand, patrol, build -
and they are named rather than read from a file, because the point is to
run identically everywhere and a file is one more thing that can differ.

Both output shapes are there because the vocabulary asks for both: a
sentence for a person and JSON for a machine, the latter carrying a
schema version from its first release so a consumer can tell a shape it
understands from one it does not.

Refusals name the thing at fault. A command line comes from outside, so
a malformed one is an ordinary outcome rather than an assertion, and the
test checks each message contains its own subject - a reader should not
have to re-read their own command line character by character to find
what a tool objected to.

The removability cells name the driver alongside the world it drives.
The local check did not ask for that and the lane would have: a
configuration that removes the world while keeping the binary depending
on it cannot build, so the cell would have proved nothing.