### PR TITLE
bench(particles): the pool's step and pack, timed at two sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,9 @@ jobs:
       # that is what makes it impossible to change what a cell builds
       # without changing what the guard checked.
       #
-      # renew-bench appears in two exclude lists because it reaches
-      # both renew-jobs and renew-frame from its bench targets.
+      # renew-bench appears in several exclude lists because its bench
+      # targets reach the crates they time (jobs, frame, rng, ecs,
+      # particles); each crate's cell excludes it alongside the crate.
       - name: Build and test without the job system
         run: |
           sel="--workspace --exclude renew-jobs --exclude renew-bench"
@@ -265,10 +266,11 @@ jobs:
       # The particle pool: arithmetic over the seeded generator. Its
       # one consumer is the voxel game, which bursts dust on a broken
       # block behind its render feature — excluded with it, as the
-      # removability rule asks of dependents.
+      # removability rule asks of dependents. renew-bench reaches the
+      # pool from its bench targets, like the job pool before it.
       - name: Build and test without the particle pool
         run: |
-          sel="--workspace --exclude renew-particles --exclude renew-sample-cube"
+          sel="--workspace --exclude renew-particles --exclude renew-sample-cube --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-particles $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "renew-jobs",
  "renew-math",
  "renew-memory",
+ "renew-particles",
  "renew-platform",
  "renew-rng",
 ]

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renew-bench"
-description = "Benchmark suite: math, allocator, and job-pool kernels with allocation-count assertions"
+description = "Benchmark suite: criterion timings over engine kernels with allocation-count assertions"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Criterion benchmarks over the math, allocator, and job-pool kernels, paired with exact allocation-count assertions."
+purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles — paired with exact allocation-count assertions."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -38,6 +38,9 @@ renew-jobs = { path = "../../crates/jobs" }
 # The storage decision was settled on measurements that were never
 # committed, so nothing here could detect a regression in what shipped.
 renew-ecs = { path = "../../crates/ecs" }
+# Bench-target-only: the pool's allocation behaviour is gated in its
+# own crate; this suite only times it.
+renew-particles = { path = "../../crates/particles" }
 
 [lints]
 workspace = true
@@ -72,4 +75,8 @@ harness = false
 
 [[bench]]
 name = "clock"
+harness = false
+
+[[bench]]
+name = "particles"
 harness = false

--- a/bench/suite/README.md
+++ b/bench/suite/README.md
@@ -12,14 +12,20 @@ splits the two jobs benchmarks usually conflate:
   vector/matrix/quaternion/AABB kernels on seeded array inputs; `alloc`
   covers the arena frame cycle, pool churn, and heap round trips;
   `alloc_counted` reruns the heap kernel under the counting allocator so
-  its overhead is a comparison between two runs.
+  its overhead is a comparison between two runs; `particles` times the
+  particle pool's step and instance pack at 1,024 and 4,096 particles
+  (its allocation gate lives with the pool's own crate, which asserts
+  exact zero on every push).
 - **Allocation counts** (`tests/zero_alloc.rs`) gate. The math kernels,
   the arena frame cycle, and pool churn must allocate **exactly zero** —
   an assertion with zero run-to-run variance, checked on every push as
   part of the ordinary test suite.
 
-Both halves call the same kernel functions in `src/lib.rs`, so what is
-timed and what is asserted can never drift apart.
+For the math and allocator kernels, both halves call the same kernel
+functions in `src/lib.rs`, so what is timed and what is asserted can
+never drift apart. Benches over other crates (jobs, ecs, rng, frame,
+particles) call those crates directly, and their gating — where they
+have it — lives with the crate that owns the behaviour.
 
 ## Running
 

--- a/bench/suite/benches/particles.rs
+++ b/bench/suite/benches/particles.rs
@@ -1,0 +1,85 @@
+//! Particle pool timings: the cost of one simulation step and one
+//! instance pack, at the two pool sizes that bracket what a scene asks
+//! for. A thousand particles is a busy scene for the current samples —
+//! the block-break burst tops out in the dozens — and four thousand is
+//! the stress ceiling the pool should absorb before anyone reaches for
+//! a second pool or a coarser effect.
+//!
+//! Every particle is given an effectively infinite lifetime, so a step
+//! updates exactly the full pool on every iteration: a real effect's
+//! expiry would drain the pool mid-measurement and the later
+//! iterations would time an emptier and emptier update. Uniform work
+//! per iteration is what makes two runs comparable.
+//!
+//! The allocation gate for these kernels does not live here: the pool
+//! commits to zero steady-state allocation in its own crate, where
+//! `tests/zero_alloc.rs` asserts exact counts over `burst`, `step`,
+//! and `write_instances` on every push. This file only times what that
+//! test already gates.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_particles::{EffectDesc, INSTANCE_STRIDE, ParticleSystem, Seed, StreamId, VelocityCone};
+
+/// Arbitrary but fixed, for the same reason the generator bench pins
+/// one: a varying seed makes two runs incomparable for no benefit.
+const SEED: Seed = Seed::from_u64(0xBE7C_0000_0000_0001);
+
+/// The simulation cadence the samples actually step at.
+const DT: f32 = 1.0 / 60.0;
+
+/// Longer than any benchmark run by orders of magnitude, so no
+/// particle expires mid-measurement and every step touches the whole
+/// pool.
+const IMMORTAL: f32 = 1.0e9;
+
+/// A pool filled to exactly `count` live particles.
+fn full_pool(count: u32) -> ParticleSystem {
+    let desc = EffectDesc {
+        capacity: count,
+        lifetime: (IMMORTAL, IMMORTAL),
+        velocity: VelocityCone {
+            axis: [0.0, 1.0, 0.0],
+            spread: 1.0,
+            speed: (1.0, 2.0),
+        },
+        gravity: [0.0, -5.0, 0.0],
+        drag_per_step: 0.99,
+        size: (0.1, 0.05),
+        color: ([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]),
+        tile: [0.0, 0.0, 1.0, 1.0],
+    };
+    let mut pool = ParticleSystem::new(&desc, SEED, StreamId::from_name("bench"));
+    pool.burst([0.0, 0.0, 0.0], count);
+    assert_eq!(
+        pool.live(),
+        count,
+        "the pool must start full or the size lies"
+    );
+    pool
+}
+
+fn particles(c: &mut Criterion) {
+    for count in [1024_u32, 4096] {
+        c.bench_function(&format!("particle_update_{count}"), |b| {
+            let mut pool = full_pool(count);
+            b.iter(|| pool.step(black_box(DT)));
+        });
+
+        c.bench_function(&format!("particle_pack_{count}"), |b| {
+            let pool = full_pool(count);
+            let mut instances = vec![0u8; count as usize * INSTANCE_STRIDE];
+            b.iter(|| {
+                // The buffer is the output; observing only the returned
+                // count would let a link-time optimizer discard the
+                // writes being timed.
+                black_box(pool.write_instances(black_box(&mut instances)));
+                black_box(&mut instances);
+            });
+        });
+    }
+}
+
+criterion_group!(benches, particles);
+criterion_main!(benches);


### PR DESCRIPTION
Four timings join the suite: `particle_update` and `particle_pack` at 1,024 and 4,096 particles — the sizes that bracket a scene. A thousand is busy for the current samples, whose burst tops out in the dozens; four thousand is the stress ceiling before a second pool or a coarser effect is the right answer.

**Measurement design.** Pools get effectively infinite lifetimes so every iteration updates exactly the stated count — real expiry would drain the pool mid-measurement and later iterations would time an emptier and emptier update. The pack bench black-boxes the buffer it writes, not just the returned count, so a link-time optimizer can never hollow the timing. The allocation gate is not duplicated: the pool's own crate asserts exact-zero steady-state counts on every push, and the bench module doc points at it.

**Numbers from this change's development machine** (Intel64 Family 6 Model 165, 16 logical cores, Windows 10, rustc 1.97.1, criterion medians): update 3.25 µs / 13.04 µs and pack 4.12 µs / 16.39 µs at 1,024 / 4,096 — 4.01× and 3.98× scaling, linear as the structure-of-arrays layout promises. A full 4,096-pool update plus pack is about 29 µs, under 0.2% of a 60 Hz frame.

**Mechanics.** The suite reaches the pool from its bench targets only, so the without-particles build cell excludes the suite alongside the pool — the same rule the other timed crates' cells already follow, and the guard comment now states the rule instead of counting its uses. Smoke mode discovers the new target automatically. The suite's manifest strings grow to name the bench families they had silently outgrown.
