### PR TITLE
docs: contributor license agreement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for sending this. Keep the sections below; delete this comment.
+The bar a change is held to is in CONTRIBUTING.md.
+-->
+
+## What changed, and why
+
+<!-- The why is the part still useful in a year. -->
+
+## Evidence
+
+<!--
+What you ran and what it printed. "Tests pass" on its own is not evidence;
+the command and its output are. If this fixes a bug, say which test fails
+without the fix.
+-->
+
+```
+```
+
+## Checklist
+
+- [ ] Tests arrive with the change — a bug fix has a test that fails without it
+- [ ] Documentation updated in the same commit as the behaviour it describes
+- [ ] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo run --bin renew -- check` all pass locally
+- [ ] No new dependencies (or discussed in an issue first)
+
+## Contributor License Agreement
+
+First pull request only — after that, leave this section out.
+
+Read [CLA.md](https://github.com/renew-engine/renew/blob/main/CLA.md), then
+fill this in:
+
+```
+I have read CLA.md and I agree to its terms.
+Name:
+Email:
+GitHub: @
+Date:
+```

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,148 @@
+# Contributor License Agreement
+
+Before a pull request can be merged, its author agrees to the terms below.
+
+## Why this exists, in plain words
+
+This document does two things. It confirms that you have the right to give
+away what you are giving away — that the code is yours to contribute, and that
+no employer or third party has a claim on it. And it grants the project a
+license broad enough that the project can keep distributing your work, now and
+under whatever licensing the project uses in future.
+
+That second part is the one worth being direct about: **it means the project
+may one day be offered under terms other than Apache-2.0**, including
+commercial terms, and your contribution would be part of that. Projects do
+this to fund their own maintenance. You should know it is possible before you
+sign, rather than discover it later.
+
+In exchange, section 9 is a commitment in the other direction: **`renew` will
+always remain available under an OSI-approved open source license, free of
+charge.** A future commercial edition can exist alongside that, never instead
+of it. Nothing you contribute can be taken out of the open source project.
+
+You keep the copyright to your contribution. This is a license, not a transfer
+of ownership — you remain free to use your own work anywhere else, for
+anything, including in competing projects.
+
+## How to agree
+
+Every pull request template carries this line. Fill it in and leave it in the
+pull request description:
+
+```
+I have read CLA.md and I agree to its terms.
+Name: <your full name>
+Email: <your email>
+GitHub: @<your username>
+Date: <YYYY-MM-DD>
+```
+
+That pull request is the record; GitHub retains it. You agree once, and it
+covers every contribution you make afterwards — you do not repeat this on
+later pull requests.
+
+If you are contributing as part of your employment, read section 4 first. Your
+employer may need to agree instead of, or as well as, you.
+
+---
+
+## The agreement
+
+In this agreement, **"the Owner"** means Cagdas Erturk, the copyright holder
+and maintainer of `renew`, and **"the Project"** means `renew` and any work
+distributed by the Owner as part of it.
+
+**1. Definitions.** "You" means the individual or legal entity agreeing to
+this document. "Contribution" means any work of authorship, including any
+modification of or addition to an existing work, that is intentionally
+submitted by You to the Owner for inclusion in the Project. "Submitted" means
+any form of electronic, verbal, or written communication sent to the Owner or
+its representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Owner for the purpose of discussing and
+improving the Project, but excluding communication that is conspicuously
+marked or otherwise designated in writing by You as "Not a Contribution."
+
+**2. Grant of copyright license.** Subject to the terms and conditions of this
+agreement, You hereby grant to the Owner and to recipients of software
+distributed by the Owner a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare derivative
+works of, publicly display, publicly perform, sublicense, and distribute Your
+Contributions and such derivative works, under any license terms the Owner
+selects, including licenses that are not open source.
+
+You retain all right, title, and interest in and to Your Contributions. This
+license is non-exclusive: nothing here limits Your own use of Your work.
+
+**3. Grant of patent license.** Subject to the terms and conditions of this
+agreement, You hereby grant to the Owner and to recipients of software
+distributed by the Owner a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to
+make, have made, use, offer to sell, sell, import, and otherwise transfer the
+Project, where such license applies only to those patent claims licensable by
+You that are necessarily infringed by Your Contributions alone or by
+combination of Your Contributions with the Project to which such Contributions
+were submitted.
+
+If any entity institutes patent litigation against You or any other entity
+alleging that Your Contribution, or the Project to which You have contributed,
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this agreement for that Contribution or
+Project shall terminate as of the date such litigation is filed.
+
+**4. You are entitled to grant this.** You represent that You are legally
+entitled to grant the above licenses. If Your employer has rights to
+intellectual property that You create, You represent that You have received
+permission to make the Contributions on behalf of that employer, that Your
+employer has waived such rights for Your Contributions, or that Your employer
+has agreed to these terms in writing.
+
+If You are agreeing on behalf of a legal entity rather than as an individual,
+You represent that You are authorised to bind that entity, and "You" in this
+agreement means that entity.
+
+**5. Your contributions are your own work.** You represent that each of Your
+Contributions is Your original creation. You represent that Your Contribution
+submissions include complete details of any third-party license or other
+restriction of which You are personally aware and which is associated with any
+part of Your Contributions.
+
+**6. Third-party work.** Should You wish to submit work that is not Your
+original creation, You may submit it separately from any Contribution,
+identifying the complete details of its source and of any license or other
+restriction of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third party: [named here]".
+
+**7. No obligation, no warranty.** You are not expected to provide support for
+Your Contributions, except to the extent You desire to provide support. You
+may provide support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+Nothing in this agreement obliges the Owner to use, merge, or distribute Your
+Contribution.
+
+**8. Tell us if something changes.** You agree to notify the Owner of any
+facts or circumstances of which You become aware that would make these
+representations inaccurate in any respect.
+
+**9. The Owner's commitment to you.** The Owner commits that the Project will
+continue to be made publicly available under the Apache License, Version 2.0,
+or another license approved by the Open Source Initiative, at no charge. The
+Owner may additionally license the Project, including Your Contributions,
+under other terms — but not instead of the open source availability described
+in this section.
+
+**10. Successors.** The Owner may assign this agreement, and the rights
+granted under it, to a legal entity that the Owner forms or controls for the
+purpose of holding and maintaining the Project, or to a successor in interest
+to the Project. Section 9 binds any such assignee.
+
+---
+
+This agreement is adapted from the Apache Software Foundation Individual
+Contributor License Agreement, with the grant in section 2 widened, and
+sections 9 and 10 added.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ please open an issue first** — not as a formality, but because the shape
 of a module is usually already decided, and a pull request that cuts
 across that decision is work nobody enjoys discarding.
 
+Every pull request also needs its author to have agreed to the
+[Contributor License Agreement](CLA.md) — once, not per change. It is
+worth reading before you write code rather than after, because it says
+what the project may do with your contribution. The short version is in
+[License and the CLA](#license-and-the-cla) below.
+
 Expect review to be slow. The project has one maintainer.
 
 ## The bar a change is held to
@@ -113,10 +119,29 @@ listing the files it touched.
 crate, read from that crate's own manifest. That manifest is the only
 place maturity is recorded, so it cannot disagree with anything else.
 
-## License
+## License and the CLA
 
-renew is licensed under the [Apache License, Version 2.0](LICENSE). Unless you
-explicitly state otherwise, any contribution intentionally submitted for
-inclusion in the project by you shall be licensed under the same terms, as
-defined in Section 5 of the license, without any additional terms or
-conditions.
+renew is licensed under the [Apache License, Version 2.0](LICENSE), and
+every contribution is distributed under those terms.
+
+Beyond that, contributors agree to a [Contributor License Agreement](CLA.md)
+before their first pull request is merged. Three things are worth saying
+plainly, because a CLA that surprises someone has failed at its job:
+
+- **You keep your copyright.** It is a license, not a transfer. Your work
+  stays yours to use anywhere else, including in a competing project.
+- **The project may one day be offered under other terms**, including
+  commercial ones, with your contribution part of that. This is what
+  allows the project to fund its own maintenance.
+- **The open source version cannot be withdrawn.** Section 9 of the
+  agreement commits renew to remaining available under an OSI-approved
+  license, at no charge. A commercial edition could exist beside it,
+  never instead of it — and anything already released stays released,
+  since an Apache-2.0 grant cannot be revoked.
+
+Agreeing takes one filled-in block in your pull request description; the
+template puts it there for you. You do it once, and it covers everything
+you contribute afterwards.
+
+If you are contributing as part of your job, read section 4 of the
+agreement first — your employer may need to agree rather than you.


### PR DESCRIPTION
## What changed, and why

Contributions currently arrive under the Apache-2.0 inbound=outbound clause alone. That
settles the license and nothing else: it does not record that a contributor had the right to
contribute what they contributed, it does not cover the case where an employer owns the work,
and it leaves the project unable to offer the code under any other terms later without tracing
and asking every past contributor individually.

That last one is the reason for the timing. The cost of adding an agreement is an afternoon
while there are no outside contributors. After the first one merges, it becomes a negotiation
with everyone who has ever sent a patch — and anyone unreachable is a permanent hole.

**`CLA.md`** is adapted from the Apache Software Foundation's individual contributor agreement,
which is the one contributors are most likely to have signed before. Two changes and two
additions:

- the copyright grant in section 2 is widened, so the project may distribute contributions
  under license terms it selects later;
- section 9 commits the project to remaining publicly available under an OSI-approved license
  at no charge — so the breadth of that grant cannot be turned into closing the project;
- section 10 lets the agreement pass to an entity formed to hold the project, and binds that
  entity to section 9 as well;
- contributors keep their copyright. The grant is non-exclusive, so a contributor's own work
  stays theirs to use anywhere, including in a competing project.

**`CONTRIBUTING.md`** states the three things a contributor most needs to know before agreeing,
rather than leaving them to infer it from the legal text: you keep your copyright, the project
may later be offered commercially with your work in it, and the open source version cannot be
withdrawn.

**`.github/PULL_REQUEST_TEMPLATE.md`** carries the block that records agreement. That is the
whole enforcement mechanism, and it is deliberately manual: an automated checker would be a
third-party dependency sitting in the review path, and one maintainer already reads every pull
request.

## Evidence

Documentation only — no behaviour, so no tests and no benchmarks. What was checked:

```
$ cargo test -p renew-cli --test source_hygiene
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.25s
```

Also verified by hand: `CLA.md` and `LICENSE` both resolve from `CONTRIBUTING.md`, the
`#license-and-the-cla` anchor matches its heading, and the template's link to `CLA.md` is
absolute rather than relative — a relative one breaks once GitHub renders the template into a
pull request body.

## Not settled here

The repository still names no copyright holder — `LICENSE` carries the unfilled
`Copyright [yyyy] [name of copyright owner]` placeholder from the stock Apache text, and there
is no `NOTICE` file. The agreement names the maintainer as the grantee, which is correct today.
Worth closing separately.
