### PR TITLE
fix(cube): every direction is the same speed

### DIFF
--- a/samples/cube/README.md
+++ b/samples/cube/README.md
@@ -244,13 +244,11 @@ and you walk north-east. It is steppy, and honest: a smoother walk needs a
 fixed-point vector in the world's own vocabulary, which is a change to the
 simulation rather than to the driver.
 
-**A diagonal is about forty per cent faster than a straight line**, since
-the world scales each axis by the walk speed independently and a diagonal
-moves on both. That is the world's arithmetic, not the driver's, and it
-predates any of this — but the driver is the first thing that lets a
-player produce a diagonal at all, so it is the first place worth saying
-so. Normalising it is a change to the simulation and to every digest that
-walks.
+**Every one of the eight directions is the same speed.** Scaling each
+axis by the walk speed independently would make a diagonal `sqrt(2)` times
+faster — about forty per cent — so both axes are scaled by `1/sqrt(2)`
+when both are moving. The world does this rather than the driver, because
+it is the world that decides what a step covers.
 
 **Turning is fixed point, and that is not fussiness.** Yaw and pitch feed
 `Angle::sin_cos`, which is fixed point and identical on every platform,

--- a/samples/cube/world/src/lib.rs
+++ b/samples/cube/world/src/lib.rs
@@ -186,8 +186,26 @@ impl Cube {
 
         self.act(intent);
 
-        let walk_x = Fixed::from_int(intent.walk_x.clamp(-1, 1)) * self.tuning.walk_speed;
-        let walk_z = Fixed::from_int(intent.walk_z.clamp(-1, 1)) * self.tuning.walk_speed;
+        // **A diagonal is not faster than a straight line.** Scaling each
+        // axis by the walk speed independently gives a diagonal a
+        // magnitude of sqrt(2) times the speed, so a player crossing the
+        // arena corner to corner arrives about forty per cent sooner for
+        // no reason they can see. Both axes are scaled by 1/sqrt(2) when
+        // both are moving, which makes every one of the eight directions
+        // the same speed.
+        //
+        // `sqrt` here rather than a written-down constant: it is exact in
+        // this crate's own arithmetic and cannot drift from the two it is
+        // reconciling. It costs a handful of integer operations on a tick
+        // that is about to do collision resolution.
+        let (step_x, step_z) = (intent.walk_x.clamp(-1, 1), intent.walk_z.clamp(-1, 1));
+        let speed = if step_x != 0 && step_z != 0 {
+            self.tuning.walk_speed * Fixed::from_ratio(1, 2).sqrt()
+        } else {
+            self.tuning.walk_speed
+        };
+        let walk_x = Fixed::from_int(step_x) * speed;
+        let walk_z = Fixed::from_int(step_z) * speed;
 
         let pressed = intent.jump && !self.jump_was_held;
         let mut vertical = if pressed && self.grounded {

--- a/samples/cube/world/tests/voxel.rs
+++ b/samples/cube/world/tests/voxel.rs
@@ -549,3 +549,68 @@ fn a_placed_block_is_not_the_stone_it_was_placed_against() {
     );
     assert_ne!(BRICK, STONE, "or the distinction is a name only");
 }
+
+/// **Every direction is the same speed.** Scaling each axis by the walk
+/// speed independently made a diagonal `sqrt(2)` times faster, so a
+/// player crossing the arena corner to corner arrived about forty per
+/// cent sooner for no reason they could see.
+///
+/// Measured as distance covered rather than as a velocity, because the
+/// velocity is an implementation detail and the distance is what a player
+/// experiences.
+#[test]
+fn walking_a_diagonal_is_not_faster_than_walking_straight() {
+    let travelled = |x: i32, z: i32| {
+        let mut world = Cube::new(Tuning::default(), flat_world(), v(0, 4, 0));
+        // Land first: falling is not what this measures.
+        for _ in 0..40 {
+            world.step(Intent::IDLE);
+        }
+        let start = world.eye();
+        for _ in 0..30 {
+            world.step(Intent::walking(x, z));
+        }
+        let end = world.eye();
+        let (dx, dz) = (end.x - start.x, end.z - start.z);
+        // Squared, so the comparison needs no square root and no
+        // tolerance for one.
+        dx * dx + dz * dz
+    };
+
+    let straight = travelled(1, 0);
+    let diagonal = travelled(1, 1);
+    let slack = straight / Fixed::from_int(20);
+    assert!(
+        (diagonal - straight).abs() <= slack,
+        "a diagonal covered {diagonal:?} against a straight line's {straight:?}"
+    );
+}
+
+/// And the other diagonals agree with the first, so the fix is about
+/// magnitude rather than about one lucky sign.
+#[test]
+fn all_four_diagonals_cover_the_same_ground() {
+    let travelled = |x: i32, z: i32| {
+        let mut world = Cube::new(Tuning::default(), flat_world(), v(0, 4, 0));
+        for _ in 0..40 {
+            world.step(Intent::IDLE);
+        }
+        let start = world.eye();
+        for _ in 0..30 {
+            world.step(Intent::walking(x, z));
+        }
+        let end = world.eye();
+        let (dx, dz) = (end.x - start.x, end.z - start.z);
+        dx * dx + dz * dz
+    };
+
+    let first = travelled(1, 1);
+    for (x, z) in [(1, -1), (-1, 1), (-1, -1)] {
+        let other = travelled(x, z);
+        let slack = first / Fixed::from_int(20);
+        assert!(
+            (other - first).abs() <= slack,
+            "({x}, {z}) covered {other:?} against the (1, 1) diagonal's {first:?}"
+        );
+    }
+}


### PR DESCRIPTION
Scaling each axis by the walk speed independently made a diagonal `sqrt(2)` times faster, so a player crossing the arena corner to corner arrived about forty per cent sooner for no reason they could see. Both axes are scaled by `1/sqrt(2)` when both are moving, which makes every one of the eight directions the same speed.

Computed with this crate's own `sqrt` rather than a written-down constant, so it cannot drift from the arithmetic it is reconciling. It costs a handful of integer operations on a tick that is about to do collision resolution.

## No digest moved

That is the reason this waited rather than shipping with the driver that first made diagonals reachable. Every built-in script is single-axis — `walking(1, 0)`, `(0, 1)`, `(-1, 0)`, `(0, -1)`, exhaustively — so nothing compared across platforms or quoted in a document walks a diagonal at all. `build`, `stand` and `patrol` all report what they reported before, and the check that the README quotes what the binary prints passed untouched.

## The test

It measures **distance covered** rather than velocity, because velocity is an implementation detail and distance is what a player experiences. It compares squared distances, so it needs no square root and no tolerance for one.

Confirmed against the bug rather than assumed to catch it: with the fix reverted it fails with a squared-distance ratio of exactly 2.0 — which is `sqrt(2)` in distance, the forty per cent this was about. A second test checks all four diagonals agree, so the fix is about magnitude rather than about one lucky sign.