### PR TITLE
feat(physics2d): push a body out of what it is inside, and keep it out

### DIFF
--- a/crates/physics2d/src/clear.rs
+++ b/crates/physics2d/src/clear.rs
@@ -118,6 +118,15 @@ impl World {
     /// from its own test: its shapes are parts of one object, and an object is
     /// not inside itself.
     ///
+    /// **Capsules are skipped, because nothing here can measure them.** The
+    /// narrowphase does not implement them — it says so where it declines
+    /// them — and this operation inherits that gap exactly: a capsule is
+    /// neither pushed out of anything nor pushes anything out, and the answer
+    /// will be `AlreadyClear` however deeply it overlaps. That is the crate's
+    /// existing position on capsules, not a new one, and it is stated here
+    /// because the clearance guarantee `move_and_slide` now makes would
+    /// otherwise read as covering them.
+    ///
     /// **The body moves; nothing else does.** Whatever it was inside stays
     /// where it is, including another body that could have been pushed instead.
     /// That is v0 being explicit rather than clever: choosing which of two

--- a/crates/physics2d/src/clear.rs
+++ b/crates/physics2d/src/clear.rs
@@ -1,0 +1,163 @@
+//! Moving a body out of what it is inside, or too close to.
+//!
+//! **The operation the vocabulary called depenetration**, and the one piece of
+//! machinery two separate obligations turned out to share.
+//!
+//! A body may begin an operation overlapping something — spawned there, or a
+//! kinematic platform moved into it — and nothing in the sweep can help: a
+//! sweep starts from where the body is and asks what it will hit, which is the
+//! wrong question when the answer is already touching it. And a slide, measured
+//! against real geometry, ends a little closer than the skin distance it was
+//! asked to keep, by an amount that grows with the distance travelled. Both are
+//! the same problem stated at different times: *the body is nearer than the
+//! skin, and something must push it out.*
+//!
+//! **It moves along the separating direction, one shape at a time, worst
+//! first.** Pushing the deepest overlap out can push the body into a shallower
+//! one, which is why this iterates rather than doing a single pass, and why it
+//! reports how many iterations it took and whether it finished. A corner
+//! between two faces needs two.
+
+use renew_fixed::{Fixed, Vec2};
+
+use crate::narrow::separation;
+use crate::query::Exclude;
+use crate::shape::Transform;
+use crate::world::{Collider, ShapeIndex, World};
+
+/// How a clearing ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClearEnd {
+    /// Nothing was closer than the skin distance, so nothing moved.
+    ///
+    /// **Distinct from `Cleared` on purpose.** A caller that wants to know
+    /// whether the body had been left somewhere it should not be — a spawn
+    /// check, a platform that may have crushed something — needs to tell "it
+    /// was fine" from "it is fine now", and a displacement of zero does not
+    /// say that: a body one raw unit inside can be pushed out by a distance
+    /// that rounds to nothing.
+    AlreadyClear,
+    /// The body was moved until nothing was closer than the skin distance.
+    Cleared,
+    /// The iteration limit ran out with something still too close.
+    ///
+    /// **Not an error and not a success.** It happens where geometry genuinely
+    /// has no room — a body wider than the gap it is in — and the honest answer
+    /// is the best position found plus the fact that it is not enough.
+    IterationsExhausted,
+}
+
+/// What a clearing did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ClearReport {
+    /// Where the body ended up.
+    pub destination: Vec2,
+    /// How far it was moved, which is zero when it was already clear.
+    pub moved: Vec2,
+    /// How many pushes it took.
+    pub iterations: u32,
+    /// Whether it finished, and how.
+    pub end: ClearEnd,
+}
+
+impl World {
+    /// The worst violation of the skin distance at a given placement: how far
+    /// short it falls, and the direction from this body toward the offender.
+    ///
+    /// **Ties break on the collider**, the same way the sweep's do, because two
+    /// equal deficits must resolve the same way on every machine or the
+    /// operation is not reproducible.
+    fn deepest_deficit(
+        &self,
+        handle: renew_ecs::Entity,
+        at: Transform,
+        mask: u32,
+        skin: Fixed,
+    ) -> Option<(Fixed, Vec2)> {
+        let extent = self.shape_extent(handle)?;
+        let excluded = [handle];
+        let mut worst: Option<(Fixed, Vec2, Collider)> = None;
+
+        for index in 0..extent {
+            let mine = Collider {
+                handle,
+                index: ShapeIndex::from_raw(index),
+            };
+            let Some((shape, local, _)) = self.shape(mine) else {
+                continue;
+            };
+            let placed = local.compose(at);
+
+            for collider in self.colliders() {
+                let Some((other, other_at)) =
+                    self.query_visible(collider, mask, Exclude::bodies(&excluded))
+                else {
+                    continue;
+                };
+                let Some((gap, direction)) = separation(shape, placed, other, other_at) else {
+                    continue;
+                };
+                if gap >= skin {
+                    continue;
+                }
+                let deficit = skin - gap;
+                let beats_it = worst.as_ref().is_none_or(|(current, _, current_collider)| {
+                    deficit > *current || (deficit == *current && collider < *current_collider)
+                });
+                if beats_it {
+                    worst = Some((deficit, direction, collider));
+                }
+            }
+        }
+        worst.map(|(deficit, direction, _)| (deficit, direction))
+    }
+
+    /// Push a body out until nothing is closer to it than the skin distance.
+    ///
+    /// Returns nothing if the handle names no live body. The body is excluded
+    /// from its own test: its shapes are parts of one object, and an object is
+    /// not inside itself.
+    ///
+    /// **The body moves; nothing else does.** Whatever it was inside stays
+    /// where it is, including another body that could have been pushed instead.
+    /// That is v0 being explicit rather than clever: choosing which of two
+    /// bodies yields is a question about mass and kind that this crate has no
+    /// answer for yet, and splitting the movement between them would make the
+    /// result depend on the order they were created in.
+    pub fn clear_of_geometry(
+        &mut self,
+        handle: renew_ecs::Entity,
+        mask: u32,
+        skin: Fixed,
+        iteration_limit: u32,
+    ) -> Option<ClearReport> {
+        let start = self.transform(handle)?;
+        let mut position = start.translation;
+        let mut iterations = 0;
+        let end = loop {
+            let here = Transform::new(position, start.rotation);
+            let Some((deficit, direction)) = self.deepest_deficit(handle, here, mask, skin) else {
+                break if iterations == 0 {
+                    ClearEnd::AlreadyClear
+                } else {
+                    ClearEnd::Cleared
+                };
+            };
+            if iterations >= iteration_limit {
+                break ClearEnd::IterationsExhausted;
+            }
+            iterations += 1;
+            // The direction runs from this body toward what it is too close
+            // to, so getting away from it means going the other way.
+            position = position - direction * deficit;
+        };
+
+        self.set_transform(handle, Transform::new(position, start.rotation));
+        Some(ClearReport {
+            destination: position,
+            moved: position - start.translation,
+            iterations,
+            end,
+        })
+    }
+}

--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -42,6 +42,7 @@
 
 pub mod bounds;
 pub mod broadphase;
+pub mod clear;
 pub mod contact;
 pub mod filter;
 pub mod narrow;
@@ -54,6 +55,7 @@ pub mod world;
 
 pub use bounds::Aabb;
 pub use broadphase::Broadphase;
+pub use clear::{ClearEnd, ClearReport};
 pub use contact::{Contact, ContactPoint, MAX_MANIFOLD_POINTS, Manifold};
 pub use filter::Filter;
 pub use narrow::collide;

--- a/crates/physics2d/src/slide.rs
+++ b/crates/physics2d/src/slide.rs
@@ -74,6 +74,14 @@ impl World {
         iteration_limit: u32,
         out: &mut [SlideHit],
     ) -> Option<SlideReport> {
+        // **Out of anything it is already inside, before asking what it will
+        // hit.** A sweep starts from where the body is and answers what is
+        // ahead of it, which is the wrong question when the answer is already
+        // touching — so a body spawned overlapping, or one a platform has been
+        // moved into, would otherwise sweep out from inside the thing it is
+        // stuck in and stay stuck.
+        self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+
         let start = self.transform(handle)?;
         let mut position = start.translation;
         let mut remaining = displacement;
@@ -124,8 +132,20 @@ impl World {
         }
 
         self.set_transform(handle, Transform::new(position, start.rotation));
+
+        // **And out again at the end, which is what makes the clearance
+        // guarantee true rather than approximate.** Measured against real
+        // geometry, the slide alone lands a little inside the skin distance by
+        // an amount that grows with the distance travelled — the sweep backs
+        // off by the skin each iteration and the arithmetic rounds each time.
+        // No smaller correction bounds it: cutting the move into pieces leaves
+        // the proportional part untouched and makes the constant part worse.
+        // Re-establishing the clearance directly is the one thing that does,
+        // and it is the same operation the body already needed on the way in.
+        let restored = self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+
         Some(SlideReport {
-            destination: position,
+            destination: restored.destination,
             hits,
             iterations,
             end,

--- a/crates/physics2d/tests/clear.rs
+++ b/crates/physics2d/tests/clear.rs
@@ -1,0 +1,324 @@
+//! Pushing a body out of what it is inside, or too close to.
+//!
+//! **The clearance is read off box arithmetic done here**, never from the
+//! engine, for the same reason the creep measurement does it: an operation that
+//! leaves the body in the wrong place must not also be the thing that decides
+//! the place was right.
+
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{BodyKind, ClearEnd, Filter, Shape, Transform, World};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn at(x: i32, y: i32) -> Transform {
+    Transform::at(v(x, y))
+}
+
+const SKIN_RAW: i64 = 64;
+const SKIN: Fixed = Fixed::from_bits(SKIN_RAW);
+const ANY: u32 = u32::MAX;
+
+#[derive(Clone, Copy)]
+struct Wall {
+    centre: (i32, i32),
+    half: (i32, i32),
+}
+
+fn separation_raw(centre: Vec2, half: Vec2, wall: Wall) -> i64 {
+    let wall_centre = v(wall.centre.0, wall.centre.1);
+    let wall_half = v(wall.half.0, wall.half.1);
+    let gap_x = (centre.x - wall_centre.x).abs().to_bits() - (half.x + wall_half.x).to_bits();
+    let gap_y = (centre.y - wall_centre.y).abs().to_bits() - (half.y + wall_half.y).to_bits();
+    if gap_x < 0 && gap_y < 0 {
+        return gap_x.max(gap_y);
+    }
+    let dx = gap_x.max(0);
+    let dy = gap_y.max(0);
+    (dx * dx + dy * dy).isqrt()
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "a test helper: the body is created in the same function, and a \
+              panic here is the failure being reported"
+)]
+fn clearance_raw(world: &World, character: Entity, walls: &[Wall]) -> i64 {
+    let here = world.transform(character).expect("a live body").translation;
+    walls
+        .iter()
+        .map(|wall| separation_raw(here, v(1, 1), *wall))
+        .min()
+        .unwrap_or(i64::MAX)
+}
+
+fn staged(start: (i32, i32), walls: &[Wall]) -> (World, Entity) {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let character = entities.spawn();
+    world.create_body(character, BodyKind::Kinematic, at(start.0, start.1));
+    world.add_shape(
+        character,
+        Shape::Box {
+            half_extents: v(1, 1),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+    for wall in walls {
+        let handle = entities.spawn();
+        world.create_body(handle, BodyKind::Static, at(wall.centre.0, wall.centre.1));
+        world.add_shape(
+            handle,
+            Shape::Box {
+                half_extents: v(wall.half.0, wall.half.1),
+            },
+            Transform::IDENTITY,
+            Filter::new(1, 1),
+        );
+    }
+    (world, character)
+}
+
+/// **A body inside a wall comes out**, from every side and from dead centre.
+///
+/// Dead centre is the case worth having: the separating direction there is a
+/// tie between four faces, and an implementation that picked none of them would
+/// leave the body where it was while reporting success.
+#[test]
+fn a_body_inside_a_wall_is_pushed_clear_of_it() {
+    let walls = [Wall {
+        centre: (0, 0),
+        half: (4, 4),
+    }];
+    for start in [(0, 0), (3, 0), (-3, 0), (0, 3), (0, -3), (4, 4), (-2, 3)] {
+        let (mut world, character) = staged(start, &walls);
+        let report = world
+            .clear_of_geometry(character, ANY, SKIN, 8)
+            .expect("a live body");
+        let clearance = clearance_raw(&world, character, &walls);
+        assert!(
+            clearance >= SKIN_RAW,
+            "started at {start:?} and ended {clearance} raw away, inside the skin of {SKIN_RAW}"
+        );
+        assert_eq!(report.end, ClearEnd::Cleared, "from {start:?}");
+        assert!(report.iterations >= 1, "from {start:?}");
+    }
+}
+
+/// A body already clear is left exactly where it is, and says so.
+///
+/// **`AlreadyClear` and `Cleared` are different answers**, because a caller
+/// checking whether a spawn was safe cannot tell them apart from the
+/// displacement alone: a body one raw unit inside is pushed out by a distance
+/// that rounds to nothing.
+#[test]
+fn a_body_already_clear_is_not_moved() {
+    let walls = [Wall {
+        centre: (0, 0),
+        half: (4, 4),
+    }];
+    for start in [(10, 0), (0, 20), (-30, -30), (6, 6)] {
+        let (mut world, character) = staged(start, &walls);
+        let before = world.transform(character).expect("a live body").translation;
+        let report = world
+            .clear_of_geometry(character, ANY, SKIN, 8)
+            .expect("a live body");
+        assert_eq!(report.end, ClearEnd::AlreadyClear, "from {start:?}");
+        assert_eq!(report.iterations, 0, "from {start:?}");
+        assert_eq!(report.moved, Vec2::ZERO, "from {start:?}");
+        assert_eq!(
+            world.transform(character).expect("a live body").translation,
+            before,
+            "from {start:?}"
+        );
+    }
+}
+
+/// **A corner needs more than one push**, which is the whole reason this
+/// iterates: coming out of one face can put the body inside the other.
+#[test]
+fn a_corner_takes_more_than_one_push() {
+    let walls = [
+        Wall {
+            centre: (-5, 0),
+            half: (4, 20),
+        },
+        Wall {
+            centre: (0, -5),
+            half: (20, 4),
+        },
+    ];
+    let (mut world, character) = staged((-1, -1), &walls);
+    let report = world
+        .clear_of_geometry(character, ANY, SKIN, 8)
+        .expect("a live body");
+
+    let clearance = clearance_raw(&world, character, &walls);
+    assert!(
+        clearance >= SKIN_RAW,
+        "left {clearance} raw from a corner, inside the skin of {SKIN_RAW}"
+    );
+    assert_eq!(report.end, ClearEnd::Cleared);
+    assert!(
+        report.iterations >= 2,
+        "a corner came out in {} push(es), so one of the two faces was never \
+         violated and this is not the case it claims to be",
+        report.iterations
+    );
+}
+
+/// **Geometry with no room reports that it ran out**, rather than claiming
+/// success or looping forever.
+#[test]
+fn a_gap_too_narrow_to_fit_reports_that_it_ran_out() {
+    // A two-unit body in a slot barely two units wide: no position satisfies
+    // both walls by the skin distance.
+    let walls = [
+        Wall {
+            centre: (-2, 0),
+            half: (1, 20),
+        },
+        Wall {
+            centre: (2, 0),
+            half: (1, 20),
+        },
+    ];
+    let (mut world, character) = staged((0, 0), &walls);
+    let report = world
+        .clear_of_geometry(character, ANY, SKIN, 6)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::IterationsExhausted);
+    assert_eq!(report.iterations, 6, "it spent the whole budget trying");
+}
+
+/// The mask is obeyed: geometry the caller is not asking about does not push.
+#[test]
+fn geometry_outside_the_mask_does_not_push() {
+    let walls = [Wall {
+        centre: (0, 0),
+        half: (4, 4),
+    }];
+    let (mut world, character) = staged((0, 0), &walls);
+    let report = world
+        .clear_of_geometry(character, 0, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(
+        report.end,
+        ClearEnd::AlreadyClear,
+        "nothing was asked about"
+    );
+    assert_eq!(report.moved, Vec2::ZERO);
+}
+
+/// A body does not push itself out of its own shapes.
+#[test]
+fn a_body_is_not_inside_itself() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let character = entities.spawn();
+    world.create_body(character, BodyKind::Kinematic, Transform::IDENTITY);
+    // Two overlapping shapes on one body: parts of one object.
+    world.add_shape(
+        character,
+        Shape::Box {
+            half_extents: v(1, 1),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+    world.add_shape(
+        character,
+        Shape::Box {
+            half_extents: v(1, 1),
+        },
+        at(1, 0),
+        Filter::new(1, 1),
+    );
+    let report = world
+        .clear_of_geometry(character, ANY, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::AlreadyClear);
+    assert_eq!(report.moved, Vec2::ZERO);
+}
+
+/// A handle naming no body answers with nothing rather than panicking.
+#[test]
+fn a_dead_handle_answers_with_nothing() {
+    let mut world = World::new();
+    let stranger = Entities::new().spawn();
+    assert!(world.clear_of_geometry(stranger, ANY, SKIN, 8).is_none());
+}
+
+/// **The same situation clears the same way every time**, and the answer does
+/// not depend on which order the geometry was created in.
+///
+/// Two equal deficits must resolve identically or the operation is not
+/// reproducible, and creation order is exactly the thing that differs between
+/// a level loaded from a file and one built by hand.
+#[test]
+fn clearing_is_reproducible_and_order_independent() {
+    let a = Wall {
+        centre: (-5, 0),
+        half: (4, 20),
+    };
+    let b = Wall {
+        centre: (0, -5),
+        half: (20, 4),
+    };
+
+    let run = |walls: &[Wall]| {
+        let (mut world, character) = staged((-1, -1), walls);
+        world
+            .clear_of_geometry(character, ANY, SKIN, 8)
+            .expect("a live body")
+            .destination
+    };
+
+    let first = run(&[a, b]);
+    assert_eq!(first, run(&[a, b]), "the same world cleared differently");
+    assert_eq!(
+        first,
+        run(&[b, a]),
+        "the geometry's creation order changed where the body ended up"
+    );
+}
+
+/// Circles are pushed out too — the operation is not box-only.
+#[test]
+fn a_circle_is_pushed_clear_as_well() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let ball = entities.spawn();
+    world.create_body(ball, BodyKind::Kinematic, at(1, 0));
+    world.add_shape(
+        ball,
+        Shape::Circle { radius: Fixed::ONE },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+    let wall = entities.spawn();
+    world.create_body(wall, BodyKind::Static, Transform::IDENTITY);
+    world.add_shape(
+        wall,
+        Shape::Box {
+            half_extents: v(4, 4),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+
+    let report = world
+        .clear_of_geometry(ball, ANY, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::Cleared);
+
+    let here = world.transform(ball).expect("a live body").translation;
+    let gap = here.x.abs().to_bits() - Fixed::from_int(5).to_bits();
+    assert!(
+        gap >= SKIN_RAW,
+        "the circle rests {gap} raw from the face, inside the skin of {SKIN_RAW}"
+    );
+}

--- a/crates/physics2d/tests/clear.rs
+++ b/crates/physics2d/tests/clear.rs
@@ -322,3 +322,81 @@ fn a_circle_is_pushed_clear_as_well() {
         "the circle rests {gap} raw from the face, inside the skin of {SKIN_RAW}"
     );
 }
+
+/// **A capsule is not pushed out of anything, because nothing can measure it.**
+///
+/// The narrowphase does not implement capsules and declines them rather than
+/// reporting "they do not touch", which would be a lie. This operation inherits
+/// that exactly, and the inheritance is worth a test: the clearance guarantee
+/// the slide now makes would otherwise read as covering every shape, and a
+/// caller putting a capsule in a level would get silence rather than an answer.
+///
+/// This test asserts the gap. Implementing capsules will fail it.
+#[test]
+fn a_capsule_is_skipped_because_nothing_can_measure_it() {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let body = entities.spawn();
+    world.create_body(body, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(
+        body,
+        Shape::Capsule {
+            radius: Fixed::ONE,
+            half_height: Fixed::ONE,
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+    let wall = entities.spawn();
+    world.create_body(wall, BodyKind::Static, Transform::IDENTITY);
+    world.add_shape(
+        wall,
+        Shape::Box {
+            half_extents: v(4, 4),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+
+    let report = world
+        .clear_of_geometry(body, ANY, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(
+        report.end,
+        ClearEnd::AlreadyClear,
+        "a capsule dead inside a box was measured after all"
+    );
+    assert_eq!(report.moved, Vec2::ZERO);
+
+    // And the other way round: a box inside a capsule is equally unmeasurable.
+    // **In a world of its own** — the first attempt reused this one, and the
+    // box was duly pushed out of the *box* wall above, which is correct
+    // behaviour and says nothing at all about capsules.
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let box_body = entities.spawn();
+    world.create_body(box_body, BodyKind::Kinematic, Transform::IDENTITY);
+    world.add_shape(
+        box_body,
+        Shape::Box {
+            half_extents: v(1, 1),
+        },
+        Transform::IDENTITY,
+        Filter::new(2, 2),
+    );
+    let capsule_wall = entities.spawn();
+    world.create_body(capsule_wall, BodyKind::Static, Transform::IDENTITY);
+    world.add_shape(
+        capsule_wall,
+        Shape::Capsule {
+            radius: Fixed::from_int(4),
+            half_height: Fixed::from_int(4),
+        },
+        Transform::IDENTITY,
+        Filter::new(2, 2),
+    );
+    let report = world
+        .clear_of_geometry(box_body, ANY, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::AlreadyClear);
+}

--- a/crates/physics2d/tests/creep.rs
+++ b/crates/physics2d/tests/creep.rs
@@ -6,7 +6,11 @@
 //! both were wrong — the second is refuted by a test in `renew-fixed`, because
 //! the proportional term it tried to bound is scale-invariant under cutting.
 //! The written conclusion was that an implementation must answer it with
-//! running code instead. This is that code.
+//! running code instead. This is that code, and it has done both halves of the
+//! job: it measured a shortfall proportional to the distance travelled, and
+//! then — once a clearance-restoring step existed to answer it — it measured
+//! the shortfall away. **What these tests assert changed when the behaviour
+//! did**, because each was pinned to a number and the numbers moved.
 //!
 //! **The clearance is measured, not asked for.** Every number below comes from
 //! axis-aligned box arithmetic done in this file, over the positions the slide
@@ -179,45 +183,21 @@ fn displacements_with_length() -> Vec<(Vec2, i64)> {
     out
 }
 
-/// The clearance a slide is allowed to fall short of the skin by, in raw
-/// units, for a slide of `units` whole units.
+/// **The property, now that it holds.**
 ///
-/// **Measured, not derived.** Over the sweep below — five iteration limits,
-/// five starting places, four skins and seventy-two displacements — the worst
-/// observed shortfall was 15072 raw at roughly 38 000 units travelled, a slope
-/// near one raw unit per 131 000 raw units of travel. This bound is that slope
-/// doubled and rounded to something a person can hold: **one raw unit of
-/// shortfall per whole unit travelled, plus four**.
+/// Before the clearance-restoring step existed this assertion was impossible:
+/// the shortfall grew with the distance travelled and a five-hundred-unit slide
+/// ended ninety-six raw units inside the wall. The sweep below is the one that
+/// measured that, unchanged — five iteration limits, five starting places, four
+/// skin distances and seventy-two displacements — and it now passes.
 ///
-/// The vocabulary derived `2 + L/8192` raw per iteration from the normal
-/// tolerance. That is about twenty-five times looser than what this
-/// implementation actually does, which is the expected direction — the
-/// derivation is what a merely adequate implementation may spend, and
-/// `renew-fixed`'s normalisation is better than adequate.
-fn allowed_shortfall_raw(units: i64) -> i64 {
-    4 + units
-}
-
-/// **The answer to the open question, measured over real geometry.**
-///
-/// The written vocabulary states the obligation and says outright that no
-/// prose mechanism has bounded it, that two attempts were wrong, and that an
-/// implementation must settle it with running code. This is the running code,
-/// and the answer is a law rather than a constant: *the clearance after a
-/// slide is the skin, less a shortfall proportional to the distance
-/// travelled.*
-///
-/// The assertion is two-sided on purpose, which is the shape a bound
-/// assertion has to have. One side requires the bound to hold. The other
-/// requires some configuration to come within a factor of eight of it — so
-/// that a bound loosened until nothing can fail it stops being a bound and
-/// starts failing this test instead.
+/// The clearance is read off box arithmetic done in this file, so a slide that
+/// stops in the wrong place cannot also rule that the place was fine.
 #[test]
-fn the_clearance_shortfall_is_bounded_by_the_distance_travelled() {
+fn a_slide_never_ends_closer_than_the_skin_minus_the_tolerance() {
     let walls = corridor();
-    let mut worst_excess = i64::MIN;
-    let mut worst_case = (0i64, 0i64, 0i64, 0u32);
-    let mut closest_approach = i64::MIN;
+    let mut worst = i64::MAX;
+    let mut worst_case = (0i64, 0i64, 0i64);
     let mut touched = 0u32;
 
     for limit in [1u32, 2, 4, 8, 16] {
@@ -239,23 +219,23 @@ fn the_clearance_shortfall_is_bounded_by_the_distance_travelled() {
 
                     let clearance = clearance_raw(&world, character, &walls);
                     // Configurations that never reached anything say nothing
-                    // about creep, and counting them would let this pass by
-                    // running in empty space.
+                    // about clearance, and counting them would let this pass
+                    // by running in empty space.
                     if clearance > 4 * skin_raw {
                         continue;
                     }
                     touched += 1;
 
-                    let allowed = allowed_shortfall_raw(units);
                     let shortfall = skin_raw - clearance;
-                    let excess = shortfall - allowed;
-                    if excess > worst_excess {
-                        worst_excess = excess;
-                        worst_case = (units, skin_raw, clearance, limit);
+                    if shortfall > i64::MIN && clearance < worst {
+                        worst = clearance;
+                        worst_case = (units, skin_raw, i64::from(limit));
                     }
-                    // How near the bound anything came, as a fraction of it.
-                    let approach = shortfall * 8 - allowed;
-                    closest_approach = closest_approach.max(approach);
+                    assert!(
+                        clearance >= skin_raw - TOLERANCE_RAW,
+                        "a slide ended {clearance} raw from geometry against a skin of \
+                         {skin_raw} — {units} units travelled, iteration limit {limit}"
+                    );
                 }
             }
         }
@@ -265,41 +245,76 @@ fn the_clearance_shortfall_is_bounded_by_the_distance_travelled() {
         touched > 500,
         "only {touched} configurations reached geometry; the sweep is not exercising the slide"
     );
+    // The worst case is worth naming even when it passes, because a sweep that
+    // stopped reaching the interesting configurations would still pass.
     assert!(
-        worst_excess < 0,
-        "a slide fell {} raw short of the skin where {} was allowed — \
-         {} units travelled, skin {}, clearance {}, iteration limit {}",
-        worst_case.1 - worst_case.2,
-        allowed_shortfall_raw(worst_case.0),
-        worst_case.0,
-        worst_case.1,
-        worst_case.2,
-        worst_case.3
-    );
-    assert!(
-        closest_approach >= 0,
-        "nothing came within a factor of eight of the bound, so the bound is \
-         too loose to be a bound"
+        worst < i64::MAX,
+        "nothing was measured at all: {worst_case:?}"
     );
 }
 
-/// **The specified property does not hold for a fixed skin, and here is the
-/// case that breaks it.**
+/// **The clearance no longer decays with the distance travelled**, which is the
+/// question four prose mechanisms failed to settle and one measurement did.
 ///
-/// The vocabulary asks for a clearance of at least the skin minus the contact
-/// tolerance — 63 raw units when the skin is 64 and the tolerance is 1. The
-/// measured shortfall grows with the distance travelled, so it passes 1 raw
-/// after a couple of units of travel and the property is unreachable for any
-/// ordinary motion.
-///
-/// **This test pins the gap rather than hiding it.** It asserts the failure,
-/// with the number, so the day the implementation restores clearance at the
-/// end of a slide — or scales the skin with the displacement, the two options
-/// the vocabulary itself lists — this test fails and has to be rewritten as
-/// the property finally holding. A gap nobody can see is the thing worth
-/// avoiding; a gap with a test around it is a decision.
+/// The shortfall used to run at about one raw unit per hundred and thirty-one
+/// thousand raw units of travel, so a long slide ended measurably deeper than a
+/// short one. Restoring the clearance at the end of the operation removes the
+/// dependence rather than bounding it: the distance travelled no longer appears
+/// in the answer.
 #[test]
-fn a_fixed_skin_cannot_meet_the_specified_clearance_over_a_long_slide() {
+fn the_clearance_does_not_decay_with_the_distance_travelled() {
+    let walls = corridor();
+    let mut readings = Vec::new();
+
+    for length in [1i32, 4, 16, 64, 256, 1024, 4096] {
+        let (mut world, character) = staged((-35, 10), &walls);
+        let mut hits = empty_hits();
+        world
+            .move_and_slide(
+                character,
+                Vec2::new(Fixed::from_int(length * 3), Fixed::from_int(-length)),
+                ANY,
+                SKIN,
+                8,
+                &mut hits,
+            )
+            .expect("a live body");
+        readings.push((length, clearance_raw(&world, character, &walls)));
+    }
+
+    let touching: Vec<(i32, i64)> = readings
+        .iter()
+        .copied()
+        .filter(|(_, clearance)| *clearance < 4 * SKIN_RAW)
+        .collect();
+    assert!(
+        touching.len() >= 4,
+        "not enough runs reached the geometry to say anything: {readings:?}"
+    );
+    for (length, clearance) in &touching {
+        assert!(
+            *clearance >= REQUIRED_RAW,
+            "a {length}-unit slide ended {clearance} raw away: {touching:?}"
+        );
+    }
+
+    // **The distance must not appear in the answer at all**, not merely be
+    // bounded: the shortest and the longest run must agree exactly.
+    let shortest = touching.first().expect("checked above").1;
+    let longest = touching.last().expect("checked above").1;
+    assert_eq!(
+        shortest, longest,
+        "four thousand units of travel ended somewhere different from four: {touching:?}"
+    );
+}
+
+/// A five-hundred-unit slide — the case that used to end ninety-six raw units
+/// inside the wall.
+///
+/// **Kept as a named case rather than folded into the sweep**, because it is
+/// the one a person can check by hand and the one the write-up quotes.
+#[test]
+fn the_case_that_used_to_end_inside_the_wall_no_longer_does() {
     let walls = corridor();
     let (mut world, character) = staged((0, 2), &walls);
     let mut hits = empty_hits();
@@ -308,21 +323,13 @@ fn a_fixed_skin_cannot_meet_the_specified_clearance_over_a_long_slide() {
         .expect("a live body");
 
     let clearance = clearance_raw(&world, character, &walls);
-    assert!(
-        clearance < REQUIRED_RAW,
-        "the specified clearance is met after all ({clearance} raw against the \
-         required {REQUIRED_RAW}) — if that is a fix rather than an accident, \
-         this test is the one to rewrite"
-    );
     assert_eq!(
-        clearance, -96,
-        "the shortfall over five hundred units changed; it was 160 raw below \
-         the skin of {SKIN_RAW}"
+        clearance, SKIN_RAW,
+        "it rests {clearance} raw from the wall; it used to be -96, and the skin is {SKIN_RAW}"
     );
 }
 
-/// A short slide *does* meet the specified property, which is what makes the
-/// law above a law rather than a blanket failure.
+/// A short slide meets it too, which it always did.
 #[test]
 fn a_short_slide_meets_the_specified_clearance() {
     let walls = corridor();
@@ -335,7 +342,7 @@ fn a_short_slide_meets_the_specified_clearance() {
     let clearance = clearance_raw(&world, character, &walls);
     assert!(
         clearance >= REQUIRED_RAW,
-        "even a twenty-unit slide fell short: {clearance} raw against {REQUIRED_RAW}"
+        "a twenty-unit slide fell short: {clearance} raw against {REQUIRED_RAW}"
     );
     assert!(
         clearance <= 4 * SKIN_RAW,
@@ -343,35 +350,27 @@ fn a_short_slide_meets_the_specified_clearance() {
     );
 }
 
-/// **A body that starts overlapping is not pushed out**, because nothing here
-/// pushes it out yet.
-///
-/// The vocabulary requires depenetration — a body that begins the operation
-/// inside something is moved clear before anything else happens — and this
-/// crate does not implement it. The sweep excludes a body from its own sweep
-/// and starts from wherever it is, so a body inside a wall stays inside it.
-///
-/// Pinned rather than left unsaid: the assertion is that the overlap survives,
-/// with the depth, so the behaviour is a recorded fact instead of an
-/// assumption, and implementing depenetration will fail this test loudly.
+/// **A body that starts overlapping is pushed out before it moves**, which it
+/// was not until the clearing operation existed.
 #[test]
-fn a_body_that_starts_inside_stays_inside_because_nothing_pushes_it_out() {
+fn a_body_that_starts_inside_is_pushed_out_before_it_moves() {
     let walls = vec![Wall {
         centre: (0, 0),
         half: (4, 4),
     }];
-    let (mut world, character) = staged((0, 0), &walls);
-    let mut hits = empty_hits();
-    world
-        .move_and_slide(character, v(1, 0), ANY, SKIN, 8, &mut hits)
-        .expect("a live body");
-
-    let clearance = clearance_raw(&world, character, &walls);
-    assert!(
-        clearance < 0,
-        "the body was moved clear of an overlap it started in ({clearance} raw) — \
-         if depenetration has been implemented, this test is the one to rewrite"
-    );
+    for start in [(0, 0), (3, 0), (0, 3), (4, 4), (-3, 2)] {
+        let (mut world, character) = staged(start, &walls);
+        let mut hits = empty_hits();
+        world
+            .move_and_slide(character, v(1, 0), ANY, SKIN, 8, &mut hits)
+            .expect("a live body");
+        let clearance = clearance_raw(&world, character, &walls);
+        assert!(
+            clearance >= REQUIRED_RAW,
+            "started inside at {start:?} and ended {clearance} raw away, \
+             inside the required {REQUIRED_RAW}"
+        );
+    }
 }
 
 /// The separation arithmetic this file relies on, checked against cases whose


### PR DESCRIPTION
`World::clear_of_geometry` moves a body until nothing is closer to it than the
skin distance, iterating because coming out of one face can put it inside
another — a corner needs two pushes, and it reports how many it took and
whether it finished.

`move_and_slide` now calls it twice, and the two calls answer two different
obligations that turned out to be one problem stated at different times.

**Before the sweep.** A sweep starts from where the body is and answers what is
ahead of it, which is the wrong question when the answer is already touching.
A body spawned overlapping, or one a moving platform has been pushed into,
used to sweep out from inside the thing it was stuck in and stay stuck.

**After the slide.** Measured against real geometry, the slide alone landed a
little inside the skin distance by an amount that grew with the distance
travelled: a five-hundred-unit slide ended ninety-six raw units *inside* the
wall. No smaller correction bounds that — cutting the move into pieces leaves
the proportional part untouched and makes the constant part worse, which is
proved elsewhere. Re-establishing the clearance directly is the one thing that
does, and it **removes** the distance dependence rather than bounding it: a
four-thousand-unit slide now ends at exactly the same clearance as a four-unit
one, asserted as equality rather than as a bound.

The body moves and nothing else does. Choosing which of two bodies yields is a
question about mass and kind this crate has no answer for yet, and splitting
the movement between them would make the result depend on the order they were
created in.

Three tests that asserted the old behaviour and its exact numbers failed the
moment this landed, which is what they were for, and each has been rewritten to
assert the property instead. The sweep that measured the shortfall is unchanged
and now passes.

Behaviour-preserving for every existing consumer: the platformer's digests are
byte-identical across this change, because its character never violated the
skin to begin with.
