### PR TITLE
feat(render3d): indexed 3D geometry, depth-tested, headless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       # other side.
       - name: Build and test without the rendering crate
         run: |
-          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-sample-hello-triangle --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-render3d --exclude renew-sample-hello-triangle --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rhi $sel
           cargo build $sel
           cargo test $sel
@@ -274,6 +274,18 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
+      # The 3D renderer: policy over the rendering crate, and no
+      # consumers at all yet -- no sample draws geometry, so nothing is
+      # excluded alongside it. That is what makes this cell cheap to keep
+      # honest now and worth having before it stops being cheap: the
+      # first consumer joins the exclude list rather than discovering,
+      # later, that the crate was never actually removable.
+      - name: Build and test without the 3D renderer
+        run: |
+          sel="--workspace --exclude renew-render3d"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render3d $sel
+          cargo build $sel
+          cargo test $sel
       # The fixed-point arithmetic, and the collision crate written in it.
       # This cell was a single leaf when it landed, with a comment saying
       # the first crate to depend on it should discover the obligation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,7 +573,7 @@ jobs:
           # which turns every "zero validation errors" assertion in
           # this step into a claim about nothing.
           export VK_ADD_LAYER_PATH="$PWD/target/fault-layer:$VK_ADD_LAYER_PATH"
-          cargo test --package renew-rhi --package renew-render2d --test fault
+          cargo test --package renew-rhi --package renew-render2d --package renew-render3d --test fault
       # The golden bootstrap/refresh ritual writes its candidate and
       # fails; surface the candidate for human inspection.
       - name: Upload golden candidates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel
@@ -494,6 +494,17 @@ jobs:
         env:
           RENEW_GOLDEN: "1"
         run: cargo test --package renew-render2d --test golden --test zero_alloc
+      # The 3D renderer's oracles, under the same rule and for a sharper
+      # reason: its tie-break case -- two coplanar quads at one depth,
+      # pushed in each order -- is the only test anywhere that makes
+      # submission order visible in a pixel, and its depth-format
+      # assertion is what lets the crate translate the depth refusal
+      # rather than pre-flighting it. Both are written to fail on a
+      # skip, which needs a lane that sets this to mean anything.
+      - name: Mesh-renderer tests on the pinned software rasterizer
+        env:
+          RENEW_GOLDEN: "1"
+        run: cargo test --package renew-render3d --test golden
       # The game's replay-capture oracle on the same pinned rasterizer:
       # committed traces replayed through the driver's own loop, drawn
       # through the sprite pipeline, compared against committed images.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
 name = "renew-render3d"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "renew-rhi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-render3d"
+version = "0.1.0"
+dependencies = [
+ "renew-rhi",
+]
+
+[[package]]
 name = "renew-replay"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/render3d/Cargo.toml
+++ b/crates/render3d/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "renew-render3d"
+description = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, one indexed draw per frame"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, one indexed draw per frame."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+# The rendering crate without its presentation feature: this crate builds
+# geometry and describes draws, it never presents, and taking the default
+# would drag windowing crates into every consumer's graph.
+[dependencies]
+renew-rhi = { path = "../rhi", default-features = false }
+
+[lints]
+workspace = true

--- a/crates/render3d/Cargo.toml
+++ b/crates/render3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renew-render3d"
-description = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, one indexed draw per frame"
+description = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, indexed draws in submission order"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, one indexed draw per frame."
+purpose = "Indexed 3D geometry over the rendering crate: one mesh pipeline, depth-tested, indexed draws in submission order."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -20,6 +20,12 @@ simulation = false
 # would drag windowing crates into every consumer's graph.
 [dependencies]
 renew-rhi = { path = "../rhi", default-features = false }
+
+# `Scene` is index-and-offset arithmetic over a byte container, which is
+# the row in the testing table that asks for properties rather than
+# examples. The same version the sibling crate pins.
+[dev-dependencies]
+proptest = "1.11"
 
 [lints]
 workspace = true

--- a/crates/render3d/README.md
+++ b/crates/render3d/README.md
@@ -1,7 +1,7 @@
 # renew-render3d
 
 Indexed 3D geometry over the rendering crate: one mesh pipeline,
-depth-tested, one indexed draw per frame. Quads go in on the host, a
+depth-tested, indexed draws in submission order. Quads go in on the host, a
 mesh comes out, and a draw item goes into a frame the caller composes.
 
 - `Scene` — the pure half. Accumulates quads into packed vertex bytes
@@ -85,8 +85,29 @@ that fails if submission order is perturbed anywhere between a push and
 a draw. Verified by doing exactly that: reversing the index order makes
 it the single failure, while every other test in the crate passes.
 
+Those oracles skip where there is no adapter, which is why the software
+rasterizer lane runs them with `RENEW_GOLDEN=1`, where a skip is a
+failure. Without that lane they would be six green ticks proving nothing
+on every runner without a GPU — including the depth-format assertion
+that lets this crate translate the depth refusal instead of pre-flighting
+it, which is a premise the design rests on rather than a detail.
+
+`Scene` gets property tests as well as examples: it is index-and-offset
+arithmetic over a byte container, and the two invariants the layer below
+relies on — whole records, and every index inside this scene's own
+corners — are statements about arbitrary quad counts that examples at one
+and two quads cannot make.
+
+**Fuzzing: N/A.** Nothing here parses external data. `Scene` serialises
+first-party `f32`s handed in by a caller, and the bytes it produces are
+consumed by the rendering crate in the same process. The obligation
+attaches when geometry arrives from a file.
+
 ## Manifest
 
 `Cargo.toml` is authoritative for maturity, core status, dependencies
 and extension points. Contract lints live in `clippy.toml`: clock reads,
-filesystem access and thread spawning are rejected at lint time.
+filesystem access and thread spawning are rejected at lint time — the
+same fourteen paths the 2D sibling names, including the spellings that
+would otherwise walk around the obvious ones (`Builder::spawn` for a
+named thread, `Read::read_to_end` for a whole file).

--- a/crates/render3d/README.md
+++ b/crates/render3d/README.md
@@ -1,0 +1,92 @@
+# renew-render3d
+
+Indexed 3D geometry over the rendering crate: one mesh pipeline,
+depth-tested, one indexed draw per frame. Quads go in on the host, a
+mesh comes out, and a draw item goes into a frame the caller composes.
+
+- `Scene` — the pure half. Accumulates quads into packed vertex bytes
+  and indices. No device, no adapter, no GPU call, so the packing and
+  the numbering are testable on any machine.
+- `MeshRenderer` — the device half. Owns the pipeline, uploads a scene
+  into a `Mesh`, and hands back an `Item`.
+- `attachment` / `depth_attachment` / `pass` — the frame pieces. `pass`
+  always attaches depth; the parts stay public for frames it does not
+  fit.
+
+```rust,ignore
+let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+let mut scene = Scene::new();
+scene.quad(corners, [0.0, 1.0, 0.0, 1.0]);
+let mesh = renderer.upload(&device, &scene)?;
+
+let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+let items = [renderer.item(&mesh)];
+target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
+```
+
+## Contract
+
+- **Push order is index order is draw order.** No sort, no batching, no
+  depth pre-pass. Two scenes built by the same calls produce
+  byte-identical buffers, and a frame drawn twice is the same image.
+- **Depth is not optional.** The pipeline tests and writes depth, and
+  `pass` attaches it. A 3D frame drawn without depth is a wrong picture
+  that looks plausible, which is worse than one that refuses.
+- **An adapter with no depth format is refused by name**, before
+  anything is created, carrying the format chain that was tried.
+- **Positions are clip space.** There is no camera; a caller drawing a
+  world transforms on its own side.
+- **Target-agnostic.** This crate never renders, never presents and
+  never touches a window. It describes draws; the caller owns the
+  target.
+- **A mesh belongs to the caller.** `upload` hands it back rather than
+  keeping it, so one mesh can be drawn by several items in a frame —
+  which the rendering crate deliberately allows.
+
+## Two decisions worth knowing
+
+**The depth refusal is a translation, not a second detection.** The
+obvious shape is to ask the device for a depth format and refuse if
+there is none. That path has no reachable trigger: it needs a genuinely
+depthless adapter, and every adapter the tests run on offers depth, so
+the centrepiece of this crate would ship with its message tested and its
+trigger never executed. Pipeline creation already refuses by name and
+names the chain, so that refusal is translated instead — and the mapping
+is driven by a unit test on every machine.
+
+**An empty scene is refused here.** The rendering crate treats empty
+geometry as a caller bug and asserts before returning its error, so an
+empty scene passed through would panic in every build this repository
+tests in. An all-air world or a fully culled mesh is ordinary data, so
+it gets an ordinary refusal.
+
+## Not in v0
+
+No camera or projection, no textures or atlas, no window or
+presentation, no image writing, and no meshing — a caller supplies quads
+already in clip space. Each is a later step. The vertex layout is a
+clip-space position and a colour, packed to 28 bytes with no padding:
+the rendering crate asserts at record time that a mesh's stride matches
+the pipeline's, and a `#[repr(C)]` struct over the maths crate's aligned
+vectors would not give 28.
+
+## Testing note
+
+The pure half's tests need no adapter and run everywhere, including the
+sanitizer lanes. The pixel oracles compute their expected image rather
+than committing one — the geometry is axis-aligned quads in flat colour,
+so the only edge in play is the diagonal each quad's triangles share,
+and the fill rule gives a sample on it to exactly one of them.
+
+One of those oracles carries more than it looks. `at_equal_depth_the_later_push_wins`
+draws two quads at the same depth in each order; under the fixed
+`LESS_OR_EQUAL` compare the later one wins, so it is the only test here
+that fails if submission order is perturbed anywhere between a push and
+a draw. Verified by doing exactly that: reversing the index order makes
+it the single failure, while every other test in the crate passes.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies
+and extension points. Contract lints live in `clippy.toml`: clock reads,
+filesystem access and thread spawning are rejected at lint time.

--- a/crates/render3d/clippy.toml
+++ b/crates/render3d/clippy.toml
@@ -1,0 +1,24 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: this crate turns quads into vertex bytes and rendering-crate
+# descriptors — it never reads a clock, never touches the filesystem,
+# never spawns a thread. Writing an image is the caller's business, which
+# is what keeps this crate testable without one.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "this crate never reads a clock; a scene is a pure function of its quads" },
+    { path = "std::time::SystemTime::now", reason = "this crate never reads a clock; a scene is a pure function of its quads" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/render3d/clippy.toml
+++ b/crates/render3d/clippy.toml
@@ -18,6 +18,12 @@ disallowed-methods = [
     { path = "std::fs::File::open", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
     { path = "std::fs::File::create", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
     { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
 ]
 
 accept-comment-above-statement = true

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -1,0 +1,331 @@
+//! The device half: one mesh pipeline, one upload, one draw item.
+//!
+//! Everything that names the rendering crate lives here, so the seam is
+//! one module wide and `scene.rs` never moves.
+//!
+//! # This crate does not render
+//!
+//! It hands back an [`Item`] and the attachments that go with it; the
+//! caller composes the frame on its own stack and gives it to whichever
+//! target it holds. The 2D sibling states the same posture, and the
+//! reason is the same: a crate that owned the render loop would have to
+//! own the target, and then it could not be used offscreen and windowed
+//! by the same caller. Nothing here presents, and nothing here touches a
+//! window.
+
+use renew_rhi::{
+    Attachment, ClearValue, Color, Device, Item, LoadOp, Mesh, MeshDesc, Pass, PipelineDesc,
+    PipelineError, RenderPipeline, StoreOp, TargetError, TargetFormat, VertexAttribute, builtin,
+};
+
+use crate::scene::{Scene, VERTEX_STRIDE};
+
+/// The per-vertex layout this crate's pipeline declares: a clip-space
+/// position, then a colour.
+///
+/// The same shapes the built-in mesh shaders read, and the same order the
+/// scene packs — three lists describing one set of bytes. They change
+/// together or the draw reads garbage, which is why the assertion the
+/// rendering crate makes at record time is worth having.
+const LAYOUT: &[VertexAttribute] = &[VertexAttribute::Vec3, VertexAttribute::Vec4];
+
+/// What can go wrong building or uploading. Creation only: the draw
+/// itself cannot fail, and the render belongs to the target.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Render3dError {
+    /// The adapter offers no depth format in the chain the rendering
+    /// crate tries, so a depth-tested pipeline cannot be built.
+    ///
+    /// **Translated from the rendering crate's own refusal rather than
+    /// detected a second time.** Pipeline creation checks depth before it
+    /// creates anything and names the chain it refused; asking the device
+    /// separately would put two authorities on one fact, and would put
+    /// the refusal on a path no lane can execute — every adapter the
+    /// tests run on offers depth.
+    DepthUnsupported {
+        /// The format chain that was refused, for the diagnostic.
+        chain: &'static str,
+    },
+    /// Building the pipeline failed for a reason that is not depth.
+    Pipeline(PipelineError),
+    /// Uploading the geometry failed.
+    Upload(TargetError),
+    /// The scene has no geometry.
+    ///
+    /// **Refused here rather than downstream, and that is deliberate.**
+    /// The rendering crate treats empty geometry as a caller bug and
+    /// asserts on it before returning its error, so an empty scene handed
+    /// through would panic in every build this repository tests in. An
+    /// all-air world and a fully culled mesh are ordinary data, not
+    /// mistakes, so they get an ordinary refusal.
+    EmptyScene,
+}
+
+impl core::fmt::Display for Render3dError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DepthUnsupported { chain } => write!(
+                f,
+                "this adapter offers no depth format ({chain}), and 3D geometry is drawn depth-tested"
+            ),
+            Self::Pipeline(error) => write!(f, "building the mesh pipeline: {error}"),
+            Self::Upload(error) => write!(f, "uploading the geometry: {error}"),
+            Self::EmptyScene => write!(f, "the scene has no geometry to upload"),
+        }
+    }
+}
+
+impl std::error::Error for Render3dError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Pipeline(error) => Some(error),
+            Self::Upload(error) => Some(error),
+            Self::DepthUnsupported { .. } | Self::EmptyScene => None,
+        }
+    }
+}
+
+impl From<PipelineError> for Render3dError {
+    /// The depth refusal is recognised and given this crate's name for
+    /// it; everything else passes through carrying its own words.
+    fn from(error: PipelineError) -> Self {
+        match error {
+            PipelineError::DepthUnsupported { chain } => Self::DepthUnsupported { chain },
+            other => Self::Pipeline(other),
+        }
+    }
+}
+
+impl From<TargetError> for Render3dError {
+    fn from(error: TargetError) -> Self {
+        Self::Upload(error)
+    }
+}
+
+/// Draws indexed geometry, depth-tested, into a target of one format.
+///
+/// Holds the pipeline and nothing else — in particular it does **not**
+/// hold a mesh. The rendering crate deliberately allows one mesh to be
+/// drawn by several items in a frame, and a renderer that owned exactly
+/// one would discard that for no gain. Geometry is uploaded separately
+/// and handed back to the caller to keep.
+pub struct MeshRenderer {
+    pipeline: RenderPipeline,
+}
+
+impl MeshRenderer {
+    /// Build the pipeline for targets of `format`.
+    ///
+    /// Depth testing and depth writing are both on, with the compare the
+    /// rendering crate fixes in v0. There is no knob: a 3D frame drawn
+    /// without depth is a wrong picture that looks plausible, which is
+    /// the failure this step exists to make impossible rather than
+    /// optional.
+    ///
+    /// # Errors
+    ///
+    /// [`Render3dError::DepthUnsupported`] when the adapter offers no
+    /// depth format — refused before anything is created, so nothing is
+    /// left behind. [`Render3dError::Pipeline`] for any other refusal,
+    /// carrying the rendering crate's own words.
+    pub fn new(device: &Device, format: TargetFormat) -> Result<Self, Render3dError> {
+        let pipeline = device.create_pipeline(
+            &PipelineDesc::mesh(builtin::MESH, format, LAYOUT)
+                .depth_state(renew_rhi::DepthState::read_write()),
+        )?;
+        Ok(Self { pipeline })
+    }
+
+    /// Upload `scene` into geometry the GPU can draw.
+    ///
+    /// The bytes are copied during the call, so the scene may be cleared
+    /// or dropped the moment it returns. The mesh belongs to the caller:
+    /// keep it while it is drawn, drop it when the geometry changes, and
+    /// upload again.
+    ///
+    /// # Errors
+    ///
+    /// [`Render3dError::EmptyScene`] when there is nothing to draw — see
+    /// the variant, which explains why this is caught here rather than
+    /// below. [`Render3dError::Upload`] for a driver refusal.
+    pub fn upload(&self, device: &Device, scene: &Scene) -> Result<Mesh, Render3dError> {
+        if scene.is_empty() {
+            return Err(Render3dError::EmptyScene);
+        }
+        let mesh = device.create_mesh(&MeshDesc::new(
+            scene.vertices(),
+            VERTEX_STRIDE,
+            scene.indices(),
+        ))?;
+        Ok(mesh)
+    }
+
+    /// The draw for `mesh`, ready to sit in a pass.
+    ///
+    /// Every index the mesh holds, in the order the scene pushed them.
+    #[must_use]
+    pub fn item<'a>(&'a self, mesh: &'a Mesh) -> Item<'a> {
+        Item::new(&self.pipeline).mesh(mesh)
+    }
+}
+
+impl core::fmt::Debug for MeshRenderer {
+    /// Nothing to report but the fact of it: the pipeline's handle is not
+    /// information, and this type holds no counts of its own.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MeshRenderer").finish_non_exhaustive()
+    }
+}
+
+/// The colour attachment a 3D frame renders into: cleared to `clear`,
+/// stored.
+#[must_use]
+pub fn attachment(clear: Color) -> Attachment {
+    Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)
+}
+
+/// The depth attachment a 3D frame needs: cleared to the far plane,
+/// discarded at the end.
+///
+/// **No load spelling and no clear value to choose.** Loading depth on a
+/// frame's first depth use is a contract violation the rendering crate
+/// refuses with a retained assertion, and one is the only clear value
+/// that means "nothing is in front yet" under the fixed compare. A
+/// parameter here would be a way to spell a mistake.
+///
+/// Discarded rather than stored because nothing reads depth after the
+/// frame; a caller that grows a use for it composes its own attachment.
+#[must_use]
+pub fn depth_attachment() -> Attachment {
+    Attachment::new(LoadOp::Clear(ClearValue::Depth(1.0)), StoreOp::Discard)
+}
+
+/// A pass over `color` drawing `items`, with depth attached.
+///
+/// The convenience that makes the ordinary path correct: depth is not
+/// optional for 3D geometry, and this is the shape that cannot omit it.
+/// The parts stay public for the frames this does not fit — a caller
+/// composing 3D geometry beside a 2D overlay builds its own pass from
+/// [`attachment`], [`depth_attachment`] and [`MeshRenderer::item`].
+#[must_use]
+pub fn pass<'a>(color: &'a [Attachment], items: &'a [Item<'a>]) -> Pass<'a> {
+    Pass::new(color, items).depth(depth_attachment())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The depth refusal, driven with no GPU at all.** This is the
+    /// whole reason the refusal is a translation rather than a device
+    /// query: the mapping is exercised on every machine, where a
+    /// pre-flight would need a depthless adapter no lane has.
+    #[test]
+    fn the_depth_refusal_is_translated_not_swallowed() {
+        let refused: Render3dError = PipelineError::DepthUnsupported {
+            chain: "D32_SFLOAT, D24_UNORM_S8_UINT",
+        }
+        .into();
+        match refused {
+            Render3dError::DepthUnsupported { chain } => {
+                assert_eq!(chain, "D32_SFLOAT, D24_UNORM_S8_UINT", "the chain survives");
+            }
+            other => panic!("the depth refusal must keep its own name, got {other:?}"),
+        }
+    }
+
+    /// Every other pipeline refusal keeps the rendering crate's words
+    /// rather than being flattened into one message.
+    #[test]
+    fn other_pipeline_failures_pass_through_intact() {
+        let refused: Render3dError = PipelineError::InvalidSpirv {
+            stage: "vertex",
+            reason: "bad magic",
+        }
+        .into();
+        let shown = refused.to_string();
+        assert!(shown.contains("bad magic"), "{shown}");
+        assert!(shown.contains("vertex"), "{shown}");
+    }
+
+    /// An upload failure names the operation and carries the cause.
+    #[test]
+    fn an_upload_failure_says_what_it_was_doing() {
+        let refused: Render3dError = TargetError::OutOfDeviceMemory {
+            call: "vkAllocateMemory(mesh)",
+        }
+        .into();
+        let shown = refused.to_string();
+        assert!(shown.contains("uploading the geometry"), "{shown}");
+        assert!(shown.contains("vkAllocateMemory(mesh)"), "{shown}");
+    }
+
+    /// Every variant says something a reader can act on.
+    #[test]
+    fn every_variant_displays_its_context() {
+        let cases = [
+            (
+                Render3dError::DepthUnsupported {
+                    chain: "D32_SFLOAT",
+                },
+                "D32_SFLOAT",
+            ),
+            (Render3dError::EmptyScene, "no geometry"),
+        ];
+        for (error, needle) in cases {
+            let shown = error.to_string();
+            assert!(shown.contains(needle), "`{shown}` missing `{needle}`");
+        }
+    }
+
+    /// The depth attachment clears to the far plane and keeps nothing —
+    /// asserted because both are decisions rather than defaults.
+    #[test]
+    fn the_depth_attachment_clears_far_and_discards() {
+        let depth = depth_attachment();
+        assert!(
+            // Bit equality, the rendering crate's own precedent for this:
+            // the value is a literal this code wrote and nothing computes
+            // on it, so a tolerance would be looser than the truth.
+            matches!(depth.load, LoadOp::Clear(ClearValue::Depth(value)) if value.to_bits() == 1.0f32.to_bits()),
+            "depth clears to the far plane, or nothing is in front of anything"
+        );
+        assert!(matches!(depth.store, StoreOp::Discard));
+    }
+
+    /// The layout and the packed stride describe the same bytes, checked
+    /// mechanically so only the shader stays coupled by comment. The
+    /// rendering crate asserts this equality at record time; failing it
+    /// here is a great deal easier to read.
+    #[test]
+    fn the_layout_and_the_stride_describe_the_same_bytes() {
+        let packed: u32 = LAYOUT
+            .iter()
+            .map(|attribute| attribute_width(*attribute))
+            .sum();
+        assert_eq!(packed, VERTEX_STRIDE, "the layout and the scene disagree");
+    }
+
+    /// The packed width of one attribute.
+    ///
+    /// Named rather than inlined so the exhaustive match is reachable:
+    /// the rendering crate's enum carries no `#[non_exhaustive]`
+    /// precisely so a new format is a compile error here, and a match
+    /// folded into the sum above would leave the arms this layout does
+    /// not use unexecuted.
+    fn attribute_width(attribute: VertexAttribute) -> u32 {
+        match attribute {
+            VertexAttribute::Vec2 => 8,
+            VertexAttribute::Vec3 => 12,
+            VertexAttribute::Vec4 => 16,
+        }
+    }
+
+    #[test]
+    fn every_attribute_reports_its_packed_width() {
+        assert_eq!(attribute_width(VertexAttribute::Vec2), 8);
+        assert_eq!(attribute_width(VertexAttribute::Vec3), 12);
+        assert_eq!(attribute_width(VertexAttribute::Vec4), 16);
+    }
+}

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -20,14 +20,19 @@ use renew_rhi::{
 
 use crate::scene::{Scene, VERTEX_STRIDE};
 
-/// The per-vertex layout this crate's pipeline declares: a clip-space
-/// position, then a colour.
+/// The per-vertex layout this crate's pipeline declares.
 ///
-/// The same shapes the built-in mesh shaders read, and the same order the
-/// scene packs — three lists describing one set of bytes. They change
-/// together or the draw reads garbage, which is why the assertion the
-/// rendering crate makes at record time is worth having.
-const LAYOUT: &[VertexAttribute] = &[VertexAttribute::Vec3, VertexAttribute::Vec4];
+/// **The rendering crate's own constant, not a copy of it.** `MESH_LAYOUT`
+/// ships beside `MESH` in `builtin`, where the shader and the layout that
+/// describes its inputs sit together and are changed together. Declaring
+/// the same two attributes here instead would have looked equivalent and
+/// would not have been: the record-time assertion that a mesh's stride
+/// matches its pipeline's compares two numbers *both* derived from
+/// whichever layout this crate passed in, so they agree by construction
+/// and cannot notice a shader that has moved on. There is no reflection
+/// anywhere in the rendering crate to catch it either. Naming the
+/// constant is what actually couples this pipeline to those shaders.
+const LAYOUT: &[VertexAttribute] = builtin::MESH_LAYOUT;
 
 /// What can go wrong building or uploading. Creation only: the draw
 /// itself cannot fail, and the render belongs to the target.
@@ -208,6 +213,30 @@ pub fn depth_attachment() -> Attachment {
 /// The parts stay public for the frames this does not fit — a caller
 /// composing 3D geometry beside a 2D overlay builds its own pass from
 /// [`attachment`], [`depth_attachment`] and [`MeshRenderer::item`].
+///
+/// # One pass per frame
+///
+/// **Two of these in one frame is a wrong picture, and nothing refuses
+/// it.** The depth attachment always clears, so a second pass starts from
+/// an empty depth buffer and draws over geometry the first pass put in
+/// front — exactly the plausible-looking wrong picture depth exists to
+/// prevent. The rendering crate's contract check does not catch it: it
+/// refuses a *load* on the frame's first depth use, which is a different
+/// mistake. Geometry that belongs in one image belongs in one `pass`,
+/// with as many items as it takes. A caller who genuinely wants two
+/// depth-sharing passes needs an attachment that loads, which v0 does not
+/// offer and which that check would refuse for the first pass anyway —
+/// it composes its own from the rendering crate directly, knowing why.
+///
+/// # Panics
+///
+/// Not here — this only builds a description. But `color` is handed on
+/// unexamined, and the rendering crate asserts at render time, in every
+/// profile, that a pass carries exactly one colour attachment. An empty
+/// or two-element slice therefore aborts at `render`, not at this call.
+/// Unlike an empty scene, which is ordinary data and gets an ordinary
+/// refusal, a caller passing the wrong number of attachments has made a
+/// structural mistake rather than presented unusual data.
 #[must_use]
 pub fn pass<'a>(color: &'a [Attachment], items: &'a [Item<'a>]) -> Pass<'a> {
     Pass::new(color, items).depth(depth_attachment())

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -227,12 +227,60 @@ mod tests {
             chain: "D32_SFLOAT, D24_UNORM_S8_UINT",
         }
         .into();
-        match refused {
-            Render3dError::DepthUnsupported { chain } => {
-                assert_eq!(chain, "D32_SFLOAT, D24_UNORM_S8_UINT", "the chain survives");
+        // `matches!` with the outcome in the message, the shape the
+        // rendering crate's own refusal tables use: an arm that runs only
+        // when the test fails is a line no passing run ever covers.
+        assert!(
+            matches!(
+                &refused,
+                Render3dError::DepthUnsupported { chain }
+                    if *chain == "D32_SFLOAT, D24_UNORM_S8_UINT"
+            ),
+            "the depth refusal must keep its own name and chain, got {refused:?}"
+        );
+    }
+
+    /// The chain of causes is intact: the two wrapping variants hand back
+    /// what they wrap, and the two that stand alone hand back nothing.
+    ///
+    /// Worth asserting because `source` is what a caller printing a chain
+    /// walks — a variant that dropped its cause would print one line
+    /// where the useful sentence is the next one.
+    #[test]
+    fn the_wrapping_variants_expose_their_cause() {
+        use std::error::Error as _;
+
+        let pipeline = Render3dError::Pipeline(PipelineError::InvalidSpirv {
+            stage: "vertex",
+            reason: "bad magic",
+        });
+        let upload = Render3dError::Upload(TargetError::OutOfDeviceMemory {
+            call: "vkAllocateMemory(mesh)",
+        });
+        assert!(
+            pipeline
+                .source()
+                .is_some_and(|cause| cause.to_string().contains("bad magic")),
+            "the pipeline refusal must hand back what it wraps"
+        );
+        assert!(
+            upload
+                .source()
+                .is_some_and(|cause| cause.to_string().contains("vkAllocateMemory(mesh)")),
+            "the upload refusal must hand back what it wraps"
+        );
+        assert!(
+            Render3dError::EmptyScene.source().is_none(),
+            "an empty scene wraps nothing; a cause here would be invented"
+        );
+        assert!(
+            Render3dError::DepthUnsupported {
+                chain: "D32_SFLOAT"
             }
-            other => panic!("the depth refusal must keep its own name, got {other:?}"),
-        }
+            .source()
+            .is_none(),
+            "the depth refusal is this crate's own words, wrapping nothing"
+        );
     }
 
     /// Every other pipeline refusal keeps the rendering crate's words

--- a/crates/render3d/src/lib.rs
+++ b/crates/render3d/src/lib.rs
@@ -1,5 +1,5 @@
 //! Indexed 3D geometry over the rendering crate: one mesh pipeline,
-//! depth-tested, one indexed draw per frame.
+//! depth-tested, indexed draws in submission order.
 //!
 //! # Contract
 //!
@@ -41,4 +41,4 @@ mod gpu;
 mod scene;
 
 pub use gpu::{MeshRenderer, Render3dError, attachment, depth_attachment, pass};
-pub use scene::{Scene, VERTEX_STRIDE};
+pub use scene::Scene;

--- a/crates/render3d/src/lib.rs
+++ b/crates/render3d/src/lib.rs
@@ -1,0 +1,44 @@
+//! Indexed 3D geometry over the rendering crate: one mesh pipeline,
+//! depth-tested, one indexed draw per frame.
+//!
+//! # Contract
+//!
+//! - **Push order is index order is draw order.** Quads are drawn in
+//!   exactly the order pushed. No sort, no batching, no depth pre-pass —
+//!   so two scenes built by the same calls produce byte-identical
+//!   buffers, and a frame drawn twice is the same image.
+//! - **Depth is not optional.** The pipeline tests and writes depth, and
+//!   [`pass`] always attaches it. A 3D frame drawn without depth is a
+//!   wrong picture that looks plausible, which is a worse failure than
+//!   one that refuses.
+//! - **An adapter with no depth format is refused by name**, before
+//!   anything is created, carrying the format chain that was tried.
+//! - **Positions are clip space.** There is no camera here; a caller
+//!   drawing a world transforms on its own side until one exists.
+//! - **Target-agnostic.** [`MeshRenderer::item`] returns the rendering
+//!   crate's own draw item and [`attachment`] the matching colour
+//!   attachment; the caller composes the frame on its own stack and
+//!   hands it to whichever target it holds. This crate never renders,
+//!   never presents, and never touches a window.
+//!
+//! The pure half ([`Scene`]) lives apart from the device half
+//! ([`MeshRenderer`]) so the packing and the numbering are testable
+//! without an adapter, and the rendering-crate seam stays one module
+//! wide.
+//!
+//! # What v0 does not do
+//!
+//! No camera or projection, no textures, no window, no image writing,
+//! and no meshing of anything — a caller supplies quads already in clip
+//! space. Each of those is a later step with its own trigger, recorded
+//! rather than left to be guessed at.
+
+// Diagnostics go through sinks; the standard output macros are banned in
+// this crate by construction, not convention.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+mod gpu;
+mod scene;
+
+pub use gpu::{MeshRenderer, Render3dError, attachment, depth_attachment, pass};
+pub use scene::{Scene, VERTEX_STRIDE};

--- a/crates/render3d/src/scene.rs
+++ b/crates/render3d/src/scene.rs
@@ -2,11 +2,17 @@
 //!
 //! Nothing here calls a device. That is what makes the arithmetic — the
 //! packing, the winding, the index numbering — testable on a machine with
-//! no adapter, which is most machines and every sanitizer lane. The
-//! sibling 2D crate draws the same line in the same place, and its pure
-//! half does still name the rendering crate's `Extent`: the property is
-//! *no device calls*, not *no dependency*, and claiming the stronger one
-//! would claim something no crate here actually does.
+//! no adapter, which is most machines and every sanitizer lane.
+//!
+//! **This file goes further than that and names the rendering crate
+//! nowhere at all** — it has no `use` statements. The property the 2D
+//! sibling states for its own pure half is the weaker one, *no device
+//! calls*, because `render2d/src/fill.rs` really does name `Extent`.
+//! Both properties are worth having and they are not the same one; what
+//! is written here is what this file does. The stride constant below is
+//! the seam that keeps it so: it repeats a number the rendering crate
+//! also knows rather than importing it, and `gpu.rs` is where the two are
+//! checked against each other.
 //!
 //! # Push order is index order is draw order
 //!
@@ -21,15 +27,22 @@
 /// colour, packed with no padding.
 ///
 /// **Not a `#[repr(C)]` struct, and that is not a style choice.** The
-/// maths crate's vector types are sixteen-byte aligned, so a struct of a
-/// `Vec3` and a `Vec4` occupies more than the twenty-eight bytes its
-/// fields need — and the rendering crate asserts, at the moment a draw is
-/// recorded, that a mesh's stride equals the stride the pipeline's
-/// per-vertex layout packs to. A padded record would fail that assertion
-/// at the draw rather than here, which is a long way from the mistake.
+/// maths crate's `Vec4` is `#[repr(C, align(16))]`; its `Vec3` is twelve
+/// bytes at align four. A `#[repr(C)]` record of the two therefore pads
+/// the `Vec3` out to the sixteen-byte boundary the `Vec4` demands and
+/// occupies **thirty-two** bytes, not twenty-eight — the alignment of one
+/// field, not of both, is what does it. The rendering crate asserts at
+/// the moment a draw is recorded that a mesh's stride equals the stride
+/// the pipeline's per-vertex layout packs to, so a padded record would
+/// fail at the draw rather than here, a long way from the mistake.
 /// Writing the bytes explicitly makes the layout the code's subject
 /// rather than the compiler's.
-pub const VERTEX_STRIDE: u32 = 28;
+///
+/// The alignment claim is about a crate this one does not depend on, so
+/// nothing compiles it. It is stated as the reason for a decision, not
+/// relied on: what the code relies on is the assertion in `gpu.rs` that
+/// this constant equals the packed width of the layout actually declared.
+pub(crate) const VERTEX_STRIDE: u32 = 28;
 
 /// Geometry accumulated on the host, ready to be uploaded once.
 ///
@@ -56,6 +69,15 @@ impl Scene {
     /// other vector. This exists because the named consumer knows its
     /// face count before it starts, and an allocation per quad on a
     /// four-thousand-face world is a cost with no reason.
+    ///
+    /// # Panics
+    ///
+    /// If `quads` is large enough that the byte count overflows, or that
+    /// the reservation itself cannot be made — the same conditions
+    /// [`Vec::with_capacity`] panics on, reached through the multiply.
+    /// A hint that cannot be honoured is a caller's arithmetic mistake,
+    /// not a condition to thread a result type through the constructor
+    /// for.
     #[must_use]
     pub fn with_capacity(quads: usize) -> Self {
         Self {
@@ -99,12 +121,33 @@ impl Scene {
     }
 
     /// Whole vertex records pushed so far.
+    ///
+    /// # Panics
+    ///
+    /// In dev builds, if the count has passed what a `u32` holds. See the
+    /// assertion's own note: the release behaviour is a saturating floor,
+    /// which is wrong rather than merely imprecise, so the dev build says
+    /// so instead of continuing.
     #[must_use]
     pub fn vertex_count(&self) -> u32 {
         // Every push adds exactly one stride, so the division is exact.
-        // The cast cannot lose: a scene that overflowed a `u32` of
-        // records would need more bytes than the host can address.
-        u32::try_from(self.vertices.len() / VERTEX_STRIDE as usize).unwrap_or(u32::MAX)
+        let records = self.vertices.len() / VERTEX_STRIDE as usize;
+        // **Asserted rather than argued away.** A scene of more than a
+        // `u32` of records needs 2^32 * 28 bytes, about 120 GiB — beyond
+        // anything this engine will build on the host, but well inside
+        // what a 64-bit host can address, so "impossible" would be a
+        // claim rather than a fact. It matters which: saturating here
+        // would make `quad` number its corners from `u32::MAX`, and those
+        // indices wrap into the low, *valid* range, where the in-range
+        // scan the rendering crate runs cannot see them. A wrong picture
+        // that passes every check is the one failure worth a dev-build
+        // abort. Release keeps the floor: a scene this size fails at
+        // upload regardless, where the refusal is an ordinary error.
+        debug_assert!(
+            u32::try_from(records).is_ok(),
+            "a scene of {records} vertex records has outgrown the u32 an index carries"
+        );
+        u32::try_from(records).unwrap_or(u32::MAX)
     }
 
     /// Indices pushed so far — six per quad, which is what an indexed
@@ -136,14 +179,19 @@ impl Scene {
     }
 
     /// The packed vertex bytes.
+    ///
+    /// Crate-visible: the upload is the only reader, and it applies the
+    /// stride itself. A caller with its own use for the bytes would be
+    /// building a mesh this crate did not describe, which is a request to
+    /// widen this deliberately rather than a gap to leave open.
     #[must_use]
-    pub fn vertices(&self) -> &[u8] {
+    pub(crate) fn vertices(&self) -> &[u8] {
         &self.vertices
     }
 
     /// The indices, in push order.
     #[must_use]
-    pub fn indices(&self) -> &[u32] {
+    pub(crate) fn indices(&self) -> &[u32] {
         &self.indices
     }
 }
@@ -274,5 +322,76 @@ mod tests {
         }
         assert_eq!(hinted.vertices(), plain.vertices());
         assert_eq!(hinted.indices(), plain.indices());
+    }
+
+    proptest::proptest! {
+        /// **The two invariants the layer below actually depends on, at
+        /// counts no example test reaches.**
+        ///
+        /// `create_mesh` scans every index and refuses one that is not
+        /// less than the vertex count, and it computes the vertex count
+        /// from `vertices.len() / stride` — so a scene whose bytes are
+        /// not a whole number of records, or whose indices point past its
+        /// own corners, is refused at upload or, worse, draws the wrong
+        /// corners. Both properties are arithmetic over the quad count,
+        /// which is exactly the shape examples at one and two quads
+        /// cannot speak for.
+        #[test]
+        fn any_number_of_quads_packs_to_whole_records_indexing_only_its_own_corners(
+            count in 0_usize..400,
+        ) {
+            let mut scene = Scene::new();
+            for _ in 0..count {
+                scene.quad(CORNERS, WHITE);
+            }
+
+            let vertices = u32::try_from(count).unwrap_or(u32::MAX) * 4;
+            proptest::prop_assert_eq!(scene.vertex_count(), vertices);
+            proptest::prop_assert_eq!(scene.index_count(), u32::try_from(count).unwrap_or(u32::MAX) * 6);
+            // Whole records: the division the layer below performs is
+            // exact, so its vertex count is this one.
+            proptest::prop_assert_eq!(
+                scene.vertices().len(),
+                count * 4 * VERTEX_STRIDE as usize
+            );
+            // Every index addresses a vertex this scene actually holds.
+            // The failing direction matters: an index equal to the count
+            // is past the last vertex, not at it.
+            proptest::prop_assert!(
+                scene.indices().iter().all(|&index| index < vertices),
+                "an index reached past the last vertex"
+            );
+            // Emptiness is the condition `upload` refuses, and it has to
+            // agree with both buffers or the guard reads one of them.
+            proptest::prop_assert_eq!(scene.is_empty(), count == 0);
+            proptest::prop_assert_eq!(scene.vertices().is_empty(), count == 0);
+        }
+
+        /// Clearing returns a scene to the state a new one is in, for any
+        /// history — so a caller rebuilding geometry every frame cannot
+        /// accumulate anything, and the indices restart from zero rather
+        /// than from where the last build stopped.
+        #[test]
+        fn clearing_any_scene_leaves_it_indistinguishable_from_a_new_one(
+            count in 0_usize..200,
+        ) {
+            let mut scene = Scene::new();
+            for _ in 0..count {
+                scene.quad(CORNERS, WHITE);
+            }
+            scene.clear();
+            proptest::prop_assert!(scene.is_empty());
+            proptest::prop_assert_eq!(scene.vertex_count(), 0);
+            proptest::prop_assert_eq!(scene.index_count(), 0);
+
+            scene.quad(CORNERS, WHITE);
+            let fresh = {
+                let mut other = Scene::new();
+                other.quad(CORNERS, WHITE);
+                other
+            };
+            proptest::prop_assert_eq!(scene.vertices(), fresh.vertices());
+            proptest::prop_assert_eq!(scene.indices(), fresh.indices());
+        }
     }
 }

--- a/crates/render3d/src/scene.rs
+++ b/crates/render3d/src/scene.rs
@@ -1,0 +1,278 @@
+//! The pure half: quads in, packed vertex bytes and indices out.
+//!
+//! Nothing here calls a device. That is what makes the arithmetic — the
+//! packing, the winding, the index numbering — testable on a machine with
+//! no adapter, which is most machines and every sanitizer lane. The
+//! sibling 2D crate draws the same line in the same place, and its pure
+//! half does still name the rendering crate's `Extent`: the property is
+//! *no device calls*, not *no dependency*, and claiming the stronger one
+//! would claim something no crate here actually does.
+//!
+//! # Push order is index order is draw order
+//!
+//! Quads are appended, and their indices are emitted in the order they
+//! were pushed. There is no sort, no batching and no depth pre-pass, so
+//! two scenes built by the same sequence of calls produce byte-identical
+//! buffers — which is the whole of this crate's contribution to the
+//! frame being reproducible. A caller who wants a different order pushes
+//! in a different order.
+
+/// Bytes in one vertex record: a three-float position and a four-float
+/// colour, packed with no padding.
+///
+/// **Not a `#[repr(C)]` struct, and that is not a style choice.** The
+/// maths crate's vector types are sixteen-byte aligned, so a struct of a
+/// `Vec3` and a `Vec4` occupies more than the twenty-eight bytes its
+/// fields need — and the rendering crate asserts, at the moment a draw is
+/// recorded, that a mesh's stride equals the stride the pipeline's
+/// per-vertex layout packs to. A padded record would fail that assertion
+/// at the draw rather than here, which is a long way from the mistake.
+/// Writing the bytes explicitly makes the layout the code's subject
+/// rather than the compiler's.
+pub const VERTEX_STRIDE: u32 = 28;
+
+/// Geometry accumulated on the host, ready to be uploaded once.
+///
+/// Cheap to build and cheap to throw away: a scene owns two vectors and
+/// nothing else, holds no device, and can be built on a machine with no
+/// adapter at all.
+#[derive(Debug, Clone, Default)]
+pub struct Scene {
+    vertices: Vec<u8>,
+    indices: Vec<u32>,
+}
+
+impl Scene {
+    /// An empty scene.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A scene sized for `quads` up front, so a caller that knows its
+    /// count allocates once.
+    ///
+    /// A hint, not a limit: pushing past it grows the buffers like any
+    /// other vector. This exists because the named consumer knows its
+    /// face count before it starts, and an allocation per quad on a
+    /// four-thousand-face world is a cost with no reason.
+    #[must_use]
+    pub fn with_capacity(quads: usize) -> Self {
+        Self {
+            vertices: Vec::with_capacity(quads * 4 * VERTEX_STRIDE as usize),
+            indices: Vec::with_capacity(quads * 6),
+        }
+    }
+
+    /// Append one quad in `colour`, as two triangles.
+    ///
+    /// Corners are in clip space and are taken in order — the two
+    /// triangles are `0,1,2` and `0,2,3`, so a caller listing its corners
+    /// around the perimeter gets a quad and one listing them crosswise
+    /// gets a bow tie. That is the caller's arithmetic, not this crate's
+    /// to second-guess: there is no winding check here, because the
+    /// pipeline culls nothing in v0 and a quad wound either way draws.
+    ///
+    /// **Clip space, because v0 has no camera.** Positions go to the
+    /// vertex stage unmodified. A projection is a later step, and until
+    /// it exists a caller drawing a world transforms on its own side.
+    pub fn quad(&mut self, corners: [[f32; 3]; 4], colour: [f32; 4]) {
+        // Recorded before the push, so the triangles below index the
+        // corners this call adds rather than whatever came before.
+        let base = self.vertex_count();
+        for corner in corners {
+            self.push_vertex(corner, colour);
+        }
+        for offset in [0, 1, 2, 0, 2, 3] {
+            self.indices.push(base + offset);
+        }
+    }
+
+    /// One vertex record, packed exactly as [`VERTEX_STRIDE`] describes.
+    fn push_vertex(&mut self, position: [f32; 3], colour: [f32; 4]) {
+        for value in position {
+            self.vertices.extend_from_slice(&value.to_ne_bytes());
+        }
+        for value in colour {
+            self.vertices.extend_from_slice(&value.to_ne_bytes());
+        }
+    }
+
+    /// Whole vertex records pushed so far.
+    #[must_use]
+    pub fn vertex_count(&self) -> u32 {
+        // Every push adds exactly one stride, so the division is exact.
+        // The cast cannot lose: a scene that overflowed a `u32` of
+        // records would need more bytes than the host can address.
+        u32::try_from(self.vertices.len() / VERTEX_STRIDE as usize).unwrap_or(u32::MAX)
+    }
+
+    /// Indices pushed so far — six per quad, which is what an indexed
+    /// draw counts.
+    #[must_use]
+    pub fn index_count(&self) -> u32 {
+        u32::try_from(self.indices.len()).unwrap_or(u32::MAX)
+    }
+
+    /// Whether anything has been pushed.
+    ///
+    /// Worth asking before an upload: an empty scene is ordinary data —
+    /// an all-air world, a fully culled mesh — and the upload refuses it
+    /// rather than handing it to a layer that treats it as a caller bug.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+
+    /// Forget every quad, keeping the allocation for the next build.
+    ///
+    /// Explicit rather than folded into a build call, for the reason the
+    /// sibling crate gives: a caller that never clears is accumulating a
+    /// static scene deliberately, and one that clears and pushes nothing
+    /// has built a legitimately empty one.
+    pub fn clear(&mut self) {
+        self.vertices.clear();
+        self.indices.clear();
+    }
+
+    /// The packed vertex bytes.
+    #[must_use]
+    pub fn vertices(&self) -> &[u8] {
+        &self.vertices
+    }
+
+    /// The indices, in push order.
+    #[must_use]
+    pub fn indices(&self) -> &[u32] {
+        &self.indices
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CORNERS: [[f32; 3]; 4] = [
+        [-1.0, -1.0, 0.0],
+        [1.0, -1.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [-1.0, 1.0, 0.0],
+    ];
+    const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+
+    /// **The stride is the one number the rendering crate asserts on**,
+    /// and a padded record would fail that assertion at the draw rather
+    /// than here. Pinned on the bytes a real push produces, not on the
+    /// constant, so the two cannot drift apart.
+    #[test]
+    fn a_vertex_record_packs_to_the_declared_stride() {
+        let mut scene = Scene::new();
+        scene.quad(CORNERS, WHITE);
+        assert_eq!(
+            scene.vertices().len(),
+            4 * VERTEX_STRIDE as usize,
+            "four corners at {VERTEX_STRIDE} bytes each"
+        );
+        assert_eq!(VERTEX_STRIDE, 12 + 16, "a vec3 position and a vec4 colour");
+    }
+
+    /// The bytes are the floats a caller handed over, in order, with
+    /// nothing between them — the property a shader reading this layout
+    /// depends on.
+    #[test]
+    fn a_record_is_its_position_then_its_colour() {
+        let mut scene = Scene::new();
+        scene.quad(CORNERS, [0.25, 0.5, 0.75, 1.0]);
+        let first = &scene.vertices()[..VERTEX_STRIDE as usize];
+        let floats: Vec<f32> = first
+            .chunks_exact(4)
+            .map(|bytes| f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+            .collect();
+        assert_eq!(floats, vec![-1.0, -1.0, 0.0, 0.25, 0.5, 0.75, 1.0]);
+    }
+
+    /// Two triangles per quad, indexing the four corners this push added.
+    #[test]
+    fn a_quad_is_two_triangles_over_four_corners() {
+        let mut scene = Scene::new();
+        scene.quad(CORNERS, WHITE);
+        assert_eq!(scene.vertex_count(), 4);
+        assert_eq!(scene.index_count(), 6);
+        assert_eq!(scene.indices(), &[0, 1, 2, 0, 2, 3]);
+    }
+
+    /// **Push order is index order**, which is the crate's whole claim
+    /// about a reproducible frame. The second quad's indices continue
+    /// from the first's vertices rather than restarting.
+    #[test]
+    fn a_second_quad_continues_the_first_ones_numbering() {
+        let mut scene = Scene::new();
+        scene.quad(CORNERS, WHITE);
+        scene.quad(CORNERS, WHITE);
+        assert_eq!(scene.vertex_count(), 8);
+        assert_eq!(scene.indices()[6..], [4, 5, 6, 4, 6, 7]);
+    }
+
+    /// The same calls twice give the same bytes — stated as a test
+    /// because it is the property the golden images rest on.
+    #[test]
+    fn the_same_pushes_produce_identical_bytes() {
+        let build = || {
+            let mut scene = Scene::new();
+            scene.quad(CORNERS, [1.0, 0.0, 0.0, 1.0]);
+            scene.quad(CORNERS, [0.0, 0.0, 1.0, 1.0]);
+            scene
+        };
+        let first = build();
+        let second = build();
+        assert_eq!(first.vertices(), second.vertices());
+        assert_eq!(first.indices(), second.indices());
+    }
+
+    /// Reversing the push order changes the buffers, so "push order is
+    /// draw order" is a claim with observable content rather than a
+    /// restatement.
+    #[test]
+    fn reversing_the_push_order_changes_the_bytes() {
+        let mut forward = Scene::new();
+        forward.quad(CORNERS, [1.0, 0.0, 0.0, 1.0]);
+        forward.quad(CORNERS, [0.0, 0.0, 1.0, 1.0]);
+        let mut backward = Scene::new();
+        backward.quad(CORNERS, [0.0, 0.0, 1.0, 1.0]);
+        backward.quad(CORNERS, [1.0, 0.0, 0.0, 1.0]);
+        assert_ne!(forward.vertices(), backward.vertices());
+        assert_eq!(
+            forward.indices(),
+            backward.indices(),
+            "the numbering is positional, so only the vertex bytes differ"
+        );
+    }
+
+    /// Empty is empty, and clearing returns to it.
+    #[test]
+    fn a_new_scene_is_empty_and_clearing_empties_one() {
+        let mut scene = Scene::new();
+        assert!(scene.is_empty());
+        scene.quad(CORNERS, WHITE);
+        assert!(!scene.is_empty());
+        scene.clear();
+        assert!(scene.is_empty());
+        assert_eq!(scene.vertex_count(), 0);
+        assert_eq!(scene.index_count(), 0);
+    }
+
+    /// The capacity hint changes no output — it is a hint, and a test
+    /// that only checked it allocated would not notice it corrupting the
+    /// geometry.
+    #[test]
+    fn the_capacity_hint_changes_nothing_but_the_allocation() {
+        let mut hinted = Scene::with_capacity(2);
+        let mut plain = Scene::new();
+        for scene in [&mut hinted, &mut plain] {
+            scene.quad(CORNERS, WHITE);
+            scene.quad(CORNERS, WHITE);
+        }
+        assert_eq!(hinted.vertices(), plain.vertices());
+        assert_eq!(hinted.indices(), plain.indices());
+    }
+}

--- a/crates/render3d/tests/fault.rs
+++ b/crates/render3d/tests/fault.rs
@@ -1,0 +1,141 @@
+//! Fault-injection scenarios: the two creation calls this crate makes,
+//! failed for real, so the error arms are executed rather than trusted.
+//!
+//! The fault layer (`tools/vk-fault-layer`) sits between this crate and
+//! the driver and fails one named call per run. The fault is armed when
+//! the instance is created, so every scenario builds its own device with
+//! the fault already in the environment.
+//!
+//! Without the layer the suite skips loudly; under `RENEW_FAULT_STRICT`
+//! (the CI lane) a skip is a failure, so the lane can never pass
+//! vacuously.
+//!
+//! **Why a driver failure and not a constructed error.** The unit tests
+//! beside the code build every variant by hand and check what each one
+//! says. What they cannot show is that the `?` in `new` and `upload`
+//! reaches the arm the hand-built value stands for — a mistranslation
+//! there produces a perfectly well-worded error about the wrong thing.
+//! Only a call that really fails proves the two halves are joined.
+
+// Arming a fault is an environment write, `unsafe` since the 2024
+// edition. Sound here: this file is a single `#[test]`, so nothing in
+// the process reads or writes the environment concurrently — the one
+// reader is the layer, on this thread, inside the calls below.
+#![allow(unsafe_code)]
+
+use renew_render3d::{MeshRenderer, Render3dError, Scene};
+use renew_rhi::{Device, DeviceDesc, DeviceError, Extent, TargetError, TargetFormat, Validation};
+
+/// The CI lane sets this: a skip becomes a failure.
+fn strict() -> bool {
+    std::env::var_os("RENEW_FAULT_STRICT").is_some_and(|value| value == "1")
+}
+
+fn arm(directive: &str) {
+    // SAFETY: single-test binary; no concurrent environment access —
+    // see the file-top note.
+    unsafe { std::env::set_var("RENEW_FAULT", directive) };
+}
+
+fn new_device() -> Result<Device, DeviceError> {
+    Device::new(&DeviceDesc {
+        app_name: "renew-render3d-fault-tests",
+        validation: Validation::IfAvailable,
+    })
+}
+
+/// One quad, which is the smallest scene that uploads.
+fn one_quad() -> Scene {
+    let mut scene = Scene::new();
+    scene.quad(
+        [
+            [-0.5, -0.5, 0.5],
+            [0.5, -0.5, 0.5],
+            [0.5, 0.5, 0.5],
+            [-0.5, 0.5, 0.5],
+        ],
+        [1.0, 1.0, 1.0, 1.0],
+    );
+    scene
+}
+
+#[test]
+fn every_creation_arm_reports_its_own_failure() {
+    // Canary: arm a fence fault and bring up a target — the same probe
+    // the rendering crate's suite uses. If the target builds anyway, the
+    // layer is not in the loader's path and every scenario below would
+    // "pass" by succeeding.
+    arm("vkCreateFence=ERROR_OUT_OF_HOST_MEMORY");
+    let armed = match new_device() {
+        Ok(device) => match device.create_offscreen_target(Extent {
+            width: 4,
+            height: 4,
+        }) {
+            Err(TargetError::Creation {
+                call: "vkCreateFence",
+                ..
+            }) => true,
+            Ok(_) => false,
+            Err(other) => {
+                eprintln!("canary: unexpected target error: {other:?}");
+                false
+            }
+        },
+        Err(DeviceError::LoaderUnavailable { message }) => {
+            assert!(
+                !strict(),
+                "RENEW_FAULT_STRICT=1 but no Vulkan runtime: {message}"
+            );
+            eprintln!("SKIP: no Vulkan runtime: {message}");
+            return;
+        }
+        Err(error) => {
+            eprintln!("canary: device bring-up failed: {error}");
+            false
+        }
+    };
+    if !armed {
+        assert!(
+            !strict(),
+            "RENEW_FAULT_STRICT=1 but fault injection is not active — the lane exists to run these scenarios"
+        );
+        eprintln!("SKIP: fault injection not active");
+        return;
+    }
+
+    // R1 — pipeline creation fails: the Pipeline arm, and the Display
+    // still says which pipeline it was building. This is the arm a
+    // depthless adapter would otherwise be needed to reach, which is
+    // exactly why the depth refusal is translated rather than detected.
+    arm("vkCreateGraphicsPipelines=ERROR_OUT_OF_HOST_MEMORY");
+    let device = new_device().expect("device for R1");
+    match MeshRenderer::new(&device, TargetFormat::Rgba8Unorm) {
+        Err(error @ Render3dError::Pipeline(_)) => {
+            assert!(
+                error.to_string().starts_with("building the mesh pipeline:"),
+                "R1: Display lost its context: {error}"
+            );
+        }
+        other => panic!("R1: expected the pipeline failure in the Pipeline arm, got {other:?}"),
+    }
+    drop(device);
+
+    // R2 — the geometry buffer fails: the Upload arm, reached only after
+    // the pipeline itself was built, so this also shows the two calls do
+    // not share an arm.
+    arm("vkCreateBuffer=ERROR_OUT_OF_HOST_MEMORY");
+    let device = new_device().expect("device for R2");
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)
+        .expect("R2: the pipeline is not the armed call");
+    match renderer.upload(&device, &one_quad()) {
+        Err(error @ Render3dError::Upload(_)) => {
+            assert!(
+                error.to_string().starts_with("uploading the geometry:"),
+                "R2: Display lost its context: {error}"
+            );
+        }
+        other => panic!("R2: expected the buffer failure in the Upload arm, got {other:?}"),
+    }
+    drop(renderer);
+    drop(device);
+}

--- a/crates/render3d/tests/golden.rs
+++ b/crates/render3d/tests/golden.rs
@@ -285,3 +285,26 @@ fn an_empty_scene_is_refused_rather_than_fatal() -> Result<(), Box<dyn std::erro
     );
     Ok(())
 }
+
+/// The renderer names itself when printed, and says nothing else.
+///
+/// Here rather than beside the pure tests because a renderer cannot be
+/// built without a device. The assertion is deliberately weak in one
+/// direction and strict in the other: the type's name has to be there,
+/// for a caller printing a struct that holds one, and the pipeline's
+/// handle must not be — a raw handle in a log is a number that means
+/// nothing to a reader and changes every run.
+#[test]
+fn the_renderer_names_itself_without_leaking_a_handle() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+    let shown = format!("{renderer:?}");
+    assert!(shown.contains("MeshRenderer"), "got: {shown}");
+    assert!(
+        shown.contains(".."),
+        "the omission should be visible rather than silent: {shown}"
+    );
+    Ok(())
+}

--- a/crates/render3d/tests/golden.rs
+++ b/crates/render3d/tests/golden.rs
@@ -1,0 +1,287 @@
+//! Pixel oracles for the 3D path, computed rather than committed.
+//!
+//! **No committed artifact, and that is an argument rather than a
+//! saving.** A committed golden exists where a silhouette edge decides
+//! which pixels are covered, because that is where implementations
+//! differ. The geometry here is axis-aligned quads covering whole
+//! rectangles in one flat colour, so the only edge in play is the
+//! diagonal each quad's two triangles share — and a shared edge is not
+//! somewhere implementations may differ: the fill rule gives a sample on
+//! it to exactly one of the two, never both and never neither. With one
+//! colour across all four corners, interpolation cannot vary the answer
+//! either.
+//!
+//! So the expected image is arithmetic, and the assertion is as strong on
+//! real hardware as on a software rasterizer.
+
+use renew_render3d::{MeshRenderer, Render3dError, Scene, attachment, pass};
+use renew_rhi::{
+    Color, Device, DeviceDesc, DeviceError, Extent, RenderDesc, TargetFormat, Validation,
+};
+
+const SIZE: u32 = 32;
+
+fn strict() -> bool {
+    std::env::var_os("RENEW_GOLDEN").is_some_and(|value| value == "1")
+}
+
+/// `Ok(None)` is the graceful skip. Under `RENEW_GOLDEN=1` — the lane
+/// that exists to run these — a skip is a failure, so the oracle can
+/// never pass vacuously.
+fn device_or_skip() -> Result<Option<Device>, DeviceError> {
+    match Device::new(&DeviceDesc {
+        app_name: "renew-render3d-golden",
+        validation: Validation::IfAvailable,
+    }) {
+        Ok(device) => {
+            assert!(
+                device.validation_active() || !strict(),
+                "RENEW_GOLDEN=1 but the validation layer is not active — the lane's oracle \
+                 would be vacuous"
+            );
+            // **Depth is the whole subject of this crate**, so a lane
+            // whose adapter offers none cannot be allowed to pass these
+            // by drawing nothing. Off the strict lane it is a reported
+            // skip; on it, a failure.
+            assert!(
+                device.depth_format_name().is_some() || !strict(),
+                "RENEW_GOLDEN=1 but the adapter offers no depth format — every oracle here \
+                 would skip, and a skipped depth test proves nothing about a depth-tested crate"
+            );
+            if device.depth_format_name().is_none() {
+                eprintln!("SKIP: adapter offers no chain depth format");
+                return Ok(None);
+            }
+            Ok(Some(device))
+        }
+        Err(DeviceError::LoaderUnavailable { message }) if !strict() => {
+            eprintln!("SKIP: no Vulkan runtime: {message}");
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn assert_no_validation_errors(device: &Device) {
+    let report = device.validation_report();
+    assert_eq!(
+        report.errors, 0,
+        "validation errors; first messages: {:?}",
+        report.first_messages
+    );
+}
+
+fn at(pixels: &[u8], x: u32, y: u32) -> [u8; 4] {
+    let i = ((y * SIZE + x) * 4) as usize;
+    [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+}
+
+/// A quad covering the whole target at `depth`, in `colour`.
+fn full_quad(scene: &mut Scene, depth: f32, colour: [f32; 4]) {
+    scene.quad(
+        [
+            [-1.0, -1.0, depth],
+            [1.0, -1.0, depth],
+            [1.0, 1.0, depth],
+            [-1.0, 1.0, depth],
+        ],
+        colour,
+    );
+}
+
+/// G1: geometry reaches the screen, byte-exact, everywhere.
+#[test]
+fn a_quad_covers_the_target_in_its_own_colour() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+
+    let mut scene = Scene::new();
+    full_quad(&mut scene, 0.5, [0.0, 1.0, 0.0, 1.0]);
+    let mesh = renderer.upload(&device, &scene)?;
+
+    // Magenta appears nowhere in the geometry, so a quad that failed to
+    // cover shows as unwritten rather than as a plausible colour.
+    let color = [attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let items = [renderer.item(&mesh)];
+    let passes = [pass(&color, &items)];
+    target.render(&RenderDesc::new(&passes))?;
+
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            assert_eq!(
+                at(&pixels, x, y),
+                [0, 255, 0, 255],
+                "pixel ({x},{y}) uncovered on adapter {:?}",
+                device.adapter()
+            );
+        }
+    }
+
+    // The same frame twice is the same bytes — the cheap local form of
+    // the reproducibility this crate claims.
+    let mut second = vec![0u8; target.byte_len()];
+    target.render(&RenderDesc::new(&passes))?;
+    target.read_back_into(&mut second);
+    assert_eq!(pixels, second, "the same frame drawn twice diverged");
+
+    drop(target);
+    drop(renderer);
+    assert_no_validation_errors(&device);
+    Ok(())
+}
+
+/// G2: the depth test decides, not the push order — proved in both
+/// orders, because only one of them distinguishes depth from painting.
+#[test]
+fn the_nearer_quad_wins_in_either_push_order() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+    let near = [0.0, 0.0, 1.0, 1.0];
+    let far = [1.0, 0.0, 0.0, 1.0];
+
+    for (label, first, second) in [
+        ("far pushed first", (0.75, far), (0.25, near)),
+        ("near pushed first", (0.25, near), (0.75, far)),
+    ] {
+        let mut scene = Scene::new();
+        full_quad(&mut scene, first.0, first.1);
+        full_quad(&mut scene, second.0, second.1);
+        let mesh = renderer.upload(&device, &scene)?;
+        let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+        let items = [renderer.item(&mesh)];
+        target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
+        let mut pixels = vec![0u8; target.byte_len()];
+        target.read_back_into(&mut pixels);
+        assert_eq!(
+            at(&pixels, SIZE / 2, SIZE / 2),
+            [0, 0, 255, 255],
+            "{label}: the near quad must win — painter's order would let the far one through \
+             when it is pushed second"
+        );
+    }
+
+    drop(target);
+    drop(renderer);
+    assert_no_validation_errors(&device);
+    Ok(())
+}
+
+/// G3: **push order is load-bearing, and this is the only test that can
+/// see it.**
+///
+/// Two quads at the *same* depth. Under the compare the rendering crate
+/// fixes — `LESS_OR_EQUAL` — a fragment at equal depth passes, so the one
+/// submitted later wins. Reverse the push order and the colour reverses
+/// with it.
+///
+/// Every other oracle here would survive a reordering somewhere in the
+/// scene, the upload or the draw. This one would not, which is what makes
+/// "push order is draw order" a claim with observable content rather than
+/// a sentence in a doc comment.
+#[test]
+fn at_equal_depth_the_later_push_wins() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+    let red = [1.0, 0.0, 0.0, 1.0];
+    let blue = [0.0, 0.0, 1.0, 1.0];
+
+    for (label, first, second, expected) in [
+        ("red then blue", red, blue, [0, 0, 255, 255]),
+        ("blue then red", blue, red, [255, 0, 0, 255]),
+    ] {
+        let mut scene = Scene::new();
+        full_quad(&mut scene, 0.5, first);
+        full_quad(&mut scene, 0.5, second);
+        let mesh = renderer.upload(&device, &scene)?;
+        let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+        let items = [renderer.item(&mesh)];
+        target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
+        let mut pixels = vec![0u8; target.byte_len()];
+        target.read_back_into(&mut pixels);
+        assert_eq!(
+            at(&pixels, SIZE / 2, SIZE / 2),
+            expected,
+            "{label}: at equal depth the later push must win"
+        );
+    }
+
+    drop(target);
+    drop(renderer);
+    assert_no_validation_errors(&device);
+    Ok(())
+}
+
+/// One mesh drawn by two items in one frame — the property the rendering
+/// crate deliberately allows, and the reason this crate hands the mesh
+/// back rather than owning it.
+#[test]
+fn one_mesh_may_be_drawn_by_several_items() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+    let mut scene = Scene::new();
+    full_quad(&mut scene, 0.5, [0.0, 1.0, 0.0, 1.0]);
+    let mesh = renderer.upload(&device, &scene)?;
+
+    let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let items = [renderer.item(&mesh), renderer.item(&mesh)];
+    target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+    assert_eq!(at(&pixels, SIZE / 2, SIZE / 2), [0, 255, 0, 255]);
+
+    drop(target);
+    drop(renderer);
+    assert_no_validation_errors(&device);
+    Ok(())
+}
+
+/// An empty scene is refused with this crate's own error rather than
+/// reaching a layer that treats it as a caller bug and asserts.
+///
+/// On a device, because the point is that the refusal happens *before*
+/// the rendering crate is asked — a unit test could not tell the
+/// difference between refusing here and panicking there.
+#[test]
+fn an_empty_scene_is_refused_rather_than_fatal() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let renderer = MeshRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
+    let scene = Scene::new();
+    let refused = renderer.upload(&device, &scene);
+    assert!(
+        matches!(refused, Err(Render3dError::EmptyScene)),
+        "an all-air scene is data, not a caller bug"
+    );
+    Ok(())
+}

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -196,6 +196,7 @@ const ALLOWS_UNSAFE: &[&str] = &[
     "crates/core/memory/src/lib.rs",
     "crates/jobs/src/lib.rs",
     "crates/render2d/tests/fault.rs",
+    "crates/render3d/tests/fault.rs",
     "crates/rhi/src/lib.rs",
     "crates/rhi/tests/fault.rs",
     "crates/rhi/tests/fault_present.rs",


### PR DESCRIPTION
A crate that turns quads into an indexed mesh and hands back a draw
item. It does not render, does not present and does not own a frame: the
caller owns the target, so the caller composes the frame — the same
posture the 2D sibling states, for the same reason.

`scene.rs` is pure and makes no device calls, so the packing maths is
testable with no adapter. `gpu.rs` owns the pipeline, the upload and the
draw item, and is the only module that names the rendering crate.

Two decisions worth naming:

**The depth refusal is a translation, not a second detection.** Pipeline
creation already refuses depth state on an adapter that has no depth
format, before creating anything, and names the chain it refused. Asking
the device separately would put two authorities on one fact and would
put the refusal on a path nothing can execute — every adapter the tests
run on offers depth. Translating it means the mapping is exercised
everywhere instead of nowhere.

**An empty scene is refused here.** Mesh creation treats empty geometry
as a caller bug and asserts before returning its error, so an empty
scene handed down would abort in every build tested here. An all-air
world and a fully culled mesh are ordinary data, so they get an ordinary
refusal.

Depth is not a knob. A 3D frame drawn without it is a wrong picture that
looks plausible; `pass()` is the shape that cannot omit it, while the
attachments and the item stay public for callers composing something
else beside the geometry.

Verification: a computed oracle rather than a committed image, plus a
tie-break case — two coplanar quads at equal depth, pushed in each
order, where the later push wins under the fixed compare. That is the
only thing that makes submission order visible in a pixel, so a
reordering anywhere changes the image. Both fallible calls are failed
for real by the injection layer.