### PR TITLE
fix(physics): clearing in three dimensions, with its own iteration budget

### DIFF
--- a/crates/physics2d/src/clear.rs
+++ b/crates/physics2d/src/clear.rs
@@ -25,6 +25,21 @@ use crate::query::Exclude;
 use crate::shape::Transform;
 use crate::world::{Collider, ShapeIndex, World};
 
+/// How many pushes the clearing step gets when a slide invokes it.
+///
+/// **Its own budget, not the slide's.** A caller may ask for a single slide
+/// iteration — that is a perfectly reasonable thing to want, and cheap — but a
+/// single *push* is not enough to re-establish a clearance, because one push
+/// lands short by whatever the separating direction's own rounding costs and
+/// the remainder grows with how deep the body was. Sharing the slide's budget
+/// made the clearance shortfall scale with the distance travelled while
+/// looking like a property of the slide, which is the wrong place to go
+/// looking.
+///
+/// Sixteen because clearing converges in two or three pushes even at a corner,
+/// so this is a runaway guard rather than a working limit.
+pub(crate) const CLEARING_ITERATIONS: u32 = 16;
+
 /// How a clearing ended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ClearEnd {

--- a/crates/physics2d/src/slide.rs
+++ b/crates/physics2d/src/slide.rs
@@ -80,7 +80,7 @@ impl World {
         // touching — so a body spawned overlapping, or one a platform has been
         // moved into, would otherwise sweep out from inside the thing it is
         // stuck in and stay stuck.
-        self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+        self.clear_of_geometry(handle, mask, skin, crate::clear::CLEARING_ITERATIONS)?;
 
         let start = self.transform(handle)?;
         let mut position = start.translation;
@@ -142,7 +142,8 @@ impl World {
         // the proportional part untouched and makes the constant part worse.
         // Re-establishing the clearance directly is the one thing that does,
         // and it is the same operation the body already needed on the way in.
-        let restored = self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+        let restored =
+            self.clear_of_geometry(handle, mask, skin, crate::clear::CLEARING_ITERATIONS)?;
 
         Some(SlideReport {
             destination: restored.destination,

--- a/crates/physics3d/src/clear.rs
+++ b/crates/physics3d/src/clear.rs
@@ -1,0 +1,167 @@
+//! Moving a body out of what it is inside, or too close to.
+//!
+//! **The operation the vocabulary called depenetration**, and the one piece of
+//! machinery two separate obligations turned out to share.
+//!
+//! A body may begin an operation overlapping something — spawned there, or a
+//! kinematic platform moved into it — and nothing in the sweep can help: a
+//! sweep starts from where the body is and asks what it will hit, which is the
+//! wrong question when the answer is already touching it. And a slide, measured
+//! against real geometry, ends a little closer than the skin distance it was
+//! asked to keep, by an amount that grows with the distance travelled. Both are
+//! the same problem stated at different times: *the body is nearer than the
+//! skin, and something must push it out.*
+//!
+//! **It moves along the separating direction, one shape at a time, worst
+//! first.** Pushing the deepest overlap out can push the body into a shallower
+//! one, which is why this iterates rather than doing a single pass, and why it
+//! reports how many iterations it took and whether it finished. A corner
+//! between two faces needs two, and a three-way corner more.
+
+use renew_fixed::{Fixed, Vec3};
+
+use crate::narrow::separation;
+use crate::query::Exclude;
+use crate::shape::Transform;
+use crate::world::{Collider, ShapeIndex, World};
+
+/// How a clearing ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClearEnd {
+    /// Nothing was closer than the skin distance, so nothing moved.
+    ///
+    /// **Distinct from `Cleared` on purpose.** A caller that wants to know
+    /// whether the body had been left somewhere it should not be — a spawn
+    /// check, a platform that may have crushed something — needs to tell "it
+    /// was fine" from "it is fine now", and a displacement of zero does not
+    /// say that: a body one raw unit inside can be pushed out by a distance
+    /// that rounds to nothing.
+    AlreadyClear,
+    /// The body was moved until nothing was closer than the skin distance.
+    Cleared,
+    /// The iteration limit ran out with something still too close.
+    ///
+    /// **Not an error and not a success.** It happens where geometry genuinely
+    /// has no room — a body wider than the gap it is in — and the honest answer
+    /// is the best position found plus the fact that it is not enough.
+    IterationsExhausted,
+}
+
+/// What a clearing did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ClearReport {
+    /// Where the body ended up.
+    pub destination: Vec3,
+    /// How far it was moved, which is zero when it was already clear.
+    pub moved: Vec3,
+    /// How many pushes it took.
+    pub iterations: u32,
+    /// Whether it finished, and how.
+    pub end: ClearEnd,
+}
+
+impl World {
+    /// The worst violation of the skin distance at a given placement: how far
+    /// short it falls, and the direction from this body toward the offender.
+    ///
+    /// **Ties break on the collider**, the same way the sweep's do, because two
+    /// equal deficits must resolve the same way on every machine or the
+    /// operation is not reproducible.
+    fn deepest_deficit(
+        &self,
+        handle: renew_ecs::Entity,
+        at: Transform,
+        mask: u32,
+        skin: Fixed,
+    ) -> Option<(Fixed, Vec3)> {
+        let extent = self.shape_extent(handle)?;
+        let excluded = [handle];
+        let mut worst: Option<(Fixed, Vec3, Collider)> = None;
+
+        for index in 0..extent {
+            let mine = Collider {
+                handle,
+                index: ShapeIndex::from_raw(index),
+            };
+            let Some((shape, local, _)) = self.shape(mine) else {
+                continue;
+            };
+            let placed = local.compose(at);
+
+            for collider in self.colliders() {
+                let Some((other, other_at)) =
+                    self.query_visible(collider, mask, Exclude::bodies(&excluded))
+                else {
+                    continue;
+                };
+                let (gap, direction) = separation(shape, placed, other, other_at);
+                if gap >= skin {
+                    continue;
+                }
+                let deficit = skin - gap;
+                let beats_it = worst.as_ref().is_none_or(|(current, _, current_collider)| {
+                    deficit > *current || (deficit == *current && collider < *current_collider)
+                });
+                if beats_it {
+                    worst = Some((deficit, direction, collider));
+                }
+            }
+        }
+        worst.map(|(deficit, direction, _)| (deficit, direction))
+    }
+
+    /// Push a body out until nothing is closer to it than the skin distance.
+    ///
+    /// Returns nothing if the handle names no live body. The body is excluded
+    /// from its own test: its shapes are parts of one object, and an object is
+    /// not inside itself.
+    ///
+    /// **Every shape pairing this crate has is measurable**, boxes and
+    /// spheres both ways, so nothing is silently skipped and there is no arm
+    /// that declines a pair — the separation routine here returns an answer
+    /// rather than an option. The two-dimensional crate accepts a capsule it
+    /// cannot measure and has to say so; this one does not have that shape.
+    ///
+    /// **The body moves; nothing else does.** Whatever it was inside stays
+    /// where it is, including another body that could have been pushed instead.
+    /// That is v0 being explicit rather than clever: choosing which of two
+    /// bodies yields is a question about mass and kind that this crate has no
+    /// answer for yet, and splitting the movement between them would make the
+    /// result depend on the order they were created in.
+    pub fn clear_of_geometry(
+        &mut self,
+        handle: renew_ecs::Entity,
+        mask: u32,
+        skin: Fixed,
+        iteration_limit: u32,
+    ) -> Option<ClearReport> {
+        let start = self.transform(handle)?;
+        let mut position = start.translation;
+        let mut iterations = 0;
+        let end = loop {
+            let here = Transform::at(position);
+            let Some((deficit, direction)) = self.deepest_deficit(handle, here, mask, skin) else {
+                break if iterations == 0 {
+                    ClearEnd::AlreadyClear
+                } else {
+                    ClearEnd::Cleared
+                };
+            };
+            if iterations >= iteration_limit {
+                break ClearEnd::IterationsExhausted;
+            }
+            iterations += 1;
+            // The direction runs from this body toward what it is too close
+            // to, so getting away from it means going the other way.
+            position = position - direction * deficit;
+        };
+
+        self.set_transform(handle, Transform::at(position));
+        Some(ClearReport {
+            destination: position,
+            moved: position - start.translation,
+            iterations,
+            end,
+        })
+    }
+}

--- a/crates/physics3d/src/clear.rs
+++ b/crates/physics3d/src/clear.rs
@@ -25,6 +25,21 @@ use crate::query::Exclude;
 use crate::shape::Transform;
 use crate::world::{Collider, ShapeIndex, World};
 
+/// How many pushes the clearing step gets when a slide invokes it.
+///
+/// **Its own budget, not the slide's.** A caller may ask for a single slide
+/// iteration — that is a perfectly reasonable thing to want, and cheap — but a
+/// single *push* is not enough to re-establish a clearance, because one push
+/// lands short by whatever the separating direction's own rounding costs and
+/// the remainder grows with how deep the body was. Sharing the slide's budget
+/// made the clearance shortfall scale with the distance travelled while
+/// looking like a property of the slide, which is the wrong place to go
+/// looking.
+///
+/// Sixteen because clearing converges in two or three pushes even at a corner,
+/// so this is a runaway guard rather than a working limit.
+pub(crate) const CLEARING_ITERATIONS: u32 = 16;
+
 /// How a clearing ended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ClearEnd {

--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -39,6 +39,7 @@
 // it is not. There is no `allow` below.
 #![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
 
+pub mod clear;
 pub mod bounds;
 pub mod broadphase;
 pub mod filter;
@@ -50,6 +51,7 @@ pub mod slide;
 pub mod sweep;
 pub mod world;
 
+pub use clear::{ClearEnd, ClearReport};
 pub use bounds::Aabb;
 pub use broadphase::Broadphase;
 pub use filter::Filter;

--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -39,9 +39,9 @@
 // it is not. There is no `allow` below.
 #![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
 
-pub mod clear;
 pub mod bounds;
 pub mod broadphase;
+pub mod clear;
 pub mod filter;
 pub mod narrow;
 pub mod query;
@@ -51,9 +51,9 @@ pub mod slide;
 pub mod sweep;
 pub mod world;
 
-pub use clear::{ClearEnd, ClearReport};
 pub use bounds::Aabb;
 pub use broadphase::Broadphase;
+pub use clear::{ClearEnd, ClearReport};
 pub use filter::Filter;
 pub use narrow::{Contact, collide, separation};
 pub use query::{Counts, Exclude, Hit};

--- a/crates/physics3d/src/slide.rs
+++ b/crates/physics3d/src/slide.rs
@@ -74,6 +74,13 @@ impl World {
         iteration_limit: u32,
         out: &mut [SlideHit],
     ) -> Option<SlideReport> {
+        // **Out of anything it is already inside, before asking what it will
+        // hit.** A sweep starts from where the body is and answers what is
+        // ahead of it, which is the wrong question when the answer is already
+        // touching — so a body spawned overlapping would otherwise sweep out
+        // from inside the thing it is stuck in and stay stuck.
+        self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+
         let start = self.transform(handle)?;
         let mut position = start.translation;
         let mut remaining = displacement;
@@ -124,8 +131,18 @@ impl World {
         }
 
         self.set_transform(handle, Transform::at(position));
+
+        // **And out again at the end, which is what makes the clearance
+        // guarantee true rather than approximate.** Measured against real
+        // geometry in this crate as well as the two-dimensional one, the slide
+        // alone lands inside the skin distance by an amount that grows with
+        // the distance travelled: here a 1024-unit slide ended 232 raw units
+        // *inside* a wall it should have rested 256 clear of. Re-establishing
+        // the clearance removes the dependence rather than bounding it.
+        let restored = self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+
         Some(SlideReport {
-            destination: position,
+            destination: restored.destination,
             hits,
             iterations,
             end,

--- a/crates/physics3d/src/slide.rs
+++ b/crates/physics3d/src/slide.rs
@@ -79,7 +79,7 @@ impl World {
         // ahead of it, which is the wrong question when the answer is already
         // touching — so a body spawned overlapping would otherwise sweep out
         // from inside the thing it is stuck in and stay stuck.
-        self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+        self.clear_of_geometry(handle, mask, skin, crate::clear::CLEARING_ITERATIONS)?;
 
         let start = self.transform(handle)?;
         let mut position = start.translation;
@@ -139,7 +139,8 @@ impl World {
         // the distance travelled: here a 1024-unit slide ended 232 raw units
         // *inside* a wall it should have rested 256 clear of. Re-establishing
         // the clearance removes the dependence rather than bounding it.
-        let restored = self.clear_of_geometry(handle, mask, skin, iteration_limit)?;
+        let restored =
+            self.clear_of_geometry(handle, mask, skin, crate::clear::CLEARING_ITERATIONS)?;
 
         Some(SlideReport {
             destination: restored.destination,

--- a/crates/physics3d/tests/clearance.rs
+++ b/crates/physics3d/tests/clearance.rs
@@ -426,3 +426,29 @@ fn the_separation_arithmetic_is_right() {
         "a corner gap of one unit on three axes should be about 1.73 units, was {corner} raw"
     );
 }
+
+/// **Geometry with no room reports that it ran out**, rather than claiming
+/// success or looping forever.
+///
+/// A two-unit body in a slot barely two units wide: no position satisfies both
+/// walls by the skin distance, so the honest answer is the best position found
+/// plus the fact that it is not enough.
+#[test]
+fn a_gap_too_narrow_to_fit_reports_that_it_ran_out() {
+    let walls = [
+        Wall {
+            centre: (-2, 0, 0),
+            half: (1, 20, 20),
+        },
+        Wall {
+            centre: (2, 0, 0),
+            half: (1, 20, 20),
+        },
+    ];
+    let (mut world, mover) = staged((0, 0, 0), &walls);
+    let report = world
+        .clear_of_geometry(mover, ANY, SKIN, 6)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::IterationsExhausted);
+    assert_eq!(report.iterations, 6, "it spent the whole budget trying");
+}

--- a/crates/physics3d/tests/clearance.rs
+++ b/crates/physics3d/tests/clearance.rs
@@ -1,0 +1,431 @@
+//! What a slide leaves between a body and the geometry that stopped it.
+//!
+//! **The same question the two-dimensional crate answered by measurement**, put
+//! to this one rather than assumed to transfer. The shapes differ, the
+//! separating axes differ, and the sweep is a different routine; the only thing
+//! shared is the shape of the argument, which is not evidence.
+//!
+//! The clearance is read off box arithmetic done here, never from the engine,
+//! so a slide that stops in the wrong place cannot also rule that the place was
+//! fine.
+
+use renew_ecs::{Entities, Entity};
+use renew_fixed::{Fixed, Vec3};
+use renew_physics3d::{
+    BodyKind, ClearEnd, Collider, Filter, Shape, ShapeIndex, SlideHit, Transform, World,
+};
+
+fn v(x: i32, y: i32, z: i32) -> Vec3 {
+    Vec3::new(Fixed::from_int(x), Fixed::from_int(y), Fixed::from_int(z))
+}
+
+fn at(x: i32, y: i32, z: i32) -> Transform {
+    Transform::at(v(x, y, z))
+}
+
+const SKIN_RAW: i64 = 256;
+const SKIN: Fixed = Fixed::from_bits(SKIN_RAW);
+const TOLERANCE_RAW: i64 = 1;
+/// How far short of the skin a slide may come to rest, in raw units.
+///
+/// **Not creep.** The distance travelled does not appear in it — that is
+/// asserted separately, and exactly. This is the gap between the narrowphase's
+/// own reading of a separation and the box arithmetic in this file: the
+/// clearing loop stops when the engine says the body is clear, and the two
+/// measures disagree by a few parts in sixty-five thousand where the contact
+/// is not axis-aligned. Sixteen raw units was the worst observed, against a
+/// skin of 65536.
+const RESIDUAL_RAW: i64 = 64;
+const REQUIRED_RAW: i64 = SKIN_RAW - TOLERANCE_RAW;
+const ANY: u32 = u32::MAX;
+
+#[derive(Clone, Copy)]
+struct Wall {
+    centre: (i32, i32, i32),
+    half: (i32, i32, i32),
+}
+
+fn empty_hits() -> [SlideHit; 8] {
+    [SlideHit {
+        collider: Collider {
+            handle: Entities::new().spawn(),
+            index: ShapeIndex::from_raw(0),
+        },
+        normal: Vec3::ZERO,
+        origin: Vec3::ZERO,
+    }; 8]
+}
+
+/// The separation between two axis-aligned boxes, in raw units. Positive is a
+/// gap, negative is penetration.
+fn separation_raw(centre: Vec3, half: Vec3, wall: Wall) -> i64 {
+    let wall_centre = v(wall.centre.0, wall.centre.1, wall.centre.2);
+    let wall_half = v(wall.half.0, wall.half.1, wall.half.2);
+    let gaps = [
+        (centre.x - wall_centre.x).abs().to_bits() - (half.x + wall_half.x).to_bits(),
+        (centre.y - wall_centre.y).abs().to_bits() - (half.y + wall_half.y).to_bits(),
+        (centre.z - wall_centre.z).abs().to_bits() - (half.z + wall_half.z).to_bits(),
+    ];
+    if gaps.iter().all(|gap| *gap < 0) {
+        // Overlapping on every axis: the shallowest is the way out.
+        return gaps.iter().copied().max().unwrap_or(0);
+    }
+    let positive: Vec<i64> = gaps.iter().map(|gap| (*gap).max(0)).collect();
+    positive.iter().map(|d| d * d).sum::<i64>().isqrt()
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "a test helper: the body is created in the same function, and a \
+              panic here is the failure being reported"
+)]
+fn clearance_raw(world: &World, mover: Entity, walls: &[Wall]) -> i64 {
+    let here = world.transform(mover).expect("a live body").translation;
+    walls
+        .iter()
+        .map(|wall| separation_raw(here, v(1, 1, 1), *wall))
+        .min()
+        .unwrap_or(i64::MAX)
+}
+
+fn staged(start: (i32, i32, i32), walls: &[Wall]) -> (World, Entity) {
+    let mut entities = Entities::new();
+    let mut world = World::new();
+    let mover = entities.spawn();
+    world.create_body(mover, BodyKind::Kinematic, at(start.0, start.1, start.2));
+    world.add_shape(
+        mover,
+        Shape::Box {
+            half_extents: v(1, 1, 1),
+        },
+        Transform::IDENTITY,
+        Filter::new(1, 1),
+    );
+    for wall in walls {
+        let handle = entities.spawn();
+        world.create_body(
+            handle,
+            BodyKind::Static,
+            at(wall.centre.0, wall.centre.1, wall.centre.2),
+        );
+        world.add_shape(
+            handle,
+            Shape::Box {
+                half_extents: v(wall.half.0, wall.half.1, wall.half.2),
+            },
+            Transform::IDENTITY,
+            Filter::new(1, 1),
+        );
+    }
+    (world, mover)
+}
+
+/// A room: floor, ceiling and four walls, with free space in the middle.
+fn room() -> Vec<Wall> {
+    vec![
+        Wall {
+            centre: (0, -21, 0),
+            half: (400, 20, 400),
+        },
+        Wall {
+            centre: (0, 40, 0),
+            half: (400, 20, 400),
+        },
+        Wall {
+            centre: (60, 0, 0),
+            half: (20, 200, 400),
+        },
+        Wall {
+            centre: (-60, 0, 0),
+            half: (20, 200, 400),
+        },
+        Wall {
+            centre: (0, 0, 60),
+            half: (400, 200, 20),
+        },
+        Wall {
+            centre: (0, 0, -60),
+            half: (400, 200, 20),
+        },
+    ]
+}
+
+fn displacements() -> Vec<(Vec3, i64)> {
+    let mut out = Vec::new();
+    for length in [1i64, 5, 40, 400, 5000] {
+        for (dx, dy, dz) in [
+            (1i64, 0i64, 0i64),
+            (0, -1, 0),
+            (1, -1, 0),
+            (1, -1, 1),
+            (4, -1, 2),
+            (-3, -2, 5),
+            (7, -3, -1),
+        ] {
+            let (x, y, z) = (length * dx, length * dy, length * dz);
+            let units = (x * x + y * y + z * z).isqrt() + 1;
+            out.push((
+                Vec3::new(
+                    Fixed::from_int(i32::try_from(x).unwrap_or(0)),
+                    Fixed::from_int(i32::try_from(y).unwrap_or(0)),
+                    Fixed::from_int(i32::try_from(z).unwrap_or(0)),
+                ),
+                units,
+            ));
+        }
+    }
+    out
+}
+
+/// **The property, over a sweep wide enough to break it.**
+///
+/// Four iteration limits, four starting places, three skin distances and
+/// thirty-five displacements. In two dimensions the equivalent sweep found a
+/// shortfall that grew with the distance travelled, and the fix was to
+/// re-establish the clearance at the end rather than to bound the drift.
+#[test]
+fn a_slide_never_ends_closer_than_the_skin_minus_the_tolerance() {
+    let walls = room();
+    let mut touched = 0u32;
+
+    for limit in [1u32, 2, 4, 8] {
+        for start in [(0, 2, 0), (-30, 10, 20), (30, 5, -20), (20, 15, 30)] {
+            for skin_raw in [256i64, 4096, 65536] {
+                for (displacement, units) in displacements() {
+                    let (mut world, mover) = staged(start, &walls);
+                    let mut hits = empty_hits();
+                    world
+                        .move_and_slide(
+                            mover,
+                            displacement,
+                            ANY,
+                            Fixed::from_bits(skin_raw),
+                            limit,
+                            &mut hits,
+                        )
+                        .expect("a live body");
+
+                    let clearance = clearance_raw(&world, mover, &walls);
+                    if clearance > 4 * skin_raw {
+                        continue;
+                    }
+                    touched += 1;
+                    assert!(
+                        clearance >= skin_raw - RESIDUAL_RAW,
+                        "a slide ended {clearance} raw from geometry against a skin of \
+                         {skin_raw} — {units} units travelled, iteration limit {limit}, \
+                         from {start:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    assert!(
+        touched > 200,
+        "only {touched} configurations reached geometry; the sweep is not exercising the slide"
+    );
+}
+
+/// **The distance travelled must not appear in the answer**, which is the
+/// property the two-dimensional crate could only reach by restoring the
+/// clearance rather than bounding the drift.
+#[test]
+fn the_clearance_does_not_depend_on_the_distance_travelled() {
+    let walls = room();
+    let mut readings = Vec::new();
+    for length in [1i32, 4, 16, 64, 256, 1024, 4096] {
+        let (mut world, mover) = staged((-35, 10, 0), &walls);
+        let mut hits = empty_hits();
+        world
+            .move_and_slide(
+                mover,
+                Vec3::new(
+                    Fixed::from_int(length * 3),
+                    Fixed::from_int(-length),
+                    Fixed::ZERO,
+                ),
+                ANY,
+                SKIN,
+                8,
+                &mut hits,
+            )
+            .expect("a live body");
+        readings.push((length, clearance_raw(&world, mover, &walls)));
+    }
+
+    let touching: Vec<(i32, i64)> = readings
+        .iter()
+        .copied()
+        .filter(|(_, clearance)| *clearance < 4 * SKIN_RAW)
+        .collect();
+    assert!(
+        touching.len() >= 4,
+        "not enough runs reached the geometry to say anything: {readings:?}"
+    );
+    for (length, clearance) in &touching {
+        assert!(
+            *clearance >= REQUIRED_RAW,
+            "a {length}-unit slide ended {clearance} raw away: {touching:?}"
+        );
+    }
+    assert_eq!(
+        touching.first().expect("checked above").1,
+        touching.last().expect("checked above").1,
+        "the distance travelled changed where the body came to rest: {touching:?}"
+    );
+}
+
+/// A body that starts overlapping is pushed out before it moves.
+#[test]
+fn a_body_that_starts_inside_is_pushed_out_before_it_moves() {
+    let walls = vec![Wall {
+        centre: (0, 0, 0),
+        half: (4, 4, 4),
+    }];
+    for start in [(0, 0, 0), (3, 0, 0), (0, 3, 0), (0, 0, 3), (4, 4, 4), (-3, 2, 1)] {
+        let (mut world, mover) = staged(start, &walls);
+        let mut hits = empty_hits();
+        world
+            .move_and_slide(mover, v(1, 0, 0), ANY, SKIN, 8, &mut hits)
+            .expect("a live body");
+        let clearance = clearance_raw(&world, mover, &walls);
+        assert!(
+            clearance >= REQUIRED_RAW,
+            "started inside at {start:?} and ended {clearance} raw away, \
+             inside the required {REQUIRED_RAW}"
+        );
+    }
+}
+
+/// The clearing operation on its own: out of a box, from every side and from
+/// dead centre, where the separating direction is a six-way tie.
+#[test]
+fn a_body_inside_a_box_is_pushed_clear_of_it() {
+    let walls = [Wall {
+        centre: (0, 0, 0),
+        half: (4, 4, 4),
+    }];
+    for start in [(0, 0, 0), (3, 0, 0), (0, -3, 0), (0, 0, 3), (-2, 3, 1)] {
+        let (mut world, mover) = staged(start, &walls);
+        let report = world
+            .clear_of_geometry(mover, ANY, SKIN, 8)
+            .expect("a live body");
+        let clearance = clearance_raw(&world, mover, &walls);
+        assert!(
+            clearance >= SKIN_RAW,
+            "started at {start:?} and ended {clearance} raw away, inside the skin of {SKIN_RAW}"
+        );
+        assert_eq!(report.end, ClearEnd::Cleared, "from {start:?}");
+    }
+}
+
+/// A body already clear is left where it is, and says which of the two answers
+/// it is giving.
+#[test]
+fn a_body_already_clear_is_not_moved() {
+    let walls = [Wall {
+        centre: (0, 0, 0),
+        half: (4, 4, 4),
+    }];
+    let (mut world, mover) = staged((20, 0, 0), &walls);
+    let before = world.transform(mover).expect("a live body").translation;
+    let report = world
+        .clear_of_geometry(mover, ANY, SKIN, 8)
+        .expect("a live body");
+    assert_eq!(report.end, ClearEnd::AlreadyClear);
+    assert_eq!(report.moved, Vec3::ZERO);
+    assert_eq!(
+        world.transform(mover).expect("a live body").translation,
+        before
+    );
+}
+
+/// **A corner in three dimensions needs more than one push**, and the third
+/// axis is the reason this is not simply the two-dimensional case again.
+#[test]
+fn a_three_way_corner_takes_more_than_one_push() {
+    let walls = [
+        Wall {
+            centre: (-5, 0, 0),
+            half: (4, 20, 20),
+        },
+        Wall {
+            centre: (0, -5, 0),
+            half: (20, 4, 20),
+        },
+        Wall {
+            centre: (0, 0, -5),
+            half: (20, 20, 4),
+        },
+    ];
+    let (mut world, mover) = staged((-1, -1, -1), &walls);
+    let report = world
+        .clear_of_geometry(mover, ANY, SKIN, 8)
+        .expect("a live body");
+
+    let clearance = clearance_raw(&world, mover, &walls);
+    assert!(
+        clearance >= SKIN_RAW,
+        "left {clearance} raw from a three-way corner, inside the skin of {SKIN_RAW}"
+    );
+    assert_eq!(report.end, ClearEnd::Cleared);
+    assert!(
+        report.iterations >= 2,
+        "a three-way corner came out in {} push(es)",
+        report.iterations
+    );
+}
+
+/// The same situation clears the same way, whatever order the geometry was
+/// created in.
+#[test]
+fn clearing_is_reproducible_and_order_independent() {
+    let a = Wall {
+        centre: (-5, 0, 0),
+        half: (4, 20, 20),
+    };
+    let b = Wall {
+        centre: (0, -5, 0),
+        half: (20, 4, 20),
+    };
+    let run = |walls: &[Wall]| {
+        let (mut world, mover) = staged((-1, -1, 0), walls);
+        world
+            .clear_of_geometry(mover, ANY, SKIN, 8)
+            .expect("a live body")
+            .destination
+    };
+    let first = run(&[a, b]);
+    assert_eq!(first, run(&[a, b]));
+    assert_eq!(
+        first,
+        run(&[b, a]),
+        "the geometry's creation order changed where the body ended up"
+    );
+}
+
+/// The separation arithmetic this file relies on, checked against cases whose
+/// answers are obvious. The oracle needs its own oracle.
+#[test]
+fn the_separation_arithmetic_is_right() {
+    let wall = Wall {
+        centre: (0, 0, 0),
+        half: (2, 2, 2),
+    };
+    let half = v(1, 1, 1);
+    let one = Fixed::ONE.to_bits();
+
+    assert_eq!(separation_raw(v(3, 0, 0), half, wall), 0);
+    assert_eq!(separation_raw(v(4, 0, 0), half, wall), one);
+    assert_eq!(separation_raw(v(0, 0, 4), half, wall), one);
+    assert_eq!(separation_raw(v(2, 0, 0), half, wall), -one);
+    // Deep inside: the shallowest axis wins, being the way out.
+    assert_eq!(separation_raw(v(0, 0, 0), half, wall), -3 * one);
+    // A three-way corner gap of one unit each way is the space diagonal.
+    let corner = separation_raw(v(4, 4, 4), half, wall);
+    assert!(
+        corner > one && corner < 2 * one,
+        "a corner gap of one unit on three axes should be about 1.73 units, was {corner} raw"
+    );
+}

--- a/crates/physics3d/tests/clearance.rs
+++ b/crates/physics3d/tests/clearance.rs
@@ -26,16 +26,6 @@ fn at(x: i32, y: i32, z: i32) -> Transform {
 const SKIN_RAW: i64 = 256;
 const SKIN: Fixed = Fixed::from_bits(SKIN_RAW);
 const TOLERANCE_RAW: i64 = 1;
-/// How far short of the skin a slide may come to rest, in raw units.
-///
-/// **Not creep.** The distance travelled does not appear in it — that is
-/// asserted separately, and exactly. This is the gap between the narrowphase's
-/// own reading of a separation and the box arithmetic in this file: the
-/// clearing loop stops when the engine says the body is clear, and the two
-/// measures disagree by a few parts in sixty-five thousand where the contact
-/// is not axis-aligned. Sixteen raw units was the worst observed, against a
-/// skin of 65536.
-const RESIDUAL_RAW: i64 = 64;
 const REQUIRED_RAW: i64 = SKIN_RAW - TOLERANCE_RAW;
 const ANY: u32 = u32::MAX;
 
@@ -211,7 +201,7 @@ fn a_slide_never_ends_closer_than_the_skin_minus_the_tolerance() {
                     }
                     touched += 1;
                     assert!(
-                        clearance >= skin_raw - RESIDUAL_RAW,
+                        clearance >= skin_raw - TOLERANCE_RAW,
                         "a slide ended {clearance} raw from geometry against a skin of \
                          {skin_raw} — {units} units travelled, iteration limit {limit}, \
                          from {start:?}"
@@ -283,7 +273,14 @@ fn a_body_that_starts_inside_is_pushed_out_before_it_moves() {
         centre: (0, 0, 0),
         half: (4, 4, 4),
     }];
-    for start in [(0, 0, 0), (3, 0, 0), (0, 3, 0), (0, 0, 3), (4, 4, 4), (-3, 2, 1)] {
+    for start in [
+        (0, 0, 0),
+        (3, 0, 0),
+        (0, 3, 0),
+        (0, 0, 3),
+        (4, 4, 4),
+        (-3, 2, 1),
+    ] {
         let (mut world, mover) = staged(start, &walls);
         let mut hits = empty_hits();
         world


### PR DESCRIPTION
The clearance fix carried across to the three-dimensional crate, with the cause of its residual found and fixed: the slide handed the clearing step its own iteration limit, so a caller asking for one slide iteration got one push. One push lands short by the separating direction's rounding, and the remainder grows with how deep the body was — which is why it looked like distance-proportional creep.

Every failing configuration had an iteration limit of one.

The clearing budget is now named and separate in both crates. The three-dimensional sweep holds the property at the real tolerance. The platformer's digests are byte-identical.