### PR TITLE
feat(samples): a command-line face for the platformer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -241,7 +241,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -281,7 +281,7 @@ jobs:
       # and this cell went red until it named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -290,7 +290,7 @@ jobs:
       # minus one leaf, and it grows the moment a sample collides.
       - name: Build and test without collision detection
         run: |
-          sel="--workspace --exclude renew-physics2d --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-physics2d --exclude renew-sample-leap --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-physics2d $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,6 +1821,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-leap"
+version = "0.1.0"
+dependencies = [
+ "renew-fixed",
+ "renew-sample-leap-world",
+]
+
+[[package]]
 name = "renew-sample-leap-world"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/leap/Cargo.toml
+++ b/samples/leap/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "renew-sample-leap"
+description = "The leap sample's driver: runs the platformer headless from a named script and answers with a digest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The platformer's command-line face: parses a script name and a tick count, runs the world headless, and prints the digest as text and as JSON."
+maturity = "bootstrap"
+core = false
+simulation = false
+
+extension_points = []
+
+[[bin]]
+name = "leap"
+path = "src/main.rs"
+
+[dependencies]
+renew-fixed = { path = "../../crates/fixed" }
+renew-sample-leap-world = { path = "world" }
+
+[lints]
+workspace = true

--- a/samples/leap/src/lib.rs
+++ b/samples/leap/src/lib.rs
@@ -1,0 +1,255 @@
+//! The platformer's command-line face.
+//!
+//! Small on purpose, and for the same reason as the voxel sample's: the world
+//! is a pure function whose tests prove it reproduces **on one machine**, and
+//! the obligation is across machines. The lane that checks that runs binaries,
+//! so it needs something executable whose output can be compared.
+
+use renew_fixed::{Fixed, Vec2};
+use renew_sample_leap_world::{Intent, Leap, Platform, Tuning};
+
+/// How a run can fail to start.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CliError {
+    /// A flag nobody knows.
+    UnknownFlag(String),
+    /// A flag that needs a value and did not get one.
+    MissingValue(&'static str),
+    /// A value that is not a number.
+    NotANumber(String),
+    /// A script name that names no script.
+    UnknownScript(String),
+}
+
+impl CliError {
+    /// What went wrong, for a person.
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::UnknownFlag(flag) => format!("unknown flag `{flag}`; try --help"),
+            Self::MissingValue(flag) => format!("`{flag}` needs a value"),
+            Self::NotANumber(text) => format!("`{text}` is not a number"),
+            Self::UnknownScript(name) => {
+                format!("no script called `{name}`; try stand, dash, hop")
+            }
+        }
+    }
+}
+
+/// A built-in input script.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Script {
+    /// Fall, land, and stay put.
+    Stand,
+    /// Run right into the wall, then back.
+    Dash,
+    /// Run and jump repeatedly.
+    Hop,
+}
+
+impl Script {
+    /// What the player asks for on a given tick.
+    #[must_use]
+    pub fn intent(self, tick: u32) -> Intent {
+        match self {
+            Self::Stand => Intent::IDLE,
+            Self::Dash => {
+                if (tick / 120).is_multiple_of(2) {
+                    Intent::running(1)
+                } else {
+                    Intent::running(-1)
+                }
+            }
+            Self::Hop => match tick % 24 {
+                0..=9 => Intent::running(1),
+                10 => Intent::jumping(1),
+                11..=20 => Intent::running(-1),
+                21 => Intent::jumping(-1),
+                _ => Intent::IDLE,
+            },
+        }
+    }
+
+    /// The name this script is asked for by.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Stand => "stand",
+            Self::Dash => "dash",
+            Self::Hop => "hop",
+        }
+    }
+
+    /// A script from its name.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "stand" => Some(Self::Stand),
+            "dash" => Some(Self::Dash),
+            "hop" => Some(Self::Hop),
+            _ => None,
+        }
+    }
+}
+
+/// What to run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Options {
+    /// Which built-in script drives the character.
+    pub script: Script,
+    /// How many ticks to run.
+    pub ticks: u32,
+    /// Print the answer as JSON rather than as a sentence.
+    pub json: bool,
+    /// Print usage and stop.
+    pub help: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            script: Script::Stand,
+            ticks: 600,
+            json: false,
+            help: false,
+        }
+    }
+}
+
+/// What the run answers with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Report {
+    /// Which script ran.
+    pub script: Script,
+    /// How many ticks it ran for.
+    pub ticks: u64,
+    /// The world's hash at the end.
+    pub digest: u64,
+    /// Whether the character finished on the ground.
+    pub grounded: bool,
+    /// Whether it finished against a wall.
+    pub against_wall: bool,
+}
+
+/// The usage text. **Every flag the parser accepts appears here.**
+#[must_use]
+pub fn usage() -> &'static str {
+    "leap — run the platformer headless and answer with a digest\n\
+     \n\
+     Usage: leap [--script NAME] [--ticks N] [--json] [--help]\n\
+     \n\
+     --script NAME   which built-in script drives the character: stand, dash, hop\n\
+     --ticks N       how many ticks to run (default 600)\n\
+     --json          print the answer as JSON rather than as a sentence\n\
+     --help          print this and stop\n"
+}
+
+/// Parse a command line.
+///
+/// # Errors
+///
+/// Returns what was wrong with it.
+pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, CliError> {
+    let mut options = Options::default();
+    let mut arguments = arguments.into_iter();
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--help" | "-h" => options.help = true,
+            "--json" => options.json = true,
+            "--script" => {
+                let name = arguments.next().ok_or(CliError::MissingValue("--script"))?;
+                options.script =
+                    Script::from_name(&name).ok_or(CliError::UnknownScript(name.clone()))?;
+            }
+            "--ticks" => {
+                let text = arguments.next().ok_or(CliError::MissingValue("--ticks"))?;
+                options.ticks = text
+                    .parse()
+                    .map_err(|_| CliError::NotANumber(text.clone()))?;
+            }
+            other => return Err(CliError::UnknownFlag(other.to_string())),
+        }
+    }
+    Ok(options)
+}
+
+/// The level every script runs in: a floor, a wall to run into, and a ledge to
+/// walk off.
+#[must_use]
+pub fn level() -> Vec<Platform> {
+    vec![
+        Platform::new(0, 0, 40, 1),
+        Platform::new(10, 5, 1, 4),
+        Platform::new(-14, 4, 3, 1),
+    ]
+}
+
+/// Run a script and answer.
+#[must_use]
+pub fn run(options: &Options) -> Report {
+    let start = Vec2::new(Fixed::ZERO, Fixed::from_int(6));
+    let mut world = Leap::new(Tuning::default(), start, &level());
+    for tick in 0..options.ticks {
+        world.step(options.script.intent(tick));
+    }
+    Report {
+        script: options.script,
+        ticks: world.tick(),
+        digest: world.digest(),
+        grounded: world.footing().grounded,
+        against_wall: world.footing().against_wall,
+    }
+}
+
+/// The one line a run answers with.
+#[must_use]
+pub fn describe(report: &Report) -> String {
+    format!(
+        "leap script={} ticks={} digest={:016x} grounded={} wall={}",
+        report.script.name(),
+        report.ticks,
+        report.digest,
+        report.grounded,
+        report.against_wall
+    )
+}
+
+/// The same answer, machine-readable, carrying its schema version from the
+/// first release.
+#[must_use]
+pub fn describe_json(report: &Report) -> String {
+    format!(
+        "{{\"schema_version\":1,\"sample\":\"leap\",\"script\":\"{}\",\"ticks\":{},\
+         \"digest\":\"{:016x}\",\"grounded\":{},\"against_wall\":{}}}",
+        report.script.name(),
+        report.ticks,
+        report.digest,
+        report.grounded,
+        report.against_wall
+    )
+}
+
+/// Parse, run, print, and answer with an exit code.
+///
+/// The whole binary, in the library, so a test can drive every refusal without
+/// spawning a process to inspect.
+pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    let options = match parse(arguments) {
+        Ok(options) => options,
+        Err(error) => {
+            eprintln!("leap: {}", error.message());
+            return 1;
+        }
+    };
+    if options.help {
+        print!("{}", usage());
+        return 0;
+    }
+    let report = run(&options);
+    if options.json {
+        println!("{}", describe_json(&report));
+    } else {
+        println!("{}", describe(&report));
+    }
+    0
+}

--- a/samples/leap/src/main.rs
+++ b/samples/leap/src/main.rs
@@ -1,0 +1,6 @@
+//! Process shell: argument strings in, exit code out. Everything else lives in
+//! the library so tests can drive it without a process.
+
+fn main() -> std::process::ExitCode {
+    std::process::ExitCode::from(renew_sample_leap::run_cli(std::env::args().skip(1)))
+}

--- a/samples/leap/tests/binary.rs
+++ b/samples/leap/tests/binary.rs
@@ -1,0 +1,83 @@
+//! The binary, run as a binary.
+//!
+//! Everything else here drives the library directly, which is faster and says
+//! nothing about whether the executable works. This spawns it — the same way
+//! the determinism lane will on three platforms — so the process shell, the
+//! argument plumbing and the exit codes are exercised as a caller meets them.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_leap");
+
+/// Run it, and give back what it said and whether it succeeded.
+///
+/// The allowance is explicit because the crate's lint configuration exempts
+/// test bodies and this is a free helper beside them. A binary cargo has just
+/// built and cannot run is not a condition worth encoding a recovery for.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn invoke(arguments: &[&str]) -> (bool, String, String) {
+    let output = Command::new(BINARY)
+        .args(arguments)
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn the_binary_runs_a_script_and_prints_a_digest() {
+    let (ok, out, _) = invoke(&["--script", "dash", "--ticks", "120"]);
+    assert!(ok, "a well-formed run should succeed");
+    assert!(out.starts_with("leap script=dash"), "got: {out}");
+    assert!(out.contains("ticks=120"), "got: {out}");
+    assert!(out.contains("digest="), "got: {out}");
+}
+
+/// **The property the lane exists for**: the same command answers the same,
+/// which is what makes comparing three platforms' output meaningful.
+#[test]
+fn the_binary_answers_the_same_twice() {
+    let first = invoke(&["--script", "hop", "--ticks", "150"]).1;
+    let second = invoke(&["--script", "hop", "--ticks", "150"]).1;
+    assert_eq!(first, second, "the same command must answer the same");
+    assert!(!first.trim().is_empty(), "and must answer at all");
+}
+
+#[test]
+fn the_binary_prints_json_when_asked() {
+    let (ok, out, _) = invoke(&["--script", "stand", "--ticks", "60", "--json"]);
+    assert!(ok);
+    let line = out.trim();
+    assert!(line.starts_with('{') && line.ends_with('}'), "got: {line}");
+    assert!(line.contains("\"schema_version\":1"), "got: {line}");
+    assert!(line.contains("\"sample\":\"leap\""), "got: {line}");
+}
+
+#[test]
+fn the_binary_prints_usage_and_stops() {
+    let (ok, out, _) = invoke(&["--help"]);
+    assert!(ok, "help is not a failure");
+    assert!(out.contains("--script"), "got: {out}");
+    assert!(!out.contains("digest="), "and it did not run anything");
+}
+
+/// A refusal goes to the error stream and sets a failing status, so a script
+/// calling this can tell without parsing anything.
+#[test]
+fn the_binary_refuses_a_bad_command_line_on_the_error_stream() {
+    let (ok, out, err) = invoke(&["--wat"]);
+    assert!(!ok, "an unknown flag must fail");
+    assert!(out.is_empty(), "and print nothing to the output stream");
+    assert!(err.contains("--wat"), "while naming the flag: {err}");
+
+    let (ok, _, err) = invoke(&["--script", "fly"]);
+    assert!(!ok);
+    assert!(err.contains("fly"), "got: {err}");
+}

--- a/samples/leap/tests/cli.rs
+++ b/samples/leap/tests/cli.rs
@@ -1,0 +1,182 @@
+//! The command line, and the line a run answers with.
+
+use renew_sample_leap::{
+    CliError, Options, Script, describe, describe_json, parse, run, run_cli, usage,
+};
+
+fn args(text: &str) -> Vec<String> {
+    text.split_whitespace().map(str::to_string).collect()
+}
+
+#[test]
+fn no_arguments_gives_the_defaults() {
+    let options = parse(Vec::new()).expect("nothing to object to");
+    assert_eq!(options, Options::default());
+    assert_eq!(options.script, Script::Stand);
+    assert_eq!(options.ticks, 600);
+}
+
+#[test]
+fn every_flag_parses() {
+    let options = parse(args("--script hop --ticks 42 --json")).expect("well formed");
+    assert_eq!(options.script, Script::Hop);
+    assert_eq!(options.ticks, 42);
+    assert!(options.json);
+    assert!(parse(args("--help")).expect("well formed").help);
+    assert!(parse(args("-h")).expect("well formed").help);
+    assert_eq!(
+        parse(args("--script dash")).expect("well formed").script,
+        Script::Dash
+    );
+}
+
+#[test]
+fn a_malformed_command_line_is_refused_and_names_what_is_wrong() {
+    assert_eq!(
+        parse(args("--wat")),
+        Err(CliError::UnknownFlag("--wat".to_string()))
+    );
+    assert_eq!(
+        parse(args("--script")),
+        Err(CliError::MissingValue("--script"))
+    );
+    assert_eq!(
+        parse(args("--ticks")),
+        Err(CliError::MissingValue("--ticks"))
+    );
+    assert_eq!(
+        parse(args("--ticks soon")),
+        Err(CliError::NotANumber("soon".to_string()))
+    );
+    assert_eq!(
+        parse(args("--script fly")),
+        Err(CliError::UnknownScript("fly".to_string()))
+    );
+
+    for (error, subject) in [
+        (CliError::UnknownFlag("--wat".to_string()), "--wat"),
+        (CliError::MissingValue("--ticks"), "--ticks"),
+        (CliError::NotANumber("soon".to_string()), "soon"),
+        (CliError::UnknownScript("fly".to_string()), "fly"),
+    ] {
+        assert!(
+            error.message().contains(subject),
+            "the refusal does not name `{subject}`: {}",
+            error.message()
+        );
+    }
+    assert!(
+        CliError::UnknownScript("fly".to_string())
+            .message()
+            .contains("dash"),
+        "an unknown script should say what the real ones are"
+    );
+}
+
+/// **Every flag the parser accepts appears in the usage text.**
+#[test]
+fn the_usage_text_documents_every_flag() {
+    let text = usage();
+    for flag in ["--script", "--ticks", "--json", "--help"] {
+        assert!(text.contains(flag), "usage does not mention {flag}");
+    }
+    for name in ["stand", "dash", "hop"] {
+        assert!(text.contains(name), "usage does not mention {name}");
+    }
+}
+
+#[test]
+fn every_script_has_a_name_that_round_trips() {
+    for script in [Script::Stand, Script::Dash, Script::Hop] {
+        assert_eq!(Script::from_name(script.name()), Some(script));
+    }
+    assert_eq!(Script::from_name("nope"), None);
+}
+
+/// The same run answers the same, which is what lets three platforms compare
+/// one line — and different runs answer differently, or the digest is not
+/// watching what it claims to.
+#[test]
+fn a_run_is_reproducible_and_discriminating() {
+    let options = Options {
+        script: Script::Hop,
+        ticks: 300,
+        json: false,
+        help: false,
+    };
+    assert_eq!(run(&options), run(&options));
+
+    let other = run(&Options {
+        script: Script::Dash,
+        ..options
+    });
+    assert_ne!(run(&options).digest, other.digest);
+
+    let longer = run(&Options {
+        ticks: 301,
+        ..options
+    });
+    assert_ne!(run(&options).digest, longer.digest);
+}
+
+#[test]
+fn standing_still_lands_and_dashing_meets_the_wall() {
+    let stood = run(&Options {
+        script: Script::Stand,
+        ticks: 200,
+        ..Options::default()
+    });
+    assert!(stood.grounded, "it falls onto the floor and stays");
+    assert!(!stood.against_wall, "and touches nothing");
+
+    // Dashing right reaches the wall at x = 10 within its first leg.
+    let dashed = run(&Options {
+        script: Script::Dash,
+        ticks: 120,
+        ..Options::default()
+    });
+    assert!(dashed.grounded, "still on the floor");
+    assert!(dashed.against_wall, "and pressed against the wall");
+}
+
+#[test]
+fn the_answer_reads_and_parses() {
+    let report = run(&Options {
+        script: Script::Dash,
+        ticks: 120,
+        ..Options::default()
+    });
+
+    let line = describe(&report);
+    assert!(line.starts_with("leap script=dash"));
+    assert!(line.contains("ticks=120"));
+    assert!(line.contains(&format!("digest={:016x}", report.digest)));
+
+    let json = describe_json(&report);
+    assert!(json.contains("\"schema_version\":1"));
+    assert!(json.contains("\"sample\":\"leap\""));
+    assert!(json.contains("\"script\":\"dash\""));
+    assert!(json.contains(&format!("\"digest\":\"{:016x}\"", report.digest)));
+    assert!(json.starts_with('{') && json.ends_with('}'));
+}
+
+#[test]
+fn a_run_of_no_ticks_answers() {
+    let report = run(&Options {
+        ticks: 0,
+        ..Options::default()
+    });
+    assert_eq!(report.ticks, 0);
+    assert!(!report.grounded, "it has not fallen yet");
+}
+
+/// The whole binary, driven without spawning one.
+#[test]
+fn the_command_line_answers_with_an_exit_code() {
+    assert_eq!(run_cli(args("--ticks 30")), 0);
+    assert_eq!(run_cli(args("--ticks 30 --json")), 0);
+    assert_eq!(run_cli(args("--help")), 0, "help is not a failure");
+    assert_eq!(run_cli(args("--wat")), 1);
+    assert_eq!(run_cli(args("--script fly")), 1);
+    assert_eq!(run_cli(args("--ticks soon")), 1);
+}


### PR DESCRIPTION
The same shape as the voxel sample's, and for the same reason: the world
is a pure function whose tests prove it reproduces on one machine, and
the obligation is across machines. The lane that checks that runs
binaries, so it needs something executable whose output can be compared.

Three built-in scripts - stand, dash, hop - named rather than read from
a file, because the point is to run identically everywhere and a file is
one more thing that can differ. Both output shapes are there because the
vocabulary asks for both, and the JSON carries a schema version from its
first release.

The whole binary is in the library and main is one expression, so the
refusals are drivable by a test rather than only by a spawned process.
There is a spawned-process test as well: it covers main itself, which
nothing in-process can, and it proves the executable works rather than
just the code behind it.

The removability cells name the driver alongside the world it drives - a
configuration that removes the world while keeping the binary depending
on it cannot build, so the cell would prove nothing.