### PR TITLE
docs(samples): the three world crates get READMEs

### DIFF
--- a/samples/chess/rules/README.md
+++ b/samples/chess/rules/README.md
@@ -1,0 +1,42 @@
+# renew-sample-chess-rules
+
+The rules of chess: positions, legal moves, and the outcome of a game.
+
+**Status: bootstrap.** A sample, not an engine module — no engine crate depends on it.
+
+## Why it exists here
+
+Every other sample in this repository is checked against itself: run it twice, compare the digest,
+and reproduction is proved while correctness is assumed. **Chess is the exception, and that is the
+point of having it.**
+
+Move generation has a published oracle. Perft counts — how many distinct legal games of a given
+length exist from a position — are known numbers that other people computed independently: 20, 400,
+8902, 197281 from the start; 97862 for Kiwipete at depth three. A wrong count here is a wrong rule,
+not a wrong opinion, and no amount of internal consistency can hide it.
+
+That makes this crate a check on the *testing* approach used everywhere else, not just on itself.
+
+## What it does
+
+The whole game: castling both sides, en passant, promotion to any of four pieces, check, checkmate,
+stalemate, and the fifty-move rule. Positions read and write Forsyth-Edwards notation, and moves
+read and write their algebraic form.
+
+**Both notations are pairs, and both are tested by round trip.** A reader checked alone is only
+checked against its author's belief about the text — and the author of the test is the author of
+the code. Held against its writer it checks a fact instead. The pair caught a hand-written position
+in its own tests that omitted the en-passant square, which is exactly the field that matters one
+move later and only for one capture.
+
+One literal is kept deliberately: the starting position's published string. Self-consistency is
+satisfied by a pair that is wrong the same way on both sides, so something has to anchor it to the
+outside world.
+
+## What it is not
+
+**No search and no evaluation.** There is no opinion here about which move is good. `samples/chess`
+plays by taking the first legal move, which is deterministic rather than strong — a search would
+make the digest a test of the search instead of the rules.
+
+No clocks, no draw-by-repetition, no notation beyond the two above.

--- a/samples/cube/world/README.md
+++ b/samples/cube/world/README.md
@@ -1,0 +1,37 @@
+# renew-sample-cube-world
+
+The voxel sample's simulation: a block grid, a player who walks and jumps in it, and the reach that
+lets them break and place blocks.
+
+**Status: bootstrap.** A sample, not an engine module. It exists to exercise `renew-physics3d`
+against a shape of problem a real game has, and it is the reason that crate has a consumer at all.
+
+## What it is
+
+A pure function of its inputs. `Cube::new` takes tuning, a `Grid` and a start position; `step`
+takes one `Intent` — walk, jump, dig, place — and advances one tick. No clock, no file, no
+unseeded randomness. The same intents produce the same digest everywhere.
+
+## What it demonstrates
+
+**A finite world has to say it is finite.** `Grid::get` returns nothing outside its bounds rather
+than guessing. Answering "air" would let a player walk off and fall forever with no way to tell
+that from a deep hole; answering "solid" would trap them at the boundary with no explanation. The
+caller decides, and the arena in `samples/cube` decides by being a closed box.
+
+**The shell cannot be cleared, and that is the world having a bottom.** `Grid::set` refuses to turn
+a boundary cell to air. This is not decoration: without it the building script dug through the
+floor and spent most of its run below the world, and its digest described a fall. Two weaker rules
+were tried first and are recorded where the rule lives — a thicker floor (anything that can dig
+once can dig again) and an unbreakable bottom layer (which stopped the digging and not the
+climbing, since a player who places blocks can build a tower over any wall).
+
+**Reach is a ray, not a radius.** Breaking and placing use a pick along the look direction, so what
+gets edited is what the player is looking at rather than whatever happens to be nearest.
+
+## What it is not
+
+Not a game: no inventory, no block types beyond stone, no world generation. The grid is whatever
+the caller builds.
+
+No lighting, meshing or rendering. `samples/cube` draws it as two slices of text.

--- a/samples/leap/world/README.md
+++ b/samples/leap/world/README.md
@@ -1,0 +1,38 @@
+# renew-sample-leap-world
+
+The platformer's simulation: one character, some solid boxes, and the rules that connect them.
+
+**Status: bootstrap.** A sample, not an engine module — nothing in the engine depends on it, and it
+exists to exercise `renew-physics2d` against a shape of problem a real game has.
+
+## What it is
+
+A pure function of its inputs. `Leap::new` takes tuning, a start position and a list of platforms;
+`step` takes one `Intent` — run left or right, jump or not — and advances the world by exactly one
+tick. Nothing reads a clock, a file, or a random number. The same intents in the same order produce
+the same digest on every machine, which is the property that lets three platforms compare one line
+of output.
+
+## What it demonstrates
+
+**Footing comes from the slide, not from a contact query.** A body stopped by `move_and_slide`
+rests a skin distance away from what stopped it — too far for a contact test to report. So
+`grounded` and `against_wall` are derived from the surfaces the slide reported hitting and which
+way each faced, which is the physics crate's intended use rather than a workaround.
+
+**Coyote time is a counter, not a timer.** The character may still jump for a few ticks after
+walking off a ledge. Counted in ticks because a fixed-timestep simulation has no other honest unit,
+and a wall-clock version would not reproduce.
+
+**The character's size is public.** `CHARACTER_HALF_EXTENTS` is exported because anything drawing
+the world needs it — a drawing that guesses puts the character somewhere it is not, and a
+one-cell-tall picture of a two-unit-tall body makes a character standing on the floor look like one
+hovering above it.
+
+## What it is not
+
+Not a game: no scoring, no enemies, no level loading. The level is whatever list of platforms the
+caller passes, and `samples/leap` supplies one with a floor, a wall and a ledge.
+
+Not tuned for feel. The numbers in `Tuning` are chosen to make the interesting cases happen
+quickly, not to be pleasant to play.


### PR DESCRIPTION
Created over the last two days without them, while the sample world crate that came before had one. Each says what it simulates, what it demonstrates about the crate underneath it, and what it deliberately is not.