### PR TITLE
feat(chess): the position can be shown, and moves can be played into it

### DIFF
--- a/samples/chess/rules/src/board.rs
+++ b/samples/chess/rules/src/board.rs
@@ -86,6 +86,25 @@ impl Kind {
         }
     }
 
+    /// A kind from the letter [`Self::letter`] gives it, in either case.
+    ///
+    /// **The inverse exists so that only one table maps letters to kinds.**
+    /// Reading Forsyth-Edwards notation and reading a promotion out of a
+    /// move both need it, and a second copy of the mapping is a second
+    /// chance to disagree with the first.
+    #[must_use]
+    pub fn from_letter(letter: char) -> Option<Self> {
+        match letter.to_ascii_lowercase() {
+            'p' => Some(Self::Pawn),
+            'n' => Some(Self::Knight),
+            'b' => Some(Self::Bishop),
+            'r' => Some(Self::Rook),
+            'q' => Some(Self::Queen),
+            'k' => Some(Self::King),
+            _ => None,
+        }
+    }
+
     /// A stable small number, so a digest does not depend on the enum's
     /// declaration order surviving an edit.
     const fn code(self) -> u32 {
@@ -192,6 +211,24 @@ impl Square {
         let file = char::from(b'a' + u8::try_from(self.file()).unwrap_or(0));
         let rank = char::from(b'1' + u8::try_from(self.rank()).unwrap_or(0));
         [file, rank]
+    }
+
+    /// The square a name like `e4` refers to, or nothing if it names none.
+    ///
+    /// **Exactly the inverse of [`Self::name`]**, and the pair is worth a
+    /// property test rather than examples: sixty-four squares is small
+    /// enough to check all of them.
+    #[must_use]
+    pub fn from_name(text: &str) -> Option<Self> {
+        let mut characters = text.chars();
+        let file = characters.next()?;
+        let rank = characters.next()?;
+        if characters.next().is_some() {
+            return None;
+        }
+        let file = i32::from(u8::try_from(file).ok()?) - i32::from(b'a');
+        let rank = i32::from(u8::try_from(rank).ok()?) - i32::from(b'1');
+        Self::at(file, rank)
     }
 }
 
@@ -398,6 +435,88 @@ pub enum FenError {
 }
 
 impl Board {
+    /// Write this position in Forsyth-Edwards notation.
+    ///
+    /// **The inverse of [`Self::from_fen`], and the reason it exists is that
+    /// a command-line game is stateless.** A player who makes one move per
+    /// invocation needs the position handed back in the form the next
+    /// invocation reads, or the game cannot continue past a single move.
+    ///
+    /// The pair is checked by round trip rather than against expected
+    /// strings: every published position this crate is tested against
+    /// survives `from_fen` then `to_fen` unchanged, which catches a field
+    /// that reads correctly and writes wrongly — the failure a one-directional
+    /// test cannot see.
+    #[must_use]
+    pub fn to_fen(&self) -> String {
+        let mut text = String::with_capacity(90);
+        for rank in (0..8).rev() {
+            let mut empty = 0u32;
+            for file in 0..8 {
+                match Square::at(file, rank).and_then(|square| self.piece_at(square)) {
+                    Some(piece) => {
+                        if empty > 0 {
+                            text.push_str(&empty.to_string());
+                            empty = 0;
+                        }
+                        let letter = piece.kind.letter();
+                        text.push(if piece.colour == Colour::White {
+                            letter.to_ascii_uppercase()
+                        } else {
+                            letter
+                        });
+                    }
+                    None => empty += 1,
+                }
+            }
+            if empty > 0 {
+                text.push_str(&empty.to_string());
+            }
+            if rank > 0 {
+                text.push('/');
+            }
+        }
+
+        text.push(' ');
+        text.push(if self.to_move == Colour::White {
+            'w'
+        } else {
+            'b'
+        });
+
+        text.push(' ');
+        let before = text.len();
+        for (held, letter) in [
+            (self.castling.white_king_side, 'K'),
+            (self.castling.white_queen_side, 'Q'),
+            (self.castling.black_king_side, 'k'),
+            (self.castling.black_queen_side, 'q'),
+        ] {
+            if held {
+                text.push(letter);
+            }
+        }
+        if text.len() == before {
+            text.push('-');
+        }
+
+        text.push(' ');
+        match self.en_passant {
+            Some(square) => {
+                let name = square.name();
+                text.push(name[0]);
+                text.push(name[1]);
+            }
+            None => text.push('-'),
+        }
+
+        text.push(' ');
+        text.push_str(&self.halfmove_clock.to_string());
+        text.push(' ');
+        text.push_str(&self.fullmove_number.to_string());
+        text
+    }
+
     /// Read a position in Forsyth–Edwards notation.
     ///
     /// **The reason this exists is the test suite, not the user interface.**
@@ -441,14 +560,8 @@ impl Board {
                 } else {
                     Colour::Black
                 };
-                let kind = match symbol.to_ascii_lowercase() {
-                    'p' => Kind::Pawn,
-                    'n' => Kind::Knight,
-                    'b' => Kind::Bishop,
-                    'r' => Kind::Rook,
-                    'q' => Kind::Queen,
-                    'k' => Kind::King,
-                    _ => return Err(FenError::UnknownPiece),
+                let Some(kind) = Kind::from_letter(symbol) else {
+                    return Err(FenError::UnknownPiece);
                 };
                 board.put(Square::at(file, rank), Some(Piece::new(colour, kind)));
                 file += 1;
@@ -482,13 +595,5 @@ impl Board {
 
 /// A square from its name, like `e4`.
 fn parse_square(text: &str) -> Option<Square> {
-    let mut characters = text.chars();
-    let file = characters.next()?;
-    let rank = characters.next()?;
-    if characters.next().is_some() {
-        return None;
-    }
-    let file = i32::from(u8::try_from(file).ok()?) - i32::from(b'a');
-    let rank = i32::from(u8::try_from(rank).ok()?) - i32::from(b'1');
-    Square::at(file, rank)
+    Square::from_name(text)
 }

--- a/samples/chess/rules/src/moves.rs
+++ b/samples/chess/rules/src/moves.rs
@@ -64,6 +64,40 @@ impl Move {
         }
         text
     }
+
+    /// A move from the text [`Self::notation`] writes, or nothing if the text
+    /// is not a move.
+    ///
+    /// **This says nothing about legality** — it reads four or five characters
+    /// into two squares and an optional promotion, and whether that move may
+    /// be played is [`legal`]'s question. Keeping the two apart means a
+    /// caller can tell "that is not a move" from "that move is not allowed",
+    /// which are different things to say to a player.
+    ///
+    /// A promotion to pawn or king is refused here rather than downstream:
+    /// `e7e8k` parses into nothing a board can represent, so the earliest
+    /// place to say no is the place that reads it.
+    #[must_use]
+    pub fn from_notation(text: &str) -> Option<Self> {
+        let from = Square::from_name(text.get(0..2)?)?;
+        let to = Square::from_name(text.get(2..4)?)?;
+        let promotion = match text.len() {
+            4 => None,
+            5 => {
+                let kind = Kind::from_letter(text.chars().nth(4)?)?;
+                if matches!(kind, Kind::Pawn | Kind::King) {
+                    return None;
+                }
+                Some(kind)
+            }
+            _ => return None,
+        };
+        Some(Self {
+            from,
+            to,
+            promotion,
+        })
+    }
 }
 
 /// A fixed-capacity list of moves.

--- a/samples/chess/rules/tests/notation.rs
+++ b/samples/chess/rules/tests/notation.rs
@@ -1,0 +1,221 @@
+//! The three round trips, and what each one catches that the other direction
+//! alone cannot.
+//!
+//! Every pair here is a reader and a writer of the same notation. A test that
+//! only reads checks the reader against the author's belief about the text; a
+//! test that only writes checks the writer against the same belief. **Held
+//! against each other they check a fact instead** — that whatever one produces,
+//! the other accepts and returns unchanged — and that fact is false the moment
+//! either side handles a field the other does not.
+
+use renew_sample_chess_rules::{Board, Colour, Kind, Move, Square, apply, legal};
+
+/// Positions with something awkward in them, deliberately chosen so the round
+/// trip has fields to get wrong: castling rights partly gone, an en-passant
+/// square live, clocks that are not zero, and an empty-heavy board that
+/// exercises the run-length digits at both ends of a rank.
+const POSITIONS: [&str; 8] = [
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+    "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+    "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3",
+    "4k3/8/8/8/8/8/8/4K2R w K - 99 60",
+    "4k3/8/8/8/8/8/8/R3K3 b Q - 13 7",
+    "8/8/8/8/8/8/8/K6k w - - 0 1",
+    "r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 4 12",
+];
+
+/// **A square's name and the square it names are inverses over the whole
+/// board.** Sixty-four is small enough to check every one rather than sample,
+/// so this is exhaustive rather than a property.
+#[test]
+fn every_square_name_round_trips() {
+    for index in 0..64u8 {
+        let square = Square::from_index(index).expect("0..64 is on the board");
+        let name: String = square.name().iter().collect();
+        assert_eq!(
+            Square::from_name(&name),
+            Some(square),
+            "`{name}` did not read back as the square that wrote it"
+        );
+    }
+}
+
+/// The reader refuses what is not a square, rather than clamping into one.
+///
+/// **`i9` and `a0` are the cases worth having**: both are two characters in
+/// the right shape, and an implementation that added offsets to an index
+/// without a bounds check would map them onto real squares.
+#[test]
+fn a_name_that_names_no_square_is_refused() {
+    for text in ["", "e", "e44", "i4", "a0", "a9", "z1", "44", "-", " e4"] {
+        assert_eq!(
+            Square::from_name(text),
+            None,
+            "`{text}` was read as a square"
+        );
+    }
+}
+
+/// **Every letter a kind writes reads back as that kind, in either case.**
+/// The case-insensitivity is load-bearing: Forsyth-Edwards notation uses case
+/// to carry colour, so the letter table must not.
+#[test]
+fn every_piece_letter_round_trips_in_both_cases() {
+    for kind in [
+        Kind::Pawn,
+        Kind::Knight,
+        Kind::Bishop,
+        Kind::Rook,
+        Kind::Queen,
+        Kind::King,
+    ] {
+        let letter = kind.letter();
+        assert_eq!(Kind::from_letter(letter), Some(kind));
+        assert_eq!(Kind::from_letter(letter.to_ascii_uppercase()), Some(kind));
+    }
+    for letter in ['x', '1', ' ', '-'] {
+        assert_eq!(Kind::from_letter(letter), None, "`{letter}` read as a kind");
+    }
+}
+
+/// **The published positions survive a round trip through the writer.**
+///
+/// This is the test that catches a field which reads correctly and writes
+/// wrongly — the half of the pair that the perft suite, which only ever reads,
+/// is blind to. Castling rights and the en-passant square are the two most
+/// likely to be dropped, and both appear here partly set rather than all or
+/// nothing.
+#[test]
+fn every_position_survives_a_round_trip() {
+    for fen in POSITIONS {
+        let board = Board::from_fen(fen).expect("a well-formed position");
+        assert_eq!(
+            board.to_fen(),
+            fen,
+            "the position did not write back as the text it was read from"
+        );
+    }
+}
+
+/// The other direction of the same pair: what the writer produces, the reader
+/// accepts, and it means the same position.
+///
+/// **Compared by digest rather than by text**, so this cannot pass by both
+/// sides sharing a mistake in one field — the digest covers the whole state,
+/// including the pieces the text round trip would also catch and the clocks
+/// it might not.
+#[test]
+fn a_written_position_reads_back_as_the_same_position() {
+    let mut board = Board::initial();
+    for step in 0..40 {
+        let written = board.to_fen();
+        let read = Board::from_fen(&written).expect("what the writer produced");
+        assert_eq!(
+            read.digest(),
+            board.digest(),
+            "the position changed passing through its own notation at move {step}"
+        );
+        assert_eq!(read.to_fen(), written);
+
+        let Some(&chosen) = legal(&board).as_slice().first() else {
+            break;
+        };
+        board = apply(&board, chosen);
+    }
+}
+
+/// The starting position writes the string every chess program agrees on.
+///
+/// **One literal, deliberately.** The round-trip tests above prove the pair is
+/// self-consistent, which a pair that is wrong in the same way on both sides
+/// would also satisfy. This anchors the pair to the outside world.
+#[test]
+fn the_starting_position_writes_the_published_string() {
+    assert_eq!(
+        Board::initial().to_fen(),
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+    );
+}
+
+/// **Every legal move in a busy position round trips through its notation**,
+/// including the promotions, which are the only moves carrying a fifth
+/// character.
+#[test]
+fn every_legal_move_round_trips() {
+    // Kiwipete plus a position whose only moves are promotions, so the
+    // five-character form is not merely represented but forced.
+    for fen in [
+        "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+        "8/PPPk4/8/8/8/8/4Kppp/8 w - - 0 1",
+    ] {
+        let board = Board::from_fen(fen).expect("a well-formed position");
+        let moves = legal(&board);
+        assert!(!moves.as_slice().is_empty(), "nothing to check in {fen}");
+        for &played in moves.as_slice() {
+            let text = played.notation();
+            assert_eq!(
+                Move::from_notation(&text),
+                Some(played),
+                "`{text}` did not read back as the move that wrote it"
+            );
+        }
+    }
+}
+
+/// Promotions specifically: all four kinds, both colours' promotion ranks.
+#[test]
+fn every_promotion_round_trips() {
+    for kind in [Kind::Knight, Kind::Bishop, Kind::Rook, Kind::Queen] {
+        for (from, to) in [("a7", "a8"), ("h2", "h1")] {
+            let played = Move::promoting(
+                Square::from_name(from).expect("a square"),
+                Square::from_name(to).expect("a square"),
+                kind,
+            );
+            assert_eq!(Move::from_notation(&played.notation()), Some(played));
+        }
+    }
+}
+
+/// **Text that is not a move is refused, and that is not the same as a move
+/// that is not allowed.** `a1a1` is a perfectly readable move that no rules
+/// permit; this reader's job is the first question only, so it accepts it.
+#[test]
+fn text_that_is_not_a_move_is_refused() {
+    for text in ["", "e2", "e2e", "e2e4e", "e2e45", "i2i4", "e0e4", "  e2e4"] {
+        assert_eq!(
+            Move::from_notation(text),
+            None,
+            "`{text}` was read as a move"
+        );
+    }
+
+    // Promotion to pawn or king is unrepresentable, so it is refused by the
+    // reader rather than by whatever would have had to cope with it later.
+    for text in ["a7a8p", "a7a8k", "a7a8K"] {
+        assert_eq!(
+            Move::from_notation(text),
+            None,
+            "`{text}` was read as a promotion"
+        );
+    }
+
+    // Legality is a different question and deliberately not asked here.
+    assert!(
+        Move::from_notation("a1a1").is_some(),
+        "readable-but-illegal is the reader's business to accept"
+    );
+}
+
+/// An empty board writes the all-empty ranks and reads back empty.
+#[test]
+fn an_empty_position_round_trips() {
+    let board = Board::from_fen("8/8/8/8/8/8/8/8 w - - 0 1").expect("well formed");
+    assert_eq!(board.to_fen(), "8/8/8/8/8/8/8/8 w - - 0 1");
+    assert_eq!(
+        board.piece_at(Square::from_name("e4").expect("a square")),
+        None
+    );
+    assert_eq!(board.to_move, Colour::White);
+}

--- a/samples/chess/rules/tests/notation.rs
+++ b/samples/chess/rules/tests/notation.rs
@@ -183,7 +183,13 @@ fn every_promotion_round_trips() {
 /// permit; this reader's job is the first question only, so it accepts it.
 #[test]
 fn text_that_is_not_a_move_is_refused() {
-    for text in ["", "e2", "e2e", "e2e4e", "e2e45", "i2i4", "e0e4", "  e2e4"] {
+    for text in [
+        "", "e2", "e2e", "e2e4e", "e2e45", "i2i4", "e0e4", "  e2e4",
+        // Longer than a move, with four good characters in front: the case
+        // the two square reads and the promotion read both accept, leaving
+        // the length itself as the only thing that can refuse it.
+        "e2e4qq", "e2e4q1", "e2e4qqqq",
+    ] {
         assert_eq!(
             Move::from_notation(text),
             None,

--- a/samples/chess/src/lib.rs
+++ b/samples/chess/src/lib.rs
@@ -1,6 +1,6 @@
 //! Chess's command-line face.
 //!
-//! Two things it can do, and they are not the same kind of thing.
+//! Three things it can do, and they are not the same kind of thing.
 //!
 //! **Counting** runs perft — how many distinct legal games of a given length
 //! exist from a position. That is a fact about chess with published values, so
@@ -11,10 +11,20 @@
 //! proves reproduction rather than correctness, which is what the cross-target
 //! lane needs and what perft cannot give it — perft's answer is the same on a
 //! broken machine and a working one, because it is a count rather than a state.
+//!
+//! **Showing** prints the position for a person, and is the mode that makes
+//! this a game rather than a test fixture. It is stateless on purpose: a move
+//! is applied to a position named on the command line and the result is
+//! written back out in the same notation, so the next invocation can read it.
+//! Nothing is stored between runs, which means a game is a shell variable and
+//! a saved game is a text file — and every position is reachable directly,
+//! without replaying the moves that led to it.
 
-use renew_sample_chess_rules::{Board, Move, Outcome, apply, legal, outcome, perft};
+use renew_sample_chess_rules::{
+    Board, Colour, Move, Outcome, Square, apply, legal, outcome, perft,
+};
 
-/// How a run can fail to start.
+/// How a run can fail to start, or fail to finish.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CliError {
     /// A flag nobody knows.
@@ -27,6 +37,14 @@ pub enum CliError {
     BadPosition(String),
     /// A depth deep enough to outlive the caller.
     DepthTooGreat(u32),
+    /// Text that is not a move at all, whatever the position.
+    NotAMove(String),
+    /// A readable move that the rules do not permit here.
+    ///
+    /// **Separate from [`Self::NotAMove`] because they are different things to
+    /// tell a player.** One is a typo; the other is a misunderstanding of the
+    /// position, and only the second is worth listing the alternatives for.
+    IllegalMove(String),
 }
 
 /// The deepest count this binary will attempt.
@@ -52,6 +70,13 @@ impl CliError {
                 "depth {depth} is past the limit of {MAX_DEPTH}; each level is about thirty \
                  times the work of the one before"
             ),
+            Self::NotAMove(text) => format!(
+                "`{text}` is not a move; moves are the two squares, like `e2e4`, with a \
+                 promotion letter for the fifth character, like `a7a8q`"
+            ),
+            Self::IllegalMove(text) => {
+                format!("`{text}` is not legal in this position")
+            }
         }
     }
 }
@@ -63,17 +88,26 @@ pub enum Mode {
     Count,
     /// Play a deterministic game.
     Play,
+    /// Print the position for a person.
+    Show,
 }
 
 /// What to run.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Options {
-    /// Counting or playing.
+    /// Counting, playing or showing.
     pub mode: Mode,
     /// The position to start from.
     pub position: Board,
     /// How deep to count, or how many half-moves to play.
     pub depth: u32,
+    /// Moves to apply to the position before the mode does anything.
+    ///
+    /// **Applied in every mode, not only when showing.** They name a position
+    /// by the route to it, which is the form a player has and Forsyth-Edwards
+    /// notation is not; counting or playing from there is then the same
+    /// question asked somewhere else.
+    pub moves: Vec<String>,
     /// Print the answer as JSON rather than as a sentence.
     pub json: bool,
     /// Print usage and stop.
@@ -86,6 +120,7 @@ impl Default for Options {
             mode: Mode::Count,
             position: Board::initial(),
             depth: 4,
+            moves: Vec::new(),
             json: false,
             help: false,
         }
@@ -103,42 +138,78 @@ pub struct Report {
     pub nodes: u64,
     /// The final position's hash, when playing.
     pub digest: u64,
-    /// How the played game stood at the end.
+    /// How the position stood at the end.
     pub result: Outcome,
     /// How many half-moves were actually played, which is fewer than asked for
     /// if the game ended.
     pub played: u32,
+    /// The position the run ended on.
+    ///
+    /// **Carried whole rather than as its notation**, so a caller can ask it
+    /// further questions without parsing the answer back.
+    pub board: Board,
 }
 
 /// The usage text. **Every flag the parser accepts appears here.**
 #[must_use]
 pub fn usage() -> &'static str {
-    "chess — count positions to a depth, or play a deterministic game\n\
+    "chess — show a position, count the games from it, or play one out\n\
      \n\
-     Usage: chess [--count | --play] [--depth N] [--fen POSITION] [--json] [--help]\n\
+     Usage: chess [--show | --count | --play] [--move MOVE]... [--fen POSITION]\n\
+     \x20             [--depth N] [--json] [--help]\n\
      \n\
+     --show          print the position, whose turn it is, and the moves available\n\
      --count         count the legal games of length N from the position (the default)\n\
      --play          play N half-moves, always taking the first legal move\n\
+     --move MOVE     a move to apply first, like `e2e4` or `a7a8q`; may be repeated,\n\
+     \x20               and implies --show unless a mode is named\n\
      --depth N       how deep to count, or how many half-moves to play (default 4)\n\
      --fen POSITION  the position, in Forsyth-Edwards notation (default the start)\n\
      --json          print the answer as JSON rather than as a sentence\n\
-     --help          print this and stop\n"
+     --help          print this and stop\n\
+     \n\
+     A game is stateless: each run prints the position it reached, and that text is\n\
+     what the next run reads.\n\
+     \n\
+       chess --show\n\
+       chess --move e2e4 --move e7e5\n\
+       chess --fen \"$position\" --move g1f3\n"
 }
 
 /// Parse a command line.
 ///
 /// # Errors
 ///
-/// Returns what was wrong with it.
+/// Returns what was wrong with it. Moves are checked here for being *moves* and
+/// not for being *legal* — legality is a question about a position, and the
+/// position may still be named by a later flag.
 pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, CliError> {
     let mut options = Options::default();
+    let mut mode_named = false;
     let mut arguments = arguments.into_iter();
     while let Some(argument) = arguments.next() {
         match argument.as_str() {
             "--help" | "-h" => options.help = true,
             "--json" => options.json = true,
-            "--count" => options.mode = Mode::Count,
-            "--play" => options.mode = Mode::Play,
+            "--count" => {
+                options.mode = Mode::Count;
+                mode_named = true;
+            }
+            "--play" => {
+                options.mode = Mode::Play;
+                mode_named = true;
+            }
+            "--show" => {
+                options.mode = Mode::Show;
+                mode_named = true;
+            }
+            "--move" => {
+                let text = arguments.next().ok_or(CliError::MissingValue("--move"))?;
+                if Move::from_notation(&text).is_none() {
+                    return Err(CliError::NotAMove(text));
+                }
+                options.moves.push(text);
+            }
             "--depth" => {
                 let text = arguments.next().ok_or(CliError::MissingValue("--depth"))?;
                 options.depth = text
@@ -153,6 +224,12 @@ pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, Cl
             other => return Err(CliError::UnknownFlag(other.to_string())),
         }
     }
+
+    // Someone who names a move and no mode is playing chess, not measuring it.
+    if !mode_named && !options.moves.is_empty() {
+        options.mode = Mode::Show;
+    }
+
     // Checked after parsing rather than at the flag, because `--depth 9
     // --play` is fine and `--depth 9 --count` is not — the limit belongs to
     // the mode, and the mode may be named after the depth.
@@ -162,20 +239,58 @@ pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, Cl
     Ok(options)
 }
 
+/// Apply the named moves to a position, refusing the first one the rules do
+/// not permit.
+///
+/// # Errors
+///
+/// Returns the move that could not be played, by the text the caller wrote.
+fn advance(mut board: Board, moves: &[String]) -> Result<Board, CliError> {
+    for text in moves {
+        let Some(wanted) = Move::from_notation(text) else {
+            return Err(CliError::NotAMove(text.clone()));
+        };
+        // **Matched against the generated list rather than applied
+        // directly.** `apply` trusts its argument, and a move that merely
+        // parses can name an empty square or the opponent's piece; asking the
+        // rules whether this exact move is among the legal ones is the only
+        // check that covers every way it could be wrong.
+        if !legal(&board).as_slice().contains(&wanted) {
+            return Err(CliError::IllegalMove(text.clone()));
+        }
+        board = apply(&board, wanted);
+    }
+    Ok(board)
+}
+
 /// Run, and answer.
-#[must_use]
-pub fn run(options: &Options) -> Report {
-    match options.mode {
+///
+/// # Errors
+///
+/// Returns the first named move the rules do not permit.
+pub fn run(options: &Options) -> Result<Report, CliError> {
+    let start = advance(options.position, &options.moves)?;
+    Ok(match options.mode {
         Mode::Count => Report {
             mode: Mode::Count,
             depth: options.depth,
-            nodes: perft(&options.position, options.depth),
-            digest: options.position.digest(),
-            result: outcome(&options.position),
+            nodes: perft(&start, options.depth),
+            digest: start.digest(),
+            result: outcome(&start),
             played: 0,
+            board: start,
+        },
+        Mode::Show => Report {
+            mode: Mode::Show,
+            depth: 0,
+            nodes: legal(&start).as_slice().len() as u64,
+            digest: start.digest(),
+            result: outcome(&start),
+            played: 0,
+            board: start,
         },
         Mode::Play => {
-            let mut board = options.position;
+            let mut board = start;
             let mut played = 0;
             for _ in 0..options.depth {
                 // **Always the first legal move**, which is a deterministic
@@ -196,9 +311,10 @@ pub fn run(options: &Options) -> Report {
                 digest: board.digest(),
                 result: outcome(&board),
                 played,
+                board,
             }
         }
-    }
+    })
 }
 
 /// The name a result is printed under.
@@ -211,7 +327,39 @@ const fn result_name(result: Outcome) -> &'static str {
     }
 }
 
-/// The one line a run answers with.
+/// The letter a square is drawn with: upper case for White, lower for Black,
+/// a dot for empty — the same convention as Forsyth-Edwards notation, so a
+/// reader who can read one can read the other.
+fn square_letter(board: &Board, file: i32, rank: i32) -> char {
+    match Square::at(file, rank).and_then(|square| board.piece_at(square)) {
+        Some(piece) if piece.colour == Colour::White => piece.kind.letter().to_ascii_uppercase(),
+        Some(piece) => piece.kind.letter(),
+        None => '.',
+    }
+}
+
+/// The board, drawn for a person, always from White's side.
+///
+/// **Always White's side, never flipped to follow the side to move.** A board
+/// that turns around between moves makes two consecutive positions
+/// incomparable by eye, which is the one thing a printed board is for.
+#[must_use]
+pub fn board_text(board: &Board) -> String {
+    let mut text = String::with_capacity(200);
+    for rank in (0..8).rev() {
+        text.push(char::from(b'1' + u8::try_from(rank).unwrap_or(0)));
+        text.push(' ');
+        for file in 0..8 {
+            text.push(' ');
+            text.push(square_letter(board, file, rank));
+        }
+        text.push('\n');
+    }
+    text.push_str("\n   a b c d e f g h");
+    text
+}
+
+/// The one line — or, when showing, the several — a run answers with.
 #[must_use]
 pub fn describe(report: &Report) -> String {
     match report.mode {
@@ -227,6 +375,21 @@ pub fn describe(report: &Report) -> String {
             report.digest,
             result_name(report.result)
         ),
+        Mode::Show => {
+            let to_move = if report.board.to_move == Colour::White {
+                "white"
+            } else {
+                "black"
+            };
+            format!(
+                "{}\n\n{to_move} to move, {} legal {}, {}\n{}",
+                board_text(&report.board),
+                report.nodes,
+                if report.nodes == 1 { "move" } else { "moves" },
+                result_name(report.result),
+                report.board.to_fen()
+            )
+        }
     }
 }
 
@@ -237,16 +400,24 @@ pub fn describe_json(report: &Report) -> String {
     let mode = match report.mode {
         Mode::Count => "count",
         Mode::Play => "play",
+        Mode::Show => "show",
     };
     format!(
         "{{\"schema_version\":1,\"sample\":\"chess\",\"mode\":\"{}\",\"depth\":{},\
-         \"nodes\":{},\"moves\":{},\"digest\":\"0x{:016x}\",\"result\":\"{}\"}}",
+         \"nodes\":{},\"moves\":{},\"digest\":\"0x{:016x}\",\"result\":\"{}\",\
+         \"to_move\":\"{}\",\"fen\":\"{}\"}}",
         mode,
         report.depth,
         report.nodes,
         report.played,
         report.digest,
-        result_name(report.result)
+        result_name(report.result),
+        if report.board.to_move == Colour::White {
+            "white"
+        } else {
+            "black"
+        },
+        report.board.to_fen()
     )
 }
 
@@ -269,7 +440,13 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
         print!("{}", usage());
         return 0;
     }
-    let report = run(&options);
+    let report = match run(&options) {
+        Ok(report) => report,
+        Err(error) => {
+            eprintln!("chess: {}", error.message());
+            return 1;
+        }
+    };
     if options.json {
         println!("{}", describe_json(&report));
     } else {

--- a/samples/chess/tests/cli.rs
+++ b/samples/chess/tests/cli.rs
@@ -1,13 +1,23 @@
 //! The command line, and the line a run answers with.
 
 use renew_sample_chess::{
-    CliError, MAX_DEPTH, Mode, Options, describe, describe_json, next_move, parse, run, run_cli,
-    usage,
+    CliError, MAX_DEPTH, Mode, Options, Report, describe, describe_json, next_move, parse, run,
+    run_cli, usage,
 };
 use renew_sample_chess_rules::{Board, Outcome};
 
 fn args(text: &str) -> Vec<String> {
     text.split_whitespace().map(str::to_string).collect()
+}
+
+/// `run` for the cases where the setup is legal by construction, so every test
+/// below is not obliged to say so. The ones about refusals call `run` itself.
+#[expect(
+    clippy::expect_used,
+    reason = "a test helper: a panic here is the failure being reported"
+)]
+fn ran(options: &Options) -> Report {
+    run(options).expect("a setup with no illegal move in it")
 }
 
 const KIWIPETE: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
@@ -119,7 +129,7 @@ fn the_usage_text_documents_every_flag() {
 #[test]
 fn counting_matches_the_published_numbers() {
     for (depth, expected) in [(1u32, 20u64), (2, 400), (3, 8_902), (4, 197_281)] {
-        let report = run(&Options {
+        let report = ran(&Options {
             depth,
             ..Options::default()
         });
@@ -127,7 +137,7 @@ fn counting_matches_the_published_numbers() {
     }
 
     let kiwipete = Board::from_fen(KIWIPETE).expect("a published position");
-    let report = run(&Options {
+    let report = ran(&Options {
         position: kiwipete,
         depth: 3,
         ..Options::default()
@@ -137,7 +147,7 @@ fn counting_matches_the_published_numbers() {
 
 #[test]
 fn counting_to_no_depth_is_the_position_itself() {
-    let report = run(&Options {
+    let report = ran(&Options {
         depth: 0,
         ..Options::default()
     });
@@ -155,14 +165,14 @@ fn playing_is_reproducible_and_discriminating() {
         depth: 30,
         ..Options::default()
     };
-    assert_eq!(run(&options), run(&options), "the same game plays the same");
-    assert_eq!(run(&options).played, 30);
+    assert_eq!(ran(&options), ran(&options), "the same game plays the same");
+    assert_eq!(ran(&options).played, 30);
 
-    let shorter = run(&Options {
+    let shorter = ran(&Options {
         depth: 29,
-        ..options
+        ..options.clone()
     });
-    assert_ne!(run(&options).digest, shorter.digest);
+    assert_ne!(ran(&options).digest, shorter.digest);
 }
 
 /// A game that ends stops rather than playing on, and says how many moves it
@@ -172,7 +182,7 @@ fn playing_past_the_end_of_a_game_stops_there() {
     // A position already checkmated: no legal move exists.
     let mated = Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
         .expect("well formed");
-    let report = run(&Options {
+    let report = ran(&Options {
         mode: Mode::Play,
         position: mated,
         depth: 20,
@@ -198,7 +208,7 @@ fn the_next_move_is_the_first_legal_one() {
 
 #[test]
 fn the_answer_reads_and_parses() {
-    let counted = run(&Options {
+    let counted = ran(&Options {
         depth: 3,
         ..Options::default()
     });
@@ -213,7 +223,7 @@ fn the_answer_reads_and_parses() {
     assert!(json.contains("\"nodes\":8902"));
     assert!(json.starts_with('{') && json.ends_with('}'));
 
-    let played = run(&Options {
+    let played = ran(&Options {
         mode: Mode::Play,
         depth: 10,
         ..Options::default()
@@ -238,7 +248,7 @@ fn every_ending_prints_under_a_name() {
         ("4k3/8/8/8/8/8/8/4K3 w - - 0 1", "ongoing"),
     ];
     for (fen, name) in cases {
-        let report = run(&Options {
+        let report = ran(&Options {
             mode: Mode::Play,
             position: Board::from_fen(fen).expect("well formed"),
             depth: 0,

--- a/samples/chess/tests/show.rs
+++ b/samples/chess/tests/show.rs
@@ -347,3 +347,20 @@ fn the_command_line_shows_and_refuses() {
     assert_eq!(run_cli(args("--move e2e5")), 1, "not legal");
     assert_eq!(run_cli(args("--move")), 1, "no value");
 }
+
+/// **`run` checks the moves it is given rather than trusting that `parse`
+/// checked them.**
+///
+/// The two are separate public entry points, and a caller building `Options`
+/// directly — which is what every test in this file does — never goes through
+/// the parser. If `run` assumed otherwise, `apply` would be handed text that
+/// names no move at all.
+#[test]
+fn run_refuses_a_non_move_that_never_passed_the_parser() {
+    let options = Options {
+        mode: Mode::Show,
+        moves: vec!["e2e4".to_string(), "wat".to_string()],
+        ..Options::default()
+    };
+    assert_eq!(run(&options), Err(CliError::NotAMove("wat".to_string())));
+}

--- a/samples/chess/tests/show.rs
+++ b/samples/chess/tests/show.rs
@@ -1,0 +1,349 @@
+//! Showing a position — the mode that makes this a game rather than a fixture.
+//!
+//! The claim under test is that **a game survives being split across
+//! invocations**. Nothing is stored between runs, so each one prints the
+//! position it reached and the next one reads that text; if the pair of
+//! notation functions were wrong anywhere, a game played in two halves would
+//! end somewhere a game played in one would not. That is the test this file
+//! exists for, and the rest support it.
+
+use renew_sample_chess::{
+    CliError, Mode, Options, Report, board_text, describe, describe_json, parse, run, run_cli,
+    usage,
+};
+use renew_sample_chess_rules::{Board, Colour, Square};
+
+fn args(text: &str) -> Vec<String> {
+    text.split_whitespace().map(str::to_string).collect()
+}
+
+/// `run` for setups that are legal by construction, so the tests below are not
+/// each obliged to say so. The ones about refusals call `run` itself.
+#[expect(
+    clippy::expect_used,
+    reason = "a test helper: a panic here is the failure being reported"
+)]
+fn ran(options: &Options) -> Report {
+    run(options).expect("a setup with no illegal move in it")
+}
+
+fn showing(moves: &[&str]) -> Report {
+    ran(&Options {
+        mode: Mode::Show,
+        moves: moves.iter().map(|m| (*m).to_string()).collect(),
+        ..Options::default()
+    })
+}
+
+/// The drawn board agrees with the position it was drawn from, square by
+/// square.
+///
+/// **Checked against `piece_at` rather than against a literal picture.** A
+/// literal would be a second copy of the starting position that could drift
+/// from the first; asking the board what is on each square makes this a test
+/// of the drawing and of nothing else.
+#[test]
+fn the_drawn_board_agrees_with_the_position() {
+    let board = Board::initial();
+    let text = board_text(&board);
+    let rows: Vec<&str> = text.lines().take(8).collect();
+    assert_eq!(rows.len(), 8, "eight ranks");
+
+    for (row, rank) in rows.iter().zip((0..8).rev()) {
+        let drawn: Vec<char> = row.chars().filter(|c| !c.is_whitespace()).collect();
+        assert_eq!(drawn.len(), 9, "a rank label and eight squares");
+        assert_eq!(
+            drawn[0],
+            char::from(b'1' + u8::try_from(rank).unwrap_or(0)),
+            "the rank is labelled"
+        );
+        for file in 0..8 {
+            let square = Square::at(file, rank).expect("on the board");
+            let expected = match board.piece_at(square) {
+                Some(piece) if piece.colour == Colour::White => {
+                    piece.kind.letter().to_ascii_uppercase()
+                }
+                Some(piece) => piece.kind.letter(),
+                None => '.',
+            };
+            let at = usize::try_from(file).unwrap_or(0) + 1;
+            assert_eq!(
+                drawn[at], expected,
+                "file {file} of rank {rank} was drawn as `{}`",
+                drawn[at]
+            );
+        }
+    }
+    assert!(text.ends_with("a b c d e f g h"), "the files are labelled");
+}
+
+/// **The board is drawn from White's side whoever is to move**, so two
+/// consecutive positions can be compared by eye.
+#[test]
+fn the_board_does_not_turn_around_between_moves() {
+    let first_rank = |report: &Report| {
+        board_text(&report.board)
+            .lines()
+            .next()
+            .expect("eight ranks")
+            .to_string()
+    };
+    assert!(first_rank(&showing(&[])).starts_with('8'));
+    assert!(
+        first_rank(&showing(&["e2e4"])).starts_with('8'),
+        "rank eight is still drawn first with Black to move"
+    );
+}
+
+/// **The claim this file exists for.** A game played across two invocations,
+/// carried only by the text one printed and the other read, reaches the same
+/// position as the same game played in one.
+#[test]
+fn a_game_continues_through_its_own_output() {
+    let opening = showing(&["e2e4", "e7e5"]);
+    let carried = opening.board.to_fen();
+
+    let continued = ran(&Options {
+        mode: Mode::Show,
+        position: Board::from_fen(&carried).expect("what the last run wrote"),
+        moves: vec!["g1f3".to_string()],
+        ..Options::default()
+    });
+    let direct = showing(&["e2e4", "e7e5", "g1f3"]);
+
+    assert_eq!(
+        continued.digest, direct.digest,
+        "a game split across two runs reached a different position than one run"
+    );
+    assert_eq!(continued.board.to_fen(), direct.board.to_fen());
+}
+
+/// The same claim over a longer game, so a field that only differs after
+/// castling or a capture cannot hide.
+///
+/// **Twenty half-moves, handing the position over at every one.** The clocks
+/// and the castling rights are the fields most likely to survive one exchange
+/// and not twenty.
+#[test]
+fn a_long_game_survives_being_handed_over_at_every_move() {
+    let mut carried = Board::initial();
+    let mut in_one = Board::initial();
+    for step in 0..20 {
+        let Some(chosen) = renew_sample_chess::next_move(&in_one) else {
+            break;
+        };
+        in_one = renew_sample_chess_rules::apply(&in_one, chosen);
+
+        // The same move, but through the notation and the text both ways.
+        let report = ran(&Options {
+            mode: Mode::Show,
+            position: carried,
+            moves: vec![chosen.notation()],
+            ..Options::default()
+        });
+        carried = Board::from_fen(&report.board.to_fen()).expect("what the run wrote");
+
+        assert_eq!(
+            carried.digest(),
+            in_one.digest(),
+            "the games diverged at half-move {step}"
+        );
+    }
+    assert_eq!(carried.to_fen(), in_one.to_fen());
+}
+
+/// **Moves apply in every mode, not only when showing** — they name a position
+/// by the route to it, and counting from there is the same question asked
+/// elsewhere.
+#[test]
+fn moves_apply_before_counting_too() {
+    let after_e4 = ran(&Options {
+        mode: Mode::Count,
+        depth: 2,
+        moves: vec!["e2e4".to_string()],
+        ..Options::default()
+    });
+    let same_by_fen = ran(&Options {
+        mode: Mode::Count,
+        depth: 2,
+        position: Board::from_fen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+            .expect("well formed"),
+        ..Options::default()
+    });
+    assert_eq!(after_e4.nodes, same_by_fen.nodes);
+    assert_eq!(after_e4.digest, same_by_fen.digest);
+}
+
+/// Naming a move and no mode means the caller is playing chess, not measuring
+/// it.
+#[test]
+fn a_move_with_no_mode_named_shows_the_board() {
+    assert_eq!(
+        parse(args("--move e2e4")).expect("well formed").mode,
+        Mode::Show
+    );
+    assert_eq!(
+        parse(args("--count --move e2e4"))
+            .expect("well formed")
+            .mode,
+        Mode::Count,
+        "a named mode wins"
+    );
+    assert_eq!(
+        parse(args("--move e2e4 --count"))
+            .expect("well formed")
+            .mode,
+        Mode::Count,
+        "and it wins on whichever side of the move it is named"
+    );
+    assert_eq!(
+        parse(Vec::new()).expect("well formed").mode,
+        Mode::Count,
+        "with no move and no mode, counting is still the default"
+    );
+}
+
+/// **Text that is not a move and a move that is not legal are different
+/// refusals**, because they are different mistakes: one is a typo, the other a
+/// misreading of the position. Only the second needs a position to detect,
+/// which is why they are refused at different times.
+#[test]
+fn the_two_kinds_of_bad_move_are_refused_differently() {
+    assert_eq!(
+        parse(args("--move wat")),
+        Err(CliError::NotAMove("wat".to_string()))
+    );
+    assert_eq!(
+        parse(args("--move e2e9")),
+        Err(CliError::NotAMove("e2e9".to_string()))
+    );
+    assert_eq!(parse(args("--move")), Err(CliError::MissingValue("--move")));
+
+    let options = parse(args("--move e2e5")).expect("it parses as a move");
+    assert_eq!(
+        run(&options),
+        Err(CliError::IllegalMove("e2e5".to_string()))
+    );
+
+    // The third of three, so the refusal is not merely about the first.
+    let options = parse(args("--move e2e4 --move e7e6 --move e2e4")).expect("all parse");
+    assert_eq!(
+        run(&options),
+        Err(CliError::IllegalMove("e2e4".to_string())),
+        "the pawn has already moved, so playing it again is illegal"
+    );
+
+    for (error, subject) in [
+        (CliError::NotAMove("wat".to_string()), "wat"),
+        (CliError::IllegalMove("e2e5".to_string()), "e2e5"),
+    ] {
+        assert!(
+            error.message().contains(subject),
+            "the refusal does not name `{subject}`: {}",
+            error.message()
+        );
+    }
+}
+
+/// A move that is legal for the other side is refused, not silently taken.
+///
+/// **The case a naive check misses**: `e7e5` is a real move by a real piece,
+/// and only the side to move makes it wrong.
+#[test]
+fn a_move_by_the_wrong_side_is_refused() {
+    let options = parse(args("--move e7e5")).expect("it parses as a move");
+    assert_eq!(
+        run(&options),
+        Err(CliError::IllegalMove("e7e5".to_string()))
+    );
+}
+
+/// Showing reports how many moves are available, and it agrees with the rules.
+#[test]
+fn showing_counts_the_moves_available() {
+    let start = showing(&[]);
+    assert_eq!(start.nodes, 20, "twenty first moves");
+    assert!(describe(&start).contains("white to move, 20 legal moves"));
+
+    let mated = ran(&Options {
+        mode: Mode::Show,
+        position: Board::from_fen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
+            .expect("well formed"),
+        ..Options::default()
+    });
+    assert_eq!(mated.nodes, 0);
+    assert!(describe(&mated).contains("checkmate"));
+
+    // The singular is not "1 legal moves".
+    let one = ran(&Options {
+        mode: Mode::Show,
+        position: Board::from_fen("7k/8/5K2/8/8/8/8/7R b - - 0 1").expect("well formed"),
+        ..Options::default()
+    });
+    assert_eq!(one.nodes, 1);
+    assert!(
+        describe(&one).contains("1 legal move,"),
+        "expected the singular: {}",
+        describe(&one)
+    );
+}
+
+/// What showing prints is what a person needs and what the next run reads.
+#[test]
+fn the_shown_answer_reads_and_parses() {
+    let report = showing(&["d2d4"]);
+
+    let text = describe(&report);
+    assert!(text.contains("black to move"));
+    assert!(
+        Board::from_fen(text.lines().last().expect("a last line")).is_ok(),
+        "the last line is the position, ready for the next run"
+    );
+
+    let json = describe_json(&report);
+    assert!(json.contains("\"schema_version\":1"));
+    assert!(json.contains("\"mode\":\"show\""));
+    assert!(json.contains("\"to_move\":\"black\""));
+    assert!(json.contains(&format!("\"fen\":\"{}\"", report.board.to_fen())));
+    assert!(json.starts_with('{') && json.ends_with('}'));
+}
+
+/// Every mode carries the position it ended on, so a caller need not parse the
+/// answer back to ask another question.
+#[test]
+fn every_mode_reports_the_position_it_ended_on() {
+    let counted = ran(&Options {
+        depth: 1,
+        ..Options::default()
+    });
+    assert_eq!(counted.board.to_fen(), Board::initial().to_fen());
+
+    let played = ran(&Options {
+        mode: Mode::Play,
+        depth: 4,
+        ..Options::default()
+    });
+    assert_ne!(played.board.to_fen(), Board::initial().to_fen());
+    assert_eq!(played.board.digest(), played.digest);
+}
+
+/// **Every flag the parser accepts appears in the usage text**, including the
+/// ones added with this mode.
+#[test]
+fn the_usage_text_documents_the_new_flags() {
+    let text = usage();
+    for flag in ["--show", "--move", "--count", "--play", "--fen"] {
+        assert!(text.contains(flag), "usage does not mention {flag}");
+    }
+}
+
+/// The whole binary, driven without spawning one, over the new surface.
+#[test]
+fn the_command_line_shows_and_refuses() {
+    assert_eq!(run_cli(args("--show")), 0);
+    assert_eq!(run_cli(args("--move e2e4")), 0);
+    assert_eq!(run_cli(args("--move e2e4 --json")), 0);
+    assert_eq!(run_cli(args("--move wat")), 1, "not a move");
+    assert_eq!(run_cli(args("--move e2e5")), 1, "not legal");
+    assert_eq!(run_cli(args("--move")), 1, "no value");
+}


### PR DESCRIPTION
Chess could count its own legality and play itself, and a person could do
neither. It can now be played a move at a time from a terminal:

  chess --show
  chess --move e2e4 --move e7e5
  chess --fen "$position" --move g1f3

**Stateless on purpose.** Each run prints the position it reached in the same
notation the next run reads, so a game is a shell variable and a saved game is
a text file — and any position is reachable directly, without replaying the
moves that led to it. Nothing is stored between runs, so there is no store to
corrupt, migrate, or lock.

That needs two inverses that did not exist. Positions could be read and not
written; moves could be written and not read. Both are pairs now, and both
pairs are tested by round trip rather than against expected strings, because a
one-directional test checks a reader against the author's belief about the
text while a round trip checks a fact. **The first thing it caught was a
hand-written position in this change's own tests that omitted the en-passant
square after `e2e4`** — exactly the field the pairing exists to protect.

Two refusals rather than one, because they are different mistakes. `--move wat`
is not a move whatever the position, and is refused while parsing; `--move e2e5`
is a real move that this position forbids, and can only be refused once there
is a position to ask. A player who typed the first wants a correction; a player
who typed the second wants the board.

Moves apply in every mode, not only when showing: they name a position by the
route to it, which is the form a player has and Forsyth-Edwards notation is
not. Counting from there is then the same question asked somewhere else.

Two duplicated tables collapsed onto the new inverses in passing — the letters
naming piece kinds, and the reading of a square's name — since a second copy of
a mapping is a second chance to disagree with the first.
