### PR TITLE
test(memory): the quiet-window checks stop racing the test harness

### DIFF
--- a/crates/core/memory/tests/quiet_window.rs
+++ b/crates/core/memory/tests/quiet_window.rs
@@ -3,6 +3,20 @@
 //! see genuine deltas. One test on purpose — the counters are
 //! process-wide, and a sibling test's allocations would race the
 //! scenarios below.
+//!
+//! # Why nothing here asserts an exact count
+//!
+//! One test stops *sibling tests* racing the counters. It does not stop
+//! the **harness**, which runs its own threads beside this one and
+//! allocates on them; a window here measures the process, not the
+//! thread. This test went red once on a lane where nothing it covers had
+//! changed, on an exact `(0, 1)`.
+//!
+//! So each assertion below states the property it is actually about and
+//! tolerates activity it is not about. What matters is that freeing
+//! alone makes a window loud, that a reported delta is the last window's
+//! rather than every window's summed, and that an empty window settles —
+//! none of which needs a number nobody controls to be exact.
 
 use renew_memory::{CountingAllocator, counters};
 
@@ -15,10 +29,13 @@ static ALLOCATOR: CountingAllocator = CountingAllocator;
     ignore = "allocation counting is invalid under instrumented allocators"
 )]
 fn the_policy_retries_reports_and_settles() {
-    // A window that allocates nothing succeeds immediately.
+    // A window that allocates nothing settles. Several attempts rather
+    // than one: a single stray allocation from the harness during the
+    // one attempt would otherwise report a policy failure that is
+    // nothing of the kind.
     assert!(
-        counters::quiet_window(1, || {}).is_ok(),
-        "an empty window must be quiet"
+        counters::quiet_window(5, || {}).is_ok(),
+        "an empty window must settle"
     );
 
     // A window that allocates every attempt fails, and the reported
@@ -30,13 +47,26 @@ fn the_policy_retries_reports_and_settles() {
         keep.push(Box::new(1u8));
     })
     .expect_err("an always-allocating window must fail");
-    assert_eq!(
-        (error.allocations, error.deallocations),
-        (1, 0),
-        "the delta must be the last window's own activity"
+    // **The subject is that the delta is the last window's, not every
+    // window's summed.** Three attempts allocate one box each, so a
+    // cumulative delta would report three. Anything under that proves
+    // the window is measured afresh — and leaves room for an allocation
+    // from elsewhere in the process, which would otherwise fail a test
+    // that is not about it.
+    assert!(
+        error.allocations >= 1 && error.allocations < 3,
+        "the delta must be the last window's own activity, got {error}"
     );
+
+    // The report's wording, from a delta built by hand. Taking it from
+    // the window above would make a formatting assertion depend on what
+    // every other thread in the process happened to do.
     assert_eq!(
-        error.to_string(),
+        counters::ActivityDelta {
+            allocations: 1,
+            deallocations: 0,
+        }
+        .to_string(),
         "+1 allocations, +0 deallocations",
         "the report is what a failing gate prints"
     );
@@ -64,10 +94,13 @@ fn the_policy_retries_reports_and_settles() {
         drop(boxes.next());
     })
     .expect_err("a window that frees must be loud");
-    assert_eq!(
-        (error.allocations, error.deallocations),
-        (0, 1),
-        "the dealloc-only delta must be visible"
+    // **The subject is that freeing alone makes a window loud**, which
+    // is what makes the both-channels check stronger than counting
+    // allocations. The allocation count is not the subject: the window
+    // allocates nothing, but the process might.
+    assert!(
+        error.deallocations >= 1,
+        "a window that freed must show it on the deallocation channel, got {error}"
     );
     drop(keep);
 }


### PR DESCRIPTION
This test went red once on a lane where nothing it covers had changed — a commit that edited two doc comments and narrowed two items to private, in a sample. It had passed on the seven commits before it.

Its header already knew the hazard: the counters are process-wide, so it is deliberately the only test in its binary. What that stops is *sibling tests*. What it does not stop is the **harness**, which runs its own threads beside this one and allocates on them. A window here measures the process, not the thread.

Every assertion was an exact count, so any of them could have been the one to go — the `(0, 1)` that failed was not special.

## Each check now states its own subject

* **freeing alone makes a window loud** — the deallocation channel is checked and the allocation count is not, because the window allocates nothing but the process might;
* **a reported delta is the last window's, not every window's summed** — three attempts allocating one box each prove it by staying under three, which leaves room for an allocation from elsewhere without weakening the property;
* **the report's wording** comes from a delta built by hand, so a formatting assertion no longer depends on what other threads happened to do;
* **an empty window** gets several attempts rather than one, so a single stray allocation cannot report a policy failure that is nothing of the kind.

## Still able to catch what it exists for

Made cumulative on purpose, it fails with `+3 allocations, +0 deallocations` where it wants fewer. Looser about what it is not measuring, exactly as strict about what it is.