### PR TITLE
feat(camera): the camera is an engine crate, and the picture is smooth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,15 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-replay $sel
           cargo build $sel
           cargo test $sel
+      # The camera crate: maths over the maths crate, its one consumer
+      # the voxel game. The exclude list is upward-closed by excluding
+      # that game with it.
+      - name: Build and test without the camera crate
+        run: |
+          sel="--workspace --exclude renew-camera --exclude renew-sample-cube"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-camera $sel
+          cargo build $sel
+          cargo test $sel
       # The 2D renderer: policy over the rendering crate, no consumers
       # yet -- the windowed game grows this list when it draws sprites.
       - name: Build and test without the 2D renderer
@@ -381,7 +390,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-camera"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-math",
+]
+
+[[package]]
 name = "renew-cli"
 version = "0.1.0"
 dependencies = [
@@ -1783,9 +1791,11 @@ name = "renew-sample-cube"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "renew-camera",
  "renew-event",
  "renew-fixed",
  "renew-frame",
+ "renew-math",
  "renew-platform",
  "renew-png",
  "renew-render3d",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 # needs nightly and sanitizer instrumentation, and pulling that into the
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
-members = ["bench/suite", "crates/asset", "crates/audio", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
+members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
     "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ Every commit on `main` clears all of these, on Windows, Linux, and macOS:
 The list this section used to carry — rendering, an ECS, the asset pipeline, audio, input
 mapping, 2D samples — has shipped. What is actually next:
 
-- **The 3D renderer, finished.** Geometry and a depth-tested draw exist and are headless-provable.
-  Still to come: meshing a voxel world into a vertex buffer, a camera (the player's by default, a
-  free one behind a flag), a window for the 3D sample, and a texture atlas generated in code so
-  golden images stay byte-comparable.
+- **The 3D renderer, deepened.** The voxel sample meshes its world, plays in a window through a
+  perspective camera — now an engine crate of its own, with display-rate smoothing between
+  simulation ticks — and draws from a texture atlas generated in code so golden images stay
+  byte-comparable. Depth is reversed engine-wide, and per-draw constants ride push constants.
+  Still to come: particles, and instancing for chunked geometry.
 - **Modules climbing the maturity ladder.** Nothing is `stable` yet, and nothing will claim it
   before its API is under change control and its parsers have been fuzzed.
 - **An editor, eventually**, as a client of the same public APIs every other tool uses — never a

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -111,7 +111,7 @@ reason = "The comparison refusing to start because no workspace root is above it
 
 [[exempt]]
 file = "samples/cube/src/windowed.rs"
-lines = [534, 535, 536, 537, 538, 539, 593]
+lines = [552, 553, 554, 555, 556, 557, 611]
 reason = "The two places a window resize is acted on: rebuilding the crosshair for the new shape, and telling the swapchain its new size. Both need a real window-system resize, and the lane that measures coverage has none - its windowed runs happen under a virtual display with no window manager, so the window it opens is the only size it will ever be. Note for anyone running coverage on a desktop: these lines ARE covered there, because a real window manager sends a resize on the way up, and the gate will call this exemption stale. The gate that decides is the headless one. Everything these lines follow from is covered everywhere: record_present drives the recovery from a dormant swapchain with a constructed outcome, the resize event handler is driven with a constructed event, and the crosshair geometry is checked at four aspects without a device."
 
 [[exempt]]

--- a/crates/camera/Cargo.toml
+++ b/crates/camera/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "renew-camera"
+description = "Presentation-side camera: view and projection matrices under the engine's clip conventions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Presentation-side camera: view and projection matrices under the engine's clip conventions (y down, z reversed into [0, 1])."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+# The maths crate and nothing else: a camera is algebra plus the
+# rendering conventions, and the conventions are this crate's own
+# contract rather than a dependency's.
+[dependencies]
+renew-math = { path = "../core/math" }
+
+# The projection's monotonicity and range claims are properties over
+# arbitrary points, which is the testing table's row for mathematics.
+# The same version every sibling pins.
+[dev-dependencies]
+proptest = "1.11"
+
+[lints]
+workspace = true

--- a/crates/camera/README.md
+++ b/crates/camera/README.md
@@ -1,0 +1,46 @@
+# renew-camera
+
+The presentation-side camera: where the eye stands, what it looks at,
+and the matrix that follows from it. Pure functions over the maths
+crate's value types — no device, no window, no clock — so every claim is
+testable on any machine. The manifest in `Cargo.toml` is authoritative
+for maturity, dependencies and core status.
+
+- `View` — eye and target, as two points rather than accumulated angles,
+  so the same values always produce the same matrix. `View::blend` is
+  the display-rate smoothing seam: a lerp between two ticks' views by
+  the frame loop's interpolation factor, bit-exactly the previous view
+  at zero, never an input to simulation.
+- `Projection` — a perspective under the engine conventions.
+- `Camera` — the pair, with `view_projection()` and the `columns()`
+  boundary shape a GPU-facing pack type consumes.
+- `aspect_of` — width over height with a degenerate-extent fallback, so
+  no infinity ever reaches a projection.
+
+## Contract
+
+The engine's clip conventions, each pinned by a test because each
+produces a *plausible* wrong picture when violated:
+
+- **Clip `y` points down.** World up is screen `-y`; the projection
+  carries an explicit minus.
+- **Clip `z` runs `[0, 1]` REVERSED: near is one, far is zero.** Depth
+  clears to zero and the compare keeps the larger value — the engine's
+  single depth convention, chosen so the perspective hyperbola's dense
+  end and the float format's dense end coincide and the far field keeps
+  distinct depth values.
+- **The matrix goes to the GPU; the divide happens there.** A caller
+  transforming its own vertices would have to clip polygons against the
+  near plane itself.
+- **No roll.** World up is fixed until a consumer needs otherwise.
+- **Floats, by design.** This crate is presentation-side. Simulation
+  state never passes through it, and the workspace structure check is
+  what enforces that direction mechanically.
+
+## What this deliberately is not
+
+Not a controller: how aim is stored, clamped and advanced is game
+policy (the voxel sample keeps its fixed-point yaw and clamped pitch on
+its own side of the boundary). Not a scene graph: transforms belong
+elsewhere. Not a viewport manager: one camera is one matrix, and a
+caller with two viewports calls it twice.

--- a/crates/camera/clippy.toml
+++ b/crates/camera/clippy.toml
@@ -1,0 +1,31 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: a camera is a pure function from a viewpoint to a matrix —
+# it never reads a clock, never touches the filesystem, never spawns a
+# thread. Floats are its medium on purpose: this crate is
+# presentation-side, and the structure checker's float fence is what
+# keeps it out of every simulation crate's closure.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a camera is a pure function of its viewpoint; time belongs to the caller" },
+    { path = "std::time::SystemTime::now", reason = "a camera is a pure function of its viewpoint; time belongs to the caller" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/camera/src/lib.rs
+++ b/crates/camera/src/lib.rs
@@ -1,0 +1,460 @@
+//! The presentation-side camera: where the eye stands, what it looks
+//! at, and the matrix that follows from it.
+//!
+//! Pure functions over [`renew_math`]'s value types — no device, no
+//! window, no clock — so every claim here is testable on any machine.
+//! Floats are the medium on purpose: a camera lives on the far side of
+//! the fixed-point boundary, and the structure checker's float fence is
+//! what keeps this crate out of every simulation crate's closure. A
+//! game's authoritative eye position and look direction stay wherever
+//! that game keeps them; what crosses into this crate is floats, once
+//! per draw, and nothing flows back.
+//!
+//! # Contract
+//!
+//! The engine's clip conventions, stated once and pinned by the tests
+//! beside them — every one of these produces a *plausible* wrong
+//! picture when violated, which is why they are the contract rather
+//! than trivia:
+//!
+//! - **Clip `y` points down.** Viewports are built with positive
+//!   height and nothing flips it, so world up is screen `-y`; the
+//!   projection carries an explicit minus.
+//! - **Clip `z` runs `[0, 1]` REVERSED: near is one, far is zero.**
+//!   Depth clears to zero and the compare keeps the larger value —
+//!   the engine's single depth convention. A perspective mapping is
+//!   hyperbolic in distance either way; reversed, its dense end and
+//!   the float format's dense end coincide, so the far field keeps
+//!   distinct depth values instead of z-fighting.
+//! - **The matrix goes to the GPU, and the divide happens there.**
+//!   `gl_Position` carries a real `w`, so the hardware divides and the
+//!   clipper removes geometry behind the eye. A caller transforming
+//!   its own vertices would have to clip polygons against the near
+//!   plane itself — inside a room, with walls behind the viewer, that
+//!   is the ordinary case rather than a corner.
+//! - **No roll.** World up is fixed; a roll control with no consumer
+//!   would be a knob that exists to be wrong. It arrives as a field
+//!   with a consumer, not before.
+
+// Diagnostics go through sinks; the standard output macros are banned in
+// this crate by construction, not convention.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+use renew_math::{Alpha, Mat4, Vec3, Vec4};
+
+/// World up. Fixed rather than carried — see the crate contract's
+/// no-roll clause.
+const UP: Vec3 = Vec3::new(0.0, 1.0, 0.0);
+
+/// Where the eye is and the point it looks at.
+///
+/// Two points rather than a point and accumulated angles: two points
+/// always produce the same matrix, which is what keeps a picture a
+/// pure function of the values that made it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct View {
+    /// Where the eye is, in world space.
+    pub eye: Vec3,
+    /// The point it looks at.
+    pub target: Vec3,
+}
+
+impl View {
+    /// A view from `eye` toward `target`.
+    #[must_use]
+    pub fn look_at(eye: Vec3, target: Vec3) -> Self {
+        Self { eye, target }
+    }
+
+    /// The view matrix: the world moved into the eye's frame.
+    ///
+    /// The rotation is the eye's basis transposed, and the translation
+    /// is minus the eye measured along each axis. A degenerate view —
+    /// the eye at its own target, or looking straight along world up —
+    /// answers a finite fallback basis rather than NaN: a picture from
+    /// a wrong viewpoint is diagnosable, a screenful of discarded
+    /// fragments is not.
+    #[must_use]
+    pub fn matrix(&self) -> Mat4 {
+        let (right, up, forward) = self.basis();
+        Mat4::from_cols(
+            Vec4::new(right.x, up.x, forward.x, 0.0),
+            Vec4::new(right.y, up.y, forward.y, 0.0),
+            Vec4::new(right.z, up.z, forward.z, 0.0),
+            Vec4::new(
+                -right.dot(self.eye),
+                -up.dot(self.eye),
+                -forward.dot(self.eye),
+                1.0,
+            ),
+        )
+    }
+
+    /// Presentation smoothing between two ticks' views: a lerp of eye
+    /// and target by `alpha`.
+    ///
+    /// **At `Alpha::ZERO` the answer is bit-exactly `prev`**, special-
+    /// cased rather than trusted to arithmetic: every lerp form turns a
+    /// negative zero into a positive one, and this repository compares
+    /// bits. Elsewhere the blend converges toward `next` and never
+    /// reaches it, because `Alpha` is clamped below one. Never an input
+    /// to simulation — the blended view exists only in the frame being
+    /// drawn.
+    #[must_use]
+    pub fn blend(prev: Self, next: Self, alpha: Alpha) -> Self {
+        let t = alpha.get();
+        if t == 0.0 {
+            return prev;
+        }
+        Self {
+            eye: prev.eye.lerp(next.eye, t),
+            target: prev.target.lerp(next.target, t),
+        }
+    }
+
+    /// The eye's own axes: right, up, and the direction it looks.
+    ///
+    /// `forward` points away from the eye into the scene, so a larger
+    /// distance along it is further away. With a right-handed basis,
+    /// `right × up = forward`, so right is up crossed *into* forward —
+    /// the other order mirrors the picture, which reads as an ordinary
+    /// photograph taken from an odd angle.
+    fn basis(&self) -> (Vec3, Vec3, Vec3) {
+        // Plain single-division normalization, guarded — NOT
+        // `try_normalize`, whose two-step rescale is more robust and
+        // bit-different. This crate replaced arithmetic that consumers'
+        // committed pictures pin, and the extraction's whole claim is
+        // that no pixel moved; the robustness the two-step form buys
+        // guards magnitudes no camera reaches. The DEGENERATE outputs
+        // deliberately differ from the code this replaced: straight-up
+        // views get a right of (1, 0, 0) where the old fallback gave
+        // (0, 0, 1), and NaN inputs take the fallback rather than
+        // propagating — different finite pictures for views no consumer
+        // produces, chosen for being explainable over being historical.
+        let direction = self.target - self.eye;
+        let forward = if direction.length_squared() > 0.0 {
+            direction.normalize()
+        } else {
+            Vec3::new(0.0, 0.0, 1.0)
+        };
+        let horizontal = UP.cross(forward);
+        let right = if horizontal.length_squared() > 0.0 {
+            horizontal.normalize()
+        } else {
+            // Looking straight along world up leaves no horizontal
+            // perpendicular; any fixed right keeps the basis finite.
+            Vec3::new(1.0, 0.0, 0.0)
+        };
+        let up = forward.cross(right);
+        (right, up, forward)
+    }
+}
+
+/// A perspective projection under the engine conventions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Projection {
+    /// Vertical field of view, in radians.
+    pub fov_y_radians: f32,
+    /// Width over height of the picture.
+    pub aspect: f32,
+    /// Nearest visible distance. Everything closer is clipped — and
+    /// under reversed depth, this plane maps to one.
+    pub near: f32,
+    /// Furthest visible distance, mapping to zero.
+    pub far: f32,
+}
+
+impl Projection {
+    /// A perspective of `fov_y_radians` at `aspect`, seeing from
+    /// `near` to `far`.
+    #[must_use]
+    pub fn perspective(fov_y_radians: f32, aspect: f32, near: f32, far: f32) -> Self {
+        Self {
+            fov_y_radians,
+            aspect,
+            near,
+            far,
+        }
+    }
+
+    /// The projection matrix: y negated because screen y grows
+    /// downward, z mapped REVERSED into `[0, 1]`.
+    ///
+    /// Derivation: `ndc(z) = (A z + B) / z` with `ndc(near) = 1` and
+    /// `ndc(far) = 0` gives `A = -near / (far - near)` and
+    /// `B = far * near / (far - near)`.
+    #[must_use]
+    pub fn matrix(&self) -> Mat4 {
+        let focal = 1.0 / (self.fov_y_radians * 0.5).tan();
+        let range = self.far - self.near;
+        Mat4::from_cols(
+            Vec4::new(focal / self.aspect, 0.0, 0.0, 0.0),
+            Vec4::new(0.0, -focal, 0.0, 0.0),
+            Vec4::new(0.0, 0.0, -self.near / range, 1.0),
+            Vec4::new(0.0, 0.0, (self.far * self.near) / range, 0.0),
+        )
+    }
+}
+
+/// A viewpoint and a projection: everything a draw needs from a camera.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Camera {
+    pub view: View,
+    pub projection: Projection,
+}
+
+impl Camera {
+    /// The view-projection matrix.
+    #[must_use]
+    pub fn view_projection(&self) -> Mat4 {
+        self.projection.matrix() * self.view.matrix()
+    }
+
+    /// The four columns, in the column-major order a GPU-facing pack
+    /// type takes — the boundary shape, so a consumer never reaches
+    /// into [`Mat4`]'s representation.
+    #[must_use]
+    pub fn columns(&self) -> [[f32; 4]; 4] {
+        let matrix = self.view_projection();
+        matrix
+            .cols
+            .map(|column| [column.x, column.y, column.z, column.w])
+    }
+}
+
+/// Width over height; a zero or otherwise degenerate extent answers
+/// 1.0, so no infinity ever reaches a projection.
+#[must_use]
+pub fn aspect_of(width: u32, height: u32) -> f32 {
+    if width == 0 || height == 0 {
+        return 1.0;
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "window extents are far below f32's exact-integer range"
+    )]
+    let ratio = width as f32 / height as f32;
+    ratio
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU64;
+
+    /// Apply a matrix to a point, dividing by `w` — what the hardware
+    /// does, and what `Mat4::transform_point` deliberately does not.
+    fn project(matrix: Mat4, point: Vec3) -> [f32; 3] {
+        let out = matrix.transform(Vec4::new(point.x, point.y, point.z, 1.0));
+        [out.x / out.w, out.y / out.w, out.z / out.w]
+    }
+
+    fn looking_north() -> Camera {
+        Camera {
+            view: View::look_at(Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 10.0)),
+            projection: Projection::perspective(core::f32::consts::FRAC_PI_2, 1.0, 0.1, 100.0),
+        }
+    }
+
+    /// The point the camera looks at lands in the middle of the picture.
+    #[test]
+    fn the_target_is_the_centre_of_the_picture() {
+        let clip = project(looking_north().view_projection(), Vec3::new(0.0, 0.0, 10.0));
+        assert!(clip[0].abs() < 1e-5, "x: {clip:?}");
+        assert!(clip[1].abs() < 1e-5, "y: {clip:?}");
+    }
+
+    /// **Up in the world is up on the screen.** Its own test with its
+    /// own message: the failure is a world rendered upside down, which
+    /// is a perfectly ordinary-looking picture.
+    #[test]
+    fn a_higher_point_is_higher_on_the_screen() {
+        let matrix = looking_north().view_projection();
+        let low = project(matrix, Vec3::new(0.0, -1.0, 10.0));
+        let high = project(matrix, Vec3::new(0.0, 1.0, 10.0));
+        assert!(
+            high[1] < low[1],
+            "screen y grows downward, so a higher point needs a smaller y; the world is upside \
+             down: high {high:?} against low {low:?}"
+        );
+    }
+
+    /// Right in the world is right on the screen — the mirror check the
+    /// basis comment stakes its cross-product order on.
+    #[test]
+    fn a_point_to_the_right_is_to_the_right() {
+        let matrix = looking_north().view_projection();
+        let left = project(matrix, Vec3::new(-1.0, 0.0, 10.0));
+        let right = project(matrix, Vec3::new(1.0, 0.0, 10.0));
+        assert!(
+            right[0] > left[0],
+            "the picture is mirrored: {left:?} {right:?}"
+        );
+    }
+
+    /// The near and far planes land on one and nought — the reversed
+    /// mapping, which is the crate contract and not a convention this
+    /// test happens to share.
+    #[test]
+    fn the_planes_map_to_the_reversed_depth_range() {
+        let camera = looking_north();
+        let matrix = camera.view_projection();
+        let near = project(matrix, Vec3::new(0.0, 0.0, camera.projection.near));
+        let far = project(matrix, Vec3::new(0.0, 0.0, camera.projection.far));
+        assert!(
+            (near[2] - 1.0).abs() < 1e-4,
+            "the near plane should be 1 under reversed depth: {near:?}"
+        );
+        assert!(
+            far[2].abs() < 1e-4,
+            "the far plane should be 0 under reversed depth: {far:?}"
+        );
+    }
+
+    /// A degenerate camera answers with a picture rather than with NaN,
+    /// in both degenerate directions.
+    #[test]
+    fn degenerate_views_still_produce_finite_matrices() {
+        let eye_at_target = View::look_at(Vec3::new(3.0, 4.0, 5.0), Vec3::new(3.0, 4.0, 5.0));
+        let straight_up = View::look_at(Vec3::ZERO, Vec3::new(0.0, 7.0, 0.0));
+        for (name, view) in [
+            ("eye at target", eye_at_target),
+            ("straight up", straight_up),
+        ] {
+            let camera = Camera {
+                view,
+                projection: looking_north().projection,
+            };
+            for column in camera.columns() {
+                for value in column {
+                    assert!(value.is_finite(), "{name} produced {value}");
+                }
+            }
+        }
+    }
+
+    /// The columns are the matrix, in order — the boundary a pack type
+    /// consumes, pinned so a transposition cannot hide in the accessor.
+    #[test]
+    fn columns_reproduce_the_matrix_in_column_order() {
+        let camera = looking_north();
+        let matrix = camera.view_projection();
+        let columns = camera.columns();
+        for (index, column) in matrix.cols.iter().enumerate() {
+            // Bits, not floats: the claim is that these are the same
+            // values, and the house style makes exactness spellable.
+            assert_eq!(
+                columns[index].map(f32::to_bits),
+                [column.x, column.y, column.z, column.w].map(f32::to_bits),
+                "column {index} moved"
+            );
+        }
+    }
+
+    /// Blending at zero is bit-exactly the previous view — including a
+    /// negative zero, which every lerp form would flip positive and
+    /// which this repository's bit comparisons would catch downstream.
+    #[test]
+    fn blend_at_zero_is_bit_exactly_the_previous_view() {
+        let prev = View::look_at(Vec3::new(-0.0, 1.0, 2.0), Vec3::new(3.0, -0.0, 5.0));
+        let next = View::look_at(Vec3::new(9.0, 9.0, 9.0), Vec3::new(8.0, 8.0, 8.0));
+        let blended = View::blend(prev, next, Alpha::ZERO);
+        let bits = |v: Vec3| [v.x.to_bits(), v.y.to_bits(), v.z.to_bits()];
+        assert_eq!(bits(blended.eye), bits(prev.eye), "eye moved at alpha 0");
+        assert_eq!(
+            bits(blended.target),
+            bits(prev.target),
+            "target moved at alpha 0"
+        );
+    }
+
+    /// Away from zero the blend converges toward the next view and
+    /// never reaches it: `Alpha` is clamped below one.
+    #[test]
+    fn blend_converges_toward_the_next_view() {
+        let prev = View::look_at(Vec3::ZERO, Vec3::new(0.0, 0.0, 1.0));
+        let next = View::look_at(Vec3::new(10.0, 0.0, 0.0), Vec3::new(10.0, 0.0, 1.0));
+        let step = NonZeroU64::new(1_000).expect("nonzero");
+        let half = View::blend(prev, next, Alpha::new(500, step));
+        assert!(
+            (half.eye.x - 5.0).abs() < 1e-4,
+            "halfway should be halfway: {:?}",
+            half.eye
+        );
+        let nearly = View::blend(prev, next, Alpha::new(999_999, step));
+        assert!(
+            nearly.eye.x < 10.0,
+            "alpha is clamped below one, so the blend never reaches next: {:?}",
+            nearly.eye
+        );
+        assert!(
+            nearly.eye.x > 9.9,
+            "but it should get close: {:?}",
+            nearly.eye
+        );
+    }
+
+    /// The degenerate-extent fallback, both axes, and the ordinary
+    /// case — no infinity may ever reach a projection.
+    #[test]
+    fn aspect_of_answers_one_for_degenerate_extents() {
+        assert!((aspect_of(0, 720) - 1.0).abs() < f32::EPSILON);
+        assert!((aspect_of(1280, 0) - 1.0).abs() < f32::EPSILON);
+        assert!((aspect_of(0, 0) - 1.0).abs() < f32::EPSILON);
+        assert!((aspect_of(1280, 720) - 1280.0 / 720.0).abs() < f32::EPSILON);
+    }
+
+    proptest::proptest! {
+        /// Anything in front of the eye is nearer than anything behind
+        /// it, over arbitrary points — and under reversed depth, nearer
+        /// means larger. A projection monotone at two typed points can
+        /// still fold in between.
+        #[test]
+        fn depth_shrinks_with_distance_from_the_eye(
+            x in -20.0f32..20.0,
+            y in -20.0f32..20.0,
+            near_z in 1.0f32..40.0,
+            step in 0.5f32..40.0,
+        ) {
+            let matrix = looking_north().view_projection();
+            let here = project(matrix, Vec3::new(x, y, near_z));
+            let there = project(matrix, Vec3::new(x, y, near_z + step));
+            proptest::prop_assert!(
+                there[2] < here[2],
+                "further should be smaller under reversed depth: {:?} then {:?}", here, there
+            );
+        }
+
+        /// Everything inside the frustum lands inside the unit depth
+        /// range the viewport maps.
+        #[test]
+        fn points_in_front_land_in_the_unit_depth_range(
+            x in -5.0f32..5.0,
+            y in -5.0f32..5.0,
+            z in 0.2f32..90.0,
+        ) {
+            let clip = project(looking_north().view_projection(), Vec3::new(x, y, z));
+            proptest::prop_assert!(
+                (0.0..=1.0).contains(&clip[2]),
+                "depth outside the range the viewport maps: {:?}", clip
+            );
+        }
+
+        /// The blend is a pure function of its inputs: the same call
+        /// twice is the same bits.
+        #[test]
+        fn blending_is_reproducible(
+            ex in -30.0f32..30.0, ey in -30.0f32..30.0, ez in -30.0f32..30.0,
+            remainder in 0u64..1_000,
+        ) {
+            let prev = View::look_at(Vec3::new(ex, ey, ez), Vec3::new(ey, ez, ex));
+            let next = View::look_at(Vec3::new(ez, ex, ey), Vec3::new(ex, ez, ey));
+            let step = NonZeroU64::new(1_000).expect("nonzero");
+            let once = View::blend(prev, next, Alpha::new(remainder, step));
+            let twice = View::blend(prev, next, Alpha::new(remainder, step));
+            let bits = |v: Vec3| [v.x.to_bits(), v.y.to_bits(), v.z.to_bits()];
+            proptest::prop_assert_eq!(bits(once.eye), bits(twice.eye));
+            proptest::prop_assert_eq!(bits(once.target), bits(twice.target));
+        }
+    }
+}

--- a/crates/render3d/README.md
+++ b/crates/render3d/README.md
@@ -84,8 +84,8 @@ it gets an ordinary refusal.
 No window or presentation, no image writing, and no meshing — a voxel
 mesher belongs to the sample that knows its world. The camera is a
 matrix, not a viewpoint type: eye/target/projection maths belongs to the
-caller (an engine camera crate is the recorded next step), and this
-crate takes the sixty-four bytes that result. The vertex layout is a
+caller — the engine's camera crate, ordinarily — and this crate takes
+the sixty-four bytes that result. The vertex layout is a
 position, a colour and a texture coordinate, packed to 36 bytes with no
 padding: the rendering crate asserts at record time that a mesh's stride
 matches the pipeline's, and a `#[repr(C)]` struct over the maths crate's

--- a/samples/cube/Cargo.toml
+++ b/samples/cube/Cargo.toml
@@ -38,6 +38,8 @@ window = [
 
 [dependencies]
 renew-platform = { path = "../../crates/core/platform", default-features = false }
+renew-camera = { path = "../../crates/camera" }
+renew-math = { path = "../../crates/core/math" }
 renew-fixed = { path = "../../crates/fixed" }
 renew-sample-cube-world = { path = "world" }
 renew-rhi = { path = "../../crates/rhi", default-features = false, optional = true }

--- a/samples/cube/src/camera.rs
+++ b/samples/cube/src/camera.rs
@@ -1,157 +1,20 @@
-//! Where the viewer stands, and the matrix that follows from it.
+//! Where the viewer stands, built over the engine's camera crate.
 //!
-//! Pure, like [`crate::mesh`] and [`crate::projection`]: the arithmetic
-//! that decides what is on screen is testable without a device.
-//!
-//! # The conventions, and what each costs if it is wrong
-//!
-//! Read out of this repository's own rendering code rather than recalled,
-//! because every one of them produces a *plausible* wrong picture.
-//!
-//! **Clip `y` points down.** The viewport is built with a positive height
-//! and nothing flips it, so world up is screen `-y`. The projection
-//! carries an explicit minus; without it the world renders upside down,
-//! which looks like an ordinary picture taken from an odd angle.
-//!
-//! **Clip `z` runs `[0, 1]` REVERSED: near is one, far is zero.** Depth
-//! clears to zero and the compare is `GREATER_OR_EQUAL`, so the larger
-//! value survives — the engine's single depth convention, chosen because
-//! float precision concentrates toward zero and a conventional mapping
-//! spends nearly all of its distinct values within a few blocks of the
-//! near plane. This is not OpenGL's `[-1, 1]`, and not the conventional
-//! Vulkan mapping either; a projection built for either draws the far
-//! wall over everything in front of it.
-//!
-//! **The matrix goes to the GPU, and the divide happens there.** That is
-//! the whole reason the shader takes a matrix: a triangle crossing
-//! `w = 0` cannot be divided, so a caller that transformed its own
-//! vertices would have to clip polygons against the near plane. Inside a
-//! room, with walls behind the viewer, that is not a corner case.
+//! The maths lives in `renew-camera` now — the look-at basis, the
+//! reversed-depth perspective, the clip conventions and the tests that
+//! pin them all moved to the engine when the camera stopped being this
+//! sample's private invention. What stays here is what is genuinely
+//! this game's: the field of view and the planes chosen for its arena,
+//! the viewpoint constructors that read its world, and the one place
+//! the two number systems meet.
 
+// Re-exported so the sibling modules that consume a viewpoint keep one
+// import path; the type is the engine's now.
+pub use renew_camera::Camera;
+
+use renew_camera::{Projection, View};
+use renew_math::Vec3;
 use renew_sample_cube_world::Cube;
-
-/// A viewpoint: where the eye is, what it looks at, and how wide.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Camera {
-    /// Where the eye is, in world space.
-    pub eye: [f32; 3],
-    /// The point it looks at.
-    pub target: [f32; 3],
-    /// Vertical field of view, in radians.
-    pub fov: f32,
-    /// Width over height of the picture.
-    pub aspect: f32,
-    /// Nearest visible distance. Everything closer is clipped.
-    pub near: f32,
-    /// Furthest visible distance.
-    pub far: f32,
-}
-
-/// World up. The camera is never asked to roll, so this is fixed rather
-/// than carried: a roll control with no consumer would be a knob that
-/// exists to be wrong.
-const UP: [f32; 3] = [0.0, 1.0, 0.0];
-
-impl Camera {
-    /// The view-projection matrix, as four columns.
-    ///
-    /// Column-major, matching what the push-constant block and the
-    /// shader both expect.
-    #[must_use]
-    pub fn view_projection(&self) -> [[f32; 4]; 4] {
-        let (right, up, forward) = self.basis();
-
-        // View: the world moved into the eye's frame. The rotation is
-        // the basis transposed, and the translation is minus the eye
-        // measured along each axis.
-        let view = [
-            [right[0], up[0], forward[0], 0.0],
-            [right[1], up[1], forward[1], 0.0],
-            [right[2], up[2], forward[2], 0.0],
-            [
-                -dot(right, self.eye),
-                -dot(up, self.eye),
-                -dot(forward, self.eye),
-                1.0,
-            ],
-        ];
-
-        // Perspective, for the engine's clip space: y negated because
-        // screen y grows downward, and z mapped REVERSED into [0, 1] —
-        // near lands on one, far on zero, so the depth values with the
-        // most float precision describe the distances that need it.
-        // Derivation: ndc(z) = (A z + B) / z with ndc(near) = 1 and
-        // ndc(far) = 0 gives A = -near / (far - near) and
-        // B = far * near / (far - near).
-        let focal = 1.0 / (self.fov * 0.5).tan();
-        let range = self.far - self.near;
-        let projection = [
-            [focal / self.aspect, 0.0, 0.0, 0.0],
-            [0.0, -focal, 0.0, 0.0],
-            [0.0, 0.0, -self.near / range, 1.0],
-            [0.0, 0.0, (self.far * self.near) / range, 0.0],
-        ];
-
-        multiply(projection, view)
-    }
-
-    /// The eye's own axes: right, up, and the direction it looks.
-    ///
-    /// `forward` points away from the eye into the scene, so a larger
-    /// distance along it is further away — which is what makes the
-    /// depth mapping monotone in the direction the compare expects.
-    fn basis(&self) -> ([f32; 3], [f32; 3], [f32; 3]) {
-        let forward = normalise([
-            self.target[0] - self.eye[0],
-            self.target[1] - self.eye[1],
-            self.target[2] - self.eye[2],
-        ]);
-        // right = up x forward, and up = forward x right. The other
-        // order mirrors the picture: with a right-handed basis,
-        // right x up = forward, so right is up crossed INTO forward.
-        let right = normalise(cross(UP, forward));
-        let up = cross(forward, right);
-        (right, up, forward)
-    }
-}
-
-/// Column-major product: `left * right`.
-fn multiply(left: [[f32; 4]; 4], right: [[f32; 4]; 4]) -> [[f32; 4]; 4] {
-    let mut out = [[0.0f32; 4]; 4];
-    for (column, source) in out.iter_mut().zip(right) {
-        for (row, cell) in column.iter_mut().enumerate() {
-            *cell = left[0][row] * source[0]
-                + left[1][row] * source[1]
-                + left[2][row] * source[2]
-                + left[3][row] * source[3];
-        }
-    }
-    out
-}
-
-fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
-    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
-}
-
-fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
-    [
-        a[1] * b[2] - a[2] * b[1],
-        a[2] * b[0] - a[0] * b[2],
-        a[0] * b[1] - a[1] * b[0],
-    ]
-}
-
-fn normalise(v: [f32; 3]) -> [f32; 3] {
-    let length = dot(v, v).sqrt();
-    if length == 0.0 {
-        // A zero direction has no normalisation. Answering with forward
-        // rather than with NaN keeps a degenerate camera producing a
-        // picture instead of an empty screen full of discarded
-        // fragments, which is far harder to diagnose.
-        return [0.0, 0.0, 1.0];
-    }
-    [v[0] / length, v[1] / length, v[2] / length]
-}
 
 /// The player's own viewpoint.
 ///
@@ -161,16 +24,23 @@ fn normalise(v: [f32; 3]) -> [f32; 3] {
 /// world rather than a wrong viewpoint.
 #[must_use]
 pub fn player_view(world: &Cube, aspect: f32) -> Camera {
+    Camera {
+        view: player_eye_view(world),
+        projection: projection(aspect),
+    }
+}
+
+/// The view half of the player's viewpoint, aspect-free.
+///
+/// Split out because display-rate smoothing blends *views* between two
+/// ticks — the projection carries the aspect, which is the window's
+/// fact rather than either tick's, so a snapshot of where the player
+/// stood must not capture it.
+#[must_use]
+pub fn player_eye_view(world: &Cube) -> View {
     let eye = to_world(world.eye());
     let look = to_world(world.look());
-    Camera {
-        eye,
-        target: [eye[0] + look[0], eye[1] + look[1], eye[2] + look[2]],
-        fov: FOV,
-        aspect,
-        near: NEAR,
-        far: FAR,
-    }
+    View::look_at(eye, eye + look)
 }
 
 /// A viewpoint given outright, for looking at the world from outside it.
@@ -182,13 +52,18 @@ pub fn player_view(world: &Cube, aspect: f32) -> Camera {
 #[must_use]
 pub fn free_view(eye: [f32; 3], target: [f32; 3], aspect: f32) -> Camera {
     Camera {
-        eye,
-        target,
-        fov: FOV,
-        aspect,
-        near: NEAR,
-        far: FAR,
+        view: View::look_at(
+            Vec3::new(eye[0], eye[1], eye[2]),
+            Vec3::new(target[0], target[1], target[2]),
+        ),
+        projection: projection(aspect),
     }
+}
+
+/// This game's projection: the one field of view and the planes chosen
+/// for its arena, shared by both viewpoints so stills and play agree.
+fn projection(aspect: f32) -> Projection {
+    Projection::perspective(FOV, aspect, NEAR, FAR)
 }
 
 /// Vertical field of view: 70 degrees, the usual first-person figure —
@@ -198,11 +73,11 @@ const FOV: f32 = 70.0 * core::f32::consts::PI / 180.0;
 
 /// The near plane, in blocks. Well inside the player's own half-extent,
 /// so a wall the player is pressed against still draws rather than
-/// vanishing.
+/// vanishing. Under reversed depth this plane maps to one.
 const NEAR: f32 = 0.05;
 
-/// The far plane. The arena's diagonal is under 60 blocks, so this sees
-/// all of it from anywhere inside.
+/// The far plane, mapping to zero. The arena's diagonal is under 60
+/// blocks, so this sees all of it from anywhere inside.
 const FAR: f32 = 200.0;
 
 /// A fixed-point vector as world-space floats.
@@ -211,8 +86,8 @@ const FAR: f32 = 200.0;
 /// point because a simulation must be bit-identical everywhere; a camera
 /// is float because that is what a GPU takes. Converting here, at the
 /// boundary, keeps the conversion out of both.
-fn to_world(v: renew_fixed::Vec3) -> [f32; 3] {
-    [scalar(v.x), scalar(v.y), scalar(v.z)]
+fn to_world(v: renew_fixed::Vec3) -> Vec3 {
+    Vec3::new(scalar(v.x), scalar(v.y), scalar(v.z))
 }
 
 /// One fixed-point scalar as a float.
@@ -229,7 +104,8 @@ mod tests {
     use super::*;
 
     /// The player's camera stands where the player stands and looks
-    /// where the player looks.
+    /// where the player looks — the integration this sample owns, now
+    /// that the matrix arithmetic is the engine crate's to prove.
     #[test]
     fn the_player_camera_is_the_players_own_viewpoint() {
         let world = crate::run_world(&crate::Options {
@@ -241,228 +117,60 @@ mod tests {
 
         // The eye is the world's eye, converted.
         let eye = to_world(world.eye());
+        let bits = |v: Vec3| [v.x.to_bits(), v.y.to_bits(), v.z.to_bits()];
         assert_eq!(
-            camera.eye.map(f32::to_bits),
-            eye.map(f32::to_bits),
+            bits(camera.view.eye),
+            bits(eye),
             "the camera stands somewhere else"
         );
         // And the target is one unit along the look direction, so the
         // two are never the same point and the basis never degenerates.
-        let separation = [
-            camera.target[0] - camera.eye[0],
-            camera.target[1] - camera.eye[1],
-            camera.target[2] - camera.eye[2],
-        ];
+        let separation = camera.view.target - camera.view.eye;
         assert!(
-            (dot(separation, separation) - 1.0).abs() < 1e-4,
+            (separation.dot(separation) - 1.0).abs() < 1e-4,
             "the look direction should be a unit step: {separation:?}"
         );
         assert!(
-            (camera.aspect - 16.0 / 9.0).abs() < f32::EPSILON,
+            (camera.projection.aspect - 16.0 / 9.0).abs() < f32::EPSILON,
             "the aspect passed in is the aspect used"
         );
     }
 
-    /// A free view is exactly the two points it was given.
+    /// A free view is exactly the two points it was given, and its
+    /// matrix is usable — the point of naming two points rather than
+    /// accumulating a direction.
     #[test]
     fn a_free_camera_is_the_points_it_was_given() {
         let camera = free_view([1.0, 2.0, 3.0], [4.0, 5.0, 6.0], 2.0);
-        assert_eq!(
-            camera.eye.map(f32::to_bits),
-            [1.0f32, 2.0, 3.0].map(f32::to_bits)
-        );
-        assert_eq!(
-            camera.target.map(f32::to_bits),
-            [4.0f32, 5.0, 6.0].map(f32::to_bits)
-        );
-        // And it produces a usable matrix, which is the point of naming
-        // two points rather than accumulating a direction.
-        for column in camera.view_projection() {
+        let bits = |v: Vec3| [v.x.to_bits(), v.y.to_bits(), v.z.to_bits()];
+        assert_eq!(bits(camera.view.eye), bits(Vec3::new(1.0, 2.0, 3.0)));
+        assert_eq!(bits(camera.view.target), bits(Vec3::new(4.0, 5.0, 6.0)));
+        for column in camera.columns() {
             for value in column {
                 assert!(value.is_finite(), "a free camera produced {value}");
             }
         }
     }
 
-    /// Apply a column-major matrix to a point, dividing by `w` — which
-    /// is what the hardware does and what `Mat4::transform_point`
-    /// deliberately does **not**.
-    fn project(matrix: [[f32; 4]; 4], point: [f32; 3]) -> [f32; 3] {
-        let mut out = [0.0f32; 4];
-        for (row, cell) in out.iter_mut().enumerate() {
-            *cell = matrix[0][row] * point[0]
-                + matrix[1][row] * point[1]
-                + matrix[2][row] * point[2]
-                + matrix[3][row];
-        }
-        [out[0] / out[3], out[1] / out[3], out[2] / out[3]]
-    }
-
-    fn looking_north() -> Camera {
-        Camera {
-            eye: [0.0, 0.0, 0.0],
-            target: [0.0, 0.0, 10.0],
-            fov: core::f32::consts::FRAC_PI_2,
-            aspect: 1.0,
-            near: 0.1,
-            far: 100.0,
-        }
-    }
-
-    /// The point the camera looks at lands in the middle of the picture.
+    /// This game's planes land where the engine convention puts them —
+    /// near on one, far on zero. The engine crate proves the mapping in
+    /// general; this pins the sample's own constants to it, because a
+    /// sample that drifted to another convention would still compile.
     #[test]
-    fn the_target_is_the_centre_of_the_picture() {
-        let clip = project(looking_north().view_projection(), [0.0, 0.0, 10.0]);
-        assert!(clip[0].abs() < 1e-5, "x: {clip:?}");
-        assert!(clip[1].abs() < 1e-5, "y: {clip:?}");
-    }
-
-    /// **Up in the world is up on the screen.**
-    ///
-    /// Its own test with its own message: the failure is a world
-    /// rendered upside down, which is a perfectly ordinary-looking
-    /// picture.
-    #[test]
-    fn a_higher_point_is_higher_on_the_screen() {
-        let matrix = looking_north().view_projection();
-        let low = project(matrix, [0.0, -1.0, 10.0]);
-        let high = project(matrix, [0.0, 1.0, 10.0]);
-        assert!(
-            high[1] < low[1],
-            "screen y grows downward, so a higher point needs a smaller y; the world is upside \
-             down: high {high:?} against low {low:?}"
-        );
-    }
-
-    /// Right in the world is right on the screen.
-    #[test]
-    fn a_point_to_the_right_is_to_the_right() {
-        let matrix = looking_north().view_projection();
-        let left = project(matrix, [-1.0, 0.0, 10.0]);
-        let right = project(matrix, [1.0, 0.0, 10.0]);
-        assert!(
-            right[0] > left[0],
-            "the picture is mirrored: {left:?} {right:?}"
-        );
-    }
-
-    /// The near and far planes land on one and nought — the reversed
-    /// mapping, deliberately, and not OpenGL's range either.
-    #[test]
-    fn the_planes_map_to_the_reversed_depth_range() {
-        let camera = looking_north();
+    fn the_games_planes_map_to_the_reversed_depth_range() {
+        let camera = free_view([0.0, 0.0, 0.0], [0.0, 0.0, 10.0], 1.0);
         let matrix = camera.view_projection();
-        let near = project(matrix, [0.0, 0.0, camera.near]);
-        let far = project(matrix, [0.0, 0.0, camera.far]);
-        assert!(
-            (near[2] - 1.0).abs() < 1e-4,
-            "the near plane should be 1 under reversed depth: {near:?}"
-        );
-        assert!(
-            far[2].abs() < 1e-4,
-            "the far plane should be 0 under reversed depth: {far:?}"
-        );
-    }
-
-    /// A degenerate camera answers with a picture rather than with NaN.
-    #[test]
-    fn an_eye_at_its_own_target_still_produces_a_matrix() {
-        let camera = Camera {
-            eye: [3.0, 4.0, 5.0],
-            target: [3.0, 4.0, 5.0],
-            ..looking_north()
+        let project = |z: f32| {
+            let out = matrix.transform(renew_math::Vec4::new(0.0, 0.0, z, 1.0));
+            out.z / out.w
         };
-        for column in camera.view_projection() {
-            for value in column {
-                assert!(value.is_finite(), "a degenerate camera produced {value}");
-            }
-        }
-    }
-
-    /// **Why the depth mapping is reversed, as a measurement.** Two
-    /// walls a block apart at the far end of the arena must land on
-    /// distinct f32 depths, or the depth test cannot order them and
-    /// which one shows becomes a rounding accident. Under the
-    /// conventional mapping (near to 0, far to 1) this camera's
-    /// near/far ratio of four thousand crushes the far half of the
-    /// range into a handful of representable values — measured here so
-    /// the motivation is a number, not a memory: at 190 and 191 blocks
-    /// the conventional mapping's gap is several times fewer f32 steps
-    /// than the reversed one's.
-    #[test]
-    fn reversed_depth_separates_the_far_field_better_than_conventional() {
-        let camera = Camera {
-            eye: [0.0, 0.0, 0.0],
-            target: [0.0, 0.0, 10.0],
-            fov: core::f32::consts::FRAC_PI_2,
-            aspect: 1.0,
-            near: NEAR,
-            far: FAR,
-        };
-        // Both mappings, computed the way the projection computes them.
-        let range = camera.far - camera.near;
-        let conventional =
-            |z: f32| (z * (camera.far / range) - (camera.far * camera.near) / range) / z;
-        let reversed =
-            |z: f32| (z * (-camera.near / range) + (camera.far * camera.near) / range) / z;
-        // Distinct representable values between the two depths: count
-        // f32 bit-steps between the mapped endpoints.
-        let steps = |mapping: &dyn Fn(f32) -> f32, a: f32, b: f32| {
-            let (lo, hi) = (mapping(a).min(mapping(b)), mapping(a).max(mapping(b)));
-            hi.to_bits() - lo.to_bits()
-        };
-        let far_pair = (190.0f32, 191.0f32);
-        let conventional_steps = steps(&conventional, far_pair.0, far_pair.1);
-        let reversed_steps = steps(&reversed, far_pair.0, far_pair.1);
         assert!(
-            reversed_steps > 4 * conventional_steps,
-            "reversed depth must separate the far field far better: {reversed_steps} \
-             f32 steps against {conventional_steps} between {} and {} blocks",
-            far_pair.0,
-            far_pair.1
+            (project(NEAR) - 1.0).abs() < 1e-4,
+            "the near plane should be 1 under reversed depth"
         );
         assert!(
-            reversed_steps > 0 && conventional_steps > 0,
-            "both mappings must at least distinguish the pair at all: \
-             reversed {reversed_steps}, conventional {conventional_steps}"
+            project(FAR).abs() < 1e-4,
+            "the far plane should be 0 under reversed depth"
         );
-    }
-
-    proptest::proptest! {
-        /// Anything in front of the eye is nearer than anything behind
-        /// it, over arbitrary points — and under reversed depth, nearer
-        /// means larger.
-        ///
-        /// The property the depth test rests on. A projection monotone
-        /// at the two points somebody typed can still fold in between.
-        #[test]
-        fn depth_shrinks_with_distance_from_the_eye(
-            x in -20.0f32..20.0,
-            y in -20.0f32..20.0,
-            near_z in 1.0f32..40.0,
-            step in 0.5f32..40.0,
-        ) {
-            let matrix = looking_north().view_projection();
-            let here = project(matrix, [x, y, near_z]);
-            let there = project(matrix, [x, y, near_z + step]);
-            proptest::prop_assert!(
-                there[2] < here[2],
-                "further should be smaller under reversed depth: {:?} then {:?}", here, there
-            );
-        }
-
-        /// Everything inside the frustum lands inside clip space.
-        #[test]
-        fn points_in_front_land_in_the_unit_depth_range(
-            x in -5.0f32..5.0,
-            y in -5.0f32..5.0,
-            z in 0.2f32..90.0,
-        ) {
-            let clip = project(looking_north().view_projection(), [x, y, z]);
-            proptest::prop_assert!(
-                (0.0..=1.0).contains(&clip[2]),
-                "depth outside the range the viewport maps: {:?}", clip
-            );
-        }
     }
 }

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -318,7 +318,7 @@ pub(crate) fn draw_scene(
     let mesh = renderer
         .upload(&device, scene)
         .map_err(|error| RenderError::Refused(error.to_string()))?;
-    let packed = RenderCamera::from_columns(camera.view_projection());
+    let packed = RenderCamera::from_columns(camera.columns());
 
     // The overlay, if there is one: geometry that is already clip space
     // and so needs the pipeline that does not transform. Built here

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -152,17 +152,14 @@ fn step_of(value: Fixed) -> i32 {
 
 /// Width over height, or 1.0 where that means nothing.
 ///
-/// A free function so the zero-height case is reachable without a
-/// window: a minimised window really does report a height of zero, and
-/// dividing by it would put an infinity into the projection and a blank
-/// frame on the screen — which looks exactly like a driver failure and is
-/// not one.
+/// The engine camera crate's helper, thinly wrapped for the rendering
+/// crate's `Extent`. This used to be a local implementation that
+/// guarded only a zero height; the engine's guards both axes, which
+/// closes the width-zero corner where the local one answered an aspect
+/// of exactly zero — and a zero aspect through a projection is the
+/// same blank-frame failure the zero-height guard exists to prevent.
 fn aspect_of(size: Extent) -> f32 {
-    if size.height == 0 {
-        return 1.0;
-    }
-    f32::from(u16::try_from(size.width).unwrap_or(u16::MAX))
-        / f32::from(u16::try_from(size.height).unwrap_or(u16::MAX))
+    renew_camera::aspect_of(size.width, size.height)
 }
 
 /// The game, running against a window.
@@ -211,6 +208,12 @@ struct CubeApp {
     /// Absent until the window is up, so device bring-up is not banked as
     /// a burst of catch-up steps the moment play starts.
     frame: Option<FrameLoop>,
+    /// The view at the previous completed tick, kept so a draw between
+    /// ticks can blend toward the current one instead of repeating it —
+    /// display-rate smoothness through the frame loop's interpolation
+    /// factor. Presentation state in floats: it is written from the
+    /// world and never read back into it, so no digest sees it.
+    previous_view: Option<renew_camera::View>,
     /// The window's size in physical pixels, kept because recovering a
     /// swapchain needs the current size and the event that reports it is
     /// not the frame that discovers the loss.
@@ -304,6 +307,7 @@ impl CubeApp {
             cursor_held: false,
             clock: Clock::start(),
             frame: None,
+            previous_view: None,
             size: Extent {
                 width: 1,
                 height: 1,
@@ -501,9 +505,23 @@ impl CubeApp {
         }))
     }
 
-    /// Draw one frame.
-    fn draw(&mut self) {
-        let camera = crate::camera::player_view(&self.world, self.aspect());
+    /// Draw one frame, blending the view `alpha` of the way from the
+    /// previous tick's toward the current one.
+    ///
+    /// The blend happens entirely on the float side — a lerp of eye and
+    /// target — and nothing flows back into the world, so every digest
+    /// and every replay comparison is untouched by how smoothly the
+    /// picture moves.
+    fn draw(&mut self, alpha: renew_math::Alpha) {
+        let current = crate::camera::player_view(&self.world, self.aspect());
+        let view = match self.previous_view {
+            Some(previous) => renew_camera::View::blend(previous, current.view, alpha),
+            None => current.view,
+        };
+        let camera = crate::camera::Camera {
+            view,
+            projection: current.projection,
+        };
         let edits = self.world.edits();
         let aimed = self.aim_cell();
         let stale = self
@@ -539,7 +557,7 @@ impl CubeApp {
             gpu.crosshair_aspect = wanted;
         }
 
-        let packed = RenderCamera::from_columns(camera.view_projection());
+        let packed = RenderCamera::from_columns(camera.columns());
         let color = [attachment(SKY)];
         let world = gpu.renderer.item(&gpu.mesh, &packed);
 
@@ -625,18 +643,31 @@ impl CubeApp {
     fn update_at(&mut self, now: Timestamp, control: &mut LoopControl) {
         // Counted rather than iterated so the borrow of `frame` ends
         // before `advance` takes the whole of `self`. Every step is the
-        // same call; only how many is in question.
-        let due = match self.frame.as_mut() {
-            Some(frame) => frame.begin_frame(now).steps().count(),
+        // same call; only how many is in question — plus how far into
+        // the next step this frame lands, which is what the draw blends
+        // by.
+        let (due, alpha) = match self.frame.as_mut() {
+            Some(frame) => {
+                let plan = frame.begin_frame(now);
+                (
+                    plan.steps().count(),
+                    renew_math::Alpha::new(plan.remainder().get(), Timestep::HZ_60.nanos()),
+                )
+            }
             // No window came up, so there is no clock anchor and nothing
             // to draw. One step a spin keeps the simulation moving for
             // whoever is reading the digest.
-            None => 1,
+            None => (1, renew_math::Alpha::ZERO),
         };
         for _ in 0..due {
+            // Snapshot before each step: after the loop this holds the
+            // view at the tick before the last, which is what a blend
+            // interpolates from. A frame with no step due keeps the
+            // snapshot it has, and only alpha moves.
+            self.previous_view = Some(crate::camera::player_eye_view(&self.world));
             self.advance();
         }
-        self.draw();
+        self.draw(alpha);
         if self.done() {
             control.exit();
         }


### PR DESCRIPTION
A new optional crate owns the viewpoint maths: a look-at view, a
reversed-depth perspective under the engine's clip conventions — stated
as a contract, each clause pinned by a test because each produces a
plausible wrong picture when violated — and a blend between two ticks'
views for display-rate smoothness. Its sole dependency is the maths
crate; floats are its medium on purpose, and the workspace structure
check is what keeps it out of every simulation crate's closure.

The voxel game deletes its private camera maths and keeps what is
genuinely its own: the field of view and planes chosen for its arena,
the viewpoint constructors that read its world, and the one place fixed
point becomes float. Its windowed driver now snapshots the view at each
completed tick and blends toward the current one by the frame loop's
interpolation factor, so the picture moves at the panel's rate while the
simulation keeps its own — the blend is a lerp on the float side, and
the play-the-game digest tests prove nothing flows back.

All five committed renders reproduce byte-for-byte after the extraction.
That claim survived one correction: the maths crate's robust two-step
normalization is bit-different from the single division this replaced,
and two pixels moved until the crate matched the original arithmetic,
with a comment recording why and a note that the degenerate paths
deliberately differ. The removability matrix gains a without-camera
cell; the sample's divergent aspect helper became a thin wrapper over
the engine's, closing a zero-width corner its own guard missed.
