### PR TITLE
fix(rhi): a lost device and an over-limit extent are both refused before the driver

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -82,12 +82,12 @@ reason = "The width guards on the pack's own header fields. Reaching one needs m
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [367]
+lines = [379]
 reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs — so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [480, 481, 482]
+lines = [492, 493, 494]
 reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless adapter. Same unreachability as the creation arm above: every measuring lane's adapter offers a depth format, and the query that decides it cannot be faulted. The error construction is driven by the display test in the error module; the branch condition's false side runs on every depth-carrying frame."
 
 [[exempt]]

--- a/crates/rhi/src/vk/buffer.rs
+++ b/crates/rhi/src/vk/buffer.rs
@@ -179,7 +179,8 @@ impl Device {
     ///
     /// # Errors
     ///
-    /// [`TargetError`] naming the Vulkan call that refused.
+    /// [`TargetError`] naming the Vulkan call that refused;
+    /// [`TargetError::DeviceLost`] on a poisoned device.
     ///
     /// # Panics
     ///
@@ -201,13 +202,6 @@ impl Device {
         // bounds every later copy into the mapping.
         assert!(capacity > 0, "a per-frame buffer needs a non-zero capacity");
 
-        let shared = Rc::clone(&self.shared);
-        let mut partial = Partial {
-            shared: Rc::clone(&shared),
-            buffer: None,
-            memory: None,
-        };
-
         let per_slot = (capacity as u64).div_ceil(SLOT_ALIGN) * SLOT_ALIGN;
         let total = per_slot.checked_mul(MAX_FRAME_SLOTS as u64);
         // Same boundary, same retained refusal: an overflowed size would
@@ -219,6 +213,27 @@ impl Device {
         );
         let slot_stride = per_slot;
         let total = total.unwrap_or(0);
+
+        // Gated like every other resource constructor in this crate, and
+        // after the contract checks for the same reason they are: a
+        // malformed request is reported as malformed even on a dead
+        // device, because that is the caller's bug either way.
+        //
+        // **The gate is the only thing that refuses here.** None of the
+        // four driver calls below lists `VK_ERROR_DEVICE_LOST` among its
+        // return codes, so without this the likely outcome after a loss
+        // was not a laundered error — it was success, handing back a live
+        // buffer on a dead device while every sibling refused.
+        if self.shared.lost.poisoned() {
+            return Err(TargetError::DeviceLost);
+        }
+
+        let shared = Rc::clone(&self.shared);
+        let mut partial = Partial {
+            shared: Rc::clone(&shared),
+            buffer: None,
+            memory: None,
+        };
 
         let info = vk::BufferCreateInfo::default()
             .size(total)

--- a/crates/rhi/src/vk/device.rs
+++ b/crates/rhi/src/vk/device.rs
@@ -88,6 +88,17 @@ pub(crate) struct DeviceShared {
     /// target creation; queried once because format support is a static
     /// property of the physical device.
     pub(crate) depth_format: Option<vk::Format>,
+    /// `maxImageDimension2D`, read once at bring-up.
+    ///
+    /// Kept for the same reason `depth_format` is: it is a static
+    /// property of the physical device, so querying it per resource
+    /// would ask the driver a question whose answer cannot change.
+    /// Creation paths compare against it and refuse by name, rather
+    /// than handing an over-limit extent to `vkCreateImage` where it
+    /// becomes a usage violation -- which reddens every lane that
+    /// asserts zero validation errors, and reports the caller's mistake
+    /// as the engine's.
+    pub(crate) max_image_dimension_2d: u32,
     pub(crate) lost: PoisonFlag,
     /// Boxed for address stability: the driver holds this pointer for
     /// the instance's whole life.
@@ -334,6 +345,11 @@ impl Device {
             instance.get_physical_device_format_properties(physical, format)
         });
 
+        // SAFETY: category 2: instance and physical device live; the
+        // query has no failure mode and fills a caller-owned struct.
+        let limits = unsafe { instance.get_physical_device_properties(physical) }.limits;
+        let max_image_dimension_2d = limits.max_image_dimension2_d;
+
         // SAFETY: category 2: instance and physical device live.
         let device_extensions = unsafe { instance.enumerate_device_extension_properties(physical) }
             .map_err(|code| {
@@ -398,6 +414,7 @@ impl Device {
                 entry,
                 adapter,
                 depth_format,
+                max_image_dimension_2d,
                 lost: PoisonFlag::default(),
                 validation: validation_counters,
                 ledger,

--- a/crates/rhi/src/vk/mesh.rs
+++ b/crates/rhi/src/vk/mesh.rs
@@ -430,8 +430,6 @@ impl Device {
         );
         let layout = checked?;
         // Gated like every other resource constructor in this crate.
-        // `create_buffer` is the one that does not, which is a recorded
-        // inconsistency rather than a precedent to copy forward.
         if self.shared.lost.poisoned() {
             return Err(TargetError::DeviceLost);
         }

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -65,10 +65,22 @@ pub(crate) fn image_memory_type(
 /// verdict is provable: a dev build asserts on a zero extent long
 /// before the returned error could be observed, and every test runs
 /// with assertions on.
-fn check_extent(extent: Extent) -> Result<(), TargetError> {
+fn check_extent(extent: Extent, max_dimension: u32) -> Result<(), TargetError> {
     if extent.width == 0 || extent.height == 0 {
         return Err(TargetError::Creation {
             call: "create_offscreen_target(zero extent)",
+            code: 0,
+        });
+    }
+    // The device's limit, handed in rather than read from the device
+    // here. A pure function of the two is testable at any limit; one
+    // that asked the device would be reachable only on an adapter whose
+    // real maximum a caller could plausibly exceed, which is no adapter
+    // any lane runs on -- the shape that ships with its message tested
+    // and its trigger never pulled.
+    if extent.width > max_dimension || extent.height > max_dimension {
+        return Err(TargetError::Creation {
+            call: "create_offscreen_target(extent exceeds the device limit)",
             code: 0,
         });
     }
@@ -179,7 +191,7 @@ impl Device {
     pub fn create_offscreen_target(&self, extent: Extent) -> Result<OffscreenTarget, TargetError> {
         // Fatal in dev builds; in release, where the assertion is
         // compiled out, the same verdict is returned instead.
-        let checked = check_extent(extent);
+        let checked = check_extent(extent, self.shared.max_image_dimension_2d);
         debug_assert!(
             checked.is_ok(),
             "offscreen targets need a non-zero extent, got {extent:?}"
@@ -954,6 +966,54 @@ impl Drop for OffscreenTarget {
 
 #[cfg(test)]
 mod tests {
+
+    /// An extent past the adapter's `maxImageDimension2D` is refused
+    /// here, by name, instead of reaching `vkCreateImage`.
+    ///
+    /// **Reachable because the limit is a parameter.** A check that read
+    /// the device would need an adapter whose real maximum a caller
+    /// could plausibly exceed, and every adapter these lanes run on
+    /// reports at least 4096 -- so the arm would ship with its message
+    /// tested and its trigger never pulled. Handing the limit in makes
+    /// both sides of the comparison ordinary to test.
+    #[test]
+    fn an_extent_past_the_device_limit_is_refused_by_name() {
+        for extent in [
+            Extent {
+                width: 65,
+                height: 8,
+            },
+            Extent {
+                width: 8,
+                height: 65,
+            },
+            Extent {
+                width: 65,
+                height: 65,
+            },
+        ] {
+            let refusal = check_extent(extent, 64).expect_err("past the limit is not a target");
+            assert!(
+                matches!(refusal, TargetError::Creation { call, code: 0 }
+                    if call == "create_offscreen_target(extent exceeds the device limit)"),
+                "{extent:?} refused as {refusal:?}, which names no cause"
+            );
+        }
+        // Inclusive: it is a maximum, not a bound to stay under, and an
+        // off-by-one here would refuse the largest target the adapter
+        // actually supports.
+        assert!(
+            check_extent(
+                Extent {
+                    width: 64,
+                    height: 64
+                },
+                64
+            )
+            .is_ok(),
+            "the limit itself is allowed"
+        );
+    }
     use super::*;
 
     /// A memory-properties table with one heap and the given types, in
@@ -1053,7 +1113,7 @@ mod tests {
                 height: 0,
             },
         ] {
-            let refusal = check_extent(extent).expect_err("a zero extent has no target");
+            let refusal = check_extent(extent, u32::MAX).expect_err("a zero extent has no target");
             assert!(
                 matches!(refusal, TargetError::Creation { call, code: 0 }
                     if call == "create_offscreen_target(zero extent)"),
@@ -1061,10 +1121,13 @@ mod tests {
             );
         }
         assert!(
-            check_extent(Extent {
-                width: 1,
-                height: 1
-            })
+            check_extent(
+                Extent {
+                    width: 1,
+                    height: 1
+                },
+                u32::MAX
+            )
             .is_ok(),
             "one pixel is a real target"
         );

--- a/crates/rhi/src/vk/texture.rs
+++ b/crates/rhi/src/vk/texture.rs
@@ -87,10 +87,17 @@ fn required_bytes(extent: Extent) -> Option<u64> {
 /// slice would leave the tail of the image as whatever the staging
 /// allocation happened to contain — a bug that renders as plausible
 /// garbage rather than as a failure.
-fn check_desc(desc: &TextureDesc<'_>) -> Result<u64, TargetError> {
+fn check_desc(desc: &TextureDesc<'_>, max_dimension: u32) -> Result<u64, TargetError> {
     if desc.extent.width == 0 || desc.extent.height == 0 {
         return Err(TargetError::Creation {
             call: "create_texture(zero extent)",
+            code: 0,
+        });
+    }
+    // Handed in, not queried -- see the note in `check_extent`.
+    if desc.extent.width > max_dimension || desc.extent.height > max_dimension {
+        return Err(TargetError::Creation {
+            call: "create_texture(extent exceeds the device limit)",
             code: 0,
         });
     }
@@ -291,7 +298,7 @@ impl Device {
         // region that runs only when the assertion fails, which is to
         // say never — and an unreachable region is a hole in the
         // coverage gate rather than a nicety.
-        let checked = check_desc(desc);
+        let checked = check_desc(desc, self.shared.max_image_dimension_2d);
         let extent = desc.extent;
         let supplied = desc.rgba8.len();
         debug_assert!(
@@ -642,6 +649,63 @@ fn upload(
 
 #[cfg(test)]
 mod tests {
+
+    /// The same refusal on the upload path, for the same reason.
+    #[test]
+    fn a_texture_past_the_device_limit_is_refused_by_name() {
+        let pixels = [0u8; 16];
+        let refusal = check_desc(
+            &TextureDesc::new(
+                Extent {
+                    width: 65,
+                    height: 2,
+                },
+                &pixels,
+            ),
+            64,
+        )
+        .expect_err("past the limit is not a texture");
+        assert!(
+            matches!(refusal, TargetError::Creation { call, code: 0 }
+                if call == "create_texture(extent exceeds the device limit)"),
+            "refused as {refusal:?}, which names no cause"
+        );
+
+        // Reported before the pixel-length rule, so a caller whose
+        // extent is impossible hears about the extent rather than about
+        // a byte count derived from it.
+        let refusal = check_desc(
+            &TextureDesc::new(
+                Extent {
+                    width: 65,
+                    height: 65,
+                },
+                &pixels,
+            ),
+            64,
+        )
+        .expect_err("past the limit is not a texture");
+        assert!(
+            matches!(refusal, TargetError::Creation { call, .. }
+                if call == "create_texture(extent exceeds the device limit)"),
+            "the extent rule must be reported before the length rule: {refusal:?}"
+        );
+
+        assert!(
+            check_desc(
+                &TextureDesc::new(
+                    Extent {
+                        width: 2,
+                        height: 2,
+                    },
+                    &pixels,
+                ),
+                2,
+            )
+            .is_ok(),
+            "the limit itself is allowed"
+        );
+    }
     use super::*;
 
     /// The byte count is `width * height * 4`, and the multiplication is
@@ -678,53 +742,62 @@ mod tests {
         let pixels = [0u8; 16];
 
         assert!(matches!(
-            check_desc(&TextureDesc::new(
-                Extent {
-                    width: 0,
-                    height: 2
-                },
-                &pixels
-            )),
+            check_desc(
+                &TextureDesc::new(
+                    Extent {
+                        width: 0,
+                        height: 2
+                    },
+                    &pixels
+                ),
+                u32::MAX
+            ),
             Err(TargetError::Creation {
                 call: "create_texture(zero extent)",
                 ..
             })
         ));
         assert!(matches!(
-            check_desc(&TextureDesc::new(
-                Extent {
-                    width: 2,
-                    height: 0
-                },
-                &pixels
-            )),
+            check_desc(
+                &TextureDesc::new(
+                    Extent {
+                        width: 2,
+                        height: 0
+                    },
+                    &pixels
+                ),
+                u32::MAX
+            ),
             Err(TargetError::Creation {
                 call: "create_texture(zero extent)",
                 ..
             })
         ));
         assert!(matches!(
-            check_desc(&TextureDesc::new(
-                Extent {
-                    width: u32::MAX,
-                    height: u32::MAX
-                },
-                &pixels
-            )),
+            check_desc(
+                &TextureDesc::new(
+                    Extent {
+                        width: u32::MAX,
+                        height: u32::MAX
+                    },
+                    &pixels
+                ),
+                u32::MAX
+            ),
             Err(TargetError::Creation {
                 call: "create_texture(extent overflows)",
                 ..
             })
         ));
         assert!(matches!(
-            check_desc(&TextureDesc::new(good, &pixels[..15])),
+            check_desc(&TextureDesc::new(good, &pixels[..15]), u32::MAX),
             Err(TargetError::Creation {
                 call: "create_texture(pixel length)",
                 ..
             })
         ));
         assert!(matches!(
-            check_desc(&TextureDesc::new(good, &pixels)),
+            check_desc(&TextureDesc::new(good, &pixels), u32::MAX),
             Ok(16)
         ));
     }

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -923,6 +923,39 @@ fn every_driver_failure_ladder_behaves() {
         }));
     }
 
+    // PB5 is not a ladder rung: the ladder above fails one driver call
+    // and checks which one is named, while this checks the refusal that
+    // happens before any call at all.
+    //
+    // **It is the one scenario here whose absence was a real defect.**
+    // `create_buffer` had no poison gate while all seven other resource
+    // entry points did, and none of the four calls it makes lists
+    // `VK_ERROR_DEVICE_LOST` among its return codes -- so on a dead
+    // device it did not fail loudly or even quietly, it *succeeded*, and
+    // handed back a live buffer. The loss is induced through a texture
+    // upload, the same way T17 induces it, because poisoning needs a
+    // submit and creating a buffer performs none.
+    verdicts.push(device_case(
+        "PB5",
+        "vkQueueSubmit2=ERROR_DEVICE_LOST",
+        |device| {
+            match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
+                Err(TargetError::DeviceLost) => {}
+                Err(other) => return Err(wrong("PB5", "DeviceLost", &other)),
+                Ok(_) => return Err("PB5: the upload survived a lost device".to_owned()),
+            }
+            match device.create_buffer(64, BufferUsage::PerFrame) {
+                Err(TargetError::DeviceLost) => Ok(()),
+                Err(other) => Err(wrong("PB5", "DeviceLost from create_buffer", &other)),
+                Ok(_) => Err(
+                    "PB5: a per-frame buffer was created on a lost device, which is the \
+                     defect this scenario exists for"
+                        .to_owned(),
+                ),
+            }
+        },
+    ));
+
     // ---- MB · mesh buffer ladder --------------------------------------------
     // Every fallible call `create_mesh` makes, in order, on the same
     // terms as the buffer ladder above: surface the right call, leave


### PR DESCRIPTION
`create_buffer` was the one resource entry point with no device-lost
gate. The other seven read the poison flag after their contract checks
and before any driver call; this one went from its capacity assertion
straight to `vkCreateBuffer`.

**What that actually did is worse than an inconsistent error.** None of
the four calls it makes — create, allocate, bind, map — lists
`VK_ERROR_DEVICE_LOST` among its return codes, so nothing failed. It
succeeded, and handed back a live buffer on a dead device, to a caller
every sibling call would have refused.

That is not read off the specification. Removing the new gate and running
the fault suite produces exactly one failure, and its message is the
finding:

```
PB5: a per-frame buffer was created on a lost device
```

The new scenario induces the loss through a texture upload, because
poisoning requires a submit and creating a buffer performs none. It sits
outside the buffer ladder deliberately: that ladder fails one driver call
and checks which one gets named, while this checks the refusal that
happens before any call at all.

A comment in the mesh path named this gap as a recorded inconsistency not
to be copied forward. It goes in the same change.