### PR TITLE
feat(cube): the world meshes to block faces, against a computed budget

### DIFF
--- a/samples/cube/README.md
+++ b/samples/cube/README.md
@@ -121,6 +121,61 @@ runs with `grounded=false`, which is a jump in progress rather than a
 fall — a jump clears about five blocks, and the script presses jump
 every seventeenth tick.
 
+## Meshing the world
+
+`mesh::faces` turns the grid into the block faces a renderer would draw:
+one quad per solid cell face whose neighbour is air. It is pure, it holds
+no renderer, and it runs on a machine with no GPU -- the same position
+the platformer's `scene` module occupies, for the same reason.
+
+**The rule is "the neighbour is air *inside* the grid", not "the neighbour
+is not solid".** Those sound identical and differ by more than half the
+mesh.
+
+`Grid::is_solid` answers `false` for cells outside the grid, deliberately:
+a player who walks out of the world should fall, so the void is not
+something to stand on. But a mesher written against that answer emits a
+face wherever the neighbour is not solid -- including every cell of the
+surrounding void -- so it also emits the box's entire **outer skin**. The
+faces are all behind the walls, so the picture from inside looks perfectly
+correct while the mesh is twice the size it should be, and the pipeline
+culls nothing, so those backfaces rasterize rather than being free.
+
+`Grid::get` answers with three cases where `is_solid` answers with two,
+and the third is the one that matters: `None` means outside. Meshing
+against `get` makes the distinction structural instead of something a
+reader has to remember.
+
+**The budget, computed before the mesher was written:**
+
+| | |
+|---|---|
+| Solid cells | 41x12x41 shell minus its 39x10x39 interior, plus a 5x2x5 mound = **5012** |
+| Cavity skin | 2(39x39) + 4(39x10) = **4602** |
+| Mound | +65 exposed, -25 floor faces it covers |
+| **Visible faces** | **4642** |
+| Outer skin, if the rule is wrong | **5330** more, for **9972** total |
+
+Both numbers are asserted. Swapping the emission rule to the naive one
+makes the arena mesh to exactly 9972, which is how the test knows it is
+testing something: the figures were derived from the arena's dimensions
+first, so a mesher that agreed with itself rather than with the arithmetic
+would fail.
+
+Faces are shaded by direction -- brightest up, dimmest down, the two
+horizontal axes distinguished. Nothing lights the scene in v0, so a world
+drawn in one colour per block type reads as a single silhouette with an
+outline; varying the colour by which way a face points is the cheapest
+thing that makes an edge visible, and it is free at runtime because the
+colour is baked into the vertex. A block type with no colour of its own
+comes out magenta rather than a plausible grey.
+
+Corners are wound counter-clockwise seen from outside, on every face, and
+a test says so -- even though the pipeline culls nothing today and a
+reversed quad draws identically. That is exactly why: the mistake is
+invisible until culling is switched on, and then half the world disappears
+with no recent change to blame.
+
 ## Shape
 
 Two crates. `world/` is the simulation: a fixed-step pure function of

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -11,6 +11,8 @@
 //! the world headless, and prints one line. Everything interesting is in the
 //! world; everything here is the seam that lets a machine ask it a question.
 
+pub mod mesh;
+
 use renew_fixed::{Fixed, Vec3};
 use renew_sample_cube_world::{Cell, Cube, Grid, Intent, STONE, Tuning};
 

--- a/samples/cube/src/mesh.rs
+++ b/samples/cube/src/mesh.rs
@@ -1,0 +1,188 @@
+//! The world's picture, as data: which block faces a renderer would draw,
+//! with no renderer in sight.
+//!
+//! Pure on purpose, and in the driver crate rather than the world crate.
+//! The world is fixed-point and declares `simulation = true`; face corners
+//! are `f32`, because that is what a vertex buffer holds. Putting them
+//! next to the simulation would mix float geometry into the one crate
+//! whose whole claim is bit-determinism, for a consumer the simulation
+//! does not have. The sibling game draws the same line in the same place.
+//!
+//! # The rule, and the trap it exists to avoid
+//!
+//! A face is emitted when a solid cell's neighbour is **air inside the
+//! grid** — not merely "not solid".
+//!
+//! `Grid::is_solid` answers `false` for cells outside the grid, and it is
+//! right to: a player who walks out of the world should fall, so outside
+//! is not something to stand on. But a mesher written against that answer
+//! emits a face wherever the neighbour is not solid, which includes every
+//! cell of the surrounding void — so it also emits the box's entire outer
+//! skin. For this arena that is **5330 extra faces against 4642 real
+//! ones**, more than doubling the mesh, and because the pipeline culls
+//! nothing those backfaces rasterize rather than being free.
+//!
+//! `Grid::get` answers with three cases where `is_solid` answers with two,
+//! and the third is the one that matters: `None` means outside. Meshing
+//! against `get` is what makes the difference structural rather than a
+//! condition somebody has to remember.
+
+use renew_sample_cube_world::grid::{AIR, Block, Cell, Grid, STONE};
+use renew_sample_cube_world::ray::Face;
+
+/// One block face a renderer would draw.
+///
+/// The cell and the direction rather than four corners, because that is
+/// the smallest thing that names the face — corners are derived, and a
+/// mesher that returned them would decide the winding for every consumer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Quad {
+    /// The solid cell this face belongs to.
+    pub cell: Cell,
+    /// Which side of that cell it is.
+    pub face: Face,
+    /// What the cell is made of, which decides the colour.
+    pub block: Block,
+}
+
+/// Half a block, in world units. A cell spans one unit and is centred on
+/// its integer coordinate, so every face sits exactly half a unit out.
+const HALF: f32 = 0.5;
+
+/// Every visible face in `grid`, in a fixed order.
+///
+/// **The order is part of the contract.** `Grid::solids` walks in
+/// ascending cell index and this walks the six faces in enum order within
+/// each cell, so the same grid always produces the same sequence — which
+/// is what makes the mesh reproducible, and what lets the renderer's
+/// submission order mean anything.
+#[must_use]
+pub fn faces(grid: &Grid) -> Vec<Quad> {
+    const SIDES: [Face; 6] = [
+        Face::East,
+        Face::West,
+        Face::Top,
+        Face::Bottom,
+        Face::North,
+        Face::South,
+    ];
+
+    let mut quads = Vec::new();
+    for (cell, block) in grid.solids() {
+        for face in SIDES {
+            let (dx, dy, dz) = face.step();
+            // `Some(AIR)`, not `!is_solid()`. See the module note: the
+            // difference is the outer skin of the world.
+            if grid.get(cell.offset(dx, dy, dz)) == Some(AIR) {
+                quads.push(Quad { cell, face, block });
+            }
+        }
+    }
+    quads
+}
+
+impl Quad {
+    /// The four corners, in world space, counter-clockwise seen from
+    /// outside the block.
+    ///
+    /// **Wound consistently even though nothing currently reads the
+    /// winding.** The pipeline culls no faces in v0, so a reversed quad
+    /// draws identically today — which is exactly why getting it right
+    /// now is cheap and getting it wrong is invisible until the day
+    /// culling is switched on and half the world disappears.
+    #[must_use]
+    pub fn corners(self) -> [[f32; 3]; 4] {
+        let (normal, u, v) = basis(self.face);
+        let centre = [
+            world_units(self.cell.x),
+            world_units(self.cell.y),
+            world_units(self.cell.z),
+        ];
+        let corner = |su: f32, sv: f32| {
+            [
+                centre[0] + (normal[0] + su * u[0] + sv * v[0]) * HALF,
+                centre[1] + (normal[1] + su * u[1] + sv * v[1]) * HALF,
+                centre[2] + (normal[2] + su * u[2] + sv * v[2]) * HALF,
+            ]
+        };
+        [
+            corner(-1.0, -1.0),
+            corner(1.0, -1.0),
+            corner(1.0, 1.0),
+            corner(-1.0, 1.0),
+        ]
+    }
+}
+
+/// A cell coordinate as a world-space distance.
+///
+/// **The precision the lint warns about cannot be reached from here.** An
+/// `i32` loses precision as an `f32` beyond 2^24, so a coordinate would
+/// have to name a cell sixteen million units from the origin — and a grid
+/// that wide would need at least 2^24 cells along that axis, which
+/// `Grid::new` allocates one byte apiece for. The allocation fails long
+/// before the arithmetic does, so the bound is enforced by the machine
+/// rather than by anyone remembering it.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "a coordinate past 2^24 needs a grid too large to allocate"
+)]
+fn world_units(coordinate: i32) -> f32 {
+    coordinate as f32
+}
+
+/// A face's outward normal and its two in-plane axes, chosen so that
+/// `u × v == normal` — which is what makes the corner order above
+/// counter-clockwise from outside without a per-face special case.
+const fn basis(face: Face) -> ([f32; 3], [f32; 3], [f32; 3]) {
+    match face {
+        Face::East => ([1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]),
+        Face::West => ([-1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]),
+        Face::Top => ([0.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, -1.0]),
+        Face::Bottom => ([0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
+        Face::North => ([0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+        Face::South => ([0.0, 0.0, -1.0], [-1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+    }
+}
+
+/// The colour a renderer should draw this face in.
+///
+/// **Shaded by direction, because a flat-coloured cube is a silhouette.**
+/// Nothing lights the scene in v0 — there is no light, no normal in the
+/// vertex format, and no shading in the built-in shader — so a world drawn
+/// in one colour per block type reads as a single blob with an outline.
+/// Varying the colour by which way a face points is the cheapest thing
+/// that makes edges visible, and it costs nothing at runtime because the
+/// colour is baked into the vertex.
+///
+/// The factors imitate a sky: brightest up, dimmest down, sides between,
+/// with the two horizontal axes distinguished so a corner between them
+/// reads as an edge.
+#[must_use]
+pub fn colour(block: Block, face: Face) -> [f32; 4] {
+    let base = base_colour(block);
+    let shade = shade(face);
+    [base[0] * shade, base[1] * shade, base[2] * shade, base[3]]
+}
+
+/// The unshaded colour of a block type.
+fn base_colour(block: Block) -> [f32; 4] {
+    match block {
+        STONE => [0.62, 0.60, 0.57, 1.0],
+        // Every other value, including `AIR`, which should never reach
+        // here because only solid cells are meshed. Magenta on purpose:
+        // a block type nobody gave a colour is a bug, and the picture
+        // should say so rather than quietly picking grey.
+        _ => [1.0, 0.0, 1.0, 1.0],
+    }
+}
+
+/// The brightness factor for a face's direction.
+fn shade(face: Face) -> f32 {
+    match face {
+        Face::Top => 1.0,
+        Face::Bottom => 0.55,
+        Face::North | Face::South => 0.82,
+        Face::East | Face::West => 0.68,
+    }
+}

--- a/samples/cube/tests/mesh.rs
+++ b/samples/cube/tests/mesh.rs
@@ -1,0 +1,261 @@
+//! The meshing rule, against a budget computed before any of it was
+//! written.
+//!
+//! §10 asks for the number first, and the design note carries it: the
+//! arena has 5012 solid cells and **4642** visible inward faces. The
+//! figure is not an observation of what this mesher produces — it was
+//! derived from the arena's dimensions, and these tests hold the code to
+//! it. A test that recorded whatever the code emitted would agree with a
+//! wrong mesher forever.
+
+use renew_sample_cube::mesh::{Quad, colour, faces};
+use renew_sample_cube_world::grid::{AIR, Cell, Grid, STONE};
+use renew_sample_cube_world::ray::Face;
+
+/// A step component as a float, without a cast.
+///
+/// `Face::step` answers with -1, 0 or 1 and nothing else, so there is no
+/// precision to lose -- and saying that in three arms is both cheaper and
+/// more honest than allowing a lint about a case that cannot arise.
+fn unit(component: i32) -> f32 {
+    match component {
+        1 => 1.0,
+        -1 => -1.0,
+        _ => 0.0,
+    }
+}
+
+/// Every direction, so a test cannot silently cover five of six.
+const EVERY_FACE: [Face; 6] = [
+    Face::East,
+    Face::West,
+    Face::Top,
+    Face::Bottom,
+    Face::North,
+    Face::South,
+];
+
+/// The arena's face count is exactly the budget.
+///
+/// **The number that matters is the one this is not.** A mesher written
+/// against `is_solid` emits the box's outer skin too — 5330 more faces,
+/// 9972 in total — and it looks perfectly correct from inside, because
+/// the extra faces are all behind the camera's back wall. Asserting the
+/// total is what separates the two.
+#[test]
+fn the_arena_meshes_to_its_computed_budget() {
+    let grid = renew_sample_cube::arena();
+    assert_eq!(
+        grid.solid_count(),
+        5012,
+        "the arena is not the one measured"
+    );
+
+    let quads = faces(&grid);
+    assert_eq!(
+        quads.len(),
+        4642,
+        "the budget is 4642 inward faces; 9972 means the outer skin is being emitted too"
+    );
+}
+
+/// Per direction, because the total can be right while the sides are not.
+///
+/// Top and bottom are 1521 each — the ceiling is 39×39, and the floor is
+/// 39×39 too once the mound's 25 covered cells are traded for the mound's
+/// own 25-cell top. Four walls of 39×10 give 400 apiece.
+#[test]
+fn each_direction_carries_its_share() {
+    let quads = faces(&renew_sample_cube::arena());
+    for (face, expected) in [
+        (Face::East, 400),
+        (Face::West, 400),
+        (Face::Top, 1521),
+        (Face::Bottom, 1521),
+        (Face::North, 400),
+        (Face::South, 400),
+    ] {
+        let found = quads.iter().filter(|quad| quad.face == face).count();
+        assert_eq!(found, expected, "{face:?} should carry {expected} faces");
+    }
+}
+
+/// A single block alone in the world meshes to **nothing**.
+///
+/// The sharpest statement of the rule in the smallest world: every one of
+/// its six neighbours is outside the grid, so a mesher reading
+/// "not solid" emits all six and this one emits none.
+#[test]
+fn a_lone_block_filling_its_grid_has_no_visible_face() {
+    let mut grid = Grid::new(Cell::new(0, 0, 0), (1, 1, 1));
+    grid.fill(Cell::new(0, 0, 0), Cell::new(0, 0, 0), STONE);
+    assert_eq!(grid.solid_count(), 1, "the block should be there");
+
+    assert_eq!(
+        faces(&grid).len(),
+        0,
+        "outside the grid is not air, so a block with nothing but void around it shows no face"
+    );
+}
+
+/// And a block with air beside it shows exactly the sides that touch air.
+///
+/// The complement of the test above: without this, emitting nothing ever
+/// would pass.
+#[test]
+fn a_block_shows_the_sides_that_touch_air() {
+    // A 3x1x1 strip: solid in the middle, air at both ends.
+    let mut grid = Grid::new(Cell::new(0, 0, 0), (3, 1, 1));
+    grid.fill(Cell::new(1, 0, 0), Cell::new(1, 0, 0), STONE);
+
+    let quads = faces(&grid);
+    assert_eq!(
+        quads.len(),
+        2,
+        "two neighbours are air; the other four are outside"
+    );
+    let mut directions: Vec<Face> = quads.iter().map(|quad| quad.face).collect();
+    directions.sort_by_key(|face| format!("{face:?}"));
+    assert_eq!(directions, vec![Face::East, Face::West]);
+}
+
+/// The order is fixed, so the same grid meshes to the same sequence.
+///
+/// This is the crate's contribution to a reproducible frame: the renderer
+/// draws in submission order, so a mesher that walked cells in a varying
+/// order would move the picture without changing the world.
+#[test]
+fn meshing_is_reproducible() {
+    let grid = renew_sample_cube::arena();
+    assert_eq!(
+        faces(&grid),
+        faces(&grid),
+        "the same grid must mesh identically"
+    );
+}
+
+/// Corners sit half a unit from the cell centre, on the face's own plane,
+/// and describe a unit square.
+#[test]
+fn a_face_is_a_unit_square_half_a_unit_out() {
+    for face in EVERY_FACE {
+        let quad = Quad {
+            cell: Cell::new(0, 0, 0),
+            face,
+            block: STONE,
+        };
+        let corners = quad.corners();
+
+        // Every corner is on the same plane, half a unit along the face's
+        // axis. Which axis that is comes from the step, so this does not
+        // restate the basis table it is checking.
+        let (dx, dy, dz) = face.step();
+        let axis = if dx != 0 {
+            0
+        } else if dy != 0 {
+            1
+        } else {
+            2
+        };
+        let sign = unit(dx + dy + dz);
+        for corner in corners {
+            assert!(
+                (corner[axis] - sign * 0.5).abs() < f32::EPSILON,
+                "{face:?}: corner {corner:?} is not on the face's plane"
+            );
+        }
+
+        // Four distinct corners, each one half-unit step from the next.
+        for index in 0..4 {
+            let here = corners[index];
+            let next = corners[(index + 1) % 4];
+            let distance = ((next[0] - here[0]).powi(2)
+                + (next[1] - here[1]).powi(2)
+                + (next[2] - here[2]).powi(2))
+            .sqrt();
+            assert!(
+                (distance - 1.0).abs() < 1e-6,
+                "{face:?}: edge {index} is {distance}, not one unit"
+            );
+        }
+    }
+}
+
+/// Winding is counter-clockwise seen from outside, on every face.
+///
+/// Nothing reads it today — the pipeline culls nothing — which is exactly
+/// why it needs a test. A reversed quad is invisible until culling is
+/// switched on, and then half the world vanishes with no recent change to
+/// blame.
+#[test]
+fn every_face_is_wound_counter_clockwise_from_outside() {
+    for face in EVERY_FACE {
+        let corners = Quad {
+            cell: Cell::new(0, 0, 0),
+            face,
+            block: STONE,
+        }
+        .corners();
+
+        let edge = |a: [f32; 3], b: [f32; 3]| [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let first = edge(corners[0], corners[1]);
+        let second = edge(corners[1], corners[2]);
+        let cross = [
+            first[1] * second[2] - first[2] * second[1],
+            first[2] * second[0] - first[0] * second[2],
+            first[0] * second[1] - first[1] * second[0],
+        ];
+
+        let (dx, dy, dz) = face.step();
+        let outward = [unit(dx), unit(dy), unit(dz)];
+        let dot = cross[0] * outward[0] + cross[1] * outward[1] + cross[2] * outward[2];
+        assert!(
+            dot > 0.0,
+            "{face:?}: the winding faces inward (cross {cross:?} against outward {outward:?})"
+        );
+    }
+}
+
+/// Every block-and-direction pair has a colour, and direction changes it.
+///
+/// The shading is the only thing separating one face from another in a
+/// picture with no light in it, so "they are all the same colour" is a
+/// real failure rather than a cosmetic one.
+#[test]
+fn colour_varies_by_direction_and_names_an_unknown_block() {
+    let top = colour(STONE, Face::Top);
+    let bottom = colour(STONE, Face::Bottom);
+    assert!(
+        top[0] > bottom[0] && top[1] > bottom[1] && top[2] > bottom[2],
+        "up should be brighter than down, or the world reads as a silhouette"
+    );
+
+    // All six differ from at least one other, and none is transparent.
+    let mut seen: Vec<[f32; 4]> = Vec::new();
+    for face in EVERY_FACE {
+        let shade = colour(STONE, face);
+        assert!(
+            (shade[3] - 1.0).abs() < f32::EPSILON,
+            "{face:?}: a block face is opaque"
+        );
+        seen.push(shade);
+    }
+    let distinct = seen
+        .iter()
+        .map(|value| format!("{value:?}"))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert!(
+        distinct.len() >= 4,
+        "at least four brightness levels, or adjacent faces blur into one shape: {distinct:?}"
+    );
+
+    // A block type nobody coloured is magenta rather than plausible, and
+    // air is meshed by nothing so it takes the same arm.
+    for unknown in [AIR, 7, 200] {
+        let shade = colour(unknown, Face::Top);
+        assert!(
+            shade[0] > 0.9 && shade[1] < 0.1 && shade[2] > 0.9,
+            "block {unknown} has no colour of its own, so it should shout: {shade:?}"
+        );
+    }
+}


### PR DESCRIPTION
One quad per solid cell face whose neighbour is air. Pure, and in the
driver crate rather than the world crate — the world is fixed-point and
its whole claim is bit-determinism, while face corners are `f32`.

**The rule is "the neighbour is air *inside* the grid", not "the
neighbour is not solid".** Those sound identical and differ by more than
half the mesh.

`Grid::is_solid` answers `false` for cells outside the grid, deliberately:
a player who walks out of the world should fall, so the void is not
something to stand on. A mesher written against that answer emits a face
wherever the neighbour is not solid — including every cell of the
surrounding void — so it also emits the box's entire **outer skin**. Every
one of those faces sits behind a wall, so the view from inside looks
perfectly correct while the mesh is twice the size it should be, and the
pipeline culls nothing, so they rasterize rather than being free.

`Grid::get` answers with three cases where `is_solid` answers with two,
and the third is the one that matters: `None` means outside.

**The budget was computed before the mesher existed**, from the arena's
dimensions:

| | |
|---|---|
| Solid cells | 41×12×41 shell less its 39×10×39 interior, plus a 5×2×5 mound = **5012** |
| Cavity skin | 2(39×39) + 4(39×10) = **4602** |
| Mound | +65 exposed, −25 floor faces covered |
| **Visible faces** | **4642** |
| Outer skin, if the rule is wrong | **5330** more — **9972** total |

Both figures are asserted, per direction as well as in total. Swapping the
emission rule to the naive one makes the arena mesh to exactly 9972, which
is how the test knows it is testing something rather than agreeing with
itself.

Faces are shaded by direction, because nothing lights the scene in v0: one
flat colour per block type reads as a single silhouette with an outline. A
block type nobody gave a colour comes out magenta rather than a plausible
grey.

Winding is counter-clockwise seen from outside on every face, and a test
says so even though the pipeline culls nothing today and a reversed quad
draws identically. That is the reason: the mistake stays invisible until
culling is switched on, and then half the world disappears with no recent
change to blame.

No renderer here and no GPU dependency — the sample's graph is unchanged.
Drawing this is the next step, and it needs a projection the maths crate
does not have yet.