### PR TITLE
refactor(png): the encoder becomes a crate, and its refusals gain causes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,19 @@ jobs:
           # happens to build.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render3d -p renew-sample-cube
           cargo build -p renew-sample-cube
+      # The image encoder. Its consumers are samples that draw a picture
+      # for their README, and each takes it optionally -- but the
+      # structure check counts a declared edge whether or not a feature
+      # enables it, so they are named here, and the property that makes
+      # the exclusion look unnecessary is probed directly below.
+      - name: Build and test without the image encoder
+        run: |
+          sel="--workspace --exclude renew-png --exclude renew-sample-cube"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-png $sel
+          cargo build $sel
+          cargo test $sel
+          RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-png -p renew-sample-cube
+          cargo build -p renew-sample-cube
       # The fixed-point arithmetic, and the collision crate written in it.
       # This cell was a single leaf when it landed, with a comment saying
       # the first crate to depend on it should discover the obligation
@@ -358,7 +371,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-png"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
 name = "renew-render2d"
 version = "0.1.0"
 dependencies = [
@@ -1778,6 +1785,7 @@ dependencies = [
  "proptest",
  "renew-fixed",
  "renew-platform",
+ "renew-png",
  "renew-render3d",
  "renew-rhi",
  "renew-sample-cube-world",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
+    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ time pending: 11666657 ns
 ## Modules
 
 Every module is independently buildable, testable, and — outside the minimal core —
-removable. CI proves the last part on every commit, and proves it *one crate at a time*: fifteen
+removable. CI proves the last part on every commit, and proves it *one crate at a time*: sixteen
 configurations, each with one optional crate and everything that depends on it excluded, every one
-built **and** tested. A sixteenth builds the minimal core alone and asserts that no optional crate
+built **and** tested. A seventeenth builds the minimal core alone and asserts that no optional crate
 reached its graph. The platform crate is built again with its windowing feature compiled away, and
 the game is built with no graphics crate in its dependency graph at all — which is the removability
 claim from the other side, and the reason the window is a feature rather than a default.
@@ -104,8 +104,9 @@ claim from the other side, and the reason the window is a feature rather than a 
 | **`renew-render3d`** | Indexed geometry, depth-tested, in submission order | `bootstrap` · optional |
 | **`renew-audio`** | Mixing and playback, behind the platform's device seam | `bootstrap` · optional |
 | **`renew-asset`** | Content-addressed asset packs, with every entry verifiable against its digest | `bootstrap` · optional |
+| **`renew-png`** | PNG encoding with no dependencies — pixels in, the bytes of a file out, so a sample can commit a picture of itself | `bootstrap` · optional |
 
-Twenty engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
+Twenty-one engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
 prints the live list with each crate's declared maturity, read from its manifest rather than from
 this table.
 
@@ -171,7 +172,7 @@ Every commit on `main` clears all of these, on Windows, Linux, and macOS:
 | No panicking shortcuts | `unwrap`, `expect`, `panic`, `todo`, `dbg!` denied outside tests |
 | `unsafe` denied by default | workspace-wide `unsafe_code = "deny"`; the crates that need it opt in per crate, and `undocumented_unsafe_blocks = "deny"` makes every block state the invariant that keeps it sound |
 | Module graph is a DAG | crate manifest and dependency-graph check (`renew check`) |
-| Optional modules stay removable | fifteen configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
+| Optional modules stay removable | sixteen configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
 | Licenses and advisories | `cargo-deny`, over the full dependency tree including dev-dependencies |
 | Sanitizers and Miri | scheduled nightly runs (ASan, TSan, Miri) |
 

--- a/crates/png/Cargo.toml
+++ b/crates/png/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "renew-png"
+description = "PNG encoding with no dependencies: RGBA pixels to the bytes of a file"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "PNG encoding with no dependencies: RGBA pixels in, the bytes of a file out. It never touches the filesystem."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/png/README.md
+++ b/crates/png/README.md
@@ -1,0 +1,86 @@
+# renew-png
+
+PNG encoding with no dependencies: RGBA pixels in, the bytes of a file
+out. It never touches the filesystem — writing the file is the caller's
+business, which is what keeps the encoder a pure function and testable
+without one.
+
+## What it is for
+
+A picture a person can look at. Samples draw their world and commit the
+result to their README; a debug capture wants the same thing. Encoding a
+PNG turns out not to need a compressor: the format's data is a zlib
+stream, and deflate's *fixed* Huffman tables are published constants, so
+the whole encoder is four chunks, two checksums and a small
+back-reference search.
+
+## The charter, so this does not become a junk drawer
+
+**The PNG format, in memory, and nothing else.**
+
+The one direction it may grow is a **decoder for the same format** —
+which `renew-asset` names as a missing piece — because encoding and
+decoding one format are one body of knowledge, and splitting them puts
+the same specification in two crates.
+
+Explicitly out of scope:
+
+- **A second image format.** That is a second crate.
+- **Anything that manipulates pixels** rather than framing them: no
+  resizing, no filtering, no colour conversion. That belongs to whoever
+  owns the pixels.
+- **File I/O.** The caller owns the file, for the same reason
+  `renew-asset` gives for owning its own.
+
+## What it does
+
+Fixed Huffman codes over a three-candidate back-reference search: the
+pixel to the left, the pixel above, and the byte before. Those are what a
+rendered picture is made of, and they take a 256×256 flat image from
+256 KiB to about **two kilobytes**.
+
+Data without that structure comes out slightly *larger* than raw, because
+fixed Huffman spends nine bits on half the byte values. That is the
+honest trade: this is an encoder for pictures of geometry, not for
+photographs.
+
+No dynamic Huffman, no filtering (every scanline carries filter byte 0),
+no palettes, no interlacing, 8-bit RGBA only.
+
+Output is a pure function of the pixels, so the same image encodes to the
+same bytes on every platform and every run — which is what lets an
+encoded file be compared rather than merely looked at.
+
+## How the format is checked
+
+The tests assert the byte layout against the specification: a
+hand-derived single-pixel file, the published check values for CRC-32 and
+Adler-32, the block split that only appears past 65535 bytes, the zlib
+header's multiple-of-31 rule, and the length and distance symbol tables
+against the published ones.
+
+**That is not enough on its own, and the tests say so.** One reading of a
+specification wrote both the encoder and the tests, so they agree with
+each other by construction. The output is therefore also handed to an
+independent decoder — flat, banded, striped and incompressible images,
+each checked for exact pixels.
+
+**It caught a real defect.** The length-symbol arithmetic was off by one,
+so every match of eleven bytes or more encoded as the wrong symbol. The
+file was still small, still structurally a PNG, still had a valid header,
+and every test passed. Only a decoder refused it. The symbol tables are
+pinned to the published ones now, so the next mistake fails here.
+
+## Errors
+
+`encode` returns `Result`, and the error names which of three caller
+mistakes it was: a shape with no pixels, a buffer that does not match the
+shape it claims, or an image too large for the format's lengths. It
+returned `Option` once, which told a caller that something was wrong and
+left them to work out which — and the three call for different fixes.
+
+## Manifest
+
+`Cargo.toml` is authoritative for maturity, core status, dependencies and
+extension points. Contract lints live in `clippy.toml`: clock reads,
+filesystem access and thread spawning are rejected at lint time.

--- a/crates/png/clippy.toml
+++ b/crates/png/clippy.toml
@@ -1,0 +1,30 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: this crate turns pixels into the bytes of a file — it never
+# reads a clock, never touches the filesystem, never spawns a thread.
+# Writing the file is the caller's business, which is what keeps the
+# encoder a pure function and testable without one.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "this crate never reads a clock; a scene is a pure function of its quads" },
+    { path = "std::time::SystemTime::now", reason = "this crate never reads a clock; a scene is a pure function of its quads" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem; a caller that writes an image owns the file" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/png/src/lib.rs
+++ b/crates/png/src/lib.rs
@@ -45,11 +45,74 @@
 //! files is not in the tree — judging the result needs an image library,
 //! and this repository has none.
 
+// An encoder hands back bytes; whoever asked for them decides where they
+// go. Printing from here would put a message somewhere the caller did
+// not choose, in a crate whose whole value is being a pure function.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
 /// The eight bytes every PNG starts with.
 const SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
 
 /// Bytes per pixel: 8-bit RGBA.
 const CHANNELS: usize = 4;
+
+/// Why an image could not be encoded.
+///
+/// **Three causes rather than one absence.** This began as an
+/// `Option<Vec<u8>>`, which told a caller that something was wrong and
+/// not which of three unrelated things — a shape with no pixels in it, a
+/// buffer that does not match the shape it claims, and an image too large
+/// for the format to describe. A caller can act on each differently, and
+/// the one that returns nothing tells them to guess.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodeError {
+    /// A width or a height of zero. An image with no pixels is not a
+    /// small image; PNG cannot describe it.
+    ZeroExtent {
+        /// The width asked for.
+        width: u32,
+        /// The height asked for.
+        height: u32,
+    },
+    /// The pixel buffer does not hold `width * height * 4` bytes.
+    PixelCount {
+        /// What the dimensions require.
+        expected: usize,
+        /// What arrived.
+        found: usize,
+    },
+    /// The image is too large for its size arithmetic to be exact — a
+    /// chunk past what a `u32` length can name, or a byte count past
+    /// what this machine can address.
+    TooLarge {
+        /// The width asked for.
+        width: u32,
+        /// The height asked for.
+        height: u32,
+    },
+}
+
+impl core::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ZeroExtent { width, height } => write!(
+                f,
+                "an image of {width}x{height} has no pixels, and PNG cannot describe one"
+            ),
+            Self::PixelCount { expected, found } => write!(
+                f,
+                "the dimensions need {expected} bytes of RGBA and {found} arrived"
+            ),
+            Self::TooLarge { width, height } => write!(
+                f,
+                "an image of {width}x{height} is past what the format's lengths can name"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EncodeError {}
 
 /// Encode `pixels` as an 8-bit RGBA PNG.
 ///
@@ -57,26 +120,34 @@ const CHANNELS: usize = 4;
 ///
 /// # Errors
 ///
-/// `None` when the dimensions are zero, when they disagree with the
-/// length of `pixels`, or when the encoded size would overflow the sizes
-/// PNG can express. Every one of those is a caller mistake rather than a
-/// condition to recover from, but an image writer that panicked on a bad
-/// size would be a poor neighbour to a command line.
-#[must_use]
-pub fn encode(width: u32, height: u32, pixels: &[u8]) -> Option<Vec<u8>> {
+/// [`EncodeError`], naming which of the three caller mistakes it was.
+/// Returned rather than asserted because an image writer that panicked on
+/// a bad size would be a poor neighbour to a command line.
+pub fn encode(width: u32, height: u32, pixels: &[u8]) -> Result<Vec<u8>, EncodeError> {
+    let too_large = || EncodeError::TooLarge { width, height };
     if width == 0 || height == 0 {
-        return None;
+        return Err(EncodeError::ZeroExtent { width, height });
     }
     // Checked throughout. The arithmetic here is exactly the arithmetic
     // that decides how much is copied later, so a wrap would produce a
     // plausible-looking header over the wrong number of bytes.
-    let row = usize::try_from(width).ok()?.checked_mul(CHANNELS)?;
-    let rows = usize::try_from(height).ok()?;
-    if pixels.len() != row.checked_mul(rows)? {
-        return None;
+    let row = usize::try_from(width)
+        .ok()
+        .and_then(|width| width.checked_mul(CHANNELS))
+        .ok_or_else(too_large)?;
+    let rows = usize::try_from(height).map_err(|_| too_large())?;
+    let expected = row.checked_mul(rows).ok_or_else(too_large)?;
+    if pixels.len() != expected {
+        return Err(EncodeError::PixelCount {
+            expected,
+            found: pixels.len(),
+        });
     }
     // Each scanline is prefixed with its filter byte.
-    let raw_len = row.checked_add(1)?.checked_mul(rows)?;
+    let raw_len = row
+        .checked_add(1)
+        .and_then(|stride| stride.checked_mul(rows))
+        .ok_or_else(too_large)?;
 
     let mut raw = Vec::with_capacity(raw_len);
     for line in pixels.chunks_exact(row) {
@@ -89,10 +160,10 @@ pub fn encode(width: u32, height: u32, pixels: &[u8]) -> Option<Vec<u8>> {
     header.extend_from_slice(&width.to_be_bytes());
     header.extend_from_slice(&height.to_be_bytes());
     header.extend_from_slice(&[8, 6, 0, 0, 0]); // depth 8, RGBA, no filter or interlace
-    chunk(&mut out, *b"IHDR", &header);
-    chunk(&mut out, *b"IDAT", &zlib(&raw, row + 1));
-    chunk(&mut out, *b"IEND", &[]);
-    Some(out)
+    chunk(&mut out, *b"IHDR", &header, &too_large)?;
+    chunk(&mut out, *b"IDAT", &zlib(&raw, row + 1), &too_large)?;
+    chunk(&mut out, *b"IEND", &[], &too_large)?;
+    Ok(out)
 }
 
 /// One PNG chunk: length, type, data, CRC.
@@ -101,8 +172,17 @@ pub fn encode(width: u32, height: u32, pixels: &[u8]) -> Option<Vec<u8>> {
 /// the data but not the length — a pairing that is easy to state and easy
 /// to get subtly wrong, which is why both are asserted by a hand-checked
 /// byte layout in the tests.
-fn chunk(out: &mut Vec<u8>, kind: [u8; 4], data: &[u8]) {
-    let length = u32::try_from(data.len()).unwrap_or(u32::MAX);
+fn chunk(
+    out: &mut Vec<u8>,
+    kind: [u8; 4],
+    data: &[u8],
+    too_large: &impl Fn() -> EncodeError,
+) -> Result<(), EncodeError> {
+    // Refused rather than saturated. A length clamped to `u32::MAX` would
+    // write a header describing four billion bytes over however many
+    // actually follow, which is a file no decoder can recover from and a
+    // failure this function is the last place to catch.
+    let length = u32::try_from(data.len()).map_err(|_| too_large())?;
     out.extend_from_slice(&length.to_be_bytes());
     out.extend_from_slice(&kind);
     out.extend_from_slice(data);
@@ -111,6 +191,7 @@ fn chunk(out: &mut Vec<u8>, kind: [u8; 4], data: &[u8]) {
     crc.eat(&kind);
     crc.eat(data);
     out.extend_from_slice(&crc.finish().to_be_bytes());
+    Ok(())
 }
 
 /// `raw` wrapped in a zlib stream, compressed with fixed Huffman codes
@@ -541,19 +622,80 @@ mod tests {
         assert_eq!(adler32(b"123456789"), 0x091e_01de);
     }
 
-    /// Malformed requests are refused rather than encoded.
+    /// Malformed requests are refused, and each says which mistake it
+    /// was.
+    ///
+    /// **The point of the error type.** All three of these once returned
+    /// the same `None`, which told a caller that something was wrong and
+    /// left them to work out which of three unrelated things — and they
+    /// call for different fixes: change the shape, send the right number
+    /// of bytes, or ask for a smaller picture.
     #[test]
-    fn impossible_images_are_refused() {
-        assert!(encode(0, 1, &[]).is_none(), "a zero width has no image");
-        assert!(encode(1, 0, &[]).is_none(), "a zero height has no image");
-        assert!(
-            encode(2, 2, &[0; 4]).is_none(),
+    fn each_impossible_image_names_its_own_cause() {
+        assert_eq!(
+            encode(0, 1, &[]),
+            Err(EncodeError::ZeroExtent {
+                width: 0,
+                height: 1
+            })
+        );
+        assert_eq!(
+            encode(1, 0, &[]),
+            Err(EncodeError::ZeroExtent {
+                width: 1,
+                height: 0
+            })
+        );
+        assert_eq!(
+            encode(2, 2, &[0; 4]),
+            Err(EncodeError::PixelCount {
+                expected: 16,
+                found: 4
+            }),
             "four bytes is one pixel, not four"
         );
-        assert!(
-            encode(u32::MAX, u32::MAX, &[0; 4]).is_none(),
+        assert_eq!(
+            encode(u32::MAX, u32::MAX, &[0; 4]),
+            Err(EncodeError::TooLarge {
+                width: u32::MAX,
+                height: u32::MAX
+            }),
             "a size that cannot be allocated is refused, not wrapped"
         );
+    }
+
+    /// Every refusal says something a reader can act on.
+    #[test]
+    fn every_refusal_displays_its_context() {
+        for (error, needle) in [
+            (
+                EncodeError::ZeroExtent {
+                    width: 0,
+                    height: 7,
+                },
+                "0x7",
+            ),
+            (
+                EncodeError::PixelCount {
+                    expected: 16,
+                    found: 4,
+                },
+                "16 bytes",
+            ),
+            (
+                EncodeError::TooLarge {
+                    width: 9,
+                    height: 9,
+                },
+                "9x9",
+            ),
+        ] {
+            let shown = error.to_string();
+            assert!(
+                shown.contains(needle),
+                "`{shown}` does not mention `{needle}`"
+            );
+        }
     }
 
     /// The same pixels encode to the same bytes, which is what lets an

--- a/samples/cube/Cargo.toml
+++ b/samples/cube/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 # carries no graphics crate at all, which is what lets the build matrix
 # prove this sample builds with the renderer removed.
 [features]
-render = ["dep:renew-rhi", "dep:renew-render3d"]
+render = ["dep:renew-rhi", "dep:renew-render3d", "dep:renew-png"]
 
 [dependencies]
 renew-platform = { path = "../../crates/core/platform", default-features = false }
@@ -32,6 +32,7 @@ renew-fixed = { path = "../../crates/fixed" }
 renew-sample-cube-world = { path = "world" }
 renew-rhi = { path = "../../crates/rhi", default-features = false, optional = true }
 renew-render3d = { path = "../../crates/render3d", optional = true }
+renew-png = { path = "../../crates/png", optional = true }
 
 # The projection is index-and-vector arithmetic, which is the row in the
 # testing table that asks for properties rather than examples. Same

--- a/samples/cube/src/lib.rs
+++ b/samples/cube/src/lib.rs
@@ -12,7 +12,6 @@
 //! world; everything here is the seam that lets a machine ask it a question.
 
 pub mod mesh;
-pub mod png;
 pub mod projection;
 #[cfg(feature = "render")]
 pub mod render;

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -7,7 +7,7 @@
 //!
 //! This module is the only one here that names a rendering crate. What it
 //! draws comes from [`crate::mesh`], where it lands comes from
-//! [`crate::projection`], and what it writes comes from [`crate::png`];
+//! [`crate::projection`], and what it writes comes from [`renew_png`];
 //! all three are pure and tested without a device.
 
 use renew_render3d::{MeshRenderer, Scene, attachment, pass};
@@ -64,8 +64,8 @@ const BACKDROP: Color = Color::new(0.09, 0.10, 0.13, 1.0);
 /// caller may reasonably carry on.
 pub fn to_png(grid: &Grid, path: &std::path::Path) -> Result<(), RenderError> {
     let pixels = draw(grid)?;
-    let png = crate::png::encode(SIZE, SIZE, &pixels)
-        .ok_or_else(|| RenderError::Output("the encoder refused the image".to_string()))?;
+    let png = renew_png::encode(SIZE, SIZE, &pixels)
+        .map_err(|error| RenderError::Output(error.to_string()))?;
     std::fs::write(path, png).map_err(|error| RenderError::Output(error.to_string()))
 }
 


### PR DESCRIPTION
It had one consumer and now has three — two more samples want to draw a
picture for their README, and a sample depending on another sample would
be a worse shape than the duplication it avoids.

`crates/png` is pure, has no dependencies, and never touches the
filesystem: writing the file stays the caller's business, which is what
keeps the encoder a function and testable without one.

**The README carries a charter**, because a crate called `png` is one
careless commit away from being a crate called `image`. The one direction
it may grow is a decoder for the same format — encoding and decoding one
format are one body of knowledge, and splitting them puts the same
specification in two crates. Resizing, filtering, colour conversion, a
second format and file I/O are all explicitly out.

**Two defects travelled with the code and are fixed rather than moved.**

`encode` returned `Option`, which told a caller that something was wrong
and left them to work out which of three unrelated things: a shape with
no pixels, a buffer that does not match the shape it claims, or an image
too large for the format's lengths. Those call for different fixes. It
returns a `Result` now whose variants carry the numbers.

And a chunk length was saturated to `u32::MAX` rather than refused —
which would write a header describing four billion bytes over however
many actually follow. That is a file no decoder can recover from, and
this function is the last place to catch it.

The encoder is optional for the sample that uses it, behind the same
feature as its renderer, so the game a player runs carries neither. The
removability matrix gains a cell of its own — sixteen now — and the
minimal-core absence loop names it, which is the part most easily
forgotten and the one whose absence silently drops a crate from the gate.

A guard caught something a module-to-crate move loses: the crate-root
`print_stdout`/`print_stderr` denies that every engine crate carries and
a module inherits from its parent.