### PR TITLE
feat(rhi): additive blending

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -81,7 +81,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1075, 1076, 1077]
+lines = [1088, 1089, 1090]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -237,6 +237,19 @@ pub enum Blend {
     /// that are not premultiplied composite wrong, visibly, not
     /// unsafely.
     PremultipliedAlpha,
+    /// `src + dst`, color and alpha alike — light on light, for
+    /// sources that accumulate rather than occlude: glows, sparks, the
+    /// particle shapes that read as energy.
+    ///
+    /// **Order-independent by arithmetic**: saturating addition is
+    /// commutative, so draw order cannot change the picture — which is
+    /// what lets unsorted batches of additive geometry stay
+    /// byte-stable under any submission order, and what makes this the
+    /// recommended mode where sorting has not been paid for. The
+    /// premultiplied convention still applies to the source bytes; the
+    /// difference from [`Self::PremultipliedAlpha`] is only the
+    /// destination factor.
+    Additive,
 }
 
 /// A vertex/fragment pair and the number of vertices its vertex stage
@@ -1220,6 +1233,18 @@ impl Device {
                 .color_blend_op(vk::BlendOp::ADD)
                 .src_alpha_blend_factor(vk::BlendFactor::ONE)
                 .dst_alpha_blend_factor(vk::BlendFactor::ONE_MINUS_SRC_ALPHA)
+                .alpha_blend_op(vk::BlendOp::ADD),
+            // The one difference from the arm above is the destination
+            // factor: the target keeps everything it has, and the
+            // source adds to it.
+            Blend::Additive => vk::PipelineColorBlendAttachmentState::default()
+                .color_write_mask(vk::ColorComponentFlags::RGBA)
+                .blend_enable(true)
+                .src_color_blend_factor(vk::BlendFactor::ONE)
+                .dst_color_blend_factor(vk::BlendFactor::ONE)
+                .color_blend_op(vk::BlendOp::ADD)
+                .src_alpha_blend_factor(vk::BlendFactor::ONE)
+                .dst_alpha_blend_factor(vk::BlendFactor::ONE)
                 .alpha_blend_op(vk::BlendOp::ADD),
         }];
         let color_blend =

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -680,6 +680,74 @@ fn push_constants_reach_the_draw_and_update_per_frame() {
     assert_no_validation_errors(&device);
 }
 
+/// Additive blending is arithmetic, so the oracle is arithmetic: two
+/// full-target draws over a black clear must land exactly on the
+/// channel sums, and — because saturating addition is commutative —
+/// both draw orders must produce identical bytes. The n/255 values
+/// make the UNORM roundtrip exact, so this compares bytes, not
+/// tolerances; the alpha channel saturates from the opaque clear and
+/// pins the saturating half of the claim.
+#[test]
+fn additive_blending_sums_channels_in_either_order() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 16,
+            height: 16,
+        })
+        .expect("offscreen target");
+    let pipeline = device
+        .create_pipeline(
+            &PipelineDesc::new(push_color_shaders(), TargetFormat::Rgba8Unorm)
+                .blend(renew_rhi::Blend::Additive)
+                .push_constant_size(16),
+        )
+        .expect("additive push-constant pipeline");
+    let push = |channels: [u8; 4]| {
+        let mut bytes = [0u8; 16];
+        for (slot, &channel) in bytes.chunks_exact_mut(4).zip(&channels) {
+            slot.copy_from_slice(&(f32::from(channel) / 255.0).to_ne_bytes());
+        }
+        bytes
+    };
+    let first = push([32, 64, 8, 16]);
+    let second = push([16, 32, 96, 8]);
+    // Black clear + both draws: channel sums, alpha saturated by the
+    // opaque clear.
+    let expected = [48u8, 96, 104, 255];
+    let color = clear(Color::new(0.0, 0.0, 0.0, 1.0));
+    let mut render = |a: &[u8; 16], b: &[u8; 16]| {
+        let items = [
+            Item::new(&pipeline).push_data(a),
+            Item::new(&pipeline).push_data(b),
+        ];
+        let passes = [Pass::new(&color, &items)];
+        target
+            .render(&RenderDesc::new(&passes))
+            .expect("additive render");
+        let mut pixels = vec![0u8; target.byte_len()];
+        target.read_back_into(&mut pixels);
+        pixels
+    };
+    let forward = render(&first, &second);
+    for (index, pixel) in forward.chunks_exact(4).enumerate() {
+        assert_eq!(
+            pixel, expected,
+            "pixel {index}: additive must land exactly on the channel sums"
+        );
+    }
+    let reversed = render(&second, &first);
+    assert_eq!(
+        forward, reversed,
+        "additive is commutative, so draw order must not change a byte"
+    );
+    drop(target);
+    drop(pipeline);
+    assert_no_validation_errors(&device);
+}
+
 #[test]
 fn wrong_readback_length_is_a_retained_contract_check() {
     let Some(device) = required_device().expect("device bring-up") else {


### PR DESCRIPTION
A third arm on the blend enum: premultiplied additive — src plus dst, ADD, colour and alpha alike, differing from the premultiplied-alpha arm only in the destination factor, baked at pipeline creation like its siblings. Light on light, for sources that accumulate rather than occlude.

The oracle is arithmetic because the mode is: two full-target draws through the push-constant fixture over a black clear land exactly on the channel sums (n/255 values, so the UNORM roundtrip is exact and the comparison is bytes, not tolerances), the alpha channel pins the saturating half against the opaque clear, and both draw orders produce identical bytes — saturating addition is commutative, so submission order cannot change the picture, observed rather than asserted.

The depth-refusal coverage exemption follows its lines: the enum arm's additions sit above it, re-pinned by content before pushing.