### PR TITLE
fix(cube): the world is a closed box, and can be looked at

### DIFF
--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -52,6 +52,8 @@ pub struct Options {
     pub script: Script,
     /// How many ticks to run.
     pub ticks: u32,
+    /// Draw the world as two slices through it.
+    pub show: bool,
     /// Print the answer as JSON rather than as a sentence.
     pub json: bool,
     /// Print usage and stop.
@@ -63,6 +65,7 @@ impl Default for Options {
         Self {
             script: Script::Stand,
             ticks: 600,
+            show: false,
             json: false,
             help: false,
         }
@@ -172,6 +175,7 @@ pub fn usage() -> &'static str {
      Usage: cube [--script NAME] [--ticks N] [--json] [--help]\n\
      \n\
      --script NAME   which built-in script drives the player: stand, patrol, build\n\
+     --show          draw two slices through the world: the plan and the elevation\n\
      --ticks N       how many ticks to run (default 600)\n\
      --json          print the answer as JSON rather than as a sentence\n\
      --help          print this and stop\n"
@@ -188,6 +192,7 @@ pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, Cl
     while let Some(argument) = arguments.next() {
         match argument.as_str() {
             "--help" | "-h" => options.help = true,
+            "--show" => options.show = true,
             "--json" => options.json = true,
             "--script" => {
                 let name = arguments.next().ok_or(CliError::MissingValue("--script"))?;
@@ -211,20 +216,41 @@ pub fn parse<I: IntoIterator<Item = String>>(arguments: I) -> Result<Options, Cl
 /// Walled, because outside the grid is not solid and a player who walks off
 /// the floor falls forever — which would make `patrol` answer with a digest
 /// about falling rather than about walking.
+///
+/// **A closed box, filled on every face**, because outside the grid is neither
+/// solid nor air and a player who leaves falls forever with nothing to land on.
+///
+/// The shell coincides with the boundary `Grid::set` refuses to clear, so the
+/// box cannot be opened from inside. That took three tries. Walls three blocks
+/// high let `build` dig through the floor; an unbreakable floor let it build a
+/// tower and step over those walls. A player that can place blocks can reach
+/// any height, so the only enclosure that holds is one with no face missing.
 #[must_use]
 pub fn arena() -> Grid {
-    let mut grid = Grid::new(Cell::new(-20, -2, -20), (41, 14, 41));
-    grid.fill(Cell::new(-20, 0, -20), Cell::new(20, 0, 20), STONE);
-    grid.fill(Cell::new(-20, 1, -20), Cell::new(-20, 3, 20), STONE);
-    grid.fill(Cell::new(20, 1, -20), Cell::new(20, 3, 20), STONE);
-    grid.fill(Cell::new(-20, 1, -20), Cell::new(20, 3, -20), STONE);
-    grid.fill(Cell::new(-20, 1, 20), Cell::new(20, 3, 20), STONE);
+    let mut grid = Grid::new(Cell::new(-20, 0, -20), (41, 12, 41));
+    let (low, high) = (Cell::new(-20, 0, -20), Cell::new(20, 11, 20));
+    grid.fill(low, Cell::new(high.x, low.y, high.z), STONE);
+    grid.fill(Cell::new(low.x, high.y, low.z), high, STONE);
+    grid.fill(low, Cell::new(low.x, high.y, high.z), STONE);
+    grid.fill(Cell::new(high.x, low.y, low.z), high, STONE);
+    grid.fill(low, Cell::new(high.x, high.y, low.z), STONE);
+    grid.fill(Cell::new(low.x, low.y, high.z), high, STONE);
+
+    // A mound inside the box, because the shell cannot be cleared and a
+    // digging script with only the shell in reach digs nothing. It sits in
+    // front of the start, along the direction the player looks.
+    grid.fill(Cell::new(2, 1, -2), Cell::new(6, 2, 2), STONE);
     grid
 }
 
-/// Run a script and answer.
+/// Run a script and answer with the world it left behind.
+///
+/// **Separate from [`run`] because drawing needs the world and a report is not
+/// one.** The grid is edited as the script runs — blocks are broken and placed
+/// — so a drawing made from `arena()` would show the world as it started
+/// rather than as it ended, which is the one thing a picture of it is for.
 #[must_use]
-pub fn run(options: &Options) -> Report {
+pub fn run_world(options: &Options) -> Cube {
     let start = Vec3::new(Fixed::ZERO, Fixed::from_int(4), Fixed::ZERO);
     let mut world = Cube::new(Tuning::default(), arena(), start);
     // Looking down and forward, so `build` has something to dig at.
@@ -237,15 +263,102 @@ pub fn run(options: &Options) -> Report {
     for tick in 0..options.ticks {
         world.step(options.script.intent(tick));
     }
+    world
+}
 
+/// Run a script and answer.
+#[must_use]
+pub fn run(options: &Options) -> Report {
+    report_of(options.script, &run_world(options))
+}
+
+/// What a finished world answers with.
+fn report_of(script: Script, world: &Cube) -> Report {
     Report {
-        script: options.script,
+        script,
         ticks: world.tick(),
         digest: world.digest(),
         solids: world.grid().solid_count(),
         edits: world.edits(),
         grounded: world.grounded(),
     }
+}
+
+/// What a cell is drawn as: the player over the blocks, solid over air.
+fn cell_char(world: &Cube, here: Cell, player: Cell) -> char {
+    if here == player {
+        '@'
+    } else if world.grid().is_solid(here) {
+        '#'
+    } else {
+        '.'
+    }
+}
+
+/// A row label, right-aligned in a four-character gutter so rows line up.
+fn gutter(value: i32, into: &mut String) {
+    let label = value.to_string();
+    for _ in label.len()..4 {
+        into.push(' ');
+    }
+    into.push_str(&label);
+    into.push(' ');
+}
+
+/// The world seen from above, sliced at the height the player is standing in.
+///
+/// **The whole grid, not a window onto it.** The arena is forty-one cells
+/// across and fits a terminal, so every picture has the same frame and two
+/// runs can be compared column for column — which the platformer's view
+/// deliberately gives up, its level being wider than a terminal is.
+#[must_use]
+pub fn plan_text(world: &Cube) -> String {
+    let player = Cell::containing(world.position());
+    let min = world.grid().min();
+    let (width, _, depth) = world.grid().size();
+    let mut text = String::new();
+    text.push_str("plan, looking down, at y=");
+    text.push_str(&player.y.to_string());
+    text.push('\n');
+    for step in 0..depth {
+        let z = min.z + step;
+        gutter(z, &mut text);
+        for column in 0..width {
+            let here = Cell::new(min.x + column, player.y, z);
+            text.push(cell_char(world, here, player));
+        }
+        text.push('\n');
+    }
+    text.push_str("     x from ");
+    text.push_str(&min.x.to_string());
+    text.push_str(", z down the side");
+    text
+}
+
+/// The world seen from the side, sliced at the depth the player is standing
+/// at, with height increasing upward the way a reader expects.
+#[must_use]
+pub fn elevation_text(world: &Cube) -> String {
+    let player = Cell::containing(world.position());
+    let min = world.grid().min();
+    let (width, height, _) = world.grid().size();
+    let mut text = String::new();
+    text.push_str("elevation, looking along z, at z=");
+    text.push_str(&player.z.to_string());
+    text.push('\n');
+    for step in (0..height).rev() {
+        let y = min.y + step;
+        gutter(y, &mut text);
+        for column in 0..width {
+            let here = Cell::new(min.x + column, y, player.z);
+            text.push(cell_char(world, here, player));
+        }
+        text.push('\n');
+    }
+    text.push_str("     x from ");
+    text.push_str(&min.x.to_string());
+    text.push_str(", y up the side");
+    text
 }
 
 /// The one line a run answers with.
@@ -302,10 +415,18 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
         print!("{}", usage());
         return 0;
     }
-    let report = run(&options);
+    let world = run_world(&options);
+    let report = report_of(options.script, &world);
     if options.json {
         println!("{}", describe_json(&report));
     } else {
+        // The pictures first, then the line: a reader scanning a terminal
+        // wants the summary nearest the prompt.
+        if options.show {
+            println!("{}", plan_text(&world));
+            println!();
+            println!("{}", elevation_text(&world));
+        }
         println!("{}", describe(&report));
     }
     0

--- a/samples/cube/tests/cli.rs
+++ b/samples/cube/tests/cli.rs
@@ -111,6 +111,7 @@ fn a_run_is_reproducible() {
     let options = Options {
         script: Script::Build,
         ticks: 300,
+        show: false,
         json: false,
         help: false,
     };

--- a/samples/cube/tests/view.rs
+++ b/samples/cube/tests/view.rs
@@ -1,0 +1,229 @@
+//! Drawing the voxel world, and the defect the drawing exposed.
+//!
+//! The first picture of this world showed the player at `y = -25` after a
+//! four-hundred-tick run in an arena whose floor is at `y = 0`. Nothing was
+//! wrong with the drawing — the player really was there, twenty-five blocks
+//! below a world it had left, and every existing test passed because they all
+//! asked whether the run reproduced rather than whether it made sense.
+//!
+//! The containment test below is the one that was missing.
+
+use renew_sample_cube::{Options, Script, elevation_text, plan_text, run, run_cli, run_world};
+use renew_sample_cube_world::Cell;
+
+fn args(text: &str) -> Vec<String> {
+    text.split_whitespace().map(str::to_string).collect()
+}
+
+const SCRIPTS: [Script; 3] = [Script::Stand, Script::Patrol, Script::Build];
+
+/// **No script puts the player outside the world, however long it runs.**
+///
+/// This is the assertion whose absence let a script spend most of its run
+/// falling below the floor. It is checked at several lengths rather than one,
+/// because the original defect needed a few hundred ticks to appear and would
+/// have passed at fifty.
+#[test]
+fn no_script_ever_leaves_the_world() {
+    for script in SCRIPTS {
+        for ticks in [1, 50, 200, 400, 1000, 2500] {
+            let world = run_world(&Options {
+                script,
+                ticks,
+                ..Options::default()
+            });
+            let grid = world.grid();
+            let (width, height, depth) = grid.size();
+            let min = grid.min();
+            let at = Cell::containing(world.position());
+
+            assert!(
+                at.x >= min.x
+                    && at.y >= min.y
+                    && at.z >= min.z
+                    && at.x < min.x + width
+                    && at.y < min.y + height
+                    && at.z < min.z + depth,
+                "{script:?} left the world after {ticks} ticks, at {at:?}"
+            );
+        }
+    }
+}
+
+/// **A script that digs must have something to dig**, or it is testing that
+/// nothing happens.
+///
+/// Closing the box made the floor unbreakable, which silently turned the
+/// digging script into a script that reaches for the shell and is refused. The
+/// arena grew a mound for it; this is what keeps the mound there.
+#[test]
+fn the_building_script_actually_breaks_and_places_blocks() {
+    let report = run(&Options {
+        script: Script::Build,
+        ticks: 300,
+        ..Options::default()
+    });
+    assert!(report.edits.0 > 0, "building broke nothing");
+    assert!(report.edits.1 > 0, "building placed nothing");
+}
+
+/// The two views are the whole grid, so two runs line up cell for cell.
+#[test]
+fn both_views_span_the_whole_grid() {
+    let world = run_world(&Options {
+        script: Script::Patrol,
+        ticks: 200,
+        ..Options::default()
+    });
+    let (width, height, depth) = world.grid().size();
+
+    let plan = plan_text(&world);
+    let plan_rows: Vec<&str> = plan
+        .lines()
+        .skip(1)
+        .take_while(|l| l.contains('.') || l.contains('#') || l.contains('@'))
+        .collect();
+    assert_eq!(plan_rows.len(), usize::try_from(depth).expect("small"));
+    for row in &plan_rows {
+        assert_eq!(
+            row.chars().skip(5).count(),
+            usize::try_from(width).expect("small")
+        );
+    }
+
+    let elevation = elevation_text(&world);
+    let side_rows: Vec<&str> = elevation
+        .lines()
+        .skip(1)
+        .take_while(|l| l.contains('.') || l.contains('#') || l.contains('@'))
+        .collect();
+    assert_eq!(side_rows.len(), usize::try_from(height).expect("small"));
+    for row in &side_rows {
+        assert_eq!(
+            row.chars().skip(5).count(),
+            usize::try_from(width).expect("small")
+        );
+    }
+}
+
+/// **The player appears in both views**, which is only true if both slice
+/// through the cell it is actually in.
+///
+/// A slice taken at the wrong height or the wrong depth would draw a perfectly
+/// plausible picture of the world with no player in it.
+#[test]
+fn the_player_appears_in_both_views() {
+    for script in SCRIPTS {
+        for ticks in [1, 120, 400] {
+            let world = run_world(&Options {
+                script,
+                ticks,
+                ..Options::default()
+            });
+            assert!(
+                plan_text(&world).contains('@'),
+                "{script:?}/{ticks}: the player is not in the plan"
+            );
+            assert!(
+                elevation_text(&world).contains('@'),
+                "{script:?}/{ticks}: the player is not in the elevation"
+            );
+        }
+    }
+}
+
+/// Both views name the slice they took, because a slice that does not say
+/// where it cut is not readable against another one.
+#[test]
+fn both_views_say_where_they_cut() {
+    let world = run_world(&Options {
+        script: Script::Stand,
+        ticks: 100,
+        ..Options::default()
+    });
+    let at = Cell::containing(world.position());
+    assert!(plan_text(&world).starts_with(&format!("plan, looking down, at y={}", at.y)));
+    assert!(
+        elevation_text(&world).starts_with(&format!("elevation, looking along z, at z={}", at.z))
+    );
+}
+
+/// **The elevation puts height upward.** Drawn the other way it is still a
+/// correct slice and an unreadable one, and the floor is what shows it: the
+/// arena's solid floor must be at the bottom of the picture.
+#[test]
+fn the_elevation_puts_the_floor_at_the_bottom() {
+    let world = run_world(&Options {
+        script: Script::Stand,
+        ticks: 100,
+        ..Options::default()
+    });
+    let text = elevation_text(&world);
+    let rows: Vec<&str> = text
+        .lines()
+        .skip(1)
+        .take_while(|l| l.contains('.') || l.contains('#') || l.contains('@'))
+        .collect();
+
+    let solid_in = |row: &str| row.chars().skip(5).filter(|c| *c == '#').count();
+    let first = rows.first().expect("rows");
+    let last = rows.last().expect("rows");
+    assert_eq!(
+        solid_in(last),
+        last.chars().skip(5).count(),
+        "the bottom row is the floor, solid all the way across"
+    );
+    assert_eq!(
+        solid_in(first),
+        first.chars().skip(5).count(),
+        "and the top row is the ceiling, since the box is closed"
+    );
+}
+
+/// A picture is a pure function of the world it is given.
+#[test]
+fn the_views_are_reproducible() {
+    let world = run_world(&Options {
+        script: Script::Build,
+        ticks: 250,
+        ..Options::default()
+    });
+    assert_eq!(plan_text(&world), plan_text(&world));
+    assert_eq!(elevation_text(&world), elevation_text(&world));
+
+    let other = run_world(&Options {
+        script: Script::Build,
+        ticks: 400,
+        ..Options::default()
+    });
+    assert_ne!(
+        plan_text(&world),
+        plan_text(&other),
+        "two very different runs drew the same plan"
+    );
+}
+
+/// **`run` and `run_world` answer about the same run.** They are separate
+/// entry points now, and a report describing a different run than the picture
+/// beside it would be worse than having no picture.
+#[test]
+fn the_report_and_the_world_agree() {
+    let options = Options {
+        script: Script::Build,
+        ticks: 300,
+        ..Options::default()
+    };
+    let report = run(&options);
+    let world = run_world(&options);
+    assert_eq!(report.digest, world.digest());
+    assert_eq!(report.solids, world.grid().solid_count());
+    assert_eq!(report.grounded, world.grounded());
+    assert_eq!(report.ticks, world.tick());
+}
+
+/// The whole binary, drawing.
+#[test]
+fn the_command_line_draws() {
+    assert_eq!(run_cli(args("--ticks 30 --show")), 0);
+    assert_eq!(run_cli(args("--ticks 30 --show --json")), 0);
+}

--- a/samples/cube/world/src/grid.rs
+++ b/samples/cube/world/src/grid.rs
@@ -171,8 +171,30 @@ impl Grid {
         self.get(cell).is_some_and(|block| block != AIR)
     }
 
-    /// Put a block in a cell. `false` if the cell is outside the grid.
+    /// Put a block in a cell. `false` if the cell is outside the grid, or if
+    /// it is on the shell and the block is air.
+    ///
+    /// **The shell cannot be cleared, and that is the world being closed
+    /// rather than a special case.** Outside the grid is neither solid nor
+    /// air, so a player who gets out of it falls forever with nothing to land
+    /// on and no way to tell that from a deep hole.
+    ///
+    /// Two attempts at this were too weak, and both are worth recording
+    /// because each looked sufficient:
+    ///
+    /// - **A thicker floor.** Anything that can dig once can dig again, so no
+    ///   thickness closes a floor against a script that repeats.
+    /// - **An unbreakable bottom layer.** It stopped the digging and not the
+    ///   climbing: `build` places blocks under itself, so it built a tower
+    ///   past the three-high walls and walked off the top.
+    ///
+    /// The shell is the boundary of the box in all three axes, so there is no
+    /// direction left to leave by. Filling is unaffected: only clearing is
+    /// refused, and only on the boundary.
     pub fn set(&mut self, cell: Cell, block: Block) -> bool {
+        if block == AIR && self.on_shell(cell) {
+            return false;
+        }
         // `index` already proved the cell is inside, so the slot is there. A
         // second `None` arm would be a branch nothing could take.
         let Some(slot) = self.index(cell).and_then(|at| self.blocks.get_mut(at)) else {
@@ -180,6 +202,24 @@ impl Grid {
         };
         *slot = block;
         true
+    }
+
+    /// Whether a cell is on the outer boundary of the grid in any axis.
+    ///
+    /// Cells outside the grid are not on its shell — they are not in it at
+    /// all, and [`Self::set`] refuses them for that reason instead.
+    #[must_use]
+    pub fn on_shell(&self, cell: Cell) -> bool {
+        let (width, height, depth) = self.size;
+        if self.index(cell).is_none() {
+            return false;
+        }
+        cell.x == self.min.x
+            || cell.y == self.min.y
+            || cell.z == self.min.z
+            || cell.x == self.min.x + width - 1
+            || cell.y == self.min.y + height - 1
+            || cell.z == self.min.z + depth - 1
     }
 
     /// Fill a rectangular region, inclusive of both corners.

--- a/samples/cube/world/tests/shell.rs
+++ b/samples/cube/world/tests/shell.rs
@@ -1,0 +1,117 @@
+//! The world is a closed box, and the boundary is what closes it.
+//!
+//! Outside the grid is neither solid nor air — [`Grid::get`] returns nothing
+//! and the caller decides — so a player who gets out has nothing to land on and
+//! nothing to tell them they have left. The shell exists so that no sequence of
+//! edits can put them there.
+
+use renew_sample_cube_world::{AIR, Cell, Grid, STONE};
+
+fn box_of(min: Cell, size: (i32, i32, i32)) -> Grid {
+    let mut grid = Grid::new(min, size);
+    let high = Cell::new(min.x + size.0 - 1, min.y + size.1 - 1, min.z + size.2 - 1);
+    grid.fill(min, high, STONE);
+    grid
+}
+
+/// **Every cell on the boundary refuses to be cleared, and every cell inside
+/// allows it.** Checked over a whole small grid rather than at a few corners,
+/// because an off-by-one in any one of the six faces is the failure this rule
+/// exists to prevent.
+#[test]
+fn the_shell_refuses_to_be_cleared_and_the_inside_does_not() {
+    let min = Cell::new(-2, -1, 3);
+    let size = (5, 4, 6);
+    let mut grid = box_of(min, size);
+
+    for x in min.x..min.x + size.0 {
+        for y in min.y..min.y + size.1 {
+            for z in min.z..min.z + size.2 {
+                let cell = Cell::new(x, y, z);
+                let on_edge = x == min.x
+                    || y == min.y
+                    || z == min.z
+                    || x == min.x + size.0 - 1
+                    || y == min.y + size.1 - 1
+                    || z == min.z + size.2 - 1;
+
+                assert_eq!(grid.on_shell(cell), on_edge, "on_shell wrong at {cell:?}");
+                assert_eq!(
+                    grid.set(cell, AIR),
+                    !on_edge,
+                    "clearing {cell:?} answered wrongly"
+                );
+                assert_eq!(
+                    grid.is_solid(cell),
+                    on_edge,
+                    "{cell:?} ended in the wrong state"
+                );
+            }
+        }
+    }
+}
+
+/// **Filling the shell is allowed; only clearing it is refused.** A rule that
+/// rejected every write to the boundary would stop a world being built in the
+/// first place, since `fill` is how the shell gets there.
+#[test]
+fn the_shell_can_be_filled_even_though_it_cannot_be_cleared() {
+    let min = Cell::new(0, 0, 0);
+    let mut grid = Grid::new(min, (3, 3, 3));
+    let corner = Cell::new(0, 0, 0);
+
+    assert!(!grid.is_solid(corner), "it starts empty");
+    assert!(grid.set(corner, STONE), "filling the shell is allowed");
+    assert!(grid.is_solid(corner));
+    assert!(!grid.set(corner, AIR), "clearing it is not");
+    assert!(grid.is_solid(corner), "and it did not happen anyway");
+}
+
+/// A cell outside the grid is not on its shell — it is not in it at all, and
+/// `set` refuses it for that reason rather than this one.
+#[test]
+fn a_cell_outside_the_grid_is_not_on_its_shell() {
+    let grid = box_of(Cell::new(0, 0, 0), (3, 3, 3));
+    for cell in [
+        Cell::new(-1, 0, 0),
+        Cell::new(3, 0, 0),
+        Cell::new(0, -1, 0),
+        Cell::new(0, 3, 0),
+        Cell::new(0, 0, -1),
+        Cell::new(0, 0, 3),
+        Cell::new(100, 100, 100),
+    ] {
+        assert!(
+            !grid.on_shell(cell),
+            "{cell:?} is outside, not on the shell"
+        );
+        assert_eq!(grid.get(cell), None, "{cell:?} is outside");
+    }
+}
+
+/// A grid one cell thick in some axis is all shell, which is degenerate but
+/// must not be a panic or an off-by-one.
+#[test]
+fn a_grid_with_no_inside_is_all_shell() {
+    let grid = box_of(Cell::new(0, 0, 0), (1, 5, 5));
+    for y in 0..5 {
+        for z in 0..5 {
+            let cell = Cell::new(0, y, z);
+            assert!(grid.on_shell(cell), "{cell:?} has no inside to be in");
+        }
+    }
+}
+
+/// The shell rule leaves the solid count alone, because a refused clear is not
+/// a clear.
+#[test]
+fn a_refused_clear_changes_nothing() {
+    let mut grid = box_of(Cell::new(0, 0, 0), (4, 4, 4));
+    let before = grid.solid_count();
+    for x in 0..4 {
+        for z in 0..4 {
+            grid.set(Cell::new(x, 0, z), AIR);
+        }
+    }
+    assert_eq!(grid.solid_count(), before, "the floor was removed");
+}


### PR DESCRIPTION
`cube --show` draws two slices: the plan looking down at the height the player
stands in, and the elevation looking along z at its depth. The whole grid in
both, not a window onto it — the arena is forty-one cells across and fits a
terminal, so two runs compare cell for cell.

**The first picture showed the player twenty-five blocks below a floor at
y = 0.** The `build` script had dug through the single-block floor beneath
itself, dropped out of the world, and spent most of its run falling. Outside
the grid is neither solid nor air, so there was nothing to land on and nothing
to say it had left. Every test passed: they all asked whether the run
reproduced, and a fall reproduces perfectly.

The fix took three attempts, and the first two are recorded where the rule now
lives because each looked sufficient:

- **A thicker floor.** Anything that can dig once can dig again, so no
  thickness closes a floor against a script that repeats.
- **An unbreakable bottom layer.** It stopped the digging and not the
  climbing — `build` places blocks under itself, so it built a tower past the
  three-high walls and stepped off the top.

What holds is a rule rather than a shape: **the grid's shell cannot be
cleared**, in all three axes, and the arena fills every face. There is no
direction left to leave by, and no sequence of edits can open the box from
inside. Filling the shell is still allowed, since that is how a world gets
built.

Closing the box made the floor unbreakable, which quietly turned the digging
script into one that reaches for the shell and is refused — it broke nothing
and the run still looked fine. The arena grew a mound inside it so that
digging has something to dig, and a test now requires that it does.

The containment test is the one that was missing all along: no script puts the
player outside the world, checked at six run lengths, because the original
defect needed a few hundred ticks to appear and would have passed at fifty.
