### PR TITLE
fix(cli): the windowed sample is reachable, and a flag stops being ignored

### DIFF
--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -29,8 +29,20 @@ crates enter the normal graph only behind the `window` feature (and
 the dev graph for the oracle); the default build carries none of
 them, and the build matrix proves it with a build-only probe.
 
-`glide --window` opens the game (`--features window` builds it):
-space or the primary mouse button flaps, the score lives in the
+`--window` opens the game, and the `window` feature is what builds the
+window in. Either of these works from a clean clone:
+
+```
+renew --features window run glide -- --window
+cargo run -p renew-sample-glide --features window --bin glide -- --window
+```
+
+The feature is not on by default, and that is the point rather than an
+oversight: the build matrix proves the game builds and runs with no
+graphics crate in its graph at all, which stops being true the moment
+the window is always compiled in.
+
+Space or the primary mouse button flaps, the score lives in the
 title, and the digest line prints at close marked `source=window` so
 nothing ever compares a wall-clock run against a scripted one. Flap
 edges ride a saturating counter consumed one per fixed step — a press
@@ -66,8 +78,8 @@ RENEW_LOG=run.log glide --window
 ```
 
 ```powershell
-$env:RENEW_LOG = "$env:USERPROFILEun.log"
-.	arget\debug\glide.exe --window
+$env:RENEW_LOG = "$env:USERPROFILE\run.log"
+.\target\debug\glide.exe --window
 ```
 
 An environment variable rather than a flag, because a panic that happens

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -147,10 +147,19 @@ fn windowed_run(options: &Options) -> Result<Report, SampleError> {
 /// The honest answer in a build with the windowing stack compiled out:
 /// name the reason and exit non-zero. Silently pretending to open a
 /// window would make the removability evidence worthless.
+///
+/// **The message names both roads, and the tool's first.** It used to say
+/// only "rebuild with `--features window`", which is a cargo flag — of no
+/// use to a reader who typed `renew run glide --window` and never ran
+/// cargo at all. A refusal that names a command the reader cannot map
+/// back to what they typed is a dead end wearing an explanation.
 #[cfg(not(feature = "window"))]
 fn windowed_run(_options: &Options) -> Result<Report, SampleError> {
     Err(SampleError::Usage(
-        "this build has no windowing support; rebuild with --features window".to_string(),
+        "this build has no windowing support. Run \
+         `renew --features window run glide --window`, or build it directly with \
+         `cargo run -p renew-sample-glide --features window --bin glide -- --window`"
+            .to_string(),
     ))
 }
 

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -57,7 +57,7 @@ that is what lets one trace be replayed across many seeds.
 | `--frames N` | Frames of simulation to run (default 600, ten seconds at 60 Hz). Headless, one frame is exactly one step; windowed, the run ends once the simulation has advanced this many steps. A close request ends it sooner. |
 | `--seed N` | Selects the movement speed. The seed axis is a placeholder until there is a random-number service; it feeds the world so the shape of the flag survives. |
 | `--dump-stats PATH` | Write the JSON report there, after the run. |
-| `--record-trace PATH` | Write the input this run saw to a trace file. |
+| `--record-trace PATH` | Write the input this run saw to a trace file. Requires `--headless`, and refused alongside `--replay-trace`: this sample records what a script produced, so there is nothing to record from a window, and re-recording a replay would write back the file it just read. |
 | `--replay-trace PATH` | Run the input in that file instead. The header owns the run, so `--input-trace`, `--frames` and `--seed` are refused alongside it. Requires `--headless`: replaying against a live window would mix recorded input with real input. |
 
 The last line on stdout is always the digest line — the string the

--- a/samples/input_echo/src/cli.rs
+++ b/samples/input_echo/src/cli.rs
@@ -267,13 +267,20 @@ mod tests {
     /// recording that happened and was empty.
     #[test]
     fn recording_is_refused_outside_a_headless_run() {
-        let refused = parse(&["--frames", "5", "--record-trace", "out.trace"]);
-        let Err(SampleError::Usage(message)) = refused else {
-            unreachable!("a windowed run cannot record, so it must say so: {refused:?}")
-        };
+        // Read off the formatted result rather than destructured: an
+        // arm for the case where the test fails is a line no passing run
+        // ever executes, and the coverage gate is right to count it.
+        let refused = format!(
+            "{:?}",
+            parse(&["--frames", "5", "--record-trace", "out.trace"])
+        );
         assert!(
-            message.contains("--record-trace") && message.contains("--headless"),
-            "the refusal must name both flags, so the reader knows which to change: {message}"
+            refused.starts_with("Err(Usage("),
+            "a windowed run cannot record, so it must refuse: {refused}"
+        );
+        assert!(
+            refused.contains("--record-trace") && refused.contains("--headless"),
+            "the refusal must name both flags, so the reader knows which to change: {refused}"
         );
     }
 
@@ -288,12 +295,14 @@ mod tests {
             "--record-trace",
             "out.trace",
         ]);
-        let Err(SampleError::Usage(message)) = refused else {
-            unreachable!("re-recording a replay must be refused: {refused:?}")
-        };
+        let refused = format!("{refused:?}");
         assert!(
-            message.contains("--record-trace") && message.contains("--replay-trace"),
-            "the refusal must name both flags: {message}"
+            refused.starts_with("Err(Usage("),
+            "re-recording a replay must be refused: {refused}"
+        );
+        assert!(
+            refused.contains("--record-trace") && refused.contains("--replay-trace"),
+            "the refusal must name both flags: {refused}"
         );
     }
 

--- a/samples/input_echo/src/cli.rs
+++ b/samples/input_echo/src/cli.rs
@@ -12,8 +12,13 @@ use crate::world::EchoWorld;
 pub const SAMPLE: &str = "input_echo";
 
 /// What the sample accepts, in the words it accepts them.
-pub const USAGE: &str = "usage: input_echo [--headless [--input-trace NAME]] [--frames N] \
-                         [--seed N] [--dump-stats PATH] [--record-trace PATH] \n                         [--replay-trace PATH]";
+pub const USAGE: &str = concat!(
+    "usage: input_echo [--frames N] [--seed N] [--dump-stats PATH]\n",
+    "       input_echo --headless [--input-trace NAME] [--record-trace PATH]\n",
+    "       input_echo --headless --replay-trace PATH\n",
+    "\nThe trace flags are headless-only: a window is driven by the person\n",
+    "at the keyboard, and this sample records only what a script produced."
+);
 
 /// The trace a headless run replays unless told otherwise.
 pub const DEFAULT_TRACE: &str = "walk";
@@ -42,10 +47,19 @@ pub struct Options {
     pub dump_stats: Option<PathBuf>,
     /// Where to write the run's input as a replayable trace, if anywhere.
     ///
-    /// Recording is independent of how the run is driven: a scripted run
-    /// records the script, a windowed run records the person. The file
-    /// says nothing about which, because a trace is the input and not the
-    /// thing that produced it.
+    /// **Headless scripted runs only; refused elsewhere.** This once said
+    /// recording was independent of how the run is driven, and that "a
+    /// windowed run records the person" -- which was never true. The flag
+    /// was read in one place, so a windowed run and a replay run both took
+    /// it, exited zero, and wrote nothing at all.
+    ///
+    /// Refused rather than implemented, following the sibling game, which
+    /// already refuses this flag beside a window and beside a replay.
+    /// Recording a live window is a real feature and a larger one than it
+    /// looks: this sample's windowed driver feeds the world a synthetic
+    /// resize outside the event path and releases held keys on focus loss,
+    /// neither of which a recording taken from the event stream would
+    /// carry, so the trace would replay into a different world.
     pub record_trace: Option<PathBuf>,
     /// A recorded trace to drive this run, instead of a named script.
     ///
@@ -121,15 +135,29 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         }
         if !overridden.is_empty() {
             return Err(SampleError::Usage(format!(
-                "--replay-trace owns the run, so {} cannot be given with it;                  the trace's own header carries them",
+                "--replay-trace owns the run, so {} cannot be given with it; \
+                 the trace's own header carries them",
                 overridden.join(" and ")
             )));
         }
         if !options.headless {
             return Err(SampleError::Usage(format!(
-                "--replay-trace needs --headless: replaying {} against a live                  window would mix recorded input with real input",
+                "--replay-trace needs --headless: replaying {} against a live window \
+                 would mix recorded input with real input",
                 path.display()
             )));
+        }
+        // Its own sentence rather than a name in the list above, because
+        // that message ends "the trace's own header carries them" -- true
+        // of the flags that set up a run, and meaningless for a flag that
+        // writes one out.
+        if options.record_trace.is_some() {
+            return Err(SampleError::Usage(
+                "--record-trace cannot be given with --replay-trace: re-recording a replay \
+                 writes back the file it just read, and proves only that the recorder is \
+                 the identity"
+                    .to_string(),
+            ));
         }
     }
     if scripted && !options.headless {
@@ -138,6 +166,17 @@ pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<Options, Sa
         // dropped would make its digest line unexplainable.
         return Err(SampleError::Usage(
             "--input-trace only applies to --headless runs; a window is driven by real input"
+                .to_string(),
+        ));
+    }
+    if options.record_trace.is_some() && !options.headless {
+        // The same rule and the same reason as the line above. This one
+        // was missing, so the flag was accepted, ignored, and the run
+        // exited zero having written no file -- which reads exactly like
+        // a recording that happened.
+        return Err(SampleError::Usage(
+            "--record-trace only applies to --headless runs; recording a window would need \
+             the live driver's own input, which this sample does not capture"
                 .to_string(),
         ));
     }
@@ -218,6 +257,65 @@ impl Report {
 
 #[cfg(test)]
 mod tests {
+
+    /// A windowed run refuses the recording flag rather than dropping it.
+    ///
+    /// **The defect this replaces was silence.** The flag parsed in every
+    /// mode and was read in one, so `input_echo --frames 5 --record-trace
+    /// out.trace` exited zero, printed an ordinary digest line, and wrote
+    /// no file -- which is indistinguishable, from the outside, from a
+    /// recording that happened and was empty.
+    #[test]
+    fn recording_is_refused_outside_a_headless_run() {
+        let refused = parse(&["--frames", "5", "--record-trace", "out.trace"]);
+        let Err(SampleError::Usage(message)) = refused else {
+            unreachable!("a windowed run cannot record, so it must say so: {refused:?}")
+        };
+        assert!(
+            message.contains("--record-trace") && message.contains("--headless"),
+            "the refusal must name both flags, so the reader knows which to change: {message}"
+        );
+    }
+
+    /// Recording a replay is refused: it would write back the file it
+    /// just read, and prove only that the recorder is the identity.
+    #[test]
+    fn recording_a_replay_is_refused() {
+        let refused = parse(&[
+            "--headless",
+            "--replay-trace",
+            "walk.trace",
+            "--record-trace",
+            "out.trace",
+        ]);
+        let Err(SampleError::Usage(message)) = refused else {
+            unreachable!("re-recording a replay must be refused: {refused:?}")
+        };
+        assert!(
+            message.contains("--record-trace") && message.contains("--replay-trace"),
+            "the refusal must name both flags: {message}"
+        );
+    }
+
+    /// The mode that can record still does.
+    ///
+    /// Here so the two refusals above cannot be satisfied by refusing the
+    /// flag everywhere, which would pass both and delete the feature.
+    #[test]
+    fn a_headless_scripted_run_still_accepts_the_recording_flag() {
+        let options = parse(&[
+            "--headless",
+            "--input-trace",
+            "walk",
+            "--record-trace",
+            "out.trace",
+        ])
+        .expect("the one mode that records must keep recording");
+        assert_eq!(
+            options.record_trace.as_deref(),
+            Some(std::path::Path::new("out.trace"))
+        );
+    }
     use super::{DEFAULT_FRAMES, DEFAULT_TRACE, Options, Report, parse_args};
     use crate::error::SampleError;
     use crate::input::Input;

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -7,6 +7,8 @@ commands the same way.
 ```
 usage: renew <command> [options]
        renew [options] run <sample> [--] [sample arguments...]
+       renew record --output <path> <sample> [--] [sample arguments...]
+       renew replay --input <path> <sample> [--] [sample arguments...]
 
 commands:
   configure  verify the toolchain and cargo are present and sane
@@ -14,21 +16,49 @@ commands:
   test       run the workspace test suite
   bench      run the workspace benchmarks
   run        build and run a workspace sample
+  record     run a sample, writing the input it saw to a file
+  replay     run a sample from a recorded input file
   lint       check formatting, then run clippy with warnings denied
   check      verify workspace crate manifests and dependencies
   coverage   hold a coverage report against the exemption manifest
   modules    list every module with its maturity, from the manifests
-  asset-pack     build an asset pack from a directory of files
+  asset-pack  build an asset pack from a directory of files
   asset-inspect  list an asset pack's entries, optionally verifying them
-  determinism    emit this target's simulation digests, or compare several targets'
+  determinism  emit this target's simulation digests, or compare several targets'
   doctor     check the development environment
 
 options:
   --json            emit one machine-readable JSON document on stdout
   --report <path>   (coverage only, required) the llvm-cov JSON export to read
   --smoke           (bench only) run each benchmark once, without statistics
+  --output <path>   (record only, required) the trace file to write
+  --input <path>    (replay only, required) the trace file to read
+  --pack <path>     (asset-pack, asset-inspect; required) the pack file
+  --from <dir>      (asset-pack only, required) the directory to pack
+  --verify          (asset-inspect only) check each entry against its digest
   --emit <path>     (determinism only) write this target's digests here
   --compare <path>  (determinism only, repeatable) a target report to compare
+  --features <list> (run, record, replay; repeatable) cargo features to build
+                    the sample with, e.g. `--features window` for a window
+  --help, -h        print this text; `renew help` does the same
+
+Everything after `run <sample>` goes to the sample untouched, including
+flags renew itself knows: `renew run hello_triangle --json` gives the sample
+`--json`, while `renew --json run hello_triangle` gives it to renew. One `--`
+after the sample name is an optional separator and is not passed on.
+
+`record` and `replay` are `run` with a trace file: their flag goes before
+the sample name for the same reason, and reaches the sample as
+`--record-trace <path>` or `--replay-trace <path>` at the front of its line.
+Recording and replaying are headless: a windowed replay is a live run
+wearing a replay's name. How a sample spells headless is the sample's own
+business — some take `--headless`, others are headless unless asked for a
+window — so its usage says which, and this tool assumes nothing.
+
+`--features` reaches cargo, not the sample. It builds the sample with those
+features on, which is how a sample's optional capabilities are named:
+`renew --features window run glide --window` builds the window in, then
+asks for it.
 ```
 
 `bench --smoke` is a second fixed entry in the command table (every bench

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -157,10 +157,39 @@ pub struct Invocation {
     /// the two modes are one subcommand because they are two halves of
     /// one claim, and parsing refuses both together and neither.
     pub emit: Option<String>,
+    /// Run, record and replay: cargo features to build the sample with,
+    /// each occurrence kept.
+    ///
+    /// **Cargo's own vocabulary, showing through deliberately.** A
+    /// sample's optional capabilities are cargo features, and the one
+    /// windowed sample cannot be started at all without naming one — so
+    /// the alternative to letting the word through was a per-sample table
+    /// mapping invented names onto features, which the sample list is
+    /// specifically built to avoid needing (samples are discovered, never
+    /// written down).
+    ///
+    /// Repeating accumulates, on the same reasoning as
+    /// [`Invocation::compare`]: two occurrences mean the union, and
+    /// keeping the last is how a caller silently loses one.
+    pub features: Vec<String>,
 }
 
 /// What parsing decided: run a subcommand, or show usage on request.
 /// Help carries the `--json` flag so usage can honor the output contract.
+///
+/// **The size gap between the variants is deliberate, not overlooked.**
+/// `Run` carries the whole parsed command line and `Help` carries one
+/// bool, which is what the lint is for — an enum whose small variant is
+/// common wastes the difference on every value. Exactly one `Parsed`
+/// exists per process: it is built by `parse`, matched immediately, and
+/// dropped. Boxing would trade a pointer chase and an allocation for
+/// bytes that are never multiplied by anything, and would put a `Box::new`
+/// in front of every construction in the tests, where the shape of the
+/// value is the thing being read.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "one value per process, built and matched at once; boxing would cost more than the gap"
+)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Parsed {
     Run(Invocation),
@@ -251,6 +280,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
     let mut from: Option<String> = None;
     let mut verify = false;
     let mut compare: Vec<String> = Vec::new();
+    let mut features: Vec<String> = Vec::new();
     let mut emit: Option<String> = None;
     let mut sample: Option<String> = None;
     let mut sample_args: Vec<String> = Vec::new();
@@ -298,6 +328,16 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             "--compare" => {
                 let path = rest.next().ok_or(ParseError::MissingValue("--compare"))?;
                 compare.push(path.clone());
+            }
+            // Repeatable for the same reason `--compare` is, and passed
+            // to cargo verbatim: cargo already unions repeated
+            // occurrences and already accepts comma- or space-separated
+            // lists inside one, so splitting or joining here would be
+            // this tool inventing a second grammar for a syntax that
+            // already has one.
+            "--features" => {
+                let names = rest.next().ok_or(ParseError::MissingValue("--features"))?;
+                features.push(names.clone());
             }
             // Its own flag rather than `--output`, which belongs to
             // `record` and means "write the input you saw here". This
@@ -352,6 +392,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
         report.as_deref(),
         trace.as_ref().map(|(flag, _)| *flag),
         sample.as_deref(),
+        &features,
     )?;
     check_asset_combination(command, pack.as_deref(), from.as_deref(), verify)?;
     check_determinism_mode(command, emit.as_deref(), &compare)?;
@@ -370,6 +411,7 @@ pub fn parse(arguments: &[String]) -> Result<Parsed, ParseError> {
             verify,
             compare,
             emit,
+            features,
         })),
         None => Err(ParseError::NoCommand),
     }
@@ -496,7 +538,15 @@ fn check_combination(
     report: Option<&str>,
     trace: Option<&'static str>,
     sample: Option<&str>,
+    features: &[String],
 ) -> Result<(), ParseError> {
+    if !features.is_empty() && !command.is_some_and(Command::takes_sample) {
+        // Features name how a *sample* is built. `renew build` builds the
+        // whole workspace and `renew test` runs all of it, so a feature
+        // there would have to mean something this tool has not decided —
+        // refusing is what keeps the flag's meaning single.
+        return Err(ParseError::UnexpectedArgument("--features".to_string()));
+    }
     if smoke && command != Some(Command::Bench) {
         // The flag belongs to exactly one subcommand; anywhere else it is
         // as unexpected as any stray argument.
@@ -575,6 +625,8 @@ pub fn usage() -> String {
         "  --verify          (asset-inspect only) check each entry against its digest\n",
         "  --emit <path>     (determinism only) write this target's digests here\n",
         "  --compare <path>  (determinism only, repeatable) a target report to compare\n",
+        "  --features <list> (run, record, replay; repeatable) cargo features to build\n",
+        "                    the sample with, e.g. `--features window` for a window\n",
         "  --help, -h        print this text; `renew help` does the same\n",
         "\nEverything after `run <sample>` goes to the sample untouched, including\n",
         "flags renew itself knows: `renew run hello_triangle --json` gives the sample\n",
@@ -583,8 +635,14 @@ pub fn usage() -> String {
         "\n`record` and `replay` are `run` with a trace file: their flag goes before\n",
         "the sample name for the same reason, and reaches the sample as\n",
         "`--record-trace <path>` or `--replay-trace <path>` at the front of its line.\n",
-        "Replaying is a headless run — pass `--headless` to the sample; it is not\n",
-        "assumed, because a windowed replay is a live run wearing a replay's name.\n",
+        "Recording and replaying are headless: a windowed replay is a live run\n",
+        "wearing a replay's name. How a sample spells headless is the sample's own\n",
+        "business — some take `--headless`, others are headless unless asked for a\n",
+        "window — so its usage says which, and this tool assumes nothing.\n",
+        "\n`--features` reaches cargo, not the sample. It builds the sample with those\n",
+        "features on, which is how a sample's optional capabilities are named:\n",
+        "`renew --features window run glide --window` builds the window in, then\n",
+        "asks for it.\n",
     ));
     text
 }
@@ -612,6 +670,7 @@ mod tests {
             verify: false,
             compare: Vec::new(),
             emit: None,
+            features: Vec::new(),
         }
     }
 
@@ -1130,6 +1189,79 @@ mod tests {
         assert_eq!(
             parse(&arguments(&["run", "sample", "--"])),
             Ok(running("sample", &[]))
+        );
+    }
+
+    /// Two occurrences mean the union, and both survive.
+    ///
+    /// The same rule `--compare` follows, for the same reason: keeping
+    /// only the last is how a caller who asked for a window *and* sound
+    /// silently gets one of them, with nothing anywhere saying so.
+    #[test]
+    fn features_accumulate_across_occurrences() {
+        assert_eq!(
+            parse(&arguments(&[
+                "--features",
+                "window",
+                "--features",
+                "audio",
+                "run",
+                "glide"
+            ])),
+            Ok(Parsed::Run(Invocation {
+                sample: Some("glide".to_string()),
+                features: vec!["window".to_string(), "audio".to_string()],
+                ..plain(Command::Run)
+            }))
+        );
+    }
+
+    /// The flag is accepted after the subcommand too, since it only has
+    /// to precede the sample name -- everything after that name is the
+    /// sample's.
+    #[test]
+    fn features_may_sit_on_either_side_of_the_subcommand() {
+        let before = parse(&arguments(&["--features", "window", "run", "glide"]));
+        let after = parse(&arguments(&["run", "--features", "window", "glide"]));
+        assert_eq!(before, after, "position before the sample name is free");
+    }
+
+    /// After the sample name it belongs to the sample, not to cargo.
+    ///
+    /// This is the pass-through contract, and it has to hold for a flag
+    /// renew itself knows -- otherwise the rule "everything after the
+    /// sample name is the sample's" would have exceptions a reader must
+    /// memorise.
+    #[test]
+    fn features_after_the_sample_name_belong_to_the_sample() {
+        assert_eq!(
+            parse(&arguments(&["run", "glide", "--features", "window"])),
+            Ok(Parsed::Run(Invocation {
+                sample: Some("glide".to_string()),
+                sample_args: vec!["--features".to_string(), "window".to_string()],
+                ..plain(Command::Run)
+            }))
+        );
+    }
+
+    /// Features name how a sample is built, so a subcommand that builds
+    /// no sample refuses them rather than ignoring them.
+    #[test]
+    fn features_are_refused_where_no_sample_is_built() {
+        for command in ["build", "test", "lint", "coverage"] {
+            assert_eq!(
+                parse(&arguments(&["--features", "window", command])),
+                Err(ParseError::UnexpectedArgument("--features".to_string())),
+                "{command} builds no sample, so the flag has no meaning there"
+            );
+        }
+    }
+
+    #[test]
+    fn features_without_a_value_says_which_flag() {
+        assert_eq!(
+            parse(&arguments(&["--features"])),
+            Err(ParseError::MissingValue("--features"))
         );
     }
 

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1217,7 +1217,13 @@ fn run_sample(invocation: &Invocation) -> ExitCode {
         .trace_flags()
         .zip(invocation.trace.as_deref())
         .map(|((_, child_flag), path)| (child_flag, path));
-    let args = plan::sample_step(&sample.package, &sample.name, lead, &invocation.sample_args);
+    let args = plan::sample_step(
+        &sample.package,
+        &sample.name,
+        lead,
+        &invocation.sample_args,
+        &invocation.features,
+    );
     match runner.execute("cargo", &args) {
         // A replay's whole result is the digest the child printed, and in
         // JSON mode this process captured the child's stdout rather than

--- a/tools/cli/src/plan.rs
+++ b/tools/cli/src/plan.rs
@@ -99,12 +99,16 @@ pub fn steps(command: Command, smoke: bool) -> &'static [Step] {
 /// sample's line, ahead of anything the caller wrote. Front rather than
 /// back because the caller's half is verbatim and may end in a flag
 /// still waiting for its value, which would otherwise swallow this one.
+/// `features` are cargo's, and so go **before** the `--`: everything
+/// after that separator belongs to the sample, and a feature landing
+/// there would be handed to the sample as an argument it never declared.
 #[must_use]
 pub fn sample_step(
     package: &str,
     binary: &str,
     lead: Option<(&str, &str)>,
     sample_args: &[String],
+    features: &[String],
 ) -> Vec<String> {
     let mut args = vec![
         "run".to_string(),
@@ -112,8 +116,12 @@ pub fn sample_step(
         package.to_string(),
         "--bin".to_string(),
         binary.to_string(),
-        "--".to_string(),
     ];
+    for names in features {
+        args.push("--features".to_string());
+        args.push(names.clone());
+    }
+    args.push("--".to_string());
     if let Some((flag, value)) = lead {
         args.push(flag.to_string());
         args.push(value.to_string());
@@ -191,6 +199,52 @@ mod tests {
         assert!(steps(Command::Replay, false).is_empty());
     }
 
+    /// Features are cargo's and land before the separator; the sample's
+    /// own arguments stay after it, untouched.
+    ///
+    /// The position is the whole point: everything after `--` is handed
+    /// to the sample, so a feature written there would arrive as an
+    /// argument the sample never declared and be refused by it, naming a
+    /// flag the caller did type but in a role they did not intend.
+    #[test]
+    fn features_go_to_cargo_and_the_separator_still_divides_the_line() {
+        let args = sample_step(
+            "renew-sample-glide",
+            "glide",
+            None,
+            &["--window".to_string()],
+            &["window".to_string(), "audio".to_string()],
+        );
+        assert_eq!(
+            args,
+            [
+                "run",
+                "--package",
+                "renew-sample-glide",
+                "--bin",
+                "glide",
+                "--features",
+                "window",
+                "--features",
+                "audio",
+                "--",
+                "--window",
+            ]
+        );
+        // Each occurrence kept: cargo unions them, and dropping one is
+        // how a caller silently loses a capability they asked for.
+        let separator = args.iter().position(|arg| arg == "--").expect("separator");
+        assert_eq!(
+            args.iter().filter(|arg| *arg == "--features").count(),
+            2,
+            "both occurrences must survive"
+        );
+        assert!(
+            args.iter().take(separator).any(|arg| arg == "audio"),
+            "features belong to cargo, ahead of the separator"
+        );
+    }
+
     #[test]
     fn a_sample_step_names_its_package_and_binary_then_hands_over() {
         let args = sample_step(
@@ -198,6 +252,7 @@ mod tests {
             "hello_triangle",
             None,
             &["--headless".to_string(), "--frames".to_string()],
+            &[],
         );
         assert_eq!(
             args,
@@ -218,7 +273,7 @@ mod tests {
     fn a_sample_step_with_nothing_to_hand_over_still_ends_in_the_separator() {
         // Uniform shape: the separator is not conditional, so nothing
         // downstream has to know whether the sample was given arguments.
-        let args = sample_step("renew-sample-input-echo", "input_echo", None, &[]);
+        let args = sample_step("renew-sample-input-echo", "input_echo", None, &[], &[]);
         assert_eq!(
             args,
             [
@@ -243,6 +298,7 @@ mod tests {
             "input_echo",
             Some(("--replay-trace", "walk.trace")),
             &["--headless".to_string(), "--seed".to_string()],
+            &[],
         );
         assert_eq!(
             args,

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -1715,3 +1715,45 @@ fn a_rustup_that_cannot_name_its_toolchain_still_counts_as_found() {
 
     let _ = fs::remove_dir_all(&directory);
 }
+
+/// The README's fenced usage block is the tool's own usage text, exactly.
+///
+/// **A hand-copied snapshot is a clock, not a document.** This block had
+/// drifted to thirteen subcommands against the tool's fifteen, and was
+/// missing six options -- so a reader who trusted it would not have known
+/// `record` and `replay` existed. Re-typing it would have restarted the
+/// same clock. Comparing it makes drift a failing test instead of a
+/// discovery months later.
+///
+/// The comparison runs against the *binary*, not against `usage()` in the
+/// library, so it also proves the two agree: a README matching a function
+/// nobody calls would prove nothing.
+#[test]
+fn the_readme_shows_the_usage_text_the_binary_prints() -> std::io::Result<()> {
+    let readme = fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("README.md"))?;
+    let printed = String::from_utf8_lossy(&run(&["--help"])?.stdout)
+        .replace("\r\n", "\n")
+        .trim_end()
+        .to_string();
+
+    // The block is the first fence whose first line starts the usage
+    // text; anchoring on that rather than on a line number keeps this
+    // working when prose moves around it.
+    let readme = readme.replace("\r\n", "\n");
+    let opened = readme
+        .find("```\nusage: renew")
+        .expect("the README should carry a fenced usage block");
+    let body_start = opened + "```\n".len();
+    let body_end = readme[body_start..]
+        .find("\n```")
+        .map(|offset| body_start + offset)
+        .expect("the usage block should be closed");
+    let block = &readme[body_start..body_end];
+
+    assert_eq!(
+        block, printed,
+        "the README's usage block and `renew --help` have parted. Re-sync the block; \
+         do not edit one to look like the other by hand."
+    );
+    Ok(())
+}

--- a/tools/cli/tests/source_hygiene.rs
+++ b/tools/cli/tests/source_hygiene.rs
@@ -127,3 +127,104 @@ fn no_text_file_carries_a_byte_order_mark_or_a_mangled_encoding() {
         faults.join("\n  ")
     );
 }
+
+/// The one-based line a byte offset falls on.
+///
+/// Clippy suggests the `bytecount` crate here. Declined: this runs once
+/// per fault found, not once per byte scanned, and a fault list long
+/// enough for the difference to matter is a tree in far worse trouble
+/// than a slow test. A dependency is presumed rejected until it earns
+/// itself, and counting newlines twice a year does not.
+#[expect(
+    clippy::naive_bytecount,
+    reason = "runs once per fault, not per byte; a dependency would cost more than it saves"
+)]
+fn line_of(bytes: &[u8], offset: usize) -> usize {
+    bytes[..offset]
+        .iter()
+        .filter(|byte| *byte == &b'\n')
+        .count()
+        + 1
+}
+
+/// A carriage return that no line feed follows, and a tab, in a tree that
+/// uses neither.
+///
+/// **A second way to damage a file, with a different cause and the same
+/// ending.** Where the checks above catch an encoding round-trip, this
+/// catches a *collapsed escape*: a shell heredoc that eats one backslash
+/// turns the two characters backslash-r into a carriage return, and
+/// backslash-t into a tab, inside whatever literal was being written.
+///
+/// It happened here, twice in one session. A sample's README gained a
+/// PowerShell block whose `$env:USERPROFILE\run.log` had become
+/// `$env:USERPROFILE` + CR + `un.log`, and whose `.\target\debug\glide.exe`
+/// had become `.` + TAB + `arget\debug\glide.exe`. It reached a merged
+/// commit, because the file is prose: nothing compiled it, and both
+/// characters are invisible in an editor and in rendered Markdown. The
+/// first person to meet it would have been a Windows user copying the
+/// block, which is the only reason that block exists. The second time,
+/// the same shell mangled the source of this very test.
+///
+/// A *lone* carriage return is the signal rather than a carriage return as
+/// such: this tree is checked out CRLF on Windows, so CR-LF pairs are
+/// ordinary, and only an unpaired one means something went wrong.
+#[test]
+fn no_text_file_carries_a_stray_control_character() {
+    const CARRIAGE_RETURN: u8 = b'\r';
+    const LINE_FEED: u8 = b'\n';
+    const TAB: u8 = b'\t';
+
+    let root = workspace_root();
+    let mut files = Vec::new();
+    text_files(&root, &mut files).expect("the workspace should be walkable");
+    assert!(
+        files.len() > 50,
+        "found only {} text files - the walk is not reaching the tree, and this would pass \
+         vacuously",
+        files.len()
+    );
+
+    let mut faults: Vec<String> = Vec::new();
+    for path in &files {
+        let shown = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .display()
+            .to_string();
+        let Ok(bytes) = std::fs::read(path) else {
+            // Unreadable is the business of the check above, which
+            // reports it; reporting it twice would say nothing new.
+            continue;
+        };
+
+        for (offset, pair) in bytes.windows(2).enumerate() {
+            if pair[0] == CARRIAGE_RETURN && pair[1] != LINE_FEED {
+                faults.push(format!(
+                    "{shown}:{}: a carriage return with no line feed after it",
+                    line_of(&bytes, offset)
+                ));
+            }
+        }
+        // A file ending in a bare carriage return is the same fault, and
+        // no two-byte window can see it.
+        if bytes.last() == Some(&CARRIAGE_RETURN) {
+            faults.push(format!("{shown}: ends with a bare carriage return"));
+        }
+        if let Some(offset) = bytes.iter().position(|b| *b == TAB) {
+            faults.push(format!(
+                "{shown}:{}: a tab, where this tree indents with spaces",
+                line_of(&bytes, offset)
+            ));
+        }
+    }
+
+    assert!(
+        faults.is_empty(),
+        "{} stray control character(s):\n  {}\n\nUsually a shell heredoc that ate a backslash, \
+         turning an escape into the character it names. Write the file with a file tool rather \
+         than through a shell literal.",
+        faults.len(),
+        faults.join("\n  ")
+    );
+}


### PR DESCRIPTION
Three things a person meets, each of which said one thing and did another.

**`renew run glide --window` could not work.** The tool builds a sample
with no features, the window is behind one, so the only windowed sample
was unreachable through the tool that exists to run samples. There was no
way to spell it either -- a feature flag was refused in both positions.

`renew --features window run glide -- --window` now works. Cargo's own
word, passed through deliberately: the alternative was a per-sample table
mapping invented names onto features, and the sample list is built to be
discovered rather than written down. The flag sits before the sample
name, like every other flag the tool owns, so the rule that everything
after that name belongs to the sample keeps no exceptions.

The refusal a reader hits without it used to say "rebuild with
`--features window`" -- a cargo flag, offered to someone who typed a
renew command and never ran cargo. It now names both roads, the tool's
first.

**`--record-trace` was accepted in two modes that ignore it.** A windowed
run and a replay run both took the flag, exited zero, and wrote no file,
which from outside is indistinguishable from a recording that happened.
Both refuse by name now.

Recording a window stays unbuilt rather than half-built, following the
game's own shipped ruling on the same flag. It is a larger feature than
it looks: the windowed driver feeds the world a resize outside the event
path and releases held keys on focus loss, so a recording taken from the
event stream would replay into a different world -- against a README that
claims every field a digest depends on is identical across a
record-replay pair.

**A PowerShell block in the game's README was corrupt.** A backslash-r
had become a carriage return and a backslash-t a tab, so both commands a
Windows reader is meant to copy were broken. It was invisible in every
editor and in rendered Markdown, and nothing compiled it. A guard now
walks every text file for stray control characters, beside the one that
already catches encoding damage -- and it caught a second instance while
this change was being written.

Also: the tool's README carried a hand-copied usage block that had
drifted to thirteen subcommands against fifteen, hiding `record` and
`replay` from anyone who trusted it. Re-typing it would only restart the
same clock, so a test now holds it against what the binary prints.