### PR TITLE
docs(samples): a README for every sample, and two digests that had drifted

### DIFF
--- a/samples/chess/README.md
+++ b/samples/chess/README.md
@@ -1,0 +1,220 @@
+# renew-sample-chess
+
+Chess in a terminal, one run per move. It counts the legal games
+from a position, plays a deterministic one out, or just prints the
+board — and it stores nothing between runs, so a game is a shell
+variable and a saved game is a text file.
+
+## Running it
+
+```
+chess                            # count the games of length four: 197281
+chess --show                     # the board, the turn, what is legal
+chess --move e2e4 --move e7e5    # apply moves, then show
+chess --count --depth 5          # 4865609
+chess --play --depth 60          # 60 half-moves, answered with a digest
+chess --show --json              # the same answer, machine-readable
+```
+
+From a fresh clone, `chess` above means
+`cargo run --bin renew -- run chess -- --show`, or, going straight
+at the package, `cargo run -p renew-sample-chess --bin chess --
+--show`. Everything after the bare `--` is this binary's own
+command line.
+
+```console
+$ chess --show
+8  r n b q k b n r
+7  p p p p p p p p
+6  . . . . . . . .
+5  . . . . . . . .
+4  . . . . . . . .
+3  . . . . . . . .
+2  P P P P P P P P
+1  R N B Q K B N R
+
+   a b c d e f g h
+
+white to move, 20 legal moves, ongoing
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+```
+
+Upper case is White, lower case is Black, a dot is an empty square
+— the same convention as the notation on the last line, so a reader
+who can read one can read the other. The board is always drawn from
+White's side, never turned around to follow the side to move: a
+board that flips between moves makes two consecutive positions
+impossible to compare by eye, which is the one thing a printed board
+is for.
+
+## A game is a shell variable
+
+The last line of a shown position *is* the position, and `--fen`
+reads exactly that text back. So the second run below consumes the
+first run's output and the game continues, with nothing stored
+anywhere in between:
+
+```console
+$ position=$(chess --move e2e4 --move e7e5 | tail -n 1)
+$ echo "$position"
+rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2
+$ chess --fen "$position" --move g1f3 | tail -n 1
+rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2
+```
+
+Redirect that line to a file instead of a variable and you have a
+saved game; keep several files and you have branches. The property
+that makes this work is that a position names itself completely —
+castling rights, the en-passant square and both clocks included — so
+no run needs to know which moves led to it. Every position is
+reachable directly, and a game handed over at every single move ends
+where the same game played in one run ends. The test suite holds
+that over twenty half-moves, because the fields most likely to
+survive one exchange and not twenty are exactly the ones a hand-
+written position tends to drop.
+
+`--move` is the other way to name a position: by the route to it,
+which is the form a player has and the notation is not.
+
+## The flags
+
+| Flag | What it does |
+|---|---|
+| `--show` | Draw the board, name the side to move, count the moves available, say how the game stands, and print the position for the next run. |
+| `--count` | Count the legal games of length `--depth` from the position. The mode with no flag. |
+| `--play` | Play `--depth` half-moves, always taking the first legal move, and answer with a digest of where it stopped. |
+| `--move MOVE` | A move to apply before anything else: the two squares, `e2e4`, with a promotion letter as a fifth character, `a7a8q`. Repeatable, and applied in every mode, not only when showing. |
+| `--fen POSITION` | The position to start from, in Forsyth-Edwards notation. Defaults to the initial position. |
+| `--depth N` | How deep to count, or how many half-moves to play. Default 4. |
+| `--json` | Answer with one line of JSON instead of prose. |
+| `--help` | Print the usage text and stop, successfully. |
+
+Naming a move and no mode selects `--show`: someone who writes a
+move is playing chess rather than measuring it. An explicit mode
+wins over that, on whichever side of the move it appears. Naming two
+modes is not an error — the last one wins.
+
+`--show` accepts `--depth` and ignores it; there is nothing for a
+depth to mean when the answer is one position, and the JSON reports
+`"depth":0` for a shown run whatever was asked for.
+
+Two ways a move can be refused, kept apart because they are
+different mistakes. `--move e2e9` is not a move at all, and is
+rejected while the command line is still being read. `--move e2e5`
+is a perfectly well-formed move that the rules do not permit here,
+which cannot be known until the position is — including the case
+where the move belongs to the other side, so `--move e7e5` as
+White's first move is refused rather than quietly taken.
+
+Refusals go to the error stream and exit 1, printing nothing on the
+output stream, so a script can tell without parsing anything. A
+completed run and `--help` exit 0.
+
+## Counting
+
+`--count` runs perft: how many distinct legal games of a given
+length exist from the position. That is the reason chess is in this
+repository at all, and the rules crate's README
+([`rules/README.md`](rules/README.md)) explains why at length. The
+short version: these are published numbers that other people
+computed independently, so a wrong one here is a wrong rule rather
+than a wrong opinion — 20, 400, 8902 and 197281 from the initial
+position for depths one to four, and 97862 at depth three from the
+position known as Kiwipete:
+
+```console
+$ chess --count --depth 3 --fen "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+chess count depth=3 nodes=97862 result=ongoing
+```
+
+**Six is as deep as this binary will go.** Each level is roughly
+thirty times the work of the one before, so depth seven from the
+start is billions of positions and hours of waiting; a refusal that
+names the limit is more use than a command that appears to hang. A
+caller who genuinely wants depth seven can call the library, which
+imposes no limit. The refusal applies to counting only — `--play
+--depth 5000` is a trivial amount of work and is allowed.
+
+The search is plain recursion with no transposition table and no
+memoisation, and the difference between build profiles is
+therefore large. On one desktop machine, depth five took 10.9 s
+built with `cargo build` and 0.30 s built with `--release`, where
+depth six took 15.9 s in release. Deep counts want `--release`.
+
+`result` in a counted run describes the *starting* position, not
+anything discovered during the count, and the `digest` field
+identifies that same position.
+
+## Playing
+
+`--play` is the mode with a digest, and the digest is the point.
+Perft cannot serve here: a count is a fact about chess, so it comes
+out the same on a machine that is working and one that is not.
+A position hash is a fact about *this* run, and comparing it across
+processes, build profiles and platforms is what shows the state
+itself survived the journey. `--play --depth 60 --json` is one of
+the pinned runs whose digests are compared that way; it answers
+`digest=0x6bf0be22d95711ee` here in both a debug and a release
+build.
+
+The move chosen is always the first legal one — a deterministic
+choice, not a good one. There is no search and no evaluation
+anywhere in this sample, deliberately: a search would turn the
+digest into a test of the search instead of a test of the rules.
+The games it produces are therefore not chess anybody would want to
+watch.
+
+Two honest limits on playing:
+
+- **The loop stops only when there is no legal move.** Reaching a
+  checkmate or a stalemate ends it early, and `moves=` in the answer
+  says how many half-moves it actually managed. The fifty-move rule
+  is *reported* in `result` but does not stop the loop, so
+  `chess --play --depth 5000` really does play five thousand
+  half-moves and then say `result=fifty-move`.
+- **Draws by repetition do not exist here**, so a long run wanders
+  rather than ending. The rules crate says what else it leaves out.
+
+## JSON
+
+`--json` replaces the whole answer with one line carrying its schema
+version, in every mode:
+
+```console
+$ chess --show --json
+{"schema_version":1,"sample":"chess","mode":"show","depth":0,"nodes":20,"moves":0,"digest":"0x1afd057861571eda","result":"ongoing","to_move":"white","fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"}
+```
+
+The fields are shared across the modes, and each mode leaves some of
+them at zero rather than omitting them, so a reader never has to
+handle three shapes:
+
+- `nodes` — positions counted when counting, moves available when
+  showing, `0` when playing.
+- `moves` — half-moves actually played, `0` in the other two modes.
+- `depth` — the depth asked for; `0` when showing.
+- `digest` and `fen` — the position the run ended on, as a hash and
+  as text. Every mode carries it, so a caller can ask that position
+  another question without parsing the prose answer back.
+
+## Shape
+
+Two crates. [`rules/`](rules/README.md) is the game: positions,
+legal moves, and how a game ends. It knows nothing about a command
+line, a terminal or a file, which is what lets the published perft
+counts be pointed straight at it.
+
+This crate is the face: it parses the command line, applies the
+named moves, chooses what to run, draws the board, writes both
+answers, and owns the exit code. It has no window, no renderer and
+no clock — the position on the command line is the entire input, and
+a printed position is the entire output. That is also what makes it
+a useful second witness for reproduction: there is no geometry and
+no floating point here at all, so a difference between two runs
+would have to be in the integer state itself rather than in
+arithmetic shared with the other samples.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status,
+dependencies and extension points.

--- a/samples/cube/README.md
+++ b/samples/cube/README.md
@@ -1,0 +1,153 @@
+# renew-sample-cube
+
+The three-dimensional sample: a voxel world with a walking, jumping,
+block-breaking player in a closed arena, run headless from a named
+script and answered with one digest line. `--show` draws the world
+it left behind as two slices of text.
+
+## Running it
+
+```
+cube                                    # the stand script, 600 ticks
+cube --script patrol --ticks 2000       # walk a loop around the arena
+cube --script build --ticks 900         # walk, jump, dig and place
+cube --script stand --ticks 100 --show  # draw what it left behind
+cube --script build --ticks 900 --json  # the same answer, for a machine
+```
+
+From a fresh clone the invocations above are spelled
+`cargo run --bin renew -- run cube -- <arguments>`, or
+`cargo run -p renew-sample-cube --bin cube -- <arguments>` to skip
+the wrapper. `--help` lists every flag the parser accepts, and a test
+holds it to that: a flag a reader cannot discover is a flag that does
+not exist as far as anyone but its author is concerned.
+
+Every run prints one line last:
+
+```console
+$ cube --script build --ticks 900
+cube script=build ticks=900 digest=0xc2b4534b2679a6a1 solids=5020 broken=2 placed=10 grounded=false
+```
+
+Two runs of the same script and tick count print identical lines —
+in one process and in separate ones. That is what the binary is for.
+The world is a pure function and its own tests assert its digest,
+which proves it reproduces on **one** machine; the obligation is
+across machines, and comparing this line is how that gets checked.
+The digest covers everything that can change future behaviour, the
+terrain included: a world whose blocks differ plays differently from
+the next tick on.
+
+`--json` prints the same report as one document instead, carrying a
+`schema_version` from its first release so a consumer can tell a shape
+it understands from one it does not:
+
+```console
+$ cube --script build --ticks 900 --json
+{"schema_version":1,"sample":"cube","script":"build","ticks":900,"digest":"0xc2b4534b2679a6a1","solids":5020,"broken":2,"placed":10,"grounded":false}
+```
+
+`--show` draws a plan and an elevation, each sliced through the cell
+the player is standing in and labelled with where it cut:
+
+```console
+$ cube --script stand --ticks 100 --show
+elevation, looking along z, at z=0
+  11 #########################################
+  10 #.......................................#
+   9 #.......................................#
+   8 #.......................................#
+   7 #.......................................#
+   6 #.......................................#
+   5 #.......................................#
+   4 #.......................................#
+   3 #.......................................#
+   2 #.....................#####.............#
+   1 #...................@.#####.............#
+   0 #########################################
+     x from -20, y up the side
+cube script=stand ticks=100 digest=0x1d07e6e9840ed836 solids=5012 broken=0 placed=0 grounded=true
+```
+
+Both views are the whole grid rather than a window onto it, so two
+runs can be read column for column. `@` is the player, `#` a solid
+block, `.` air; height increases upward in the elevation, because a
+picture drawn the other way is still a correct slice and an
+unreadable one. The pictures come before the summary line: a reader
+scanning a terminal wants the summary nearest the prompt.
+
+Two limits worth stating. `--show` draws nothing under `--json` — the
+machine-readable output is one document and a picture is not part of
+it — and the flag is accepted rather than refused there. And the
+drawing is text: there is no renderer in this sample's dependency
+graph at all.
+
+## The arena
+
+Forty-one cells across, twelve high and forty-one deep — x and z from
+−20 to 20, y from 0 to 11 — and it is a **closed box, solid on every
+face**.
+
+That is not decoration. Outside the grid is neither solid nor air:
+the grid answers "I do not know" past its edge rather than guessing,
+so a player who leaves it falls forever with nothing to land on. The
+shell refuses to be turned back into air, and the boundary it refuses
+is the boundary in all three axes, so there is no direction left to
+leave by. Weaker enclosures were tried first and are recorded in
+[`world/README.md`](world/README.md) beside the rule itself.
+
+Drawing the world is what exposed the problem. The first picture of it
+showed the player twenty-five blocks below a floor at y = 0 after a
+four-hundred-tick run — the building script had dug through the floor
+and spent most of its run outside the world, and its digest described
+a fall. Every test passed, because they all asked whether the run
+reproduced rather than whether it made sense. `tests/view.rs` now runs
+every script at six lengths and asserts the player is still inside the
+grid, which is the assertion that was missing.
+
+Closing the box also made the floor unbreakable, which quietly turned
+the digging script into a script that reaches for the shell and is
+refused. So the arena has a mound — x 2 to 6, y 1 to 2, z −2 to 2 —
+sitting in front of the start along the direction the player looks,
+and a test keeps it there.
+
+The player's look direction is set once, down and forward, and never
+changes: what a script digs at is whatever its walking puts in front
+of it. That is why `build` edits less than its button presses suggest.
+Over nine hundred ticks it breaks two blocks and places ten, all
+within the first four hundred and fifty; after that it has walked into
+a corner where the only thing in reach is shell. It also ends most
+runs with `grounded=false`, which is a jump in progress rather than a
+fall — a jump clears about five blocks, and the script presses jump
+every seventeenth tick.
+
+## Shape
+
+Two crates. `world/` is the simulation: a fixed-step pure function of
+terrain and per-tick intent, with no clock, no file and no randomness
+— see [`world/README.md`](world/README.md). This crate is the driver.
+It builds the arena, owns the scripts, runs the loop, and owns
+everything printed.
+
+The scripts are built in and named rather than read from a file,
+because the point of the binary is to be run identically on three
+platforms and compared, and a file is one more thing that can differ
+between them.
+
+Everything the binary does — parsing, running, drawing, choosing the
+exit code — lives in the library, so it can be driven by a test
+without spawning a process; the parts most worth testing are the
+refusals, and a spawned process is what makes those hardest to
+inspect. `tests/binary.rs` spawns one anyway, because the process
+shell, the argument plumbing and the exit codes are only exercised as
+a caller meets them.
+
+Exit codes: `0` for a completed run and for `--help`, `1` for a
+command line this sample cannot honour. A refusal goes to the error
+stream, prints nothing on the output stream, and names the thing at
+fault — an unknown script also lists the real ones.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies
+and extension points.

--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -11,7 +11,7 @@ cargo run -p renew-sample-hello-triangle --bin hello_triangle -- --headless --fr
 
 ```console
 $ cargo run -p renew-sample-hello-triangle --bin hello_triangle -- --headless --frames 600
-renew-frame sample=hello_triangle seed=0 frames=600 ticks=600 dropped=0 schedule_hash=0xefc2181bbc0d588d state_hash=0x5d3ec02c32278af9
+renew-frame sample=hello_triangle seed=0 frames=600 ticks=600 dropped=0 schedule_hash=0x55ce27c8dcb97c4d state_hash=0x5d3ec02c32278af9
 ```
 
 That line is the same on every run, in every process, and in a build

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -10,7 +10,7 @@ cargo run -p renew-sample-input-echo --bin input_echo -- --headless --input-trac
 
 ```console
 $ cargo run -p renew-sample-input-echo --bin input_echo -- --headless --input-trace walk
-renew-frame sample=input_echo seed=0 source=walk frames=20 ticks=20 dropped=0 schedule_hash=0xcaa0947bf9fa1305 state_hash=0x833e49c9dd637b92
+renew-frame sample=input_echo seed=0 source=walk frames=20 ticks=20 dropped=0 schedule_hash=0x64972ba6d4f30765 state_hash=0x833e49c9dd637b92
 ```
 
 ## What it does

--- a/samples/leap/README.md
+++ b/samples/leap/README.md
@@ -1,0 +1,222 @@
+# renew-sample-leap
+
+The platformer: one character that runs, jumps, lands and slides
+along a level of solid boxes, run headless from a named script and
+answered with one digest line. `--show` draws the level and the
+character as the box the simulation actually collides with.
+
+## Running it
+
+```
+leap                                    # the stand script, 600 ticks
+leap --script dash --ticks 120          # run right until the wall stops it
+leap --script hop --ticks 900           # jump, land, jump again
+leap --script dash --ticks 120 --show   # draw where it ended up
+leap --script hop --ticks 900 --json    # the same answer, for a machine
+```
+
+From a fresh clone those are spelled
+`cargo run --bin renew -- run leap -- <arguments>`, or
+`cargo run -p renew-sample-leap --bin leap -- <arguments>` to skip
+the wrapper. Everything after the bare `--` is this binary's own
+command line, and `--help` lists every flag it accepts.
+
+Every run prints one line last:
+
+```console
+$ leap --script dash --ticks 120
+leap script=dash ticks=120 digest=0xc75411dac5b49142 grounded=true wall=true
+```
+
+Two runs of the same script and tick count print identical lines — in
+one process and in separate ones. That is what the binary is for. The
+world is a pure function and its own tests assert its digest, which
+proves it reproduces on **one** machine; the obligation is across
+machines, and comparing this line is how that gets checked. The line
+above is also what a release build prints: every quantity in the
+simulation is fixed-point, so there is no floating-point rounding left
+to differ between profiles.
+
+The digest covers the character's position, its velocity, its footing
+and the jump latch — the latch because two characters standing in the
+same place at the same speed still diverge on the next tick if one is
+holding the button and the other is not. It does not cover the level,
+which no script can change.
+
+`--json` prints the same report as one document instead, carrying a
+`schema_version` from its first release so a consumer can tell a shape
+it understands from one it does not:
+
+```console
+$ leap --script hop --ticks 900 --json
+{"schema_version":1,"sample":"leap","script":"hop","ticks":900,"digest":"0xd292bcd20d1b62a1","grounded":false,"against_wall":false}
+```
+
+## The flags
+
+| Flag | What it does |
+|---|---|
+| `--script NAME` | Which built-in script drives the character: `stand`, `dash` or `hop`. Default `stand`. |
+| `--ticks N` | How many ticks to run. Default 600. Zero is allowed, and answers without stepping the world at all. |
+| `--show` | Draw the level around the character before printing the line. |
+| `--json` | Answer with one line of JSON rather than a sentence. |
+| `--help`, `-h` | Print the usage text and stop, successfully — nothing runs. |
+
+Naming a flag twice is not an error; the last one wins, so
+`--script stand --script hop` runs `hop`. `--ticks` takes a whole
+number of ticks and nothing else, so `--ticks -5` is refused as not a
+number rather than quietly clamped to zero.
+
+## The picture
+
+`--show` draws the level around the character — `#` solid, `@` the
+character, `.` air — with the world's y down the left edge and the
+cell the character is standing in named on the last line:
+
+```console
+$ leap --script dash --ticks 120 --show
+  10 .............................................................
+   9 .............................................................
+   8 ...............................##............................
+   7 ...............................##............................
+   6 ...............................##............................
+   5 ...............................##............................
+   4 .....######....................##............................
+   3 .....######..................@@##............................
+   2 .............................@@##............................
+   1 .............................@@##............................
+   0 #############################################################
+  -1 #############################################################
+  -2 .............................................................
+     x=8 y=2
+leap script=dash ticks=120 digest=0xc75411dac5b49142 grounded=true wall=true
+```
+
+The character is drawn **as the box the simulation collides with** —
+one unit wide and two tall, taken from the half-extents the world
+crate exports for exactly this — rather than as a single mark. A
+one-cell mark would be a picture of something that is not in the
+simulation, and it would sit happily beside a wrong answer as well as
+a right one. Drawn at its real size, the picture can be held against
+the line beneath it: a character the line calls `grounded` has
+something solid under its feet, and one it calls `wall=true` has
+something solid beside it, which is what `@@##` above means.
+`tests/view.rs` asserts both, and asserts them without recomputing the
+overlap arithmetic the drawing uses — a test that re-derives the
+implementation's own reasoning agrees with it wherever it is wrong.
+
+The picture comes before the summary line, because a reader scanning a
+terminal wants the summary nearest the prompt.
+
+Four honest limits on the drawing.
+
+- **It is quantised to whole cells**, and a body stopped by a slide
+  rests a skin distance short of what stopped it rather than exactly
+  on it. So a two-unit-tall character standing on the floor covers
+  three rows, as above, and two positions inside the same cell draw
+  the same picture.
+- **The view follows the character** — sixty-one cells by seventeen —
+  rather than framing the level, because a level may be larger than a
+  terminal and a character that walks off the drawing tells the reader
+  nothing. The consequence is that two pictures from different ticks
+  do not line up by eye; the coordinates on the left edge and the last
+  line are what makes them comparable, so they are printed.
+- **`--show` draws nothing under `--json`.** The machine-readable
+  output is one document and a picture is not part of it; the flag is
+  accepted there rather than refused.
+- **It is text.** There is no renderer in this sample's dependency
+  graph at all.
+
+## The level
+
+Three solid boxes, the same for every script:
+
+- a floor centred on the origin, spanning x from −40 to 40, with its
+  top surface at y = 1;
+- a wall from x = 9 to x = 11, rising from the floor to y = 9;
+- a ledge from x = −17 to x = −11, between y = 3 and y = 5.
+
+The character starts in mid-air at x = 0, y = 6, and falls onto the
+floor. The floor is finite and there is nothing beneath it, so a
+character that walked off its end would fall with nothing to land on
+— none of the three scripts gets near it, because each is stopped by
+the wall or the ledge long before x = ±40.
+
+## The scripts
+
+They are built in and named rather than read from a file, because the
+point of the binary is to be run identically on three platforms and
+compared, and a file is one more thing that can differ between them.
+
+**`stand`** asks for nothing at all. The character falls from the
+start, lands, and stays: `grounded=true wall=false`. It is the run
+where anything moving is a defect.
+
+**`dash`** runs right for 120 ticks, then left for 120, and repeats —
+**and this is the shape the sample exists to test.** It reaches the
+wall on tick 43 and spends the remaining 77 ticks of that leg pressed
+against it, still asking to move right the whole time. That is the
+case a collision routine gets wrong in interesting ways: keep the
+horizontal speed and the character tunnels into the wall or jitters
+along it; spend the vertical speed along with it and the character
+sticks to the wall instead of standing on the floor. For all 77 ticks
+the line says `grounded=true wall=true`, and the picture above shows
+why — the character is beside the wall, not inside it.
+
+Running back the other way it does not pass under the ledge: the
+ledge's underside is at y = 3 and a character standing on the floor
+reaches exactly that high, so it stops with its left edge against the
+ledge's right face, prints `######@@` in the picture, and presses
+there — `wall=true` again — for the rest of that leg.
+
+**`hop`** runs right for ten ticks, jumps, runs left for ten, jumps
+again, once every twenty-four ticks. A jump is worth about seven units
+of height and takes roughly fifty ticks to come back down, so most of
+those presses arrive in mid-air and do nothing at all: a jump fires on
+the tick the button goes down, and only while the character is
+grounded or inside its coyote window. That is why most `hop` runs end
+`grounded=false` — a jump in progress rather than a fall. Ten ticks
+each way also cancel out, so `hop` stays within a couple of units of
+where it started and never touches the wall.
+
+## What the line does not print
+
+The world knows more about the character's footing than the report
+carries. How many ticks it has been airborne — the thing coyote time
+is made of — reaches the digest but not the printed line. Whether a
+move ran out of slide iterations with displacement still unspent
+reaches neither, and a caller who wants that distinction calls the
+library rather than the binary. [`world/README.md`](world/README.md)
+explains what those two facts are and why they are kept apart.
+
+## Shape
+
+Two crates. [`world/`](world/README.md) is the simulation: a pure
+fixed-step function of per-tick intent, standing on the
+two-dimensional collision crate, with no clock, no file and no
+randomness at any dependency depth. This crate is the driver — it
+owns the level, the scripts, the loop, the drawing, and everything
+printed.
+
+Everything the binary does — parsing, running, drawing, choosing the
+exit code — lives in the library, so a test can drive it without
+spawning a process; the parts most worth testing are the refusals, and
+a spawned process is what makes those hardest to inspect.
+`tests/binary.rs` spawns one anyway, because the process shell, the
+argument plumbing and the exit codes are only exercised as a caller
+meets them.
+
+Exit codes: `0` for a completed run and for `--help`, `1` for a
+command line this sample cannot honour. A refusal goes to the error
+stream, prints nothing on the output stream, and names the thing at
+fault — an unknown script also lists the real ones:
+
+```console
+$ leap --script fly
+leap: no script called `fly`; try stand, dash, hop
+```
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies
+and extension points.


### PR DESCRIPTION
Three sample drivers had no README — `chess`, `cube` and `leap`, the three most recent. Their world crates were given one earlier; the drivers beside them were missed.

Each new file follows the shape the existing sample READMEs use: what the sample is, how to run it, what every flag does, and the split between the simulation crate and the driver. **Every command shown was run and every quoted line is real output** — including the perft counts, which are published values computed independently elsewhere, so a wrong one here would be a wrong rule rather than a wrong opinion.

Each also gives the invocation that works from a fresh clone (`cargo run --bin renew -- run <sample> -- …`), since the CLI is a workspace binary rather than something a clone installs.

Two existing READMEs quoted a `schedule_hash` the code no longer produces — `hello_triangle` and `input_echo`. Both reproduce deterministically at their new values, and in both the `state_hash` was correct all along; only the schedule hash had drifted, which is why it went unnoticed.
