### PR TITLE
feat(platform): RENEW_LOG sends diagnostics and panics to a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,7 @@ dependencies = [
 name = "renew-sample-chess"
 version = "0.1.0"
 dependencies = [
+ "renew-platform",
  "renew-sample-chess-rules",
 ]
 
@@ -1767,6 +1768,7 @@ name = "renew-sample-cube"
 version = "0.1.0"
 dependencies = [
  "renew-fixed",
+ "renew-platform",
  "renew-sample-cube-world",
 ]
 
@@ -1832,6 +1834,7 @@ name = "renew-sample-leap"
 version = "0.1.0"
 dependencies = [
  "renew-fixed",
+ "renew-platform",
  "renew-sample-leap-world",
 ]
 

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -27,7 +27,7 @@ window = ["dep:winit", "dep:raw-window-handle"]
 # compiling only where something actually plays. It carries the
 # diagnostics crate with it, because the stream's error callback is the
 # one place in this crate that reports from a thread it does not own.
-audio-out = ["dep:cpal", "dep:renew-diag"]
+audio-out = ["dep:cpal"]
 
 [dependencies]
 # The event vocabulary this crate re-exports as its `event` module.
@@ -60,7 +60,10 @@ cpal = { version = "=0.18.1", optional = true, default-features = false }
 # Carried by `audio-out` alone: the audio thread's error callback is the
 # only reporter in this crate, so the default and headless graphs are
 # exactly what they were without it.
-renew-diag = { path = "../diag", optional = true }
+# Not optional: the file sink in `diag.rs` is part of this crate's
+# always-available surface. The audio seam also uses it, which is why
+# this line used to be optional.
+renew-diag = { path = "../diag" }
 
 [lints]
 workspace = true

--- a/crates/core/platform/src/diag.rs
+++ b/crates/core/platform/src/diag.rs
@@ -134,13 +134,11 @@ pub fn log_to_file(path: impl Into<PathBuf>) {
     // this adds the copy that survives the terminal closing.
     let previous = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let location = info
-            .location()
-            .map_or_else(|| "unknown location".to_owned(), ToString::to_string);
-        renew_diag::error!(
-            target: "panic",
-            "{info} (at {location})"
-        );
+        // `{info}` already carries the location and the payload — the
+        // same text the default hook prints. Formatting the location
+        // separately duplicated it, and left an arm for a location that
+        // is absent, which no real panic produces.
+        renew_diag::error!(target: "panic", "{info}");
         previous(info);
     }));
 }
@@ -187,6 +185,25 @@ mod tests {
         let text = std::fs::read_to_string(&dir).expect("the sink created the file");
         assert_eq!(text, "WARN a: first\nERROR b: second\n");
         let _ = std::fs::remove_file(&dir);
+    }
+
+    /// The path is reported back, so a caller that built the sink from a
+    /// value can say where records went without keeping its own copy.
+    #[test]
+    fn the_sink_reports_its_own_path() {
+        let path = std::env::temp_dir().join("renew-filesink-path");
+        let sink = FileSink::new(&path);
+        assert_eq!(sink.path(), path);
+    }
+
+    /// The debug form names the file and nothing else — a sink has no
+    /// counts, and the path is the only thing a reader wants.
+    #[test]
+    fn the_debug_form_names_the_file() {
+        let sink = FileSink::new("somewhere.log");
+        let shown = format!("{sink:?}");
+        assert!(shown.starts_with("FileSink"), "{shown}");
+        assert!(shown.contains("somewhere.log"), "{shown}");
     }
 
     /// A path that cannot be written is dropped rather than fatal — the

--- a/crates/core/platform/src/diag.rs
+++ b/crates/core/platform/src/diag.rs
@@ -124,6 +124,16 @@ pub fn path_from_value(value: Option<std::ffi::OsString>) -> Option<PathBuf> {
 /// Send this process's diagnostics, and any panic, to `path` — or do
 /// nothing at all, when there is no path.
 ///
+/// `note` is recorded first, if given: a line the caller wants at the
+/// top of every log, such as which other switches exist. This crate does
+/// not know what it means and does not interpret it.
+///
+/// # Errors
+///
+/// The path could not be written. Nothing is installed in that case, so
+/// a caller that reports the error is telling the truth about a run that
+/// is not being logged.
+///
 /// Installs a [`FileSink`] as the process-wide sink and chains a panic
 /// hook that records the panic before the default one runs — so a run
 /// that dies leaves its reason on disk rather than only on a console
@@ -146,16 +156,32 @@ pub fn path_from_value(value: Option<std::ffi::OsString>) -> Option<PathBuf> {
 /// Never for a bad path — a sink that cannot write drops its records
 /// silently, as its own contract states. Calling this twice is the
 /// reporting crate's contract violation, not this function's.
-pub fn log_to_file(path: Option<impl Into<PathBuf>>) {
+pub fn log_to_file(
+    path: Option<impl Into<PathBuf>>,
+    note: Option<&str>,
+) -> Result<(), crate::fs::FsError> {
     // `None` is the ordinary case — a run nobody asked to log — and it
     // is taken here rather than at every call site so a binary wires
     // this in unconditionally and has one line to get right instead of
     // a condition each.
     let Some(path) = path else {
-        return;
+        return Ok(());
     };
+    let path = path.into();
+
+    // **Written to once, here, before anything is installed.** A sink
+    // drops records it cannot write, which is right for a record and
+    // wrong for the moment somebody switches logging on: a mistyped
+    // path would otherwise look exactly like a run that had nothing to
+    // report, and the reader would draw the opposite conclusion. Failing
+    // here hands the caller something to say, and installs nothing.
+    crate::fs::append(&path, b"")?;
+
     let sink: &'static FileSink = Box::leak(Box::new(FileSink::new(path)));
     renew_diag::install(sink);
+    if let Some(note) = note {
+        renew_diag::info!(target: "diagnostics", "{note}");
+    }
 
     // Chained rather than replaced: the default hook prints to the
     // console, which is what a developer watching a terminal wants, and
@@ -169,6 +195,7 @@ pub fn log_to_file(path: Option<impl Into<PathBuf>>) {
         renew_diag::error!(target: "panic", "{info}");
         previous(info);
     }));
+    Ok(())
 }
 
 #[cfg(test)]
@@ -256,7 +283,7 @@ mod tests {
     /// be, which is why it has an integration test of its own.
     #[test]
     fn no_path_installs_nothing() {
-        log_to_file(None::<PathBuf>);
+        log_to_file(None::<PathBuf>, None).expect("no path is not a failure");
         // Reaching here at all is the assertion: had this installed a
         // sink, the integration test in this crate would then be unable
         // to install its own, and would fail.

--- a/crates/core/platform/src/diag.rs
+++ b/crates/core/platform/src/diag.rs
@@ -101,7 +101,8 @@ impl core::fmt::Debug for FileSink {
     }
 }
 
-/// Send this process's diagnostics, and any panic, to `path`.
+/// Send this process's diagnostics, and any panic, to `path` — or do
+/// nothing at all, when there is no path.
 ///
 /// Installs a [`FileSink`] as the process-wide sink and chains a panic
 /// hook that records the panic before the default one runs — so a run
@@ -125,7 +126,14 @@ impl core::fmt::Debug for FileSink {
 /// Never for a bad path — a sink that cannot write drops its records
 /// silently, as its own contract states. Calling this twice is the
 /// reporting crate's contract violation, not this function's.
-pub fn log_to_file(path: impl Into<PathBuf>) {
+pub fn log_to_file(path: Option<impl Into<PathBuf>>) {
+    // `None` is the ordinary case — a run nobody asked to log — and it
+    // is taken here rather than at every call site so a binary wires
+    // this in unconditionally and has one line to get right instead of
+    // a condition each.
+    let Some(path) = path else {
+        return;
+    };
     let sink: &'static FileSink = Box::leak(Box::new(FileSink::new(path)));
     renew_diag::install(sink);
 
@@ -204,6 +212,18 @@ mod tests {
         let shown = format!("{sink:?}");
         assert!(shown.starts_with("FileSink"), "{shown}");
         assert!(shown.contains("somewhere.log"), "{shown}");
+    }
+
+    /// **The no-path case installs nothing**, which is the arm every
+    /// ordinary run takes. Testable here precisely because it does not
+    /// consume the process-wide sink slot — the installing arm cannot
+    /// be, which is why it has an integration test of its own.
+    #[test]
+    fn no_path_installs_nothing() {
+        log_to_file(None::<PathBuf>);
+        // Reaching here at all is the assertion: had this installed a
+        // sink, the integration test in this crate would then be unable
+        // to install its own, and would fail.
     }
 
     /// A path that cannot be written is dropped rather than fatal — the

--- a/crates/core/platform/src/diag.rs
+++ b/crates/core/platform/src/diag.rs
@@ -101,6 +101,26 @@ impl core::fmt::Debug for FileSink {
     }
 }
 
+/// Interpret an environment value as a log path.
+///
+/// **Pure, and it takes the value rather than reading it.** This crate
+/// is a doorway to the operating system and deliberately not a source of
+/// ambient configuration, so the binary reads its own environment and
+/// hands the result here. That split is also what makes the rule
+/// testable: every answer is reachable without a process-wide write that
+/// would race whatever else shares the test binary.
+///
+/// Absent and empty both mean off. An empty value is a shell exporting
+/// nothing, which is a way of saying no rather than a file with no name.
+#[must_use]
+pub fn path_from_value(value: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let value = value?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(value))
+}
+
 /// Send this process's diagnostics, and any panic, to `path` — or do
 /// nothing at all, when there is no path.
 ///
@@ -212,6 +232,22 @@ mod tests {
         let shown = format!("{sink:?}");
         assert!(shown.starts_with("FileSink"), "{shown}");
         assert!(shown.contains("somewhere.log"), "{shown}");
+    }
+
+    /// Absent, empty and named — the three answers, none of which needs
+    /// the environment touched.
+    #[test]
+    fn a_value_is_a_path_only_when_it_names_one() {
+        assert_eq!(path_from_value(None), None, "unset is off");
+        assert_eq!(
+            path_from_value(Some(std::ffi::OsString::new())),
+            None,
+            "an empty export is a way of saying no, not a file with no name"
+        );
+        assert_eq!(
+            path_from_value(Some(std::ffi::OsString::from("run.log"))),
+            Some(PathBuf::from("run.log"))
+        );
     }
 
     /// **The no-path case installs nothing**, which is the arm every

--- a/crates/core/platform/src/diag.rs
+++ b/crates/core/platform/src/diag.rs
@@ -1,0 +1,206 @@
+//! A diagnostics sink that writes to a file.
+//!
+//! The reporting crate defines the [`Sink`](renew_diag::Sink) trait and
+//! forbids filesystem access in its own lint configuration, on the
+//! grounds that sinks own their I/O. This crate owns the filesystem. So
+//! the file-writing sink lives here, and nowhere else in the engine has
+//! to grow a filesystem exception to get one.
+//!
+//! # Mechanism, not policy
+//!
+//! **Nothing here reads the environment, and nothing here installs
+//! itself.** That is this crate's contract — it is a doorway to the
+//! operating system, not a source of ambient configuration — and it is
+//! also the more useful split: a binary decides *whether* to log and
+//! *where*, because a binary is the thing that owns its command line,
+//! its environment and its files. This module only knows how to turn a
+//! record into a line and put it on the end of a file.
+//!
+//! # Why a whole file per record
+//!
+//! [`FileSink`] opens, appends and closes on every record rather than
+//! holding a handle. A held handle needs an owner, a close, and a story
+//! about what happens when the process dies badly — and the records this
+//! is built for are emitted when something has *already* gone wrong,
+//! where a syscall costs nothing anybody will measure. A run that logs
+//! nothing pays nothing, and a run that crashes has its last line on
+//! disk rather than in a buffer that died with it.
+//!
+//! That last property is the whole reason this is not a buffered writer.
+
+use std::path::PathBuf;
+
+use renew_diag::{Record, Sink};
+
+/// A sink that appends one line per record to a file.
+///
+/// Lines are `LEVEL target: message`, newline-terminated — the level
+/// first because a reader scanning a log is looking for the severe ones,
+/// and the target second because it says which part of the engine spoke.
+///
+/// # Failure is silent, and that is deliberate
+///
+/// A sink that cannot write has nowhere to report it: the reporting
+/// channel is the thing that is broken, and a panic here would turn a
+/// diagnostic into the fault. So a failed write is dropped. The caller
+/// who wants to know whether logging works should check the path itself
+/// after the run — the file is created on the first record, so its
+/// absence and its emptiness mean the same thing, which is that nothing
+/// was reported.
+pub struct FileSink {
+    path: PathBuf,
+}
+
+impl FileSink {
+    /// A sink appending to `path`.
+    ///
+    /// The file is neither created nor truncated here: it is opened on
+    /// the first record and appended to thereafter, so several runs
+    /// pointed at one path accumulate rather than overwrite each other.
+    /// A caller who wants one run per file chooses a fresh path.
+    #[must_use]
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// The path records are appended to.
+    #[must_use]
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Format one record exactly as [`Sink::write`] does.
+    ///
+    /// Split out so the formatting is testable without a filesystem —
+    /// the line's shape is the part a reader depends on, and it should
+    /// not need a temporary directory to pin.
+    #[must_use]
+    pub fn line(record: &Record<'_>) -> String {
+        format!(
+            "{} {}: {}\n",
+            record.level().as_str(),
+            record.target(),
+            record.message()
+        )
+    }
+}
+
+impl Sink for FileSink {
+    fn write(&self, record: &Record<'_>) {
+        // Dropped rather than reported: see the type's contract. There is
+        // no channel left to complain through.
+        let _ = crate::fs::append(&self.path, Self::line(record).as_bytes());
+    }
+}
+
+impl core::fmt::Debug for FileSink {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FileSink")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+/// Send this process's diagnostics, and any panic, to `path`.
+///
+/// Installs a [`FileSink`] as the process-wide sink and chains a panic
+/// hook that records the panic before the default one runs — so a run
+/// that dies leaves its reason on disk rather than only on a console
+/// nobody was capturing.
+///
+/// **The path is a parameter, not something read from the environment.**
+/// This crate is a doorway to the operating system and deliberately not
+/// a source of ambient configuration; the binary decides whether to log
+/// and where, because the binary owns its command line and environment.
+///
+/// # The leak, which is deliberate
+///
+/// The sink is leaked, because the reporting crate takes a `'static`
+/// reference and a process-wide sink lives until the process ends. One
+/// allocation, once, at startup — the alternative is a global slot that
+/// exists only to avoid the word "leak" while having the same lifetime.
+///
+/// # Panics
+///
+/// Never for a bad path — a sink that cannot write drops its records
+/// silently, as its own contract states. Calling this twice is the
+/// reporting crate's contract violation, not this function's.
+pub fn log_to_file(path: impl Into<PathBuf>) {
+    let sink: &'static FileSink = Box::leak(Box::new(FileSink::new(path)));
+    renew_diag::install(sink);
+
+    // Chained rather than replaced: the default hook prints to the
+    // console, which is what a developer watching a terminal wants, and
+    // this adds the copy that survives the terminal closing.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let location = info
+            .location()
+            .map_or_else(|| "unknown location".to_owned(), ToString::to_string);
+        renew_diag::error!(
+            target: "panic",
+            "{info} (at {location})"
+        );
+        previous(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use renew_diag::Level;
+
+    /// The line's shape, pinned without touching a filesystem.
+    #[test]
+    fn a_record_becomes_one_terminated_line() {
+        let line = FileSink::line(&Record::new(
+            Level::Error,
+            "renew-rhi",
+            format_args!("device lost at {}", 12),
+        ));
+        assert_eq!(line, "ERROR renew-rhi: device lost at 12\n");
+    }
+
+    /// Every level reaches the line, so a reader filtering by severity
+    /// sees the word the level crate defines rather than a local
+    /// spelling.
+    #[test]
+    fn every_level_prints_its_own_name() {
+        for level in [Level::Error, Level::Warn, Level::Info, Level::Debug] {
+            let line = FileSink::line(&Record::new(level, "t", format_args!("m")));
+            assert!(
+                line.starts_with(level.as_str()),
+                "{level:?} produced {line:?}"
+            );
+        }
+    }
+
+    /// Records really do accumulate: a second write appends rather than
+    /// replacing, which is what makes a log of a crashing run readable.
+    #[test]
+    fn records_accumulate_in_order() {
+        let dir = std::env::temp_dir().join("renew-filesink-accumulate");
+        let _ = std::fs::remove_file(&dir);
+        let sink = FileSink::new(&dir);
+        sink.write(&Record::new(Level::Warn, "a", format_args!("first")));
+        sink.write(&Record::new(Level::Error, "b", format_args!("second")));
+        let text = std::fs::read_to_string(&dir).expect("the sink created the file");
+        assert_eq!(text, "WARN a: first\nERROR b: second\n");
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    /// A path that cannot be written is dropped rather than fatal — the
+    /// reporting channel being broken must not become the failure.
+    #[test]
+    fn an_unwritable_path_is_survived() {
+        // A directory component that is not a directory: the open fails
+        // on every supported platform.
+        let sink = FileSink::new(
+            std::env::temp_dir()
+                .join("renew-filesink-missing")
+                .join("nested")
+                .join("log.txt"),
+        );
+        sink.write(&Record::new(Level::Error, "t", format_args!("m")));
+    }
+}

--- a/crates/core/platform/src/fs.rs
+++ b/crates/core/platform/src/fs.rs
@@ -155,6 +155,28 @@ pub fn write(path: &Path, contents: &[u8]) -> Result<(), FsError> {
     std::fs::write(path, contents).map_err(|error| classify(path, &error))
 }
 
+/// Append `contents` to the file at `path`, creating it if it is not
+/// there.
+///
+/// **Open, append, close, once per call — deliberately.** A log that
+/// holds a file handle open must decide who closes it and when, and a
+/// diagnostic that is only written when something has already gone wrong
+/// is the wrong place to spend that complexity. The cost is a syscall
+/// per record on a path that is silent in a healthy run.
+///
+/// # Errors
+///
+/// [`FsError`] naming the path, classified by kind.
+pub fn append(path: &Path, contents: &[u8]) -> Result<(), FsError> {
+    use std::io::Write as _;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .and_then(|mut file| file.write_all(contents))
+        .map_err(|error| classify(path, &error))
+}
+
 /// Whether the path exists right now. Honest about failure: an
 /// inaccessible parent is an error, not `false`. Like every existence
 /// check, the answer can be stale by the time it is used — open the

--- a/crates/core/platform/src/lib.rs
+++ b/crates/core/platform/src/lib.rs
@@ -37,6 +37,13 @@ mod clock;
 /// code that *produces* these values from the OS stays here, in
 /// [`window`], and does need a windowing library.
 pub use renew_event as event;
+/// A diagnostics sink that writes to a file.
+///
+/// Here because the reporting crate forbids filesystem access in its own
+/// lint configuration and this crate is the filesystem's doorway. It
+/// reads no environment and installs nothing: a binary decides whether
+/// to log and where.
+pub mod diag;
 pub mod fs;
 pub mod thread;
 

--- a/crates/core/platform/tests/log_to_file.rs
+++ b/crates/core/platform/tests/log_to_file.rs
@@ -35,7 +35,7 @@ fn records_and_panics_both_reach_the_file() {
     // had written things it did not.
     let _ = std::fs::remove_file(&path);
 
-    renew_platform::diag::log_to_file(&path);
+    renew_platform::diag::log_to_file(Some(&path));
 
     renew_diag::error!(target: "test", "an error with a value: {}", 7);
     renew_diag::warn!(target: "test", "a warning");

--- a/crates/core/platform/tests/log_to_file.rs
+++ b/crates/core/platform/tests/log_to_file.rs
@@ -1,0 +1,78 @@
+//! The file-logging installer, exercised end to end in its own process.
+//!
+//! **An integration test rather than a unit test, and the reason is the
+//! shape of the thing being tested.** Installing a diagnostics sink is
+//! process-wide and may happen once — a second call is a contract
+//! violation the reporting crate asserts on. A unit test would therefore
+//! be at the mercy of whatever else in the same binary had already
+//! installed one, and two such tests could never both run. Each
+//! integration test is its own binary and its own process, so this one
+//! owns the slot outright.
+//!
+//! That is also why it is worth having: `log_to_file` is the whole
+//! feature, and every other test in this crate can only reach the pieces
+//! it is assembled from.
+
+use std::path::PathBuf;
+
+/// A path in the temporary directory, unique to this test binary, with
+/// no run of a clock or a random number — the file name is a constant
+/// because exactly one process ever writes it.
+fn log_path() -> PathBuf {
+    std::env::temp_dir().join("renew-platform-log-to-file.log")
+}
+
+/// Install, emit, panic, and read the whole lot back.
+///
+/// One test rather than three, deliberately: the installation can only
+/// happen once in a process, so everything that depends on it has to
+/// share a test. Splitting them would mean either three binaries or two
+/// tests silently doing nothing.
+#[test]
+fn records_and_panics_both_reach_the_file() {
+    let path = log_path();
+    // A previous run's file would make an append-only sink look like it
+    // had written things it did not.
+    let _ = std::fs::remove_file(&path);
+
+    renew_platform::diag::log_to_file(&path);
+
+    renew_diag::error!(target: "test", "an error with a value: {}", 7);
+    renew_diag::warn!(target: "test", "a warning");
+
+    // The panic hook is chained, so the default one still runs and still
+    // prints. `catch_unwind` keeps this test alive to read the file.
+    let panicked = std::panic::catch_unwind(|| {
+        panic!("deliberate, to prove the hook records it");
+    });
+    assert!(panicked.is_err(), "the panic must have happened");
+
+    let text = std::fs::read_to_string(&path).expect("the sink created the file");
+
+    assert!(
+        text.contains("ERROR test: an error with a value: 7"),
+        "the error record and its formatted value are missing from {text:?}"
+    );
+    assert!(
+        text.contains("WARN test: a warning"),
+        "the warning is missing from {text:?}"
+    );
+    assert!(
+        text.contains("deliberate, to prove the hook records it"),
+        "the panic message is missing from {text:?}"
+    );
+    assert!(
+        text.contains("panic"),
+        "the panic record should name itself as one, in {text:?}"
+    );
+    // The panic arrived after the records that preceded it: the file is
+    // a log, so order is part of what it is for.
+    let error_at = text.find("an error with a value").expect("error present");
+    let panic_at = text.find("deliberate, to prove").expect("panic present");
+    assert!(
+        error_at < panic_at,
+        "records must appear in the order they happened, in {text:?}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/core/platform/tests/log_to_file.rs
+++ b/crates/core/platform/tests/log_to_file.rs
@@ -35,7 +35,8 @@ fn records_and_panics_both_reach_the_file() {
     // had written things it did not.
     let _ = std::fs::remove_file(&path);
 
-    renew_platform::diag::log_to_file(Some(&path));
+    renew_platform::diag::log_to_file(Some(&path), Some("a note the caller wanted first"))
+        .expect("a writable path installs");
 
     renew_diag::error!(target: "test", "an error with a value: {}", 7);
     renew_diag::warn!(target: "test", "a warning");
@@ -48,6 +49,11 @@ fn records_and_panics_both_reach_the_file() {
     assert!(panicked.is_err(), "the panic must have happened");
 
     let text = std::fs::read_to_string(&path).expect("the sink created the file");
+
+    assert!(
+        text.contains("a note the caller wanted first"),
+        "the caller's opening note is missing from {text:?}"
+    );
 
     assert!(
         text.contains("ERROR test: an error with a value: 7"),
@@ -75,4 +81,24 @@ fn records_and_panics_both_reach_the_file() {
     );
 
     let _ = std::fs::remove_file(&path);
+}
+
+/// A path that cannot be written is reported, and installs nothing.
+///
+/// Separate from the test above because it must run *before* anything is
+/// installed to be meaningful — and it does, because a failing path
+/// returns before it touches the sink slot at all.
+#[test]
+fn an_unwritable_path_is_reported_rather_than_silently_ignored() {
+    // A directory component that is not a directory: the open fails on
+    // every supported platform.
+    let bad = std::env::temp_dir()
+        .join("renew-platform-not-a-directory.log")
+        .join("nested")
+        .join("run.log");
+    let refused = renew_platform::diag::log_to_file(Some(bad), None);
+    assert!(
+        refused.is_err(),
+        "a path that cannot be written must be said out loud, or a mistyped one          looks exactly like a run with nothing to report"
+    );
 }

--- a/samples/chess/Cargo.toml
+++ b/samples/chess/Cargo.toml
@@ -21,6 +21,7 @@ name = "chess"
 path = "src/main.rs"
 
 [dependencies]
+renew-platform = { path = "../../crates/core/platform", default-features = false }
 renew-sample-chess-rules = { path = "rules" }
 
 [lints]

--- a/samples/chess/src/lib.rs
+++ b/samples/chess/src/lib.rs
@@ -429,6 +429,13 @@ pub fn next_move(board: &Board) -> Option<Move> {
 
 /// Parse, run, print, and answer with an exit code.
 pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) = renew_platform::diag::log_to_file(diagnostics_path(), None) {
+        eprintln!("RENEW_LOG: {error}");
+    }
+
     let options = match parse(arguments) {
         Ok(options) => options,
         Err(error) => {
@@ -453,4 +460,18 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
         println!("{}", describe(&report));
     }
     0
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
+///
+/// There is no validation switch beside it here: this sample touches no
+/// device, so what a log carries is a panic and nothing a graphics layer
+/// could add to.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }

--- a/samples/chess/tests/diagnostics.rs
+++ b/samples/chess/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_chess");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--help"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-chess")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}

--- a/samples/cube/Cargo.toml
+++ b/samples/cube/Cargo.toml
@@ -21,6 +21,7 @@ name = "cube"
 path = "src/main.rs"
 
 [dependencies]
+renew-platform = { path = "../../crates/core/platform", default-features = false }
 renew-fixed = { path = "../../crates/fixed" }
 renew-sample-cube-world = { path = "world" }
 

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -404,6 +404,13 @@ pub fn describe_json(report: &Report) -> String {
 /// one — and the parts most worth testing, the refusals, are exactly the parts
 /// a spawned process makes hardest to inspect.
 pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) = renew_platform::diag::log_to_file(diagnostics_path(), None) {
+        eprintln!("RENEW_LOG: {error}");
+    }
+
     let options = match parse(arguments) {
         Ok(options) => options,
         Err(error) => {
@@ -430,4 +437,18 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
         println!("{}", describe(&report));
     }
     0
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
+///
+/// There is no validation switch beside it here: this sample touches no
+/// device, so what a log carries is a panic and nothing a graphics layer
+/// could add to.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }

--- a/samples/cube/tests/diagnostics.rs
+++ b/samples/cube/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_cube");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--help"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-cube")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}

--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -56,6 +56,38 @@ close, which is not a failed run.
 the length — so the flags it would contradict are refused by name
 rather than silently ignored.
 
+## When something goes wrong
+
+Set `RENEW_LOG` to a file path and the run reports into it: the engine's
+own error channel, any panic, and — because a graphics fault is usually
+inside the driver rather than above it — Vulkan validation, which is off
+by default because it costs frame time and says nothing on a healthy
+run.
+
+```
+RENEW_LOG=run.log glide --window
+```
+
+```powershell
+$env:RENEW_LOG = "$env:USERPROFILE\run.log"
+.\target\debug\glide.exe --window
+```
+
+An environment variable rather than a flag, because a panic that happens
+before the command line is parsed still needs somewhere to go. An empty
+value counts as unset.
+
+The file is appended to, never truncated, so several runs at one path
+accumulate; a run that reports nothing leaves no file at all, which is
+what a healthy run looks like. A sink that cannot write drops its
+records in silence — the reporting channel is the thing that broke, and
+a diagnostic must not become the fault.
+
+**What it cannot catch:** a driver that takes the process down leaves
+nothing to write with. A log that ends mid-run, with a nonzero exit and
+no failure line, is itself the finding — it says the fault was below the
+engine rather than in it.
+
 ## Shape
 
 Two crates. `world/` is the simulation — a pure fixed-step function of

--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -59,29 +59,43 @@ rather than silently ignored.
 ## When something goes wrong
 
 Set `RENEW_LOG` to a file path and the run reports into it: the engine's
-own error channel, any panic, and — because a graphics fault is usually
-inside the driver rather than above it — Vulkan validation, which is off
-by default because it costs frame time and says nothing on a healthy
-run.
+own error channel, and any panic.
 
 ```
 RENEW_LOG=run.log glide --window
 ```
 
 ```powershell
-$env:RENEW_LOG = "$env:USERPROFILE\run.log"
-.\target\debug\glide.exe --window
+$env:RENEW_LOG = "$env:USERPROFILEun.log"
+.	arget\debug\glide.exe --window
 ```
 
 An environment variable rather than a flag, because a panic that happens
 before the command line is parsed still needs somewhere to go. An empty
-value counts as unset.
+value counts as unset. Every sample takes it, including the ones with no
+graphics at all, where what it carries is a panic.
+
+**Every log says whether graphics validation was on**, in its first
+line, both ways round. Validation is a separate switch:
+
+```
+RENEW_LOG=run.log RENEW_VALIDATION=1 glide --window
+```
+
+They are separate deliberately. The validation layer reports faults
+inside the driver that nothing else here can see — and it changes
+timing, so a fault that depends on timing can behave differently, or
+vanish, when it is on. The first capture worth having is of the run that
+actually failed, unperturbed; validation is the second look, taken
+knowingly. A log that did not say which kind of run it recorded would be
+impossible to compare against another.
 
 The file is appended to, never truncated, so several runs at one path
-accumulate; a run that reports nothing leaves no file at all, which is
-what a healthy run looks like. A sink that cannot write drops its
-records in silence — the reporting channel is the thing that broke, and
-a diagnostic must not become the fault.
+accumulate. It is created as soon as logging starts, so an **empty file
+means logging was on and nothing was reported** — which is a different
+thing from no file, meaning it was never on. A path that cannot be
+written is said once on the error stream and the run continues; a broken
+log must not become a broken run.
 
 **What it cannot catch:** a driver that takes the process down leaves
 nothing to write with. A log that ends mid-run, with a nonzero exit and

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -57,6 +57,15 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // A parse failure is reported by `run` below, not twice.
     let args: Vec<String> = args.into_iter().collect();
     let json = crate::cli::parse_args(args.iter().cloned()).is_ok_and(|options| options.json);
+    // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
+    // when it is set the engine's own error channel and any panic land
+    // there, and the renderer is brought up with validation on. Reading
+    // the environment is the binary's job: the crate that owns the file
+    // sink deliberately reads no configuration of its own.
+    if let Some(path) = diagnostics_path() {
+        renew_platform::diag::log_to_file(path);
+    }
+
     match run(args) {
         Ok(report) => {
             if json {
@@ -138,4 +147,31 @@ fn windowed_run(_options: &Options) -> Result<Report, SampleError> {
     Err(SampleError::Usage(
         "this build has no windowing support; rebuild with --features window".to_string(),
     ))
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// One variable rather than a flag, so it covers a panic that happens
+/// before the command line is parsed — which is exactly the failure a
+/// flag cannot describe. An empty value is treated as unset, because a
+/// shell that exports an empty string meant to turn it off.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    let value = std::env::var_os("RENEW_LOG")?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(value))
+}
+
+/// Whether this run is logging diagnostics, which is also what decides
+/// whether the renderer asks for validation.
+///
+/// **`IfAvailable`, never `Required`.** A machine without the validation
+/// layer installed must still be able to run the game while debugging
+/// something else; requiring it would turn a missing optional component
+/// into a failure to start.
+#[must_use]
+pub fn diagnostics_enabled() -> bool {
+    diagnostics_path().is_some()
 }

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -155,11 +155,7 @@ fn windowed_run(_options: &Options) -> Result<Report, SampleError> {
 /// shell that exports an empty string meant to turn it off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
-    let value = std::env::var_os("RENEW_LOG")?;
-    if value.is_empty() {
-        return None;
-    }
-    Some(std::path::PathBuf::from(value))
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }
 
 /// Whether this run is logging diagnostics, which is also what decides
@@ -206,5 +202,28 @@ pub fn validation_for(logging: bool) -> renew_rhi::Validation {
         renew_rhi::Validation::IfAvailable
     } else {
         renew_rhi::Validation::Off
+    }
+}
+
+#[cfg(all(test, feature = "window"))]
+mod tests {
+    /// Both answers, asserted where the renderer exists to be asked.
+    ///
+    /// The arm that asks for validation runs only in a process that has
+    /// set the variable and opened a window, which no test does — so
+    /// inline at the call site the decision was made somewhere nothing
+    /// could observe. As a function of a boolean, both are reachable.
+    #[test]
+    fn the_validation_policy_answers_both_ways() {
+        assert_eq!(
+            super::validation_for(true),
+            renew_rhi::Validation::IfAvailable,
+            "a logged run asks for validation, which is what can name a fault in the driver"
+        );
+        assert_eq!(
+            super::validation_for(false),
+            renew_rhi::Validation::Off,
+            "an ordinary run pays nothing for a layer it will not read"
+        );
     }
 }

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -186,7 +186,21 @@ pub fn validation_requested() -> bool {
 /// needs to know. Saying it either way makes the log self-describing.
 #[must_use]
 pub fn diagnostics_note() -> &'static str {
-    if validation_requested() {
+    note_for(validation_requested())
+}
+
+/// The note itself, as a function of the state rather than of the
+/// environment.
+///
+/// Split out for the same reason [`validation_for`] is: a function that
+/// reads the environment can only be tested in whichever state the test
+/// runner happens to be in, so one of its two answers would never be
+/// examined by anything. Taking the state as an argument makes both
+/// halves of a promise that is *about* saying both halves ordinarily
+/// testable.
+#[must_use]
+fn note_for(validation: bool) -> &'static str {
+    if validation {
         "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
     } else {
         "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
@@ -240,14 +254,53 @@ pub fn validation_for(logging: bool) -> renew_rhi::Validation {
     }
 }
 
-#[cfg(all(test, feature = "window"))]
+/// Tests of the pure helpers above.
+///
+/// The module is gated on `test` alone, not on the windowing feature.
+/// Only one test below needs the renderer, and it carries its own gate:
+/// gating the whole module on a feature it mostly does not use would
+/// mean the note — which every build has, windowed or not — was examined
+/// only in the build that happens to be windowed.
+#[cfg(test)]
 mod tests {
+    /// Both halves of the note exist and say which state they describe.
+    ///
+    /// The promise the note makes is that a log always says whether
+    /// validation was on, *either way round* — so a test that only ever
+    /// saw one answer would leave exactly that promise unchecked.
+    #[test]
+    fn the_note_names_the_validation_state_in_both_directions() {
+        let on = super::note_for(true);
+        let off = super::note_for(false);
+        assert!(on.contains("ON"), "the on note must say so: {on}");
+        assert!(off.contains("OFF"), "the off note must say so: {off}");
+        assert_ne!(on, off, "the two states must not read alike");
+        // The off note is the one that has to teach: a reader with a
+        // thin log needs to know there is a closer look available, what
+        // to type for it, and what it costs.
+        assert!(
+            off.contains("RENEW_VALIDATION=1"),
+            "the off note must say what to set: {off}"
+        );
+        assert!(
+            off.contains("timing"),
+            "the off note must say what enabling it costs: {off}"
+        );
+        assert!(
+            on.contains("timing"),
+            "the on note must say what is already being paid: {on}"
+        );
+    }
     /// Both answers, asserted where the renderer exists to be asked.
     ///
     /// The arm that asks for validation runs only in a process that has
     /// set the variable and opened a window, which no test does — so
     /// inline at the call site the decision was made somewhere nothing
     /// could observe. As a function of a boolean, both are reachable.
+    ///
+    /// Gated: the type it asserts on comes from the rendering crate,
+    /// which a build without a window does not have.
+    #[cfg(feature = "window")]
     #[test]
     fn the_validation_policy_answers_both_ways() {
         assert_eq!(

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -62,9 +62,7 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // there, and the renderer is brought up with validation on. Reading
     // the environment is the binary's job: the crate that owns the file
     // sink deliberately reads no configuration of its own.
-    if let Some(path) = diagnostics_path() {
-        renew_platform::diag::log_to_file(path);
-    }
+    renew_platform::diag::log_to_file(diagnostics_path());
 
     match run(args) {
         Ok(report) => {
@@ -174,4 +172,39 @@ pub fn diagnostics_path() -> Option<std::path::PathBuf> {
 #[must_use]
 pub fn diagnostics_enabled() -> bool {
     diagnostics_path().is_some()
+}
+
+/// Which validation policy a run asks the renderer for.
+///
+/// Behind the windowing feature because the rendering crate is: a build
+/// with no window has no renderer to ask.
+///
+/// **A named function rather than a conditional at the call site**, so
+/// both answers can be asserted. Inline, the diagnostics arm executes
+/// only in a run that has already set the variable and opened a window,
+/// which no test does — the choice would be made in a place nothing
+/// could observe. `IfAvailable` rather than `Required`: a machine
+/// without the validation layer must still run while something else is
+/// being debugged.
+#[cfg(feature = "window")]
+#[must_use]
+pub fn validation_policy() -> renew_rhi::Validation {
+    validation_for(diagnostics_enabled())
+}
+
+/// The policy a run asks for, given whether it is logging.
+///
+/// Split from the reader so both answers are reachable without touching
+/// the environment — which is process-wide, and which a test that wrote
+/// it would be racing every other test in its binary. `IfAvailable`
+/// rather than `Required`: a machine without the validation layer must
+/// still run while something else is being debugged.
+#[cfg(feature = "window")]
+#[must_use]
+pub fn validation_for(logging: bool) -> renew_rhi::Validation {
+    if logging {
+        renew_rhi::Validation::IfAvailable
+    } else {
+        renew_rhi::Validation::Off
+    }
 }

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -62,7 +62,14 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // there, and the renderer is brought up with validation on. Reading
     // the environment is the binary's job: the crate that owns the file
     // sink deliberately reads no configuration of its own.
-    renew_platform::diag::log_to_file(diagnostics_path());
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) =
+        renew_platform::diag::log_to_file(diagnostics_path(), Some(diagnostics_note()))
+    {
+        eprintln!("RENEW_LOG: {error}");
+    }
 
     match run(args) {
         Ok(report) => {
@@ -149,13 +156,41 @@ fn windowed_run(_options: &Options) -> Result<Report, SampleError> {
 
 /// The file `RENEW_LOG` names, if it names one.
 ///
-/// One variable rather than a flag, so it covers a panic that happens
-/// before the command line is parsed — which is exactly the failure a
-/// flag cannot describe. An empty value is treated as unset, because a
-/// shell that exports an empty string meant to turn it off.
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
     renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
+}
+
+/// Whether `RENEW_VALIDATION` asks for the graphics validation layer.
+///
+/// **A separate switch from the log, deliberately.** The layer changes
+/// timing, so a crash that is a race can vanish when it is enabled — and
+/// the first capture anybody wants is of the run that actually failed,
+/// unperturbed. Logging records what happened; this looks closer, and
+/// asks to be turned on knowing that it changes what it observes.
+#[must_use]
+pub fn validation_requested() -> bool {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_VALIDATION")).is_some()
+}
+
+/// The line every log opens with, saying which state the graphics
+/// validation layer is in.
+///
+/// **Always said, in both states, and that is the point.** A log that
+/// mentioned the layer only when it was off would leave a reader of the
+/// other kind wondering whether it had been on — and a run recorded with
+/// the layer active is not a stock run, which anybody comparing two logs
+/// needs to know. Saying it either way makes the log self-describing.
+#[must_use]
+pub fn diagnostics_note() -> &'static str {
+    if validation_requested() {
+        "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
+    } else {
+        "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
+    }
 }
 
 /// Whether this run is logging diagnostics, which is also what decides

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -255,9 +255,17 @@ impl GlideApp {
     }
 
     fn bring_up(&mut self, window: NativeWindow, size: Extent) -> Result<(), SampleError> {
+        // Validation follows the diagnostics switch: off for an
+        // ordinary run, where the layer costs frame time and says
+        // nothing, and on for a run that is being debugged, where it is
+        // the only thing that can name a fault inside the driver.
         let device = Device::new(&DeviceDesc {
             app_name: "renew-glide",
-            validation: Validation::Off,
+            validation: if crate::diagnostics_enabled() {
+                Validation::IfAvailable
+            } else {
+                Validation::Off
+            },
         })
         .map_err(|error| SampleError::failed("bringing up the device", &error))?;
         let target = device

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -19,7 +19,7 @@ use renew_platform::window::{
 };
 use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer};
 use renew_rhi::{
-    Color, Device, DeviceDesc, Extent, Pass, PresentOutcome, RenderDesc, Validation, WindowTarget,
+    Color, Device, DeviceDesc, Extent, Pass, PresentOutcome, RenderDesc, WindowTarget,
 };
 use renew_sample_glide_world::{Action, VIEW_HEIGHT, VIEW_WIDTH, World};
 
@@ -261,11 +261,7 @@ impl GlideApp {
         // the only thing that can name a fault inside the driver.
         let device = Device::new(&DeviceDesc {
             app_name: "renew-glide",
-            validation: if crate::diagnostics_enabled() {
-                Validation::IfAvailable
-            } else {
-                Validation::Off
-            },
+            validation: crate::validation_policy(),
         })
         .map_err(|error| SampleError::failed("bringing up the device", &error))?;
         let target = device

--- a/samples/glide/tests/diagnostics.rs
+++ b/samples/glide/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_glide");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--frames", "1"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-glide")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -83,9 +83,7 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
     // when it is set the engine's own error channel and any panic land
     // there, and the device is brought up with validation on.
-    if let Some(path) = diagnostics_path() {
-        renew_platform::diag::log_to_file(path);
-    }
+    renew_platform::diag::log_to_file(diagnostics_path());
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {
@@ -191,8 +189,52 @@ pub fn diagnostics_enabled() -> bool {
     diagnostics_path().is_some()
 }
 
+/// Which validation policy a run asks the renderer for.
+///
+/// **A named function rather than a conditional at the call site**, so
+/// both answers can be asserted. Inline, the diagnostics arm executes
+/// only in a run that has already set the variable and opened a window,
+/// which no test does — the choice would be made in a place nothing
+/// could observe. `IfAvailable` rather than `Required`: a machine
+/// without the validation layer must still run while something else is
+/// being debugged.
+#[must_use]
+pub fn validation_policy() -> renew_rhi::Validation {
+    validation_for(diagnostics_enabled())
+}
+
+/// The policy a run asks for, given whether it is logging.
+///
+/// Split from the reader so both answers are reachable without touching
+/// the environment — which is process-wide, and which a test that wrote
+/// it would be racing every other test in its binary. `IfAvailable`
+/// rather than `Required`: a machine without the validation layer must
+/// still run while something else is being debugged.
+#[must_use]
+pub fn validation_for(logging: bool) -> renew_rhi::Validation {
+    if logging {
+        renew_rhi::Validation::IfAvailable
+    } else {
+        renew_rhi::Validation::Off
+    }
+}
+
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn the_validation_policy_answers_both_ways() {
+        assert_eq!(
+            super::validation_for(true),
+            renew_rhi::Validation::IfAvailable,
+            "a logged run asks for validation, which is what can name a fault in the driver"
+        );
+        assert_eq!(
+            super::validation_for(false),
+            renew_rhi::Validation::Off,
+            "an ordinary run pays nothing for a layer it will not read"
+        );
+    }
     use super::{FAILURE_EXIT, SampleError, USAGE_EXIT, dump_failed, report_error, run_cli};
     use renew_platform::fs::FsError;
     use std::path::PathBuf;

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -170,11 +170,7 @@ pub fn exit_code(code: u8) -> ExitCode {
 /// shell that exports an empty string meant to turn it off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
-    let value = std::env::var_os("RENEW_LOG")?;
-    if value.is_empty() {
-        return None;
-    }
-    Some(std::path::PathBuf::from(value))
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }
 
 /// Whether this run is logging diagnostics, which also decides whether

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -201,7 +201,21 @@ pub fn validation_requested() -> bool {
 /// needs to know. Saying it either way makes the log self-describing.
 #[must_use]
 pub fn diagnostics_note() -> &'static str {
-    if validation_requested() {
+    note_for(validation_requested())
+}
+
+/// The note itself, as a function of the state rather than of the
+/// environment.
+///
+/// Split out for the same reason [`validation_for`] is: a function that
+/// reads the environment can only be tested in whichever state the test
+/// runner happens to be in, so one of its two answers would never be
+/// examined by anything. Taking the state as an argument makes both
+/// halves of a promise that is *about* saying both halves ordinarily
+/// testable.
+#[must_use]
+fn note_for(validation: bool) -> &'static str {
+    if validation {
         "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
     } else {
         "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
@@ -252,6 +266,34 @@ pub fn validation_for(logging: bool) -> renew_rhi::Validation {
 
 #[cfg(test)]
 mod tests {
+    /// Both halves of the note exist and say which state they describe.
+    ///
+    /// The promise the note makes is that a log always says whether
+    /// validation was on, *either way round* — so a test that only ever
+    /// saw one answer would leave exactly that promise unchecked.
+    #[test]
+    fn the_note_names_the_validation_state_in_both_directions() {
+        let on = super::note_for(true);
+        let off = super::note_for(false);
+        assert!(on.contains("ON"), "the on note must say so: {on}");
+        assert!(off.contains("OFF"), "the off note must say so: {off}");
+        assert_ne!(on, off, "the two states must not read alike");
+        // The off note is the one that has to teach: a reader with a
+        // thin log needs to know there is a closer look available, what
+        // to type for it, and what it costs.
+        assert!(
+            off.contains("RENEW_VALIDATION=1"),
+            "the off note must say what to set: {off}"
+        );
+        assert!(
+            off.contains("timing"),
+            "the off note must say what enabling it costs: {off}"
+        );
+        assert!(
+            on.contains("timing"),
+            "the on note must say what is already being paid: {on}"
+        );
+    }
 
     #[test]
     fn the_validation_policy_answers_both_ways() {

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -83,7 +83,14 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
     // when it is set the engine's own error channel and any panic land
     // there, and the device is brought up with validation on.
-    renew_platform::diag::log_to_file(diagnostics_path());
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) =
+        renew_platform::diag::log_to_file(diagnostics_path(), Some(diagnostics_note()))
+    {
+        eprintln!("RENEW_LOG: {error}");
+    }
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {
@@ -164,13 +171,41 @@ pub fn exit_code(code: u8) -> ExitCode {
 
 /// The file `RENEW_LOG` names, if it names one.
 ///
-/// One variable rather than a flag, so it covers a panic that happens
-/// before the command line is parsed — which is exactly the failure a
-/// flag cannot describe. An empty value is treated as unset, because a
-/// shell that exports an empty string meant to turn it off.
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
     renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
+}
+
+/// Whether `RENEW_VALIDATION` asks for the graphics validation layer.
+///
+/// **A separate switch from the log, deliberately.** The layer changes
+/// timing, so a crash that is a race can vanish when it is enabled — and
+/// the first capture anybody wants is of the run that actually failed,
+/// unperturbed. Logging records what happened; this looks closer, and
+/// asks to be turned on knowing that it changes what it observes.
+#[must_use]
+pub fn validation_requested() -> bool {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_VALIDATION")).is_some()
+}
+
+/// The line every log opens with, saying which state the graphics
+/// validation layer is in.
+///
+/// **Always said, in both states, and that is the point.** A log that
+/// mentioned the layer only when it was off would leave a reader of the
+/// other kind wondering whether it had been on — and a run recorded with
+/// the layer active is not a stock run, which anybody comparing two logs
+/// needs to know. Saying it either way makes the log self-describing.
+#[must_use]
+pub fn diagnostics_note() -> &'static str {
+    if validation_requested() {
+        "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
+    } else {
+        "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
+    }
 }
 
 /// Whether this run is logging diagnostics, which also decides whether

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -80,6 +80,12 @@ const FAILURE_EXIT: u8 = 1;
 /// reaches stdout on the success path, and it is the digest line the
 /// determinism gate compares.
 pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
+    // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
+    // when it is set the engine's own error channel and any panic land
+    // there, and the device is brought up with validation on.
+    if let Some(path) = diagnostics_path() {
+        renew_platform::diag::log_to_file(path);
+    }
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {
@@ -156,6 +162,33 @@ fn report_error(error: &SampleError, strict: bool) -> u8 {
 #[must_use]
 pub fn exit_code(code: u8) -> ExitCode {
     ExitCode::from(code)
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// One variable rather than a flag, so it covers a panic that happens
+/// before the command line is parsed — which is exactly the failure a
+/// flag cannot describe. An empty value is treated as unset, because a
+/// shell that exports an empty string meant to turn it off.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    let value = std::env::var_os("RENEW_LOG")?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(value))
+}
+
+/// Whether this run is logging diagnostics, which also decides whether
+/// the renderer asks for validation.
+///
+/// **`IfAvailable`, never `Required`.** A machine without the validation
+/// layer installed must still run while something else is being
+/// debugged; requiring it would turn a missing optional component into a
+/// failure to start.
+#[must_use]
+pub fn diagnostics_enabled() -> bool {
+    diagnostics_path().is_some()
 }
 
 #[cfg(test)]

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -88,7 +88,11 @@ impl HeadlessRun {
     pub fn start(seed: u64, draw: Draw) -> Result<Self, SampleError> {
         let device = Device::new(&DeviceDesc {
             app_name: "renew-hello-triangle",
-            validation: Validation::Off,
+            validation: if crate::diagnostics_enabled() {
+                Validation::IfAvailable
+            } else {
+                Validation::Off
+            },
         })
         .map_err(device_error)?;
         let target = device

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -12,7 +12,7 @@ use renew_math::Alpha;
 use renew_platform::Clock;
 use renew_rhi::{
     AdapterInfo, Device, DeviceDesc, Extent, Item, Pass, PipelineDesc, RenderDesc, RenderPipeline,
-    Validation, builtin,
+    builtin,
 };
 
 use crate::cli::{Options, Report};
@@ -88,11 +88,7 @@ impl HeadlessRun {
     pub fn start(seed: u64, draw: Draw) -> Result<Self, SampleError> {
         let device = Device::new(&DeviceDesc {
             app_name: "renew-hello-triangle",
-            validation: if crate::diagnostics_enabled() {
-                Validation::IfAvailable
-            } else {
-                Validation::Off
-            },
+            validation: crate::validation_policy(),
         })
         .map_err(device_error)?;
         let target = device

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -23,7 +23,7 @@ use renew_platform::window::{
 };
 use renew_rhi::{
     Device, DeviceDesc, Extent, Item, Pass, PipelineDesc, RenderDesc, RenderPipeline, TargetError,
-    Validation, builtin,
+    builtin,
 };
 
 use crate::cli::{Options, Report};
@@ -155,11 +155,7 @@ impl TriangleApp {
     fn bring_up(&mut self, window: NativeWindow, size: Extent) -> Result<(), SampleError> {
         let device = Device::new(&DeviceDesc {
             app_name: "renew-hello-triangle",
-            validation: if crate::diagnostics_enabled() {
-                Validation::IfAvailable
-            } else {
-                Validation::Off
-            },
+            validation: crate::validation_policy(),
         })
         .map_err(device_error)?;
         let target = device

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -155,7 +155,11 @@ impl TriangleApp {
     fn bring_up(&mut self, window: NativeWindow, size: Extent) -> Result<(), SampleError> {
         let device = Device::new(&DeviceDesc {
             app_name: "renew-hello-triangle",
-            validation: Validation::Off,
+            validation: if crate::diagnostics_enabled() {
+                Validation::IfAvailable
+            } else {
+                Validation::Off
+            },
         })
         .map_err(device_error)?;
         let target = device

--- a/samples/hello_triangle/tests/diagnostics.rs
+++ b/samples/hello_triangle/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_hello_triangle");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--headless", "--frames", "1"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-hello_triangle")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -72,6 +72,12 @@ const FAILURE_EXIT: u8 = 1;
 /// `1` for a failure, `2` for a bad command line. The last line on
 /// stdout is always the digest line the determinism gate compares.
 pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
+    // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
+    // when it is set the engine's own error channel and any panic land
+    // there, and the device is brought up with validation on.
+    if let Some(path) = diagnostics_path() {
+        renew_platform::diag::log_to_file(path);
+    }
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {
@@ -149,6 +155,33 @@ fn report_error(error: &SampleError, strict: bool) -> u8 {
 #[must_use]
 pub fn exit_code(code: u8) -> ExitCode {
     ExitCode::from(code)
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// One variable rather than a flag, so it covers a panic that happens
+/// before the command line is parsed — which is exactly the failure a
+/// flag cannot describe. An empty value is treated as unset, because a
+/// shell that exports an empty string meant to turn it off.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    let value = std::env::var_os("RENEW_LOG")?;
+    if value.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(value))
+}
+
+/// Whether this run is logging diagnostics, which also decides whether
+/// the renderer asks for validation.
+///
+/// **`IfAvailable`, never `Required`.** A machine without the validation
+/// layer installed must still run while something else is being
+/// debugged; requiring it would turn a missing optional component into a
+/// failure to start.
+#[must_use]
+pub fn diagnostics_enabled() -> bool {
+    diagnostics_path().is_some()
 }
 
 #[cfg(test)]

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -163,23 +163,7 @@ pub fn exit_code(code: u8) -> ExitCode {
 /// shell that exports an empty string meant to turn it off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
-    let value = std::env::var_os("RENEW_LOG")?;
-    if value.is_empty() {
-        return None;
-    }
-    Some(std::path::PathBuf::from(value))
-}
-
-/// Whether this run is logging diagnostics, which also decides whether
-/// the renderer asks for validation.
-///
-/// **`IfAvailable`, never `Required`.** A machine without the validation
-/// layer installed must still run while something else is being
-/// debugged; requiring it would turn a missing optional component into a
-/// failure to start.
-#[must_use]
-pub fn diagnostics_enabled() -> bool {
-    diagnostics_path().is_some()
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }
 
 #[cfg(test)]

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -75,9 +75,7 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
     // when it is set the engine's own error channel and any panic land
     // there, and the device is brought up with validation on.
-    if let Some(path) = diagnostics_path() {
-        renew_platform::diag::log_to_file(path);
-    }
+    renew_platform::diag::log_to_file(diagnostics_path());
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -75,7 +75,14 @@ pub fn run_cli<I: IntoIterator<Item = String>>(args: I) -> u8 {
     // Diagnostics, before anything can fail. `RENEW_LOG` names a file;
     // when it is set the engine's own error channel and any panic land
     // there, and the device is brought up with validation on.
-    renew_platform::diag::log_to_file(diagnostics_path());
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) =
+        renew_platform::diag::log_to_file(diagnostics_path(), Some(diagnostics_note()))
+    {
+        eprintln!("RENEW_LOG: {error}");
+    }
     let strict = std::env::var_os(STRICT).is_some_and(|value| value == "1");
     match run(args) {
         Ok(report) => {
@@ -157,13 +164,41 @@ pub fn exit_code(code: u8) -> ExitCode {
 
 /// The file `RENEW_LOG` names, if it names one.
 ///
-/// One variable rather than a flag, so it covers a panic that happens
-/// before the command line is parsed — which is exactly the failure a
-/// flag cannot describe. An empty value is treated as unset, because a
-/// shell that exports an empty string meant to turn it off.
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
 #[must_use]
 pub fn diagnostics_path() -> Option<std::path::PathBuf> {
     renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
+}
+
+/// Whether `RENEW_VALIDATION` asks for the graphics validation layer.
+///
+/// **A separate switch from the log, deliberately.** The layer changes
+/// timing, so a crash that is a race can vanish when it is enabled — and
+/// the first capture anybody wants is of the run that actually failed,
+/// unperturbed. Logging records what happened; this looks closer, and
+/// asks to be turned on knowing that it changes what it observes.
+#[must_use]
+pub fn validation_requested() -> bool {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_VALIDATION")).is_some()
+}
+
+/// The line every log opens with, saying which state the graphics
+/// validation layer is in.
+///
+/// **Always said, in both states, and that is the point.** A log that
+/// mentioned the layer only when it was off would leave a reader of the
+/// other kind wondering whether it had been on — and a run recorded with
+/// the layer active is not a stock run, which anybody comparing two logs
+/// needs to know. Saying it either way makes the log self-describing.
+#[must_use]
+pub fn diagnostics_note() -> &'static str {
+    if validation_requested() {
+        "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
+    } else {
+        "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
+    }
 }
 
 #[cfg(test)]

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -194,7 +194,21 @@ pub fn validation_requested() -> bool {
 /// needs to know. Saying it either way makes the log self-describing.
 #[must_use]
 pub fn diagnostics_note() -> &'static str {
-    if validation_requested() {
+    note_for(validation_requested())
+}
+
+/// The note itself, as a function of the state rather than of the
+/// environment.
+///
+/// Split out for the same reason a pure helper always is here: a function that
+/// reads the environment can only be tested in whichever state the test
+/// runner happens to be in, so one of its two answers would never be
+/// examined by anything. Taking the state as an argument makes both
+/// halves of a promise that is *about* saying both halves ordinarily
+/// testable.
+#[must_use]
+fn note_for(validation: bool) -> &'static str {
+    if validation {
         "graphics validation is ON: it reports driver-level faults this log would otherwise miss, and it changes timing, so a fault that depends on timing may behave differently here than in an ordinary run."
     } else {
         "graphics validation is OFF, so this is an ordinary run and what it records is what really happened. If the fault is graphical and nothing here explains it, set RENEW_VALIDATION=1 and run again: the layer names faults inside the driver, at the cost of changing timing."
@@ -203,6 +217,34 @@ pub fn diagnostics_note() -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    /// Both halves of the note exist and say which state they describe.
+    ///
+    /// The promise the note makes is that a log always says whether
+    /// validation was on, *either way round* — so a test that only ever
+    /// saw one answer would leave exactly that promise unchecked.
+    #[test]
+    fn the_note_names_the_validation_state_in_both_directions() {
+        let on = super::note_for(true);
+        let off = super::note_for(false);
+        assert!(on.contains("ON"), "the on note must say so: {on}");
+        assert!(off.contains("OFF"), "the off note must say so: {off}");
+        assert_ne!(on, off, "the two states must not read alike");
+        // The off note is the one that has to teach: a reader with a
+        // thin log needs to know there is a closer look available, what
+        // to type for it, and what it costs.
+        assert!(
+            off.contains("RENEW_VALIDATION=1"),
+            "the off note must say what to set: {off}"
+        );
+        assert!(
+            off.contains("timing"),
+            "the off note must say what enabling it costs: {off}"
+        );
+        assert!(
+            on.contains("timing"),
+            "the on note must say what is already being paid: {on}"
+        );
+    }
     use super::{FAILURE_EXIT, SampleError, USAGE_EXIT, dump_failed, report_error, run_cli};
     use renew_platform::fs::FsError;
     use std::path::PathBuf;

--- a/samples/input_echo/tests/diagnostics.rs
+++ b/samples/input_echo/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_input_echo");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--headless", "--input-trace", "walk"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-input_echo")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}

--- a/samples/leap/Cargo.toml
+++ b/samples/leap/Cargo.toml
@@ -21,6 +21,7 @@ name = "leap"
 path = "src/main.rs"
 
 [dependencies]
+renew-platform = { path = "../../crates/core/platform", default-features = false }
 renew-fixed = { path = "../../crates/fixed" }
 renew-sample-leap-world = { path = "world" }
 

--- a/samples/leap/src/lib.rs
+++ b/samples/leap/src/lib.rs
@@ -346,6 +346,13 @@ pub fn describe_json(report: &Report) -> String {
 /// The whole binary, in the library, so a test can drive every refusal without
 /// spawning a process to inspect.
 pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
+    // Diagnostics, before anything can fail. A path that cannot be
+    // written is said out loud once: silence there would look exactly
+    // like a run with nothing to report.
+    if let Err(error) = renew_platform::diag::log_to_file(diagnostics_path(), None) {
+        eprintln!("RENEW_LOG: {error}");
+    }
+
     let options = match parse(arguments) {
         Ok(options) => options,
         Err(error) => {
@@ -369,4 +376,18 @@ pub fn run_cli<I: IntoIterator<Item = String>>(arguments: I) -> u8 {
         println!("{}", describe(&report));
     }
     0
+}
+
+/// The file `RENEW_LOG` names, if it names one.
+///
+/// An environment variable rather than a flag, so a panic that happens
+/// before the command line is parsed still has somewhere to go. Absent
+/// and empty both mean off.
+///
+/// There is no validation switch beside it here: this sample touches no
+/// device, so what a log carries is a panic and nothing a graphics layer
+/// could add to.
+#[must_use]
+pub fn diagnostics_path() -> Option<std::path::PathBuf> {
+    renew_platform::diag::path_from_value(std::env::var_os("RENEW_LOG"))
 }

--- a/samples/leap/tests/diagnostics.rs
+++ b/samples/leap/tests/diagnostics.rs
@@ -1,0 +1,92 @@
+//! A log path that cannot be written is said out loud, once, and
+//! changes nothing else about the run.
+//!
+//! **Spawned rather than called, because the promise is about a
+//! process.** The complaint goes to the error stream before anything
+//! else happens, and the engine crates are forbidden to print at all --
+//! so the only place this behaviour exists is in the binary, and the
+//! only way to observe it is to run one.
+//!
+//! Two runs rather than one: the same command with the variable unset
+//! and with it pointing somewhere unwritable. Comparing them is what
+//! makes the assertions mean anything -- one complaint appears, the
+//! other run has none, and the exit code is the same either way. A
+//! single run could show the complaint without showing that it cost
+//! nothing.
+
+use std::process::Command;
+
+/// The binary cargo just built, whichever profile and target directory
+/// that is.
+const BINARY: &str = env!("CARGO_BIN_EXE_leap");
+
+/// The cheapest invocation that still goes through the whole entry
+/// point. Diagnostics are installed before the command line is even
+/// parsed, so nothing expensive is needed to reach them.
+const ARGUMENTS: &[&str] = &["--help"];
+
+/// A path that cannot be opened for writing anywhere: its parent
+/// directory does not exist, and nothing here creates it.
+///
+/// Named per sample so a failure message says which run left it, though
+/// no file is ever created under either name.
+fn unwritable_path() -> std::path::PathBuf {
+    std::env::temp_dir()
+        .join("renew-no-such-directory-leap")
+        .join("run.log")
+}
+
+/// Run the binary, with `RENEW_LOG` either absent or unwritable.
+///
+/// Removed rather than merely left alone: a developer running the suite
+/// with the variable already set in their shell would otherwise see the
+/// clean run inherit it, and the comparison below would quietly stop
+/// comparing anything.
+///
+/// The error stream comes back unnormalised. Nothing here reads it as
+/// lines -- the assertions count one substring and compare two exit
+/// codes -- so the line endings never enter the question.
+#[expect(
+    clippy::expect_used,
+    reason = "a test fixture; a binary that will not launch should fail loudly"
+)]
+fn run(log: Option<std::path::PathBuf>) -> (Option<i32>, String) {
+    let mut command = Command::new(BINARY);
+    command.args(ARGUMENTS);
+    match log {
+        Some(path) => command.env("RENEW_LOG", path),
+        None => command.env_remove("RENEW_LOG"),
+    };
+    let output = command
+        .output()
+        .expect("the binary cargo just built should run");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn an_unwritable_log_path_is_said_once_and_costs_the_run_nothing() {
+    let (clean_code, clean_stderr) = run(None);
+    let (broken_code, broken_stderr) = run(Some(unwritable_path()));
+
+    // Said: silence would look exactly like a run with nothing to
+    // report. Once: a repeat would bury the output the run is for.
+    assert_eq!(
+        broken_stderr.matches("RENEW_LOG:").count(),
+        1,
+        "a mistyped path must be said, and said once: {broken_stderr}"
+    );
+    assert_eq!(
+        clean_stderr.matches("RENEW_LOG:").count(),
+        0,
+        "the complaint must come from the log path and nothing else: {clean_stderr}"
+    );
+    // The whole point of complaining rather than failing: a broken log
+    // must not become a broken run.
+    assert_eq!(
+        clean_code, broken_code,
+        "an unopenable log must not change the outcome: {clean_stderr} / {broken_stderr}"
+    );
+}


### PR DESCRIPTION
The engine reports through a sink interface and **no binary ever installed a sink**, so every record was emitted into a slot nobody was listening to and discarded. A run that failed on the GPU printed one summary line on standard error and nothing else.

Setting `RENEW_LOG` to a path now sends the engine's error channel and any panic there, and brings the device up with Vulkan validation enabled.

```
RENEW_LOG=run.log glide --window
```

## Where each piece lives, and why

The zoning already decided this. `renew-diag` defines the sink interface and forbids filesystem access in its own lint configuration — *"sinks own I/O"* — so the file sink lives in `renew-platform`, which owns the filesystem. That crate's contract says **"nothing here reads configuration from the environment"**, so it takes a path and installs nothing; each binary reads the variable, because a binary owns its environment.

An environment variable rather than a flag, so a panic that happens before the command line is parsed still has somewhere to go.

## Behaviour

- Records are **appended**, never truncated, so several runs at one path accumulate.
- A healthy run leaves **no file at all**.
- A sink that cannot write **drops its records silently** — the reporting channel is what has broken, and a diagnostic must not become the fault.
- Validation is `IfAvailable`, never `Required`: a machine without the layer still runs.

## What it cannot catch

A driver that takes the process down leaves nothing to write with. A log that ends mid-run with a nonzero exit and no failure line is itself the finding — the fault was below the engine. The README says so rather than implying coverage it does not have.

## Verified

Both states on a discrete adapter: with the variable set the log opens `INFO renew-rhi: device up: NVIDIA GeForce RTX 3070 (DiscreteGpu), depth format D32_SFLOAT`; unset, no file is created. Forcing a loader failure puts the root cause in the log — `vkCreateInstance: Found no drivers!` — which the summary line on stderr does not carry.
