### PR TITLE
docs(physics): both physics crates get the README they should have shipped with

### DIFF
--- a/crates/physics2d/README.md
+++ b/crates/physics2d/README.md
@@ -1,0 +1,115 @@
+# renew-physics2d
+
+Collision detection and kinematic movement in two dimensions, in fixed point.
+
+**Status: bootstrap.** The public surface is expected to change. There is no dynamics here — no
+forces, no mass, no impulses. What exists is the part a character controller needs: a set of
+colliders you can query, sweep against, and move through.
+
+## What it does
+
+| | |
+|---|---|
+| **Bodies and shapes** | A body carries a transform and any number of shapes, each with its own local placement and filter. Boxes and circles are measurable; capsules are accepted and **not implemented** — see below. |
+| **Broadphase** | A rebuildable pair list over bounding boxes, inflated by the contact tolerance so a near miss still reaches the narrowphase. |
+| **Narrowphase** | Separating-axis tests with incident-face clipping, producing a manifold: one normal, up to two points, each with a depth. |
+| **Queries** | Point, ray and overlap, each with a mask and an exclusion list. |
+| **Sweeps** | Conservative advancement: a moving shape against a static one, answering when it first touches. It cannot tunnel — that is the property the technique is chosen for. |
+| **Slide** | Move a body along a displacement, sliding along whatever stops it, reporting what it hit and which way each surface faced. |
+| **Clearing** | Push a body out until nothing is closer than the skin distance. |
+
+## Why it is fixed point
+
+Every number here is `renew-fixed`'s `Fixed` — Q47.16 in an `i64`. Floating-point arithmetic is
+denied at the crate root, not by convention but by the compiler.
+
+The reason is reproduction. A simulation that must produce identical results on different machines
+cannot afford an addition whose rounding depends on the compiler's instruction selection. Fixed
+point makes the arithmetic exact and the overflow behaviour identical everywhere, and pays for it
+in range — which is why the bounds are measured and written down rather than assumed.
+
+## Key decisions, and why
+
+**The slide reports ground state; the contact array does not.** A body stopped by a slide rests a
+skin distance from what stopped it — far enough that a contact test will not report it. So the hits
+the slide writes are the only record that it landed, what it landed on, and which way that surface
+faced. A character controller reads its footing from there.
+
+**Touching is not the same as being obstructed.** A body resting against a wall and sliding along
+it is in contact for the whole move; reporting that as a blocking hit would stop it dead. A hit
+blocks only when the body is not already moving away from the surface. Penetration is the
+exception — a body genuinely inside something reports whichever way it is moving.
+
+**The clearing step runs twice per slide, and has its own iteration budget.** Once before the
+sweep, because a sweep asks what is ahead and that is the wrong question when the answer is already
+touching. Once after, because the slide alone lands slightly inside the skin distance by an amount
+that grows with the distance travelled. Re-establishing the clearance directly **removes** that
+dependence rather than bounding it; every attempt to bound it failed, because cutting a move into
+pieces leaves the proportional part untouched and makes the constant part worse.
+
+The budget is separate from the slide's on purpose. A caller asking for one slide iteration is
+asking about the slide, not about how many pushes it takes to re-establish a clearance — and
+sharing the two made the shortfall scale with distance while looking like a property of the slide.
+
+**Ties break on the collider, everywhere.** Two surfaces met at the same instant — which is what a
+corner is — must resolve the same way on every machine, so every "closest" and "earliest" search
+here breaks ties on a stable identifier rather than on iteration order.
+
+**Clearing moves the body and nothing else.** Choosing which of two bodies yields is a question
+about mass and kind this crate has no answer for, and splitting the movement between them would
+make the result depend on the order they were created in.
+
+## What is not here
+
+- **Capsules.** The shape exists and nothing can measure it. The narrowphase declines such pairs
+  rather than reporting that they do not touch, which would be a lie, and the clearing step
+  inherits that exactly: a capsule is neither pushed out of anything nor pushes anything out.
+  Tests pin this in both directions, so implementing capsules will fail them.
+- **Rotation in sweeps.** Shapes rotate; sweeps treat the rotation as fixed for the duration.
+- **Dynamics.** No forces, no restitution, no joints.
+- **A spatial index that persists between frames.** The broadphase is rebuilt.
+
+## Example
+
+```rust
+use renew_ecs::Entities;
+use renew_fixed::{Fixed, Vec2};
+use renew_physics2d::{BodyKind, Filter, Shape, Transform, World};
+
+let mut entities = Entities::new();
+let mut world = World::new();
+
+let floor = entities.spawn();
+world.create_body(
+    floor,
+    BodyKind::Static,
+    Transform::at(Vec2::new(Fixed::ZERO, Fixed::from_int(-1))),
+);
+world.add_shape(
+    floor,
+    Shape::Box { half_extents: Vec2::new(Fixed::from_int(40), Fixed::ONE) },
+    Transform::IDENTITY,
+    Filter::new(1, 1),
+);
+
+let player = entities.spawn();
+world.create_body(
+    player,
+    BodyKind::Kinematic,
+    Transform::at(Vec2::new(Fixed::ZERO, Fixed::from_int(4))),
+);
+world.add_shape(
+    player,
+    Shape::Box { half_extents: Vec2::new(Fixed::ONE, Fixed::ONE) },
+    Transform::IDENTITY,
+    Filter::new(2, 1),
+);
+```
+
+Then call `move_and_slide` with the displacement, a mask, a skin distance, an iteration limit, and
+a slice for it to write hits into. **`SlideHit` has no `Default`**, so the slice is built
+explicitly — `samples/leap/world/src/lib.rs` shows a complete call, and is the shortest honest
+example of the whole loop.
+
+`samples/leap` is a working consumer: a platformer with running, jumping, walls and ledges,
+operable headless and drawable from the command line.

--- a/crates/physics2d/src/lib.rs
+++ b/crates/physics2d/src/lib.rs
@@ -39,6 +39,10 @@
 // function of the compiler's instruction selection, and this crate's whole
 // obligation is that it is not. There is no `allow` below.
 #![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
+// The README is the crate front page and its example compiles with the
+// rest of the tests, so a signature change breaks it rather than leaving
+// it quietly wrong.
+#![doc = include_str!("../README.md")]
 
 pub mod bounds;
 pub mod broadphase;

--- a/crates/physics3d/README.md
+++ b/crates/physics3d/README.md
@@ -1,0 +1,67 @@
+# renew-physics3d
+
+Collision detection and kinematic movement in three dimensions, in fixed point.
+
+**Status: bootstrap.** The public surface is expected to change. No dynamics — no forces, no mass,
+no impulses.
+
+**Axis-aligned only, deliberately.** `Transform` here carries a translation and nothing else. That
+is not an oversight and not a stub: a rotation in fixed point needs an orientation type that
+composes without drifting, and that type does not exist yet. A `Transform` with a rotation field
+nothing respected would be worse than one that does not offer it, because callers would set it and
+be quietly ignored.
+
+## What it does
+
+The same surface as `renew-physics2d`, one dimension up: bodies with shapes and filters, a
+broadphase over bounding boxes, separating-axis narrowphase, point and ray and overlap queries,
+conservative-advancement sweeps that cannot tunnel, `move_and_slide`, and `clear_of_geometry`.
+
+Shapes are **boxes and spheres**. Every pairing of them is measurable, so nothing is silently
+skipped — unlike the two-dimensional crate, which accepts a capsule it cannot measure and says so.
+
+## Why it is fixed point
+
+Every number is `renew-fixed`'s `Fixed`, and float arithmetic is denied at the crate root by the
+compiler rather than by convention. A simulation that must reproduce on different machines cannot
+afford an addition whose rounding depends on instruction selection.
+
+Three dimensions costs range: the coordinate bounds are tighter than the two-dimensional ones
+because a squared distance sums three terms instead of two. Those bounds are measured and written
+down rather than reasoned about, in the fixed-point crate's own bounds harness.
+
+## Key decisions, and why
+
+Most of them are the two-dimensional crate's, for the same reasons — read that README for the full
+argument. The ones specific to three dimensions:
+
+**The clearing step has its own iteration budget, and finding out why is worth recording.** A slide
+hands `clear_of_geometry` a fixed budget rather than its own iteration limit. Sharing them meant a
+caller asking for a single slide iteration got a single push, and one push lands short by whatever
+the separating direction's rounding costs — with a remainder that grows with how deep the body was.
+Depth after a one-iteration slide grows with distance travelled, so the shortfall correlated with
+distance and looked exactly like accumulated drift. It was not: it was a budget of one.
+
+The two-dimensional crate had the same latent case and was passing only because its arithmetic
+converges in a single push where three dimensions does not.
+
+**A three-way corner needs more than one push.** Coming out of one face can put the body inside
+another, which is why clearing iterates and reports how many pushes it took and whether it
+finished. Where geometry genuinely has no room — a body wider than the slot it is in — it says it
+ran out rather than claiming success.
+
+**The clearance is verified against arithmetic outside the engine.** The tests compute box
+separation from centres and half-extents themselves, so a slide that stops in the wrong place
+cannot also be the thing that rules the place was fine. That oracle has its own test, being the
+one piece of reasoning nothing else checks.
+
+## What is not here
+
+- **Rotation.** See above. Sweeps, queries and manifolds all assume axis-aligned boxes.
+- **Capsules or convex hulls.** Boxes and spheres only.
+- **Dynamics**, and **a persistent spatial index** — the broadphase is rebuilt.
+
+## Consumer
+
+`samples/cube` is a working consumer: a voxel world with a walking, jumping, block-breaking player
+in a closed arena, operable headless and drawable as two slices from the command line.

--- a/crates/physics3d/src/lib.rs
+++ b/crates/physics3d/src/lib.rs
@@ -38,6 +38,9 @@
 // compiler's instruction selection, and this crate's whole obligation is that
 // it is not. There is no `allow` below.
 #![deny(clippy::float_arithmetic, clippy::print_stdout, clippy::print_stderr)]
+// The README is the crate front page, included so it is built with the
+// crate rather than drifting from it.
+#![doc = include_str!("../README.md")]
 
 pub mod bounds;
 pub mod broadphase;


### PR DESCRIPTION
Neither crate had a README. Each now says what it does, what it deliberately does not, and why.

Both are included as crate documentation, which makes their examples doctests — the first version of the two-dimensional example used a constructor that does not exist, and nothing would have caught it because a README is not built.