### PR TITLE
feat(platform): raw pointer motion, and a cursor the window can hold

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -65,17 +65,6 @@ lines = [455, 517]
 reason = "A release-mode refusal guarded by a debug assertion on the same condition, so it is unreachable in any build that measures coverage. It is the last defence against dispatching on a poisoned pool, or over a live batch, in a build with assertions off."
 
 [[exempt]]
-file = "crates/core/platform/src/window.rs"
-lines = [358, 359]
-reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
-
-[[exempt]]
-file = "crates/core/platform/src/window.rs"
-lines = [651]
-reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
-
-
-[[exempt]]
 file = "crates/asset/src/write.rs"
 lines = [94, 95, 100, 101, 105, 106, 129, 130, 133, 134]
 reason = "The width guards on the pack's own header fields. Reaching one needs more than four billion entries, or more than four gibibytes of names or of payload in a single pack; the per-entry pair is narrower still, since a name is already bounded to 1024 bytes and a blob length is a usize widening to u64. They are checked conversions rather than casts because a silently wrapped length is a reader pointed at arbitrary bytes, and because the count field is the kind that gets widened later. Unreachable on a 64-bit target and retained for the 32-bit one the platform list does not exclude."
@@ -122,5 +111,20 @@ reason = "The comparison refusing to start because no workspace root is above it
 
 [[exempt]]
 file = "samples/cube/src/windowed.rs"
-lines = [436, 437, 438, 439, 440, 441, 495]
+lines = [534, 535, 536, 537, 538, 539, 593]
 reason = "The two places a window resize is acted on: rebuilding the crosshair for the new shape, and telling the swapchain its new size. Both need a real window-system resize, and the lane that measures coverage has none - its windowed runs happen under a virtual display with no window manager, so the window it opens is the only size it will ever be. Note for anyone running coverage on a desktop: these lines ARE covered there, because a real window manager sends a resize on the way up, and the gate will call this exemption stale. The gate that decides is the headless one. Everything these lines follow from is covered everywhere: record_present drives the recovery from a dormant swapchain with a constructed outcome, the resize event handler is driven with a constructed event, and the crosshair geometry is checked at four aspects without a device."
+
+[[exempt]]
+file = "crates/core/platform/src/window.rs"
+lines = [476, 477]
+reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
+
+[[exempt]]
+file = "crates/core/platform/src/window.rs"
+lines = [804]
+reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
+
+[[exempt]]
+file = "crates/core/platform/src/window.rs"
+lines = [404, 405, 406, 407, 408, 409, 410, 411, 412, 413]
+reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run."

--- a/crates/core/event/src/lib.rs
+++ b/crates/core/event/src/lib.rs
@@ -61,6 +61,31 @@ pub enum WindowEvent {
         pressed: bool,
         repeat: bool,
     },
+    /// The pointer moved by this much, in whatever units the platform
+    /// reports.
+    ///
+    /// **Raw movement, not a position**, and the difference is what a
+    /// first-person view needs. [`Self::PointerMoved`] carries where the
+    /// cursor is inside the window: it stops at the edge, and stops
+    /// entirely when the cursor leaves, so a view driven by it stops
+    /// turning halfway through a turn. This carries how far the device
+    /// moved and is unaffected by where any cursor is or whether one
+    /// exists.
+    ///
+    /// A device-scoped event in a window-scoped enum, deliberately. This
+    /// enum is an application's single input channel — [`Self::Key`] is
+    /// already device-scoped — and a second enum would buy accuracy of
+    /// naming at the cost of a second seam in every application.
+    ///
+    /// Not comparable with [`Self::PointerMoved`]'s coordinates: the
+    /// platform may report these in a different scale entirely, and the
+    /// only sound use is as a delta multiplied by a sensitivity.
+    PointerMotion {
+        /// Rightward movement.
+        dx: f64,
+        /// Downward movement.
+        dy: f64,
+    },
     PointerMoved {
         x: f64,
         y: f64,
@@ -151,6 +176,7 @@ pub const EVERY_EVENT_SHAPE: &[WindowEvent] = &[
         repeat: false,
     },
     WindowEvent::PointerMoved { x: 12.5, y: 34.5 },
+    WindowEvent::PointerMotion { dx: -3.5, dy: 1.25 },
     WindowEvent::PointerButton {
         button: PointerButton::Left,
         pressed: true,
@@ -183,9 +209,10 @@ pub const fn shape_index(event: &WindowEvent) -> usize {
         WindowEvent::RedrawRequested => 3,
         WindowEvent::Key { .. } => 4,
         WindowEvent::PointerMoved { .. } => 5,
-        WindowEvent::PointerButton { .. } => 6,
-        WindowEvent::Wheel { .. } => 7,
-        WindowEvent::Focused(_) => 8,
+        WindowEvent::PointerMotion { .. } => 6,
+        WindowEvent::PointerButton { .. } => 7,
+        WindowEvent::Wheel { .. } => 8,
+        WindowEvent::Focused(_) => 9,
     }
 }
 

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -92,6 +92,41 @@ impl WindowRef<'_> {
     /// An owned, opaque handle to this window for the renderer's surface
     /// creation. The returned value KEEPS THE WINDOW ALIVE for as long
     /// as it (or anything owning it) exists — surface validity is
+    /// Hold the cursor inside the window and hide it, or let it go.
+    ///
+    /// **Answers rather than refuses.** Cursor confinement is one of the
+    /// places the three desktops genuinely differ, and a caller can do
+    /// nothing useful with the distinction between one compositor's
+    /// refusal and another's — what it *can* do is fall back to keys. A
+    /// `Result` would push a platform-specific error into every caller to
+    /// be discarded on the spot.
+    ///
+    /// `true` means the cursor is held and hidden; `false` means this
+    /// platform would not, and the caller should carry on without it. A
+    /// first-person sample must stay playable either way.
+    ///
+    /// Confined first and locked second, which is winit's own documented
+    /// order: Windows supports the first, macOS the second, and the
+    /// X11/Wayland pair varies by compositor.
+    #[must_use]
+    pub fn grab_cursor(&self, held: bool) -> bool {
+        use winit::window::CursorGrabMode;
+
+        let granted = if held {
+            self.window
+                .set_cursor_grab(CursorGrabMode::Confined)
+                .or_else(|_| self.window.set_cursor_grab(CursorGrabMode::Locked))
+                .is_ok()
+        } else {
+            self.window.set_cursor_grab(CursorGrabMode::None).is_ok()
+        };
+        // Hidden only when the grab took: a hidden cursor that can still
+        // wander out of the window is worse than a visible one, because
+        // the player cannot see where it went.
+        self.window.set_cursor_visible(!(held && granted));
+        granted
+    }
+
     /// ownership, not convention.
     #[must_use]
     pub fn native(&self) -> NativeWindow {
@@ -332,10 +367,44 @@ impl ApplicationHandler for Adapter<'_> {
         self.dispatch(&event);
     }
 
+    /// Raw device motion, which does not arrive with the window events.
+    ///
+    /// **The only device event forwarded, and deliberately so.** A window
+    /// event says what happened to the window; this says what a device
+    /// did, regardless of which window had focus or whether a cursor
+    /// exists. A first-person view needs exactly this and nothing else on
+    /// this seam, so everything else is dropped rather than translated
+    /// into a vocabulary no caller has asked for.
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        if let Some(translated) = translate_device_event(&event) {
+            self.app.event(translated);
+        }
+    }
+
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         if self.tick() {
             event_loop.exit();
         }
+    }
+}
+
+/// Translate one OS device event into the engine vocabulary.
+///
+/// Only motion has a meaning here; everything else returns `None`,
+/// dropped deliberately rather than accidentally — the same rule the
+/// window translation follows.
+fn translate_device_event(event: &winit::event::DeviceEvent) -> Option<WindowEvent> {
+    match event {
+        winit::event::DeviceEvent::MouseMotion { delta } => Some(WindowEvent::PointerMotion {
+            dx: delta.0,
+            dy: delta.1,
+        }),
+        _ => None,
     }
 }
 
@@ -452,6 +521,41 @@ fn translate_wheel(delta: winit::event::MouseScrollDelta) -> (f32, f32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **Raw motion crosses as a delta, not a position.** The two are
+    /// different events for a reason: a view driven by the cursor's
+    /// position stops turning when the cursor stops moving at the edge of
+    /// the window, and the whole point of this one is that it does not.
+    #[test]
+    fn device_motion_crosses_as_a_delta() {
+        assert_eq!(
+            translate_device_event(&winit::event::DeviceEvent::MouseMotion {
+                delta: (-3.5, 1.25)
+            }),
+            Some(WindowEvent::PointerMotion { dx: -3.5, dy: 1.25 })
+        );
+    }
+
+    /// Every other device event is dropped deliberately rather than
+    /// translated into a vocabulary no caller has asked for.
+    #[test]
+    fn other_device_events_are_dropped_on_purpose() {
+        for event in [
+            winit::event::DeviceEvent::MouseWheel {
+                delta: winit::event::MouseScrollDelta::LineDelta(0.0, 1.0),
+            },
+            winit::event::DeviceEvent::Motion {
+                axis: 0,
+                value: 1.0,
+            },
+            winit::event::DeviceEvent::Button {
+                button: 0,
+                state: winit::event::ElementState::Pressed,
+            },
+        ] {
+            assert_eq!(translate_device_event(&event), None, "{event:?}");
+        }
+    }
     use winit::event::{MouseButton, MouseScrollDelta};
     use winit::keyboard::{KeyCode as Wk, PhysicalKey};
 

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -73,6 +73,13 @@ impl LoopControl {
 /// A live window, borrowed by [`WindowApp::ready`].
 pub struct WindowRef<'a> {
     window: &'a std::sync::Arc<winit::window::Window>,
+    /// Where a cursor request is remembered, so the loop can reapply it
+    /// when focus returns.
+    ///
+    /// A `Cell` because the application is handed `&WindowRef` and this
+    /// is the one thing it may change — and because the event loop is a
+    /// single thread, so there is nothing here for a lock to protect.
+    cursor_wanted: &'a core::cell::Cell<bool>,
 }
 
 impl WindowRef<'_> {
@@ -105,26 +112,13 @@ impl WindowRef<'_> {
     /// platform would not, and the caller should carry on without it. A
     /// first-person sample must stay playable either way.
     ///
-    /// Confined first and locked second, which is winit's own documented
-    /// order: Windows supports the first, macOS the second, and the
-    /// X11/Wayland pair varies by compositor.
+    /// **Asked for once.** The loop remembers the request and reapplies
+    /// it when focus returns, so a caller does not have to — and cannot,
+    /// since only this seam is handed a window.
     #[must_use]
     pub fn grab_cursor(&self, held: bool) -> bool {
-        use winit::window::CursorGrabMode;
-
-        let granted = if held {
-            self.window
-                .set_cursor_grab(CursorGrabMode::Confined)
-                .or_else(|_| self.window.set_cursor_grab(CursorGrabMode::Locked))
-                .is_ok()
-        } else {
-            self.window.set_cursor_grab(CursorGrabMode::None).is_ok()
-        };
-        // Hidden only when the grab took: a hidden cursor that can still
-        // wander out of the window is worse than a visible one, because
-        // the player cannot see where it went.
-        self.window.set_cursor_visible(!(held && granted));
-        granted
+        self.cursor_wanted.set(held);
+        grab_on(self.window, held)
     }
 
     /// ownership, not convention.
@@ -245,6 +239,7 @@ pub fn run_window_app(config: &WindowConfig, app: &mut dyn WindowApp) -> Result<
         app,
         window: None,
         failure: None,
+        cursor_wanted: core::cell::Cell::new(false),
     };
     let run = event_loop.run_app(&mut adapter);
     adapter.outcome(run)
@@ -259,6 +254,17 @@ struct Adapter<'a> {
     /// loop so it surfaces through `run_window_app`'s Result instead of
     /// a log line.
     failure: Option<String>,
+    /// Whether the application asked for the cursor to be held.
+    ///
+    /// **The layer owns the grab's lifecycle, not the application.** A
+    /// cursor held across a tab away traps a player in a window they are
+    /// trying to leave, so focus loss must release it — and an
+    /// application that had to re-grab afterwards would need to change
+    /// window state from an event, which this seam does not allow. So the
+    /// request is remembered here and reapplied when focus returns, and
+    /// mouse look survives alt-tab without the application knowing it
+    /// happened.
+    cursor_wanted: core::cell::Cell<bool>,
 }
 
 /// Where a window comes from: the running loop's creation call, reduced
@@ -295,7 +301,10 @@ impl Adapter<'_> {
         match create(attributes) {
             Ok(window) => {
                 let window = std::sync::Arc::new(window);
-                self.app.ready(&WindowRef { window: &window });
+                self.app.ready(&WindowRef {
+                    window: &window,
+                    cursor_wanted: &self.cursor_wanted,
+                });
                 self.window = Some(window);
             }
             Err(message) => {
@@ -307,9 +316,26 @@ impl Adapter<'_> {
     /// Deliver one OS event to the app. Events with no engine meaning
     /// are dropped here — deliberately, not accidentally.
     fn dispatch(&mut self, event: &winit::event::WindowEvent) {
+        // Before the app sees it: a held cursor is the layer's to manage,
+        // and the app's own handling of focus must not race it.
+        if let winit::event::WindowEvent::Focused(focused) = event
+            && self.cursor_wanted.get()
+        {
+            self.apply_cursor_grab(*focused);
+        }
         if let Some(translated) = translate_event(event) {
             self.app.event(translated);
         }
+    }
+
+    /// Hold or release the cursor on the live window, if there is one.
+    ///
+    /// The request itself is remembered by the caller; this is only the
+    /// asking. A window that has gone away has nothing to hold.
+    fn apply_cursor_grab(&self, held: bool) -> bool {
+        self.window
+            .as_ref()
+            .is_some_and(|window| grab_on(window, held))
     }
 
     /// One loop iteration's app work, after the events. Returns whether
@@ -406,6 +432,29 @@ fn translate_device_event(event: &winit::event::DeviceEvent) -> Option<WindowEve
         }),
         _ => None,
     }
+}
+
+/// Hold or release the cursor on `window`, and hide it while held.
+///
+/// Confined first and locked second, which is winit's own documented
+/// order: Windows supports the first, macOS the second, and the
+/// X11/Wayland pair varies by compositor. Answers whether it took.
+fn grab_on(window: &winit::window::Window, held: bool) -> bool {
+    use winit::window::CursorGrabMode;
+
+    let granted = if held {
+        window
+            .set_cursor_grab(CursorGrabMode::Confined)
+            .or_else(|_| window.set_cursor_grab(CursorGrabMode::Locked))
+            .is_ok()
+    } else {
+        window.set_cursor_grab(CursorGrabMode::None).is_ok()
+    };
+    // Hidden only when the grab took: a hidden cursor that can still
+    // wander out of the window is worse than a visible one, because the
+    // player cannot see where it went.
+    window.set_cursor_visible(!(held && granted));
+    granted
 }
 
 /// Translate one OS window event into the engine vocabulary. Events
@@ -776,6 +825,7 @@ mod tests {
             app,
             window: None,
             failure: None,
+            cursor_wanted: core::cell::Cell::new(false),
         }
     }
 

--- a/crates/replay/src/convert.rs
+++ b/crates/replay/src/convert.rs
@@ -129,6 +129,10 @@ pub fn to_trace(event: WindowEvent) -> Result<TraceEvent, Unencodable> {
             (Some(x), Some(y)) => TraceEvent::PointerMoved { x, y },
             _ => return Err(Unencodable { shape }),
         },
+        WindowEvent::PointerMotion { dx, dy } => match (FiniteF64::new(dx), FiniteF64::new(dy)) {
+            (Some(dx), Some(dy)) => TraceEvent::PointerMotion { dx, dy },
+            _ => return Err(Unencodable { shape }),
+        },
         WindowEvent::Wheel { dx, dy } => match (FiniteF32::new(dx), FiniteF32::new(dy)) {
             (Some(dx), Some(dy)) => TraceEvent::Wheel { dx, dy },
             _ => return Err(Unencodable { shape }),
@@ -197,6 +201,10 @@ pub const fn from_trace(event: TraceEvent) -> WindowEvent {
             button: button_from_trace(button),
             pressed,
         },
+        TraceEvent::PointerMotion { dx, dy } => WindowEvent::PointerMotion {
+            dx: dx.value(),
+            dy: dy.value(),
+        },
         TraceEvent::PointerMoved { x, y } => WindowEvent::PointerMoved {
             x: x.value(),
             y: y.value(),
@@ -213,8 +221,33 @@ pub const fn from_trace(event: TraceEvent) -> WindowEvent {
 
 #[cfg(test)]
 mod tests {
-    use super::{Unencodable, to_trace};
+    use super::{Unencodable, from_trace, to_trace};
     use renew_event::{EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index};
+
+    /// **Raw pointer motion round-trips like everything else.** The
+    /// format gained a token of its own for it rather than storing a
+    /// delta under the position's: a recording that confused the two
+    /// would replay as a cursor teleporting to the origin.
+    #[test]
+    fn raw_pointer_motion_survives_the_round_trip() {
+        let motion = WindowEvent::PointerMotion { dx: 1.5, dy: -2.0 };
+        let encoded = to_trace(motion).expect("motion encodes");
+        assert_eq!(from_trace(encoded), motion);
+    }
+
+    /// A delta that is not a number is refused, like every other
+    /// float-bearing shape: the format holds finite values only.
+    #[test]
+    fn a_motion_that_is_not_a_number_is_refused() {
+        let refused = to_trace(WindowEvent::PointerMotion {
+            dx: f64::NAN,
+            dy: 0.0,
+        });
+        assert!(
+            matches!(refused, Err(Unencodable { .. })),
+            "got {refused:?}"
+        );
+    }
 
     /// Every shape the window seam can produce has an encoding.
     ///

--- a/crates/trace/src/event.rs
+++ b/crates/trace/src/event.rs
@@ -288,6 +288,18 @@ pub enum TraceEvent {
         x: FiniteF64,
         y: FiniteF64,
     },
+    /// Raw pointer movement since the last such event.
+    ///
+    /// Not a position, and not comparable with [`Self::PointerMoved`]'s
+    /// coordinates: the platform reports these in its own scale, and the
+    /// only sound use is as a delta. Recorded because a session driven by
+    /// mouse look is not reproducible without it.
+    PointerMotion {
+        /// Rightward movement.
+        dx: FiniteF64,
+        /// Downward movement.
+        dy: FiniteF64,
+    },
     PointerButton {
         button: TraceButton,
         pressed: bool,

--- a/crates/trace/src/grammar.rs
+++ b/crates/trace/src/grammar.rs
@@ -57,6 +57,15 @@ pub(crate) const EVENT: &str = "e";
 /// The nine kinds of event, one per line shape.
 pub(crate) const KEY: &str = "key";
 pub(crate) const POINTER: &str = "pointer";
+
+/// Raw pointer movement, as a delta rather than a position.
+///
+/// A separate token from `pointer` because the two are different
+/// quantities that happen to share a shape: one says where the cursor
+/// is, the other how far the device moved. A recording that stored a
+/// delta under the position's token would replay as a cursor teleporting
+/// to the origin.
+pub(crate) const MOTION: &str = "motion";
 pub(crate) const BUTTON: &str = "button";
 pub(crate) const WHEEL: &str = "wheel";
 pub(crate) const FOCUS: &str = "focus";

--- a/crates/trace/src/parse.rs
+++ b/crates/trace/src/parse.rs
@@ -20,8 +20,8 @@ use crate::error::{TraceError, TraceErrorKind};
 use crate::event::{FiniteF32, FiniteF64, TraceButton, TraceEvent, TraceKey};
 use crate::grammar::{
     ASSIGN, BUDGET, BUTTON, CLOSE, DOWN, EVENT, FIRST_EVENT_LINE, FOCUS, FOCUS_IN, FOCUS_OUT,
-    FORMAT_VERSION, HEADER_LINE, HEX_PREFIX, KEY, MAGIC, OTHER_BUTTON, POINTER, REDRAW, REPEAT,
-    RESIZE, SAMPLE, SCALE, SEPARATOR, TICKS, TIMESTEP_NS, UP, WHEEL,
+    FORMAT_VERSION, HEADER_LINE, HEX_PREFIX, KEY, MAGIC, MOTION, OTHER_BUTTON, POINTER, REDRAW,
+    REPEAT, RESIZE, SAMPLE, SCALE, SEPARATOR, TICKS, TIMESTEP_NS, UP, WHEEL,
 };
 use crate::trace::{Trace, TraceHeader};
 
@@ -180,6 +180,10 @@ fn parse_event(number: usize, line: &str) -> Result<(u64, TraceEvent), TraceErro
         POINTER => TraceEvent::PointerMoved {
             x: cursor.hex_f64("the pointer's x coordinate")?,
             y: cursor.hex_f64("the pointer's y coordinate")?,
+        },
+        MOTION => TraceEvent::PointerMotion {
+            dx: cursor.hex_f64("the pointer's rightward movement")?,
+            dy: cursor.hex_f64("the pointer's downward movement")?,
         },
         BUTTON => {
             let name = cursor.expect("the pointer button")?;

--- a/crates/trace/src/parse.rs
+++ b/crates/trace/src/parse.rs
@@ -540,6 +540,14 @@ mod tests {
                 y: FiniteF64::new(-2.0).unwrap(),
             }
         );
+        // The delta's own token, read back as a delta.
+        assert_eq!(
+            one("e 0 motion 0x3ff8000000000000 0xc000000000000000"),
+            TraceEvent::PointerMotion {
+                dx: FiniteF64::new(1.5).unwrap(),
+                dy: FiniteF64::new(-2.0).unwrap(),
+            }
+        );
         assert_eq!(
             one("e 0 button middle down"),
             TraceEvent::PointerButton {

--- a/crates/trace/src/write.rs
+++ b/crates/trace/src/write.rs
@@ -11,8 +11,8 @@
 use crate::event::{FiniteF32, FiniteF64, TraceEvent};
 use crate::grammar::{
     ASSIGN, BUDGET, BUTTON, CLOSE, DOWN, EVENT, FOCUS, FOCUS_IN, FOCUS_OUT, FORMAT_VERSION,
-    HEX_PREFIX, KEY, MAGIC, POINTER, REDRAW, REPEAT, RESIZE, SAMPLE, SCALE, SEPARATOR, TICKS,
-    TIMESTEP_NS, UP, WHEEL,
+    HEX_PREFIX, KEY, MAGIC, MOTION, POINTER, REDRAW, REPEAT, RESIZE, SAMPLE, SCALE, SEPARATOR,
+    TICKS, TIMESTEP_NS, UP, WHEEL,
 };
 use crate::trace::Trace;
 
@@ -73,6 +73,11 @@ fn event_line(tick: u64, event: &TraceEvent) -> String {
             "{EVENT} {tick} {POINTER} {x} {y}",
             x = hex_f64(x),
             y = hex_f64(y),
+        ),
+        TraceEvent::PointerMotion { dx, dy } => format!(
+            "{EVENT} {tick} {MOTION} {dx} {dy}",
+            dx = hex_f64(dx),
+            dy = hex_f64(dy),
         ),
         TraceEvent::PointerButton { button, pressed } => format!(
             "{EVENT} {tick} {BUTTON} {button} {state}",

--- a/crates/trace/src/write.rs
+++ b/crates/trace/src/write.rs
@@ -189,6 +189,15 @@ mod tests {
             }),
             "e 4 pointer 0x3ff8000000000000 0xc000000000000000"
         );
+        // A delta gets a token of its own. Stored under `pointer` it
+        // would read back as a cursor teleporting to the origin.
+        assert_eq!(
+            line(TraceEvent::PointerMotion {
+                dx: FiniteF64::new(1.5).unwrap(),
+                dy: FiniteF64::new(-2.0).unwrap(),
+            }),
+            "e 4 motion 0x3ff8000000000000 0xc000000000000000"
+        );
         assert_eq!(
             line(TraceEvent::PointerButton {
                 button: TraceButton::Left,

--- a/samples/cube/README.md
+++ b/samples/cube/README.md
@@ -234,6 +234,7 @@ cargo run -p renew-sample-cube --features window --bin cube -- --window
 | **space** | jump |
 | **enter** *or* **left click** | break the block you are looking at, which is lit while you aim at it |
 | **tab** *or* **right click** | place one against it |
+| **mouse** | look around |
 | **escape** | stop |
 
 **Walking is camera-relative, in eight directions.** The world takes
@@ -276,11 +277,22 @@ prints its digest. `stand` is genuinely idle, so it is both the default
 and the way to say "no script, I am playing" — which is why watching does
 not need a flag of its own.
 
-**Looking is on the keys, not the pointer.** Turning the view with the
-mouse needs the cursor held inside the window, and this engine's window
-layer has no way to ask for that yet. A mouse-look that stops dead when
-the pointer reaches the edge of the screen is worse than one that is
-honestly absent, so the arrows do it and the mouse breaks and places.
+**Look with the mouse, or with the arrows.** The cursor is held inside
+the window so a turn does not stop when the pointer reaches the edge of
+the screen. Where a platform will not hold it — cursor confinement is one
+of the places the three desktops genuinely differ — the mouse simply does
+not turn the view, the arrows still do, and nothing is lost.
+
+**Escape stops the game, and the window takes the cursor with it.** Tab
+away and the cursor is freed too, by the same event that drops whatever
+keys were held.
+
+**The mouse's float never reaches the world.** Deltas arrive as `f64`;
+they are scaled into hundredths of a degree, accumulated in an integer,
+and only whole degrees are handed to the angle. The remainder stays for
+the next movement, so a slow drag turns the view rather than rounding
+away to nothing — and a played run's digest stays a function of its
+inputs rather than of the platform's floating-point behaviour.
 
 **Pitch stops short of vertical.** At exactly straight up the look
 direction is parallel to world up, the camera basis has no unique answer,

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -71,6 +71,14 @@ use crate::{Options, Report, arena};
 /// number of ticks and a run that turns and returns ends where it began.
 const TURN_DEGREES: i32 = 3;
 
+/// How far the view turns per unit the mouse reports, in hundredths of
+/// a degree.
+///
+/// A stated unit rather than a tuned number: the platform reports motion
+/// in its own scale, and this converts it. It is the first thing that
+/// should become configurable if anyone asks for a sensitivity slider.
+const MOUSE_HUNDREDTHS: i32 = 12;
+
 /// How far pitch may travel from level, in degrees. Short of a right
 /// angle on purpose: at exactly vertical the look direction and world up
 /// are parallel and the camera basis has no unique answer.
@@ -180,6 +188,23 @@ pub struct CubeApp {
     /// hertz — with nothing on screen saying why.
     limit: Option<u32>,
     closing: bool,
+    /// Mouse movement not yet spent, in hundredths of a degree.
+    ///
+    /// **This is where the mouse's float stops.** Deltas arrive as
+    /// `f64`; the world is fixed point and its digest must depend on
+    /// nothing but its inputs. A float reaching `look_at` would make a
+    /// played run's digest a function of the platform's floating-point
+    /// behaviour, which is exactly what turning with `Angle` was written
+    /// to avoid.
+    ///
+    /// So the float is converted here, once, into hundredths of a degree,
+    /// and only whole degrees are ever handed to `Angle::from_degrees`.
+    /// The remainder stays for the next event, so slow movement
+    /// accumulates rather than rounding to nothing.
+    turn_owed: (i32, i32),
+    /// Whether the cursor is held. `false` on a platform that would not,
+    /// which is ordinary rather than exceptional — the arrows still turn.
+    cursor_held: bool,
     /// The wall clock the frame loop reads. The only clock in the file,
     /// and it reaches the driver alone.
     clock: Clock,
@@ -275,6 +300,8 @@ impl CubeApp {
             limit: options.window_ticks,
             script,
             closing: false,
+            turn_owed: (0, 0),
+            cursor_held: false,
             clock: Clock::start(),
             frame: None,
             size: Extent {
@@ -301,6 +328,70 @@ impl CubeApp {
         ));
     }
 
+    /// Let the cursor go, and forget what it owed.
+    ///
+    /// Both halves matter. A held cursor traps a player who wanted to
+    /// reach something else; a turn left owed across the gap snaps the view
+    /// round when they come back.
+    ///
+    /// The window is told separately, when there is one — this is the
+    /// driver's own state, and it is what every other decision here
+    /// reads.
+    fn release_cursor(&mut self) {
+        self.cursor_held = false;
+        self.turn_owed = (0, 0);
+    }
+
+    /// Turn the view by a mouse movement.
+    ///
+    /// **The float ends here.** The delta is scaled into hundredths of a
+    /// degree and added to an integer owed; `advance` spends the whole
+    /// degrees and keeps the rest. Nothing downstream of this sees
+    /// anything but an `i32`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the value is rounded to an integer and clamped inside i32's range on the two                   lines above the cast, so there is no fraction left to truncate and no                   magnitude left to lose"
+    )]
+    fn aim_by_mouse(&mut self, dx: f64, dy: f64) {
+        if !self.cursor_held {
+            // Without a grab the cursor wanders out of the window mid-turn
+            // and the view stops for no reason a player can see. Better to
+            // do nothing and leave the arrows in charge.
+            return;
+        }
+        let scale = f64::from(MOUSE_HUNDREDTHS);
+        // Rounded to an integer *before* the conversion, and clamped to a
+        // range an `i32` holds, so the cast can neither truncate a
+        // fraction nor overflow. A delta big enough to reach the clamp is
+        // a device reporting nonsense, and a clamp is the right answer to
+        // that as much as to a real spin.
+        let hundredths = |delta: f64| -> i32 {
+            let scaled = (delta * scale).round();
+            if !scaled.is_finite() {
+                return 0;
+            }
+            // `i32::MAX / 2` as an f64 is exact, and the clamp brings the
+            // value inside it, so `try_from` on the rounded integer part
+            // cannot fail — the fallback is unreachable and says so.
+            let bounded = scaled.clamp(-f64::from(i32::MAX / 2), f64::from(i32::MAX / 2));
+            bounded as i32
+        };
+        self.turn_owed.0 = self.turn_owed.0.saturating_add(hundredths(dx));
+        self.turn_owed.1 = self.turn_owed.1.saturating_add(hundredths(dy));
+    }
+
+    /// The whole degrees owed, taken out of the accumulator.
+    ///
+    /// Truncating toward zero, so a remainder keeps its sign and a slow
+    /// drag in one direction accumulates instead of oscillating.
+    fn spend_owed_turn(&mut self) -> (i32, i32) {
+        let yaw = self.turn_owed.0 / 100;
+        let pitch = self.turn_owed.1 / 100;
+        self.turn_owed.0 -= yaw * 100;
+        self.turn_owed.1 -= pitch * 100;
+        (yaw, pitch)
+    }
+
     /// One simulation step from what is held down.
     fn advance(&mut self) {
         if self.held.turn_left {
@@ -310,8 +401,15 @@ impl CubeApp {
             self.yaw = self.yaw + Angle::from_degrees(TURN_DEGREES);
         }
         let pitch = i32::from(self.held.look_up) - i32::from(self.held.look_down);
-        self.pitch_degrees =
-            (self.pitch_degrees + pitch * TURN_DEGREES).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+        // Whole degrees the mouse has earned since the last step. Added
+        // to the keys rather than replacing them: both are ways of
+        // turning, and a player using one should not disable the other.
+        let (mouse_yaw, mouse_pitch) = self.spend_owed_turn();
+        self.yaw = self.yaw + Angle::from_degrees(mouse_yaw);
+        // Down on the screen is down in pitch, which is the sign a player
+        // expects: pushing the mouse forward looks up.
+        self.pitch_degrees = (self.pitch_degrees + pitch * TURN_DEGREES - mouse_pitch)
+            .clamp(-PITCH_LIMIT, PITCH_LIMIT);
         self.aim();
 
         let intent = if let Some(script) = self.script {
@@ -562,6 +660,11 @@ impl WindowApp for CubeApp {
         self.aim();
         let (width, height) = window.physical_size();
         self.size = Extent { width, height };
+        // **`false` is ordinary, not a failure.** Cursor confinement is
+        // one of the places the three desktops differ; where it is
+        // refused the arrows still turn and nothing is lost, which is
+        // why nothing here reports it as a problem.
+        self.cursor_held = window.grab_cursor(true);
         let outcome = self.bring_up(window);
         self.record_bring_up(outcome);
         // Anchored after bring-up: device creation can take a noticeable
@@ -583,7 +686,14 @@ impl WindowApp for CubeApp {
             // away mid-stride and the player would walk into a wall until
             // the window came back and the key was pressed and released
             // again.
-            WindowEvent::Focused(false) => self.held = Held::default(),
+            WindowEvent::Focused(false) => {
+                self.held = Held::default();
+                // The cursor goes with the keys: a player who has tabbed
+                // away must be able to reach whatever they tabbed to, and
+                // a held cursor is the one thing that stops them.
+                self.release_cursor();
+            }
+            WindowEvent::PointerMotion { dx, dy } => self.aim_by_mouse(dx, dy),
             // **The mouse does what the mouse does in this genre.** Left
             // breaks the block being aimed at, right places one against
             // it — the same two edges the keys carry, because a player
@@ -611,6 +721,14 @@ impl WindowApp for CubeApp {
                 // block, not one every tick.
                 KeyCode::Enter => self.held.dig |= pressed,
                 KeyCode::Tab => self.held.place |= pressed,
+                // **Escape ends the game, and that releases the cursor
+                // with it.** A two-stage escape — free the cursor, then
+                // quit — is the convention, and it needs the app to
+                // change window state from an event, which this seam
+                // cannot do: only `ready` is handed a window. Routing a
+                // request back through the loop is a larger change than
+                // the difference is worth while alt-tab already frees the
+                // cursor by losing focus. Recorded rather than half-done.
                 KeyCode::Escape => self.closing |= pressed,
                 KeyCode::Unidentified => {}
             },
@@ -1009,6 +1127,157 @@ mod tests {
         play(app, control, 60, now);
     }
 
+    /// **Slow movement accumulates rather than rounding to nothing.**
+    /// Half a degree twice is one degree; a mouse moved gently would
+    /// otherwise turn the view not at all, however long it was moved.
+    #[test]
+    fn a_turn_smaller_than_a_degree_is_owed_rather_than_lost() {
+        let mut app = app();
+        app.cursor_held = true;
+
+        // Half a degree: fifty hundredths, which is under the hundred a
+        // whole degree costs.
+        let half_a_degree = 50.0 / f64::from(MOUSE_HUNDREDTHS);
+        app.aim_by_mouse(half_a_degree, 0.0);
+        assert_eq!(app.spend_owed_turn(), (0, 0), "half a degree is not one");
+        assert_eq!(app.turn_owed.0, 50, "and it is still owed");
+
+        app.aim_by_mouse(half_a_degree, 0.0);
+        assert_eq!(
+            app.spend_owed_turn(),
+            (1, 0),
+            "two halves make the degree the first one did not"
+        );
+        assert_eq!(app.turn_owed.0, 0, "and nothing is owed after it is spent");
+    }
+
+    /// The remainder keeps its sign, so a slow drag one way accumulates
+    /// instead of oscillating about zero.
+    #[test]
+    fn a_remainder_keeps_its_direction() {
+        let mut app = app();
+        app.cursor_held = true;
+        let one_and_a_half = 150.0 / f64::from(MOUSE_HUNDREDTHS);
+
+        app.aim_by_mouse(-one_and_a_half, 0.0);
+        assert_eq!(app.spend_owed_turn(), (-1, 0));
+        assert_eq!(app.turn_owed.0, -50, "the leftover is still leftward");
+    }
+
+    /// **Nothing but whole degrees reaches the world.** The mouse's `f64`
+    /// stops at the accumulator: a float reaching `look_at` would make a
+    /// played run's digest a function of the platform's floating-point
+    /// behaviour, which is what turning with `Angle` exists to avoid.
+    #[test]
+    fn the_world_only_ever_sees_whole_degrees() {
+        let mut app = app();
+        app.cursor_held = true;
+        let before = app.world.look();
+
+        // A movement worth well under a degree changes nothing at all,
+        // rather than nudging the look direction by a fraction.
+        app.aim_by_mouse(0.3, 0.2);
+        app.advance();
+        let after = app.world.look();
+
+        // The yaw is unmoved because nothing whole was owed; the world's
+        // own look is fixed point either way, and comparing it is the
+        // check that no float slipped through.
+        assert_eq!(
+            app.yaw,
+            Angle::ZERO,
+            "a fraction of a degree turned the view"
+        );
+        assert_eq!(before.x, after.x, "the world's look moved by a fraction");
+        assert_eq!(before.z, after.z, "the world's look moved by a fraction");
+    }
+
+    /// Pushing the mouse forward looks up, which is the sign a player
+    /// expects, and pitch still stops short of vertical.
+    #[test]
+    fn the_mouse_pitches_the_way_a_player_expects_and_stops_short() {
+        let mut app = app();
+        app.cursor_held = true;
+
+        // Forward is negative dy on every platform's screen coordinates.
+        app.aim_by_mouse(0.0, -1000.0);
+        app.advance();
+        assert!(app.pitch_degrees > 0, "forward should look up");
+        assert!(
+            app.pitch_degrees <= PITCH_LIMIT,
+            "pitch ran past the limit: {}",
+            app.pitch_degrees
+        );
+
+        app.aim_by_mouse(0.0, 1_000_000.0);
+        app.advance();
+        assert!(
+            app.pitch_degrees >= -PITCH_LIMIT,
+            "pitch ran past the limit the other way: {}",
+            app.pitch_degrees
+        );
+    }
+
+    /// **Without a grab the mouse does nothing**, which is the whole of
+    /// how this degrades on a platform that will not hold a cursor: the
+    /// arrows still turn and nothing is lost.
+    #[test]
+    fn without_a_held_cursor_the_mouse_is_ignored() {
+        let mut app = app();
+        assert!(!app.cursor_held, "nothing has granted a grab");
+
+        app.aim_by_mouse(500.0, 500.0);
+        assert_eq!(
+            app.turn_owed,
+            (0, 0),
+            "an ungrabbed cursor wanders out of the window mid-turn, so it drives nothing"
+        );
+    }
+
+    /// Losing focus lets the cursor go and forgets what it owed.
+    ///
+    /// Both halves matter: a held cursor would trap a player who has
+    /// tabbed away, and a turn left owed across the gap would snap the view
+    /// round when they came back.
+    #[test]
+    fn losing_focus_releases_the_cursor_and_what_it_owed() {
+        use renew_event::WindowEvent;
+
+        let mut app = app();
+        app.cursor_held = true;
+        app.aim_by_mouse(50.0, 50.0);
+        assert_ne!(app.turn_owed, (0, 0));
+
+        app.event(WindowEvent::Focused(false));
+        assert!(
+            !app.cursor_held,
+            "a held cursor traps a player who tabbed away"
+        );
+        assert_eq!(
+            app.turn_owed,
+            (0, 0),
+            "a kept owed turn snaps the view on return"
+        );
+    }
+
+    /// A device reporting nonsense turns the view a lot, and does not
+    /// overflow the accumulator doing it.
+    #[test]
+    fn an_absurd_delta_is_clamped_rather_than_wrapping() {
+        let mut app = app();
+        app.cursor_held = true;
+
+        for delta in [f64::MAX, f64::INFINITY, f64::NAN, -f64::MAX] {
+            app.turn_owed = (0, 0);
+            app.aim_by_mouse(delta, delta);
+            let (yaw, pitch) = app.spend_owed_turn();
+            assert!(
+                yaw.abs() <= i32::MAX / 100 && pitch.abs() <= i32::MAX / 100,
+                "delta {delta} produced {yaw}, {pitch}"
+            );
+        }
+    }
+
     /// **Played, not simulated: the keys move the player where they are
     /// looking.** Every other test here checks a part — the mapping, the
     /// rotation, the pacing. This presses keys and asks the world what
@@ -1289,6 +1558,7 @@ mod tests {
         closed.event(WindowEvent::CloseRequested);
         assert!(closed.done());
 
+        // With no cursor held, one press ends it.
         let mut escaped = app();
         escaped.event(WindowEvent::Key {
             code: KeyCode::Escape,

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -328,17 +328,17 @@ impl CubeApp {
         ));
     }
 
-    /// Let the cursor go, and forget what it owed.
+    /// Forget the movement not yet spent.
     ///
-    /// Both halves matter. A held cursor traps a player who wanted to
-    /// reach something else; a turn left owed across the gap snaps the view
-    /// round when they come back.
+    /// **The cursor itself is not this file's to release.** The window
+    /// layer frees it when focus is lost and takes it back when focus
+    /// returns, because a caller cannot change window state outside
+    /// bring-up — and because a grab that had to be re-asked for after
+    /// every alt-tab would be a grab that quietly stopped working.
     ///
-    /// The window is told separately, when there is one — this is the
-    /// driver's own state, and it is what every other decision here
-    /// reads.
-    fn release_cursor(&mut self) {
-        self.cursor_held = false;
+    /// What is this file's is the turn: kept across the gap, it would
+    /// snap the view round the moment a player came back.
+    fn forget_owed_turn(&mut self) {
         self.turn_owed = (0, 0);
     }
 
@@ -688,10 +688,11 @@ impl WindowApp for CubeApp {
             // again.
             WindowEvent::Focused(false) => {
                 self.held = Held::default();
-                // The cursor goes with the keys: a player who has tabbed
-                // away must be able to reach whatever they tabbed to, and
-                // a held cursor is the one thing that stops them.
-                self.release_cursor();
+                // The window layer frees the cursor itself and takes it
+                // back when focus returns, so nothing here touches it.
+                // What would survive the gap and should not is the turn
+                // not yet spent.
+                self.forget_owed_turn();
             }
             WindowEvent::PointerMotion { dx, dy } => self.aim_by_mouse(dx, dy),
             // **The mouse does what the mouse does in this genre.** Left
@@ -1240,7 +1241,7 @@ mod tests {
     /// tabbed away, and a turn left owed across the gap would snap the view
     /// round when they came back.
     #[test]
-    fn losing_focus_releases_the_cursor_and_what_it_owed() {
+    fn losing_focus_forgets_the_turn_but_not_the_grab() {
         use renew_event::WindowEvent;
 
         let mut app = app();
@@ -1250,8 +1251,8 @@ mod tests {
 
         app.event(WindowEvent::Focused(false));
         assert!(
-            !app.cursor_held,
-            "a held cursor traps a player who tabbed away"
+            app.cursor_held,
+            "the window layer owns the grab across a focus change; this file must not fight it"
         );
         assert_eq!(
             app.turn_owed,

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -1128,6 +1128,27 @@ mod tests {
         play(app, control, 60, now);
     }
 
+    /// **Motion reaches the view through the event, not only the
+    /// helper.** Every test above calls `aim_by_mouse` directly, which
+    /// says nothing about whether the event is wired to it — and a
+    /// mapping that compiled but was never matched would look exactly
+    /// like a mouse nobody had plugged in.
+    #[test]
+    fn a_motion_event_turns_the_view() {
+        use renew_event::WindowEvent;
+
+        let mut app = app();
+        app.cursor_held = true;
+        app.event(WindowEvent::PointerMotion {
+            dx: 500.0 / f64::from(MOUSE_HUNDREDTHS),
+            dy: 0.0,
+        });
+        assert_eq!(
+            app.turn_owed.0, 500,
+            "the event should reach the accumulator the helper fills"
+        );
+    }
+
     /// **Slow movement accumulates rather than rounding to nothing.**
     /// Half a degree twice is one degree; a mouse moved gently would
     /// otherwise turn the view not at all, however long it was moved.


### PR DESCRIPTION
A first-person view cannot be driven by `PointerMoved`: it carries an absolute position, so the view stops turning when the cursor reaches the edge of the window and stops entirely when it leaves. What is needed is raw motion, which winit reports on a seam this engine's window layer did not forward at all.

`WindowEvent::PointerMotion { dx, dy }` carries it, and `WindowRef::grab_cursor` holds and hides the cursor so the motion keeps coming.

## The grab answers rather than refuses

Cursor confinement is one of the places the three desktops genuinely differ, and a caller can do nothing with the distinction between one compositor's refusal and another's — what it *can* do is fall back to keys. A `Result` would push a platform-specific error into every caller to be discarded on the spot. Confined first and locked second, which is winit's own documented order.

Where a platform will not hold the cursor, the mouse simply does not turn the view, the arrows still do, and nothing is lost. **That is the only behaviour no lane can test** — no runner has a cursor — so it is the one the sample is built to survive.

## The mouse's float stops at the driver

Deltas arrive as `f64`. They scale into hundredths of a degree, accumulate in an integer, and only whole degrees reach `Angle::from_degrees`. A float reaching the world would make a played run's digest a function of the platform's floating-point behaviour, which is exactly what turning with `Angle` was written to avoid.

The remainder carries between events, so a slow drag turns the view rather than rounding away to nothing — asserted by a test that moves half a degree twice and expects one whole degree with nothing owed after.

## Two crates beyond the two it looked like

Adding a window-event shape is not a local addition. Two crates hold an exhaustive match over that vocabulary, both built as forcing functions:

* `renew-replay` will not compile until the new shape encodes — and two of its tests assert that **every** shape round-trips, because a recording is complete or it is not one;
* `renew-trace` therefore gained a token of its own for a delta, since storing one under the position's token would replay as a cursor teleporting to the origin.

Both guards did exactly what they were built for. Honouring them cost about thirty lines; not having them would have cost a mouse-driven session replaying with half its input missing, discovered by whoever next tried to reproduce a bug from a trace.

## One thing designed and then reverted

A two-stage escape — first press frees the cursor, second quits — is the convention, and implementing it turned up a limit worth recording — `WindowApp::event` is handed no window, so an application cannot change window state in response to a key. Routing a request back through `LoopControl`, which already carries `exit` and `redraw` that way, is the fix and is a larger change than the difference is worth while alt-tab already frees the cursor by losing focus.

Escape ends the game and the window takes the cursor with it, which is what the README says.