### PR TITLE
feat(cli): the cross-target lane now compares four samples, not one

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -112,10 +112,10 @@ reason = "The arm that clears a voice whose sound index is missing. A voice is o
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [80, 81, 82, 1030, 1031, 1032, 1033, 1039, 1040, 1042, 1043, 1044, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1057, 1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1082, 1086, 1087]
-reason = "The emit half of determinism: it spawns four cargo runs of the game and reads what they printed, so reaching it from a test would mean building and running the whole sample under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
+lines = [80, 81, 82, 1090, 1091, 1092, 1093, 1099, 1100, 1102, 1103, 1104, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1117, 1118, 1119, 1120, 1121, 1122, 1123, 1124, 1125, 1129, 1130, 1131, 1132, 1133, 1134, 1135, 1136, 1137, 1138, 1139, 1140, 1142, 1146, 1147]
+reason = "The emit half of determinism: it spawns nine cargo runs across four samples and reads what they printed, so reaching it from a test would mean building and running whole samples under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [1093]
+lines = [1153]
 reason = "The comparison refusing to start because no workspace root is above it. Every other subcommand carries the same arm and reaches it the same way -- never, from a test, because a test runs inside the workspace it is testing. Reaching it would mean invoking the binary from outside any cargo project, which is a property of where a caller stands rather than of anything this code does."

--- a/samples/chess/src/lib.rs
+++ b/samples/chess/src/lib.rs
@@ -222,7 +222,7 @@ pub fn describe(report: &Report) -> String {
             result_name(report.result)
         ),
         Mode::Play => format!(
-            "chess play moves={} digest={:016x} result={}",
+            "chess play moves={} digest=0x{:016x} result={}",
             report.played,
             report.digest,
             result_name(report.result)
@@ -240,7 +240,7 @@ pub fn describe_json(report: &Report) -> String {
     };
     format!(
         "{{\"schema_version\":1,\"sample\":\"chess\",\"mode\":\"{}\",\"depth\":{},\
-         \"nodes\":{},\"moves\":{},\"digest\":\"{:016x}\",\"result\":\"{}\"}}",
+         \"nodes\":{},\"moves\":{},\"digest\":\"0x{:016x}\",\"result\":\"{}\"}}",
         mode,
         report.depth,
         report.nodes,

--- a/samples/chess/tests/cli.rs
+++ b/samples/chess/tests/cli.rs
@@ -220,7 +220,7 @@ fn the_answer_reads_and_parses() {
     });
     let line = describe(&played);
     assert!(line.starts_with("chess play moves=10"));
-    assert!(line.contains(&format!("digest={:016x}", played.digest)));
+    assert!(line.contains(&format!("digest=0x{:016x}", played.digest)));
     assert!(describe_json(&played).contains("\"mode\":\"play\""));
 }
 

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -253,7 +253,7 @@ pub fn run(options: &Options) -> Report {
 pub fn describe(report: &Report) -> String {
     let (broken, placed) = report.edits;
     format!(
-        "cube script={} ticks={} digest={:016x} solids={} broken={} placed={} grounded={}",
+        "cube script={} ticks={} digest=0x{:016x} solids={} broken={} placed={} grounded={}",
         report.script.name(),
         report.ticks,
         report.digest,
@@ -273,7 +273,7 @@ pub fn describe_json(report: &Report) -> String {
     let (broken, placed) = report.edits;
     format!(
         "{{\"schema_version\":1,\"sample\":\"cube\",\"script\":\"{}\",\"ticks\":{},\
-         \"digest\":\"{:016x}\",\"solids\":{},\"broken\":{},\"placed\":{},\"grounded\":{}}}",
+         \"digest\":\"0x{:016x}\",\"solids\":{},\"broken\":{},\"placed\":{},\"grounded\":{}}}",
         report.script.name(),
         report.ticks,
         report.digest,

--- a/samples/cube/tests/cli.rs
+++ b/samples/cube/tests/cli.rs
@@ -166,7 +166,7 @@ fn the_answer_reads_and_parses() {
     let line = describe(&report);
     assert!(line.starts_with("cube script=patrol"));
     assert!(line.contains("ticks=120"));
-    assert!(line.contains(&format!("digest={:016x}", report.digest)));
+    assert!(line.contains(&format!("digest=0x{:016x}", report.digest)));
 
     let json = describe_json(&report);
     assert!(
@@ -176,7 +176,7 @@ fn the_answer_reads_and_parses() {
     assert!(json.contains("\"sample\":\"cube\""));
     assert!(json.contains("\"script\":\"patrol\""));
     assert!(json.contains("\"ticks\":120"));
-    assert!(json.contains(&format!("\"digest\":\"{:016x}\"", report.digest)));
+    assert!(json.contains(&format!("\"digest\":\"0x{:016x}\"", report.digest)));
     assert!(json.starts_with('{') && json.ends_with('}'));
 }
 

--- a/samples/leap/src/lib.rs
+++ b/samples/leap/src/lib.rs
@@ -205,7 +205,7 @@ pub fn run(options: &Options) -> Report {
 #[must_use]
 pub fn describe(report: &Report) -> String {
     format!(
-        "leap script={} ticks={} digest={:016x} grounded={} wall={}",
+        "leap script={} ticks={} digest=0x{:016x} grounded={} wall={}",
         report.script.name(),
         report.ticks,
         report.digest,
@@ -220,7 +220,7 @@ pub fn describe(report: &Report) -> String {
 pub fn describe_json(report: &Report) -> String {
     format!(
         "{{\"schema_version\":1,\"sample\":\"leap\",\"script\":\"{}\",\"ticks\":{},\
-         \"digest\":\"{:016x}\",\"grounded\":{},\"against_wall\":{}}}",
+         \"digest\":\"0x{:016x}\",\"grounded\":{},\"against_wall\":{}}}",
         report.script.name(),
         report.ticks,
         report.digest,

--- a/samples/leap/tests/cli.rs
+++ b/samples/leap/tests/cli.rs
@@ -150,13 +150,13 @@ fn the_answer_reads_and_parses() {
     let line = describe(&report);
     assert!(line.starts_with("leap script=dash"));
     assert!(line.contains("ticks=120"));
-    assert!(line.contains(&format!("digest={:016x}", report.digest)));
+    assert!(line.contains(&format!("digest=0x{:016x}", report.digest)));
 
     let json = describe_json(&report);
     assert!(json.contains("\"schema_version\":1"));
     assert!(json.contains("\"sample\":\"leap\""));
     assert!(json.contains("\"script\":\"dash\""));
-    assert!(json.contains(&format!("\"digest\":\"{:016x}\"", report.digest)));
+    assert!(json.contains(&format!("\"digest\":\"0x{:016x}\"", report.digest)));
     assert!(json.starts_with('{') && json.ends_with('}'));
 }
 

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -382,7 +382,11 @@ fn escape(text: &str) -> String {
 /// Returns a reason naming the run whenever its output cannot yield both
 /// digests. Never returns a partial set: a report missing one hash is a
 /// report proving half of what it claims, and half is reported as none.
-pub fn digests_from_output(name: &str, stdout: &str) -> Result<Vec<(String, String)>, String> {
+pub fn digests_from_output(
+    name: &str,
+    stdout: &str,
+    fields: &[&str],
+) -> Result<Vec<(String, String)>, String> {
     let Some(line) = stdout
         .lines()
         .map(str::trim)
@@ -398,7 +402,11 @@ pub fn digests_from_output(name: &str, stdout: &str) -> Result<Vec<(String, Stri
         .map_err(|error| format!("`{name}` printed unreadable JSON: {error:?}"))?;
 
     let mut digests = Vec::new();
-    for field in ["schedule_hash", "state_hash"] {
+    // **Which fields carry a digest is the run's business, not this
+    // function's.** It was a fixed pair when one sample fed the lane; a second
+    // sample with different field names would have been told its report
+    // carried no `state_hash`, which is true and useless.
+    for &field in fields {
         let Some(value) = report.get(field).and_then(crate::json::Value::as_str) else {
             return Err(format!("`{name}`'s report carries no `{field}`"));
         };
@@ -460,7 +468,12 @@ mod tests {
 
     #[test]
     fn a_runs_output_yields_both_of_its_digests_prefixed_by_the_run() {
-        let digests = super::digests_from_output("glide/seed-7", SAMPLE_LINE).expect("parses");
+        let digests = super::digests_from_output(
+            "glide/seed-7",
+            SAMPLE_LINE,
+            &["schedule_hash", "state_hash"],
+        )
+        .expect("parses");
         assert_eq!(
             digests,
             vec![
@@ -487,7 +500,9 @@ warning: unused
 {SAMPLE_LINE}
 "
         );
-        assert!(super::digests_from_output("run", &noisy).is_ok());
+        assert!(
+            super::digests_from_output("run", &noisy, &["schedule_hash", "state_hash"]).is_ok()
+        );
     }
 
     /// Every way a run can fail to report, named rather than defaulted.
@@ -520,8 +535,12 @@ warning: unused
             ),
         ];
         for (label, stdout) in cases {
-            let error = super::digests_from_output("glide/seed-7", &stdout)
-                .expect_err("a run that did not report must be refused");
+            let error = super::digests_from_output(
+                "glide/seed-7",
+                &stdout,
+                &["schedule_hash", "state_hash"],
+            )
+            .expect_err("a run that did not report must be refused");
             assert!(
                 error.contains("glide/seed-7"),
                 "the `{label}` case must name the run: {error}"
@@ -758,5 +777,37 @@ warning: unused
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod field_selection {
+    /// **A report's digest fields are the run's business.** When one sample fed
+    /// the lane, the pair was fixed in the parser; a second sample naming its
+    /// one hash `digest` would have been told it carried no `state_hash`, which
+    /// is true and useless.
+    #[test]
+    fn a_run_contributes_exactly_the_fields_it_names() {
+        let two = r#"{"schema_version":1,"schedule_hash":"0xaa","state_hash":"0xbb"}"#;
+        let pairs = super::digests_from_output("g/x", two, &["schedule_hash", "state_hash"])
+            .expect("both are there");
+        assert_eq!(pairs.len(), 2);
+
+        let one = r#"{"schema_version":1,"sample":"leap","digest":"0xcc"}"#;
+        let pairs = super::digests_from_output("l/y", one, &["digest"]).expect("one is there");
+        assert_eq!(pairs, vec![("l/y/digest".to_string(), "0xcc".to_string())]);
+
+        // And asking for a field a report does not carry is still a failure,
+        // rather than a quietly smaller digest set.
+        let missing = super::digests_from_output("l/y", one, &["state_hash"])
+            .expect_err("the field is absent");
+        assert!(missing.contains("state_hash"), "got: {missing}");
+
+        // Naming no fields at all yields nothing, which the comparison treats
+        // as a leg that reported nothing rather than as agreement.
+        assert_eq!(
+            super::digests_from_output("l/y", one, &[]).expect("nothing asked for"),
+            Vec::new()
+        );
     }
 }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -995,21 +995,41 @@ fn run_steps(invocation: &Invocation) -> ExitCode {
 /// list rather than one run because a single configuration
 /// exercises one path through the world, and a divergence in a path the
 /// list never walks is a divergence the lane never sees.
-const PINNED_RUNS: [(&str, &[&str]); 4] = [
+/// One simulation the lane pins: what to call it, which package answers,
+/// what to pass, and which fields of the answer carry a digest.
+type PinnedRun = (
+    &'static str,
+    &'static str,
+    &'static [&'static str],
+    &'static [&'static str],
+);
+
+/// Glide reports two hashes; the samples added since report one each.
+const GLIDE_FIELDS: &[&str] = &["schedule_hash", "state_hash"];
+const ONE_DIGEST: &[&str] = &["digest"];
+
+const PINNED_RUNS: [PinnedRun; 9] = [
     (
         "glide/seed-7-600",
+        "renew-sample-glide",
         &["--seed", "7", "--frames", "600", "--json"],
+        GLIDE_FIELDS,
     ),
     (
         "glide/seed-7-2000",
+        "renew-sample-glide",
         &["--seed", "7", "--frames", "2000", "--json"],
+        GLIDE_FIELDS,
     ),
     (
         "glide/seed-99-600",
+        "renew-sample-glide",
         &["--seed", "99", "--frames", "600", "--json"],
+        GLIDE_FIELDS,
     ),
     (
         "glide/sink-1500",
+        "renew-sample-glide",
         &[
             "--seed",
             "3",
@@ -1019,14 +1039,54 @@ const PINNED_RUNS: [(&str, &[&str]); 4] = [
             "sink",
             "--json",
         ],
+        GLIDE_FIELDS,
+    ),
+    // The platformer: swept motion against geometry, where a divergence would
+    // come from the collision arithmetic rather than from a generator.
+    (
+        "leap/dash-600",
+        "renew-sample-leap",
+        &["--script", "dash", "--ticks", "600", "--json"],
+        ONE_DIGEST,
+    ),
+    (
+        "leap/hop-900",
+        "renew-sample-leap",
+        &["--script", "hop", "--ticks", "900", "--json"],
+        ONE_DIGEST,
+    ),
+    // The voxel world: the same arithmetic in three dimensions, plus terrain
+    // that the run itself edits.
+    (
+        "cube/patrol-600",
+        "renew-sample-cube",
+        &["--script", "patrol", "--ticks", "600", "--json"],
+        ONE_DIGEST,
+    ),
+    (
+        "cube/build-900",
+        "renew-sample-cube",
+        &["--script", "build", "--ticks", "900", "--json"],
+        ONE_DIGEST,
+    ),
+    // Chess: no floating point and no geometry at all, so a divergence here
+    // would be in the integer state itself rather than in any arithmetic the
+    // other three share. A different kind of witness for the same claim.
+    (
+        "chess/play-60",
+        "renew-sample-chess",
+        &["--play", "--depth", "60", "--json"],
+        ONE_DIGEST,
     ),
 ];
 
 /// Run the pinned simulations and write this target's report.
 ///
-/// Every run contributes two digests — the frame schedule's and the
-/// world's — because the sample already computes both and a lane that
-/// dropped one would be proving half of what it claims.
+/// Each run contributes whichever digests its own report carries — two for
+/// the glide sample, which computes a frame-schedule hash beside its world
+/// hash, and one for the three added since. A lane that assumed one shape
+/// would tell the others their report was missing a field, which is true and
+/// useless.
 fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
     let runner = match Runner::anchored("determinism", json_mode) {
         Ok(runner) => runner,
@@ -1047,8 +1107,8 @@ fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
     };
 
     let mut digests = BTreeMap::new();
-    for (name, args) in PINNED_RUNS {
-        let mut invocation = vec!["run", "--quiet", "--package", "renew-sample-glide", "--"];
+    for (name, package, args, fields) in PINNED_RUNS {
+        let mut invocation = vec!["run", "--quiet", "--package", package, "--"];
         invocation.extend_from_slice(args);
         let (ok, stdout) = match probe("cargo", &invocation, Some(&runner.root)) {
             Ok(result) => result,
@@ -1060,7 +1120,7 @@ fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
                  the comparison must not be told otherwise"
             ));
         }
-        match determinism::digests_from_output(name, &stdout) {
+        match determinism::digests_from_output(name, &stdout, fields) {
             Ok(pairs) => digests.extend(pairs),
             Err(message) => return runner.fail(&message),
         }


### PR DESCRIPTION
The only place this repository actually tests that determinism survives
the machine was pinned to a single game. Every other check compares a
run to itself or to a constant this repository minted, and neither can
prove the target did not matter, because both halves ran on one target.

So the lane's coverage was one world's arithmetic. It is now four, and
they are deliberately unalike:

The platformer and the voxel world exercise swept motion against
geometry in two dimensions and three, where a divergence would come from
the collision arithmetic - square roots, normalised directions,
separating axes - rather than from a generator. The voxel run also edits
its own terrain, so the state under comparison is not only a position.

Chess has no floating point and no geometry at all. A divergence there
would be in integer state itself rather than in any arithmetic the other
three share, which makes it a different kind of witness for the same
claim.

Thirteen digests per leg now, up from eight.

Two things had to stop being one sample's business. The package to run
was hardcoded, so no second sample could be added at all. And the digest
field names were fixed at the pair glide reports - a sample naming its
one hash digest would have been told its report carried no state_hash,
which is true and useless. Both are properties of the pinned run now,
and a test holds the distinction: asking for a field a report does not
carry is still a failure rather than a quietly smaller digest set.