### PR TITLE
feat(samples): a command-line face for chess, exposing the oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-sample-chess"
+version = "0.1.0"
+dependencies = [
+ "renew-sample-chess-rules",
+]
+
+[[package]]
 name = "renew-sample-chess-rules"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/samples/chess/Cargo.toml
+++ b/samples/chess/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "renew-sample-chess"
+description = "The chess sample's driver: counts positions to a depth, or plays a deterministic game, and answers with a digest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Chess's command-line face: runs perft against a position, or plays a deterministic game, and prints the result as text and as JSON."
+maturity = "bootstrap"
+core = false
+simulation = false
+
+extension_points = []
+
+[[bin]]
+name = "chess"
+path = "src/main.rs"
+
+[dependencies]
+renew-sample-chess-rules = { path = "rules" }
+
+[lints]
+workspace = true

--- a/samples/chess/src/lib.rs
+++ b/samples/chess/src/lib.rs
@@ -1,0 +1,279 @@
+//! Chess's command-line face.
+//!
+//! Two things it can do, and they are not the same kind of thing.
+//!
+//! **Counting** runs perft — how many distinct legal games of a given length
+//! exist from a position. That is a fact about chess with published values, so
+//! this mode is the oracle made runnable: a wrong number here is a wrong rule,
+//! not a wrong opinion.
+//!
+//! **Playing** walks a deterministic game and answers with a digest. That
+//! proves reproduction rather than correctness, which is what the cross-target
+//! lane needs and what perft cannot give it — perft's answer is the same on a
+//! broken machine and a working one, because it is a count rather than a state.
+
+use renew_sample_chess_rules::{Board, Move, Outcome, apply, legal, outcome, perft};
+
+/// How a run can fail to start.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CliError {
+    /// A flag nobody knows.
+    UnknownFlag(String),
+    /// A flag that needs a value and did not get one.
+    MissingValue(&'static str),
+    /// A value that is not a number.
+    NotANumber(String),
+    /// A position that is not a position.
+    BadPosition(String),
+    /// A depth deep enough to outlive the caller.
+    DepthTooGreat(u32),
+}
+
+/// The deepest count this binary will attempt.
+///
+/// Perft grows by roughly thirty per level, so depth seven from the start is
+/// three billion positions and hours of work. A refusal with a number in it is
+/// more useful than a command that appears to hang, and a caller who genuinely
+/// wants that can call the library.
+pub const MAX_DEPTH: u32 = 6;
+
+impl CliError {
+    /// What went wrong, for a person.
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::UnknownFlag(flag) => format!("unknown flag `{flag}`; try --help"),
+            Self::MissingValue(flag) => format!("`{flag}` needs a value"),
+            Self::NotANumber(text) => format!("`{text}` is not a number"),
+            Self::BadPosition(text) => {
+                format!("`{text}` is not a position in Forsyth-Edwards notation")
+            }
+            Self::DepthTooGreat(depth) => format!(
+                "depth {depth} is past the limit of {MAX_DEPTH}; each level is about thirty \
+                 times the work of the one before"
+            ),
+        }
+    }
+}
+
+/// What to do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Mode {
+    /// Count positions to a depth.
+    Count,
+    /// Play a deterministic game.
+    Play,
+}
+
+/// What to run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Options {
+    /// Counting or playing.
+    pub mode: Mode,
+    /// The position to start from.
+    pub position: Board,
+    /// How deep to count, or how many half-moves to play.
+    pub depth: u32,
+    /// Print the answer as JSON rather than as a sentence.
+    pub json: bool,
+    /// Print usage and stop.
+    pub help: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Count,
+            position: Board::initial(),
+            depth: 4,
+            json: false,
+            help: false,
+        }
+    }
+}
+
+/// What the run answers with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Report {
+    /// Which mode ran.
+    pub mode: Mode,
+    /// The depth counted, or the half-moves played.
+    pub depth: u32,
+    /// Positions counted, when counting.
+    pub nodes: u64,
+    /// The final position's hash, when playing.
+    pub digest: u64,
+    /// How the played game stood at the end.
+    pub result: Outcome,
+    /// How many half-moves were actually played, which is fewer than asked for
+    /// if the game ended.
+    pub played: u32,
+}
+
+/// The usage text. **Every flag the parser accepts appears here.**
+#[must_use]
+pub fn usage() -> &'static str {
+    "chess — count positions to a depth, or play a deterministic game\n\
+     \n\
+     Usage: chess [--count | --play] [--depth N] [--fen POSITION] [--json] [--help]\n\
+     \n\
+     --count         count the legal games of length N from the position (the default)\n\
+     --play          play N half-moves, always taking the first legal move\n\
+     --depth N       how deep to count, or how many half-moves to play (default 4)\n\
+     --fen POSITION  the position, in Forsyth-Edwards notation (default the start)\n\
+     --json          print the answer as JSON rather than as a sentence\n\
+     --help          print this and stop\n"
+}
+
+/// Parse a command line.
+///
+/// # Errors
+///
+/// Returns what was wrong with it.
+pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, CliError> {
+    let mut options = Options::default();
+    let mut arguments = arguments.into_iter();
+    while let Some(argument) = arguments.next() {
+        match argument.as_str() {
+            "--help" | "-h" => options.help = true,
+            "--json" => options.json = true,
+            "--count" => options.mode = Mode::Count,
+            "--play" => options.mode = Mode::Play,
+            "--depth" => {
+                let text = arguments.next().ok_or(CliError::MissingValue("--depth"))?;
+                options.depth = text
+                    .parse()
+                    .map_err(|_| CliError::NotANumber(text.clone()))?;
+            }
+            "--fen" => {
+                let text = arguments.next().ok_or(CliError::MissingValue("--fen"))?;
+                options.position =
+                    Board::from_fen(&text).map_err(|_| CliError::BadPosition(text.clone()))?;
+            }
+            other => return Err(CliError::UnknownFlag(other.to_string())),
+        }
+    }
+    // Checked after parsing rather than at the flag, because `--depth 9
+    // --play` is fine and `--depth 9 --count` is not — the limit belongs to
+    // the mode, and the mode may be named after the depth.
+    if options.mode == Mode::Count && options.depth > MAX_DEPTH {
+        return Err(CliError::DepthTooGreat(options.depth));
+    }
+    Ok(options)
+}
+
+/// Run, and answer.
+#[must_use]
+pub fn run(options: &Options) -> Report {
+    match options.mode {
+        Mode::Count => Report {
+            mode: Mode::Count,
+            depth: options.depth,
+            nodes: perft(&options.position, options.depth),
+            digest: options.position.digest(),
+            result: outcome(&options.position),
+            played: 0,
+        },
+        Mode::Play => {
+            let mut board = options.position;
+            let mut played = 0;
+            for _ in 0..options.depth {
+                // **Always the first legal move**, which is a deterministic
+                // choice rather than a good one. A search would make this a
+                // test of the search; taking the first makes it a test of the
+                // rules and of nothing else.
+                let moves = legal(&board);
+                let Some(&chosen) = moves.as_slice().first() else {
+                    break;
+                };
+                board = apply(&board, chosen);
+                played += 1;
+            }
+            Report {
+                mode: Mode::Play,
+                depth: options.depth,
+                nodes: 0,
+                digest: board.digest(),
+                result: outcome(&board),
+                played,
+            }
+        }
+    }
+}
+
+/// The name a result is printed under.
+const fn result_name(result: Outcome) -> &'static str {
+    match result {
+        Outcome::Checkmate => "checkmate",
+        Outcome::Stalemate => "stalemate",
+        Outcome::FiftyMove => "fifty-move",
+        Outcome::Ongoing => "ongoing",
+    }
+}
+
+/// The one line a run answers with.
+#[must_use]
+pub fn describe(report: &Report) -> String {
+    match report.mode {
+        Mode::Count => format!(
+            "chess count depth={} nodes={} result={}",
+            report.depth,
+            report.nodes,
+            result_name(report.result)
+        ),
+        Mode::Play => format!(
+            "chess play moves={} digest={:016x} result={}",
+            report.played,
+            report.digest,
+            result_name(report.result)
+        ),
+    }
+}
+
+/// The same answer, machine-readable, carrying its schema version from the
+/// first release.
+#[must_use]
+pub fn describe_json(report: &Report) -> String {
+    let mode = match report.mode {
+        Mode::Count => "count",
+        Mode::Play => "play",
+    };
+    format!(
+        "{{\"schema_version\":1,\"sample\":\"chess\",\"mode\":\"{}\",\"depth\":{},\
+         \"nodes\":{},\"moves\":{},\"digest\":\"{:016x}\",\"result\":\"{}\"}}",
+        mode,
+        report.depth,
+        report.nodes,
+        report.played,
+        report.digest,
+        result_name(report.result)
+    )
+}
+
+/// The move a play would take next, for a caller that wants to follow along.
+#[must_use]
+pub fn next_move(board: &Board) -> Option<Move> {
+    legal(board).as_slice().first().copied()
+}
+
+/// Parse, run, print, and answer with an exit code.
+pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    let options = match parse(arguments) {
+        Ok(options) => options,
+        Err(error) => {
+            eprintln!("chess: {}", error.message());
+            return 1;
+        }
+    };
+    if options.help {
+        print!("{}", usage());
+        return 0;
+    }
+    let report = run(&options);
+    if options.json {
+        println!("{}", describe_json(&report));
+    } else {
+        println!("{}", describe(&report));
+    }
+    0
+}

--- a/samples/chess/src/main.rs
+++ b/samples/chess/src/main.rs
@@ -1,0 +1,6 @@
+//! Process shell: argument strings in, exit code out. Everything else lives in
+//! the library so tests can drive it without a process.
+
+fn main() -> std::process::ExitCode {
+    std::process::ExitCode::from(renew_sample_chess::run_cli(std::env::args().skip(1)))
+}

--- a/samples/chess/tests/binary.rs
+++ b/samples/chess/tests/binary.rs
@@ -1,0 +1,106 @@
+//! The binary, run as a binary.
+//!
+//! Everything else here drives the library directly, which is faster and says
+//! nothing about whether the executable works. This spawns it — the same way
+//! the determinism lane will on three platforms — so the process shell, the
+//! argument plumbing and the exit codes are exercised as a caller meets them.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_chess");
+
+/// Run it, and give back what it said and whether it succeeded.
+///
+/// The allowance is explicit because the crate's lint configuration exempts
+/// test bodies and this is a free helper beside them. A binary cargo has just
+/// built and cannot run is not a condition worth encoding a recovery for.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn invoke(arguments: &[&str]) -> (bool, String, String) {
+    let output = Command::new(BINARY)
+        .args(arguments)
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn the_binary_counts_and_prints_the_published_number() {
+    let (ok, out, _) = invoke(&["--count", "--depth", "3"]);
+    assert!(ok, "a well-formed run should succeed");
+    assert!(out.starts_with("chess count depth=3"), "got: {out}");
+    assert!(
+        out.contains("nodes=8902"),
+        "the published count for depth three: {out}"
+    );
+}
+
+/// The same command answers the same, which is what makes comparing three
+/// platforms' output mean anything.
+#[test]
+fn the_binary_answers_the_same_twice() {
+    let first = invoke(&["--play", "--depth", "20"]).1;
+    let second = invoke(&["--play", "--depth", "20"]).1;
+    assert_eq!(first, second, "the same command must answer the same");
+    assert!(
+        first.contains("digest="),
+        "and must answer with one: {first}"
+    );
+}
+
+#[test]
+fn the_binary_prints_json_when_asked() {
+    let (ok, out, _) = invoke(&["--count", "--depth", "2", "--json"]);
+    assert!(ok);
+    let line = out.trim();
+    assert!(line.starts_with('{') && line.ends_with('}'), "got: {line}");
+    assert!(line.contains("\"schema_version\":1"), "got: {line}");
+    assert!(line.contains("\"sample\":\"chess\""), "got: {line}");
+    assert!(line.contains("\"nodes\":400"), "got: {line}");
+}
+
+#[test]
+fn the_binary_takes_a_position() {
+    let (ok, out, _) = invoke(&[
+        "--count",
+        "--depth",
+        "2",
+        "--fen",
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+    ]);
+    assert!(ok, "a published position should parse");
+    assert!(out.contains("nodes=2039"), "the published count: {out}");
+}
+
+#[test]
+fn the_binary_prints_usage_and_stops() {
+    let (ok, out, _) = invoke(&["--help"]);
+    assert!(ok, "help is not a failure");
+    assert!(out.contains("--depth"), "got: {out}");
+    assert!(!out.contains("nodes="), "and it counted nothing");
+}
+
+/// A refusal goes to the error stream with a failing status, so a script
+/// calling this can tell without parsing anything.
+#[test]
+fn the_binary_refuses_a_bad_command_line_on_the_error_stream() {
+    let (ok, out, err) = invoke(&["--wat"]);
+    assert!(!ok, "an unknown flag must fail");
+    assert!(out.is_empty(), "and print nothing to the output stream");
+    assert!(err.contains("--wat"), "while naming the flag: {err}");
+
+    let (ok, _, err) = invoke(&["--fen", "banana"]);
+    assert!(!ok);
+    assert!(err.contains("banana"), "got: {err}");
+
+    let (ok, _, err) = invoke(&["--count", "--depth", "9"]);
+    assert!(!ok, "a depth that would outlive the caller must fail");
+    assert!(err.contains('9'), "and say how deep is too deep: {err}");
+}

--- a/samples/chess/tests/cli.rs
+++ b/samples/chess/tests/cli.rs
@@ -1,0 +1,266 @@
+//! The command line, and the line a run answers with.
+
+use renew_sample_chess::{
+    CliError, MAX_DEPTH, Mode, Options, describe, describe_json, next_move, parse, run, run_cli,
+    usage,
+};
+use renew_sample_chess_rules::{Board, Outcome};
+
+fn args(text: &str) -> Vec<String> {
+    text.split_whitespace().map(str::to_string).collect()
+}
+
+const KIWIPETE: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
+
+#[test]
+fn no_arguments_counts_to_four_from_the_start() {
+    let options = parse(Vec::new()).expect("nothing to object to");
+    assert_eq!(options.mode, Mode::Count);
+    assert_eq!(options.depth, 4);
+    assert_eq!(options.position, Board::initial());
+    assert!(!options.json);
+}
+
+#[test]
+fn every_flag_parses() {
+    let options = parse(args("--play --depth 12 --json")).expect("well formed");
+    assert_eq!(options.mode, Mode::Play);
+    assert_eq!(options.depth, 12);
+    assert!(options.json);
+
+    assert!(parse(args("--help")).expect("well formed").help);
+    assert!(parse(args("-h")).expect("well formed").help);
+    assert_eq!(
+        parse(args("--play --count")).expect("well formed").mode,
+        Mode::Count,
+        "the last mode named wins"
+    );
+
+    let with_position = parse(
+        std::iter::once("--fen".to_string())
+            .chain(std::iter::once(KIWIPETE.to_string()))
+            .collect::<Vec<_>>(),
+    )
+    .expect("a published position");
+    assert_ne!(with_position.position, Board::initial());
+}
+
+#[test]
+fn a_malformed_command_line_is_refused_and_names_what_is_wrong() {
+    assert_eq!(
+        parse(args("--wat")),
+        Err(CliError::UnknownFlag("--wat".to_string()))
+    );
+    assert_eq!(
+        parse(args("--depth")),
+        Err(CliError::MissingValue("--depth"))
+    );
+    assert_eq!(parse(args("--fen")), Err(CliError::MissingValue("--fen")));
+    assert_eq!(
+        parse(args("--depth deep")),
+        Err(CliError::NotANumber("deep".to_string()))
+    );
+    assert_eq!(
+        parse(args("--fen banana")),
+        Err(CliError::BadPosition("banana".to_string()))
+    );
+
+    for (error, subject) in [
+        (CliError::UnknownFlag("--wat".to_string()), "--wat"),
+        (CliError::MissingValue("--fen"), "--fen"),
+        (CliError::NotANumber("deep".to_string()), "deep"),
+        (CliError::BadPosition("banana".to_string()), "banana"),
+        (CliError::DepthTooGreat(9), "9"),
+    ] {
+        assert!(
+            error.message().contains(subject),
+            "the refusal does not name `{subject}`: {}",
+            error.message()
+        );
+    }
+}
+
+/// **A depth that would outlive the caller is refused with a number**, because
+/// a command that appears to hang is worse than one that says no. Perft grows
+/// about thirtyfold per level.
+#[test]
+fn a_count_too_deep_is_refused_and_a_play_that_deep_is_not() {
+    assert_eq!(
+        parse(args("--count --depth 9")),
+        Err(CliError::DepthTooGreat(9))
+    );
+    assert!(
+        parse(args("--count --depth 6")).is_ok(),
+        "the limit itself is allowed"
+    );
+    assert_eq!(MAX_DEPTH, 6);
+
+    // Playing nine half-moves is nothing, so the limit must not apply to it —
+    // and the flag order must not matter either.
+    assert!(parse(args("--play --depth 9")).is_ok());
+    assert!(
+        parse(args("--depth 9 --play")).is_ok(),
+        "the limit belongs to the mode, which may be named after the depth"
+    );
+}
+
+/// **Every flag the parser accepts appears in the usage text.**
+#[test]
+fn the_usage_text_documents_every_flag() {
+    let text = usage();
+    for flag in ["--count", "--play", "--depth", "--fen", "--json", "--help"] {
+        assert!(text.contains(flag), "usage does not mention {flag}");
+    }
+}
+
+/// **The oracle, through the command line.** These counts are published facts
+/// about chess, so a wrong one here is a wrong rule rather than a wrong
+/// opinion.
+#[test]
+fn counting_matches_the_published_numbers() {
+    for (depth, expected) in [(1u32, 20u64), (2, 400), (3, 8_902), (4, 197_281)] {
+        let report = run(&Options {
+            depth,
+            ..Options::default()
+        });
+        assert_eq!(report.nodes, expected, "perft({depth}) from the start");
+    }
+
+    let kiwipete = Board::from_fen(KIWIPETE).expect("a published position");
+    let report = run(&Options {
+        position: kiwipete,
+        depth: 3,
+        ..Options::default()
+    });
+    assert_eq!(report.nodes, 97_862, "perft(3) from Kiwipete");
+}
+
+#[test]
+fn counting_to_no_depth_is_the_position_itself() {
+    let report = run(&Options {
+        depth: 0,
+        ..Options::default()
+    });
+    assert_eq!(report.nodes, 1);
+    assert_eq!(report.result, Outcome::Ongoing);
+}
+
+/// Playing answers with a digest, which is what the cross-target lane compares
+/// — perft cannot serve that purpose, because a count is the same number on a
+/// broken machine and a working one.
+#[test]
+fn playing_is_reproducible_and_discriminating() {
+    let options = Options {
+        mode: Mode::Play,
+        depth: 30,
+        ..Options::default()
+    };
+    assert_eq!(run(&options), run(&options), "the same game plays the same");
+    assert_eq!(run(&options).played, 30);
+
+    let shorter = run(&Options {
+        depth: 29,
+        ..options
+    });
+    assert_ne!(run(&options).digest, shorter.digest);
+}
+
+/// A game that ends stops rather than playing on, and says how many moves it
+/// actually managed.
+#[test]
+fn playing_past_the_end_of_a_game_stops_there() {
+    // A position already checkmated: no legal move exists.
+    let mated = Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
+        .expect("well formed");
+    let report = run(&Options {
+        mode: Mode::Play,
+        position: mated,
+        depth: 20,
+        ..Options::default()
+    });
+    assert_eq!(report.played, 0, "there was nothing to play");
+    assert_eq!(report.result, Outcome::Checkmate);
+    assert_eq!(next_move(&mated), None);
+}
+
+#[test]
+fn the_next_move_is_the_first_legal_one() {
+    let board = Board::initial();
+    let chosen = next_move(&board).expect("twenty to choose from");
+    assert_eq!(
+        chosen,
+        *renew_sample_chess_rules::legal(&board)
+            .as_slice()
+            .first()
+            .expect("twenty to choose from")
+    );
+}
+
+#[test]
+fn the_answer_reads_and_parses() {
+    let counted = run(&Options {
+        depth: 3,
+        ..Options::default()
+    });
+    let line = describe(&counted);
+    assert!(line.starts_with("chess count depth=3"));
+    assert!(line.contains("nodes=8902"));
+
+    let json = describe_json(&counted);
+    assert!(json.contains("\"schema_version\":1"));
+    assert!(json.contains("\"sample\":\"chess\""));
+    assert!(json.contains("\"mode\":\"count\""));
+    assert!(json.contains("\"nodes\":8902"));
+    assert!(json.starts_with('{') && json.ends_with('}'));
+
+    let played = run(&Options {
+        mode: Mode::Play,
+        depth: 10,
+        ..Options::default()
+    });
+    let line = describe(&played);
+    assert!(line.starts_with("chess play moves=10"));
+    assert!(line.contains(&format!("digest={:016x}", played.digest)));
+    assert!(describe_json(&played).contains("\"mode\":\"play\""));
+}
+
+/// Every ending has a name, so a caller reading the output never sees a state
+/// it cannot interpret.
+#[test]
+fn every_ending_prints_under_a_name() {
+    let cases = [
+        (
+            "rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3",
+            "checkmate",
+        ),
+        ("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1", "stalemate"),
+        ("4k3/8/8/8/8/8/8/4K2R w - - 100 60", "fifty-move"),
+        ("4k3/8/8/8/8/8/8/4K3 w - - 0 1", "ongoing"),
+    ];
+    for (fen, name) in cases {
+        let report = run(&Options {
+            mode: Mode::Play,
+            position: Board::from_fen(fen).expect("well formed"),
+            depth: 0,
+            ..Options::default()
+        });
+        assert!(
+            describe(&report).contains(name),
+            "expected {name} for {fen}, got {}",
+            describe(&report)
+        );
+        assert!(describe_json(&report).contains(name));
+    }
+}
+
+/// The whole binary, driven without spawning one.
+#[test]
+fn the_command_line_answers_with_an_exit_code() {
+    assert_eq!(run_cli(args("--count --depth 2")), 0);
+    assert_eq!(run_cli(args("--play --depth 4 --json")), 0);
+    assert_eq!(run_cli(args("--help")), 0, "help is not a failure");
+    assert_eq!(run_cli(args("--wat")), 1);
+    assert_eq!(run_cli(args("--depth deep")), 1);
+    assert_eq!(run_cli(args("--fen banana")), 1);
+    assert_eq!(run_cli(args("--count --depth 9")), 1);
+}


### PR DESCRIPTION
Two modes, and they are not the same kind of thing.

Counting runs perft - how many distinct legal games of a given length
exist from a position. That is a published fact about chess, so this
mode is the oracle made runnable: a wrong number is a wrong rule rather
than a wrong opinion, and the binary answers 8902 at depth three from
the start and 2039 for Kiwipete at depth two without anything in the
test suite being consulted.

Playing walks a deterministic game and answers with a digest. That
proves reproduction rather than correctness, which is what the
cross-target lane needs and what perft cannot give it - a count is the
same number on a broken machine and a working one, because it is a count
rather than a state. The move chosen is always the first legal one,
which is deterministic rather than good: a search would make this a test
of the search, and taking the first makes it a test of the rules.

A count deeper than six is refused with a number in the message. Perft
grows about thirtyfold per level, so depth seven from the start is three
billion positions and hours of work, and a command that appears to hang
is worse than one that says no. The limit belongs to the mode rather
than the flag, so a play of nine half-moves is fine whichever order the
flags arrive in - and there is a test for that ordering, because
checking at the flag would have been the obvious way to write it and
wrong.

Every ending prints under a name, so a caller reading the output never
meets a state it cannot interpret.