### PR TITLE
feat(leap): the platformer can be looked at

### DIFF
--- a/samples/leap/src/lib.rs
+++ b/samples/leap/src/lib.rs
@@ -6,7 +6,7 @@
 //! so it needs something executable whose output can be compared.
 
 use renew_fixed::{Fixed, Vec2};
-use renew_sample_leap_world::{Intent, Leap, Platform, Tuning};
+use renew_sample_leap_world::{CHARACTER_HALF_EXTENTS, Intent, Leap, Platform, Tuning};
 
 /// How a run can fail to start.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -99,6 +99,8 @@ pub struct Options {
     pub script: Script,
     /// How many ticks to run.
     pub ticks: u32,
+    /// Draw the level and the character where it ended up.
+    pub show: bool,
     /// Print the answer as JSON rather than as a sentence.
     pub json: bool,
     /// Print usage and stop.
@@ -110,6 +112,7 @@ impl Default for Options {
         Self {
             script: Script::Stand,
             ticks: 600,
+            show: false,
             json: false,
             help: false,
         }
@@ -129,6 +132,12 @@ pub struct Report {
     pub grounded: bool,
     /// Whether it finished against a wall.
     pub against_wall: bool,
+    /// Where the character ended up.
+    ///
+    /// **Carried so that drawing needs no second run.** The alternative is a
+    /// caller stepping the world again to find out, which is the same
+    /// simulation done twice and one chance for the two to disagree.
+    pub position: Vec2,
 }
 
 /// The usage text. **Every flag the parser accepts appears here.**
@@ -139,6 +148,7 @@ pub fn usage() -> &'static str {
      Usage: leap [--script NAME] [--ticks N] [--json] [--help]\n\
      \n\
      --script NAME   which built-in script drives the character: stand, dash, hop\n\
+     --show          draw the level and where the character ended up\n\
      --ticks N       how many ticks to run (default 600)\n\
      --json          print the answer as JSON rather than as a sentence\n\
      --help          print this and stop\n"
@@ -156,6 +166,7 @@ pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, Cl
         match argument.as_str() {
             "--help" | "-h" => options.help = true,
             "--json" => options.json = true,
+            "--show" => options.show = true,
             "--script" => {
                 let name = arguments.next().ok_or(CliError::MissingValue("--script"))?;
                 options.script =
@@ -198,7 +209,108 @@ pub fn run(options: &Options) -> Report {
         digest: world.digest(),
         grounded: world.footing().grounded,
         against_wall: world.footing().against_wall,
+        position: world.position(),
     }
+}
+
+/// How wide and tall a drawn view is, in world units — one character each.
+///
+/// Odd on both axes so the character sits in the exact middle rather than
+/// half a cell off it, and small enough that a view fits an ordinary terminal
+/// without wrapping. The level is wider than this, which is the point: the
+/// view follows the character rather than showing everything.
+const VIEW_WIDTH: i64 = 61;
+/// How tall a drawn view is. See [`VIEW_WIDTH`].
+const VIEW_HEIGHT: i64 = 17;
+
+/// The whole part of a coordinate, rounded toward negative infinity.
+///
+/// **Not [`Fixed::trunc_int`], which rounds toward zero.** Truncation maps
+/// everything in (-1, 1) onto the cell `0`, so the two cells either side of
+/// the origin become one and every drawn thing left of it is off by one. That
+/// is invisible in a level built to the right of the origin and wrong the
+/// moment one is not — this level has a ledge at x = -14.
+fn floor_int(value: Fixed) -> i64 {
+    let whole = value.trunc_int();
+    if value.fract() < Fixed::ZERO {
+        whole - 1
+    } else {
+        whole
+    }
+}
+
+/// Whether a box covers the unit cell whose lower-left corner is `(x, y)`.
+///
+/// Cells are half-open — `[x, x + 1)` — so a box ending exactly on a cell
+/// boundary does not bleed into the cell beyond it, and two boxes meeting at a
+/// boundary do not both claim the same cell.
+///
+/// **One test for the character and the platforms alike.** They are the same
+/// kind of thing to the simulation, and a drawing that treated them
+/// differently would be able to disagree with it about which of them is
+/// touching what.
+fn covers(centre: Vec2, half_extents: Vec2, x: i64, y: i64) -> bool {
+    let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) else {
+        return false;
+    };
+    let left = Fixed::from_int(x);
+    let bottom = Fixed::from_int(y);
+    let right = left + Fixed::ONE;
+    let top = bottom + Fixed::ONE;
+    centre.x - half_extents.x < right
+        && centre.x + half_extents.x > left
+        && centre.y - half_extents.y < top
+        && centre.y + half_extents.y > bottom
+}
+
+/// The level drawn around the character: `#` is solid, `@` is the character,
+/// `.` is air.
+///
+/// **The view follows the character rather than framing the level**, because
+/// a level is allowed to be larger than a terminal and a character that walks
+/// off the drawing tells the reader nothing. The consequence is that two
+/// pictures from different ticks are not directly comparable by eye — the
+/// coordinates on the left edge are what makes them comparable, so they are
+/// printed.
+#[must_use]
+pub fn world_text(platforms: &[Platform], position: Vec2) -> String {
+    let centre_x = floor_int(position.x);
+    let centre_y = floor_int(position.y);
+    let mut text =
+        String::with_capacity(usize::try_from((VIEW_WIDTH + 8) * VIEW_HEIGHT).unwrap_or(1024));
+    for row in 0..VIEW_HEIGHT {
+        let y = centre_y + VIEW_HEIGHT / 2 - row;
+        // Right-aligned in a four-character gutter, built by hand rather than
+        // formatted: the rows must line up, and this is the whole of that
+        // requirement.
+        let label = y.to_string();
+        for _ in label.len()..4 {
+            text.push(' ');
+        }
+        text.push_str(&label);
+        text.push(' ');
+        for column in 0..VIEW_WIDTH {
+            let x = centre_x - VIEW_WIDTH / 2 + column;
+            // The character is drawn over the level rather than under it, so
+            // it is never hidden by the floor it is standing on.
+            if covers(position, CHARACTER_HALF_EXTENTS, x, y) {
+                text.push('@');
+            } else if platforms
+                .iter()
+                .any(|platform| covers(platform.centre, platform.half_extents, x, y))
+            {
+                text.push('#');
+            } else {
+                text.push('.');
+            }
+        }
+        text.push('\n');
+    }
+    text.push_str("     x=");
+    text.push_str(&floor_int(position.x).to_string());
+    text.push_str(" y=");
+    text.push_str(&floor_int(position.y).to_string());
+    text
 }
 
 /// The one line a run answers with.
@@ -249,6 +361,11 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
     if options.json {
         println!("{}", describe_json(&report));
     } else {
+        // The picture first, then the line: a reader scanning a terminal
+        // wants the summary nearest the prompt.
+        if options.show {
+            println!("{}", world_text(&level(), report.position));
+        }
         println!("{}", describe(&report));
     }
     0

--- a/samples/leap/tests/cli.rs
+++ b/samples/leap/tests/cli.rs
@@ -101,6 +101,7 @@ fn a_run_is_reproducible_and_discriminating() {
     let options = Options {
         script: Script::Hop,
         ticks: 300,
+        show: false,
         json: false,
         help: false,
     };

--- a/samples/leap/tests/cli.rs
+++ b/samples/leap/tests/cli.rs
@@ -175,6 +175,12 @@ fn a_run_of_no_ticks_answers() {
 #[test]
 fn the_command_line_answers_with_an_exit_code() {
     assert_eq!(run_cli(args("--ticks 30")), 0);
+    assert_eq!(run_cli(args("--ticks 30 --show")), 0, "the picture prints");
+    assert_eq!(
+        run_cli(args("--ticks 30 --show --json")),
+        0,
+        "asking for both prints the machine-readable one, and does not crash"
+    );
     assert_eq!(run_cli(args("--ticks 30 --json")), 0);
     assert_eq!(run_cli(args("--help")), 0, "help is not a failure");
     assert_eq!(run_cli(args("--wat")), 1);

--- a/samples/leap/tests/view.rs
+++ b/samples/leap/tests/view.rs
@@ -1,0 +1,290 @@
+//! Drawing the level, and the ways a drawing can lie about the simulation.
+//!
+//! **None of these tests recomputes the overlap arithmetic the drawing uses.**
+//! A test that re-derives the implementation's own reasoning agrees with it
+//! wherever it is wrong, which is the failure mode this repository has already
+//! paid for once. What is asserted here instead is what a *reader* of the
+//! picture would conclude — where the character is, what it is touching, how
+//! big it is — held against what the simulation independently reports.
+
+use renew_sample_leap::{Options, Script, level, run, world_text};
+use renew_sample_leap_world::Platform;
+
+/// The picture as a grid of rows, with the coordinate gutter stripped.
+fn rows(text: &str) -> Vec<Vec<char>> {
+    text.lines()
+        .filter(|line| line.contains('.') || line.contains('#') || line.contains('@'))
+        .map(|line| line.chars().skip(5).collect())
+        .collect()
+}
+
+/// Which rows and columns hold a given character.
+fn cells(grid: &[Vec<char>], wanted: char) -> Vec<(usize, usize)> {
+    let mut found = Vec::new();
+    for (r, row) in grid.iter().enumerate() {
+        for (c, drawn) in row.iter().enumerate() {
+            if *drawn == wanted {
+                found.push((r, c));
+            }
+        }
+    }
+    found
+}
+
+fn drawn(script: Script, ticks: u32) -> Vec<Vec<char>> {
+    let report = run(&Options {
+        script,
+        ticks,
+        ..Options::default()
+    });
+    rows(&world_text(&level(), report.position))
+}
+
+/// The view is a fixed rectangle, so two pictures line up column for column.
+#[test]
+fn the_view_is_a_fixed_rectangle() {
+    let grid = drawn(Script::Stand, 200);
+    assert_eq!(grid.len(), 17, "seventeen rows");
+    for row in &grid {
+        assert_eq!(row.len(), 61, "sixty-one columns");
+    }
+    assert!(
+        grid.len() % 2 == 1 && grid[0].len() % 2 == 1,
+        "odd on both axes, so the character has an exact middle to sit in"
+    );
+}
+
+/// **The character is drawn as the size it is**, not as a single cell.
+///
+/// One wide and two tall are its half-extents doubled; a cell more in either
+/// direction is the box straddling a cell boundary, which is ordinary. Three
+/// wide or four tall would mean the drawing disagrees with the shape the
+/// simulation collides with.
+#[test]
+fn the_character_is_drawn_at_its_own_size() {
+    for (script, ticks) in [
+        (Script::Stand, 200),
+        (Script::Dash, 120),
+        (Script::Hop, 300),
+        (Script::Hop, 47),
+    ] {
+        let grid = drawn(script, ticks);
+        let marks = cells(&grid, '@');
+        assert!(!marks.is_empty(), "the character is always in view");
+
+        let columns: Vec<usize> = marks.iter().map(|(_, c)| *c).collect();
+        let rows_used: Vec<usize> = marks.iter().map(|(r, _)| *r).collect();
+        let width = columns.iter().max().unwrap_or(&0) - columns.iter().min().unwrap_or(&0) + 1;
+        let height =
+            rows_used.iter().max().unwrap_or(&0) - rows_used.iter().min().unwrap_or(&0) + 1;
+
+        assert!(
+            (1..=2).contains(&width),
+            "{script:?}/{ticks}: drawn {width} cells wide, but it is one unit wide"
+        );
+        assert!(
+            (2..=3).contains(&height),
+            "{script:?}/{ticks}: drawn {height} cells tall, but it is two units tall"
+        );
+        assert_eq!(
+            marks.len(),
+            width * height,
+            "{script:?}/{ticks}: the character is a rectangle with no holes"
+        );
+    }
+}
+
+/// **A character the simulation calls grounded is drawn touching something.**
+///
+/// This is the assertion that catches an off-by-one in the drawing: if the
+/// rows were shifted by one, a resting character would float over a gap of
+/// air, and the picture would contradict the `grounded=true` printed beneath
+/// it.
+#[test]
+fn a_grounded_character_is_drawn_standing_on_something() {
+    for (script, ticks) in [(Script::Stand, 200), (Script::Dash, 120)] {
+        let report = run(&Options {
+            script,
+            ticks,
+            ..Options::default()
+        });
+        assert!(report.grounded, "{script:?} should end on the floor");
+
+        let grid = rows(&world_text(&level(), report.position));
+        let marks = cells(&grid, '@');
+        let lowest = marks.iter().map(|(r, _)| *r).max().expect("in view");
+        let columns: Vec<usize> = marks
+            .iter()
+            .filter(|(r, _)| *r == lowest)
+            .map(|(_, c)| *c)
+            .collect();
+
+        // Rows run downward, so the row below the feet is the next index.
+        let below = &grid[lowest + 1];
+        assert!(
+            columns.iter().any(|c| below[*c] == '#'),
+            "{script:?}: nothing solid is drawn under a grounded character"
+        );
+    }
+}
+
+/// **A character the simulation calls wall-bound is drawn beside something.**
+#[test]
+fn a_walled_character_is_drawn_against_something() {
+    let report = run(&Options {
+        script: Script::Dash,
+        ticks: 120,
+        ..Options::default()
+    });
+    assert!(report.against_wall, "dashing ends against the wall");
+
+    let grid = rows(&world_text(&level(), report.position));
+    let marks = cells(&grid, '@');
+    let rightmost = marks.iter().map(|(_, c)| *c).max().expect("in view");
+    assert!(
+        marks
+            .iter()
+            .filter(|(_, c)| *c == rightmost)
+            .any(|(r, _)| grid[*r][rightmost + 1] == '#'),
+        "nothing solid is drawn beside a character pressed against a wall"
+    );
+}
+
+/// **The ledge on the negative side of the origin is drawn on the correct
+/// side of it.**
+///
+/// This is the test for rounding toward negative infinity rather than toward
+/// zero. Truncation folds everything in (-1, 1) onto the cell `0`, which
+/// shifts every drawn thing left of the origin by one — invisible in a level
+/// built entirely to the right, and this level has a ledge at x = -14.
+#[test]
+fn the_ledge_left_of_the_origin_is_drawn_where_it_is() {
+    // Drawn from a viewpoint that puts the whole ledge in frame.
+    let ledge = Platform::new(-14, 4, 3, 1);
+    let text = world_text(
+        &[ledge],
+        renew_fixed::Vec2::new(
+            renew_fixed::Fixed::from_int(-14),
+            renew_fixed::Fixed::from_int(4),
+        ),
+    );
+    let grid = rows(&text);
+    let solid = cells(&grid, '#');
+    assert!(!solid.is_empty(), "the ledge is in frame");
+
+    // The view is centred on x = -14, so the ledge's cells sit around the
+    // middle column. Its span is [-17, -11], which is six cells.
+    let columns: Vec<usize> = solid.iter().map(|(_, c)| *c).collect();
+    let left = *columns.iter().min().expect("in frame");
+    let right = *columns.iter().max().expect("in frame");
+    assert_eq!(right - left + 1, 6, "the ledge is six cells wide");
+    assert!(
+        left < 30 && right > 30,
+        "the ledge straddles the centre column it is centred on, at {left}..={right}"
+    );
+
+    // And the same platform mirrored to the positive side must draw the same
+    // shape — the whole point of rounding consistently.
+    let mirrored = Platform::new(14, 4, 3, 1);
+    let there = rows(&world_text(
+        &[mirrored],
+        renew_fixed::Vec2::new(
+            renew_fixed::Fixed::from_int(14),
+            renew_fixed::Fixed::from_int(4),
+        ),
+    ));
+    assert_eq!(
+        cells(&there, '#'),
+        solid,
+        "a platform drew differently on the two sides of the origin"
+    );
+}
+
+/// The view follows the character, so it is never off the picture however far
+/// it walks.
+#[test]
+fn the_character_is_always_in_frame() {
+    for ticks in [0, 1, 37, 120, 240, 359, 600] {
+        for script in [Script::Stand, Script::Dash, Script::Hop] {
+            let grid = drawn(script, ticks);
+            assert!(
+                !cells(&grid, '@').is_empty(),
+                "{script:?} at {ticks} ticks walked off its own picture"
+            );
+        }
+    }
+}
+
+/// Drawing is a pure function of the position it is given.
+///
+/// **The picture is quantised to cells, so a single tick of movement may draw
+/// identically and that is correct** — this asserted the opposite at first and
+/// the failure was the test's, not the drawing's. What must differ is a
+/// position that differs by more than a cell; what must not is the same
+/// position drawn twice.
+#[test]
+fn the_picture_follows_the_position() {
+    let at = |ticks| {
+        world_text(
+            &level(),
+            run(&Options {
+                script: Script::Hop,
+                ticks,
+                ..Options::default()
+            })
+            .position,
+        )
+    };
+
+    assert_eq!(at(200), at(200), "the same position drew differently");
+    assert_ne!(
+        at(0),
+        at(200),
+        "two positions a long way apart drew the same picture"
+    );
+}
+
+/// An empty level draws as empty air with the character in the middle of it.
+#[test]
+fn a_level_with_nothing_in_it_draws_the_character_alone() {
+    let text = world_text(&[], renew_fixed::Vec2::ZERO);
+    let grid = rows(&text);
+    assert!(cells(&grid, '#').is_empty(), "nothing solid to draw");
+    assert!(
+        !cells(&grid, '@').is_empty(),
+        "the character is still there"
+    );
+    assert!(text.contains("x=0 y=0"), "the coordinates are printed");
+}
+
+/// The coordinates are printed, because a view that follows the character
+/// makes two pictures incomparable without them.
+#[test]
+fn the_view_says_where_it_is_looking() {
+    let report = run(&Options {
+        script: Script::Dash,
+        ticks: 120,
+        ..Options::default()
+    });
+    let text = world_text(&level(), report.position);
+    assert!(
+        text.lines().last().expect("a last line").contains("x="),
+        "the last line names the coordinates"
+    );
+    // The gutter labels every row with its world y, so a reader can locate a
+    // feature without counting rows.
+    assert!(
+        text.lines()
+            .next()
+            .expect("a first line")
+            .trim()
+            .starts_with(char::is_numeric)
+            || text
+                .lines()
+                .next()
+                .expect("a first line")
+                .trim()
+                .starts_with('-'),
+        "each row is labelled with its world coordinate"
+    );
+}

--- a/samples/leap/tests/view.rs
+++ b/samples/leap/tests/view.rs
@@ -288,3 +288,34 @@ fn the_view_says_where_it_is_looking() {
         "each row is labelled with its world coordinate"
     );
 }
+
+/// **A view at the far edge of the coordinate range draws air rather than
+/// crashing.**
+///
+/// The view spans thirty cells either side of the character, so a character
+/// standing at the largest representable whole coordinate has cells beyond it
+/// that no longer fit the type the overlap test works in. Those cells are not
+/// solid — nothing can be there — and the drawing says so instead of panicking
+/// or wrapping around to claim something is.
+#[test]
+fn a_view_at_the_edge_of_the_range_draws_air_rather_than_crashing() {
+    let far = renew_fixed::Vec2::new(
+        renew_fixed::Fixed::from_int(i32::MAX),
+        renew_fixed::Fixed::ZERO,
+    );
+    // A platform large enough that, were the guard to wrap instead of refuse,
+    // it would be claimed as covering the unrepresentable cells.
+    let text = world_text(&[Platform::new(0, 0, 40, 1)], far);
+    let grid = rows(&text);
+    assert_eq!(grid.len(), 17, "the view is still whole");
+    for row in &grid {
+        assert_eq!(row.len(), 61);
+    }
+    // Column 60 is thirty cells right of the character, which is past the
+    // largest representable whole coordinate. It must be air, not floor.
+    let past_the_end: Vec<char> = grid.iter().map(|row| row[60]).collect();
+    assert!(
+        past_the_end.iter().all(|drawn| *drawn != '#'),
+        "a cell beyond the representable range was drawn as solid"
+    );
+}

--- a/samples/leap/world/src/lib.rs
+++ b/samples/leap/world/src/lib.rs
@@ -149,6 +149,15 @@ impl Platform {
 }
 
 /// Everything the terrain collides with.
+/// How large the character is, measured from its centre.
+///
+/// **Public because anything drawing the world needs it.** A drawing that
+/// guesses the size puts the character somewhere it is not — one cell tall
+/// when it is two makes a character standing on the floor look like a
+/// character hovering above it, and the picture then contradicts the
+/// `grounded` flag printed beside it.
+pub const CHARACTER_HALF_EXTENTS: Vec2 = Vec2::new(Fixed::from_ratio(1, 2), Fixed::ONE);
+
 const TERRAIN_LAYER: u32 = 0b01;
 /// Everything the character is.
 const CHARACTER_LAYER: u32 = 0b10;
@@ -200,7 +209,7 @@ impl Leap {
         physics.add_shape(
             character,
             Shape::Box {
-                half_extents: Vec2::new(Fixed::from_ratio(1, 2), Fixed::ONE),
+                half_extents: CHARACTER_HALF_EXTENTS,
             },
             Transform::IDENTITY,
             Filter::new(CHARACTER_LAYER, TERRAIN_LAYER),


### PR DESCRIPTION
`leap --show` draws the level and the character in it. The simulation was
correct and invisible: a digest and two booleans, which say whether the
character is on the ground but not what it is standing on.

**The character is drawn as the box it collides with, not as one cell.** The
first version marked a single cell at the centre, and a character resting on
the floor appeared to hover one row above it — a picture contradicting the
`grounded=true` printed underneath. The world now names its own size and the
drawing asks for it, so the two cannot drift apart. The same overlap test
draws the character and the platforms, because they are the same kind of thing
to the simulation, and a drawing that treated them differently could disagree
with it about what is touching what.

**Coordinates are rounded toward negative infinity, not toward zero.**
Truncation folds everything in (-1, 1) onto the cell `0`, so every drawn thing
left of the origin shifts by one. That is invisible in a level built entirely
to the right of the origin, and this level has a ledge at x = -14. There is a
test that draws the same platform on both sides of the origin and requires the
two pictures to match.

The view follows the character rather than framing the level, since a level may
be larger than a terminal and a character walking off its own picture tells the
reader nothing. The cost is that two pictures are not comparable by eye, so
every row is labelled with its world coordinate and the viewpoint is printed.

**The tests assert what a reader of the picture would conclude, not the
arithmetic the picture is made of.** A test that re-derives the
implementation's reasoning agrees with it wherever it is wrong. So: a character
the simulation calls grounded must be drawn with something solid directly
beneath it, one pressed against a wall must be drawn beside something, and the
drawn shape must be the size the simulation collides with. That last one
caught this change's own hovering bug.

One assertion here was wrong and is now recorded as such in the test that
replaced it: a single tick of movement may legitimately draw an identical
picture, because the view is quantised to cells.
