### PR TITLE
refactor(cube): the sample's surface is as wide as its use

### DIFF
--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -267,7 +267,7 @@ pub fn build_world_space(grid: &Grid, aimed: Option<Cell>) -> Scene {
 /// # Errors
 ///
 /// As [`draw`].
-pub fn draw_through(
+pub(crate) fn draw_through(
     grid: &Grid,
     camera: &crate::camera::Camera,
     aimed: Option<Cell>,
@@ -281,7 +281,7 @@ pub fn draw_through(
 /// # Errors
 ///
 /// As [`draw_through`].
-pub fn draw_scene(
+pub(crate) fn draw_scene(
     scene: &Scene,
     camera: &crate::camera::Camera,
     overlay: Option<&Scene>,

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -166,7 +166,7 @@ fn aspect_of(size: Extent) -> f32 {
 }
 
 /// The game, running against a window.
-pub struct CubeApp {
+struct CubeApp {
     world: Cube,
     held: Held,
     yaw: Angle,


### PR DESCRIPTION
A sweep after six changes to this sample, asking mechanically of every public item whether anything outside its own file names it.

Three did not:

* `draw_through` and `draw_scene` — the drawing helpers sitting behind `to_png_through` and the paths a caller actually reaches;
* `CubeApp` — the window application, which only `run` in the same file ever builds.

`RenderError` is the interesting exception and stays public. Nothing names it either, but it is the return type of every public drawing function, so a caller has to be able to name it whether or not one does today. A mechanical check cannot see that; it is the reason the sweep is a prompt to look rather than a rule to apply.

No behaviour changes. The sample's pictures and digests are untouched.