### PR TITLE
feat(ui): the retained widget tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,15 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-camera $sel
           cargo build $sel
           cargo test $sel
+      # The widget tree: pure structure with no dependencies and no
+      # consumers yet — the UI's later layers and their first embedding
+      # game grow this list when they arrive.
+      - name: Build and test without the widget tree
+        run: |
+          sel="--workspace --exclude renew-ui"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui $sel
+          cargo build $sel
+          cargo test $sel
       # The 2D renderer: policy over the rendering crate, no consumers
       # yet -- the windowed game grows this list when it draws sprites.
       - name: Build and test without the 2D renderer
@@ -402,7 +411,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,6 +1902,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-ui"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-memory",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
-    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "crates/ui", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "renew-ui"
+description = "The retained widget tree: arena-backed nodes with generational ids, capacities fixed at construction"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The simulation-side widget tree: an arena of generationally addressed nodes with capacities fixed by UiLimits at construction, refusing rather than growing. Layout, input, and state digestion arrive in later steps; the tree is their common ground."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+[lints]
+workspace = true
+
+[dependencies]
+
+# Property tests for the tree's invariants — the containers row of the
+# testing table — and the engine's counting allocator for the
+# zero-allocation gate, which ships with the crate's first per-frame
+# code rather than after it.
+[dev-dependencies]
+proptest = "1.11"
+renew-memory = { path = "../core/memory" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under instrumented allocators, so the gate ignores itself
+# there.
+[features]
+sanitized = []

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -1,0 +1,49 @@
+# renew-ui
+
+The retained widget tree: an arena of generationally addressed nodes,
+capacities fixed at construction. This crate is the simulation-side
+ground the rest of the UI stands on — layout solving, input handling,
+and state digestion arrive as their own steps and all walk the tree
+built here.
+
+Machine-readable facts — maturity, dependencies, core status — live in
+this crate's manifest metadata (`Cargo.toml`, `[package.metadata.renew]`).
+
+## Shape
+
+Nodes live in one arena, linked intrusively: parent, first and last
+child, previous and next sibling. Children keep insertion order —
+document order — which is the order every later consumer (layout,
+drawing, hit-testing) walks them in. No node owns a collection, so the
+steady state allocates nothing: insertion pops a free slot, removal
+pushes one back, and the arena never grows. A test holds the tree to
+that promise with a counting allocator: after construction, insert,
+remove, and walk touch the heap exactly zero times.
+
+## Addressing
+
+A `NodeId` is a slot index plus the generation the slot carried when
+the node was created. Removing a node bumps its slot's generation, so
+every id that named it goes stale at once and stays stale forever —
+the generation is 64 bits, and no physical run recycles one slot often
+enough to see it repeat. A stale id is data, not a fault: every
+operation given one misses — `None`, `false`, an empty iterator, or
+`UiRefused::MissingParent` — rather than panicking or touching the
+slot's new tenant.
+
+That promise is scoped to the tree that issued the id. A `NodeId`
+carries no memory of its tree: two trees issue the same id sequence,
+so an id used on the wrong tree is not detected — it may miss, or it
+may name an unrelated node. Holding ids across trees is a logic
+error.
+
+## Bounds
+
+`UiLimits` fixes the arena's size at construction (zero clamps to one:
+a tree exists to hold at least its root). A full tree refuses insertion
+with `UiRefused::Full` and stands unchanged. Nothing here grows, and
+nothing here panics on data — the two refusals are the API's whole
+error vocabulary, and property tests drive random operation sequences
+against the tree's invariants: reachability matches the live count,
+children and parents agree, capacity is a wall, and stale ids miss
+everywhere at once.

--- a/crates/ui/clippy.toml
+++ b/crates/ui/clippy.toml
@@ -1,0 +1,42 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: the widget tree is simulation-designated — its state will
+# feed digests once absorption lands — so it reads no clock, touches no
+# filesystem, spawns no thread, and holds no self-seeding container.
+# The float deny is at the crate root, beside the sentence explaining it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
+    { path = "std::time::SystemTime::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; simulation is single-threaded and parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::env::var", reason = "a value from the environment would make one run differ from the next with nothing in the inputs to explain it" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "self-seeding entropy has no place in state that will feed a digest" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "self-seeding entropy has no place in state that will feed a digest" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle" },
+    { path = "std::fs::OpenOptions", reason = "the long way to the same handle, and the one a ban on File::open misses" },
+    { path = "std::path::Path", reason = "the crate takes node ids and limits, never a path" },
+    { path = "std::path::PathBuf", reason = "the crate takes node ids and limits, never a path" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,0 +1,587 @@
+//! The retained widget tree: an arena of generationally addressed
+//! nodes, capacities fixed at construction.
+//!
+//! This crate is the simulation-side ground the rest of the UI stands
+//! on. Layout solving, input handling, and state digestion arrive as
+//! their own steps; what ships here is the structure they all share —
+//! a tree whose nodes are stable to address, cheap to add and remove,
+//! and bounded by an explicit limit rather than by whatever the heap
+//! allows.
+//!
+//! **Shape.** Nodes live in one arena, linked intrusively: parent,
+//! first and last child, previous and next sibling. Children keep
+//! insertion order — document order — which is the order every later
+//! consumer (layout, drawing, hit-testing) walks them in. No node owns
+//! a collection, so the steady state allocates nothing: insertion pops
+//! a free slot, removal pushes one back, and the arena never grows.
+//!
+//! **Addressing.** A [`NodeId`] is a slot index plus the generation the
+//! slot carried when the node was created. Removing a node bumps the
+//! slot's generation, so every id that named it goes stale at once and
+//! stays stale forever — the generation is 64 bits, so recycling one
+//! slot every nanosecond exhausts it after five centuries; no physical
+//! run reaches a repeat. A stale id is data, not a fault, and every
+//! operation given one misses — answers `None`, `false`, an empty
+//! iterator, or [`UiRefused::MissingParent`] — rather than panicking or
+//! touching the wrong node.
+//!
+//! One honesty the ids cannot offer: a `NodeId` carries no memory of
+//! which tree issued it. Two trees issue the same sequence of ids, so
+//! an id from one tree used on another is **not detected** — it may
+//! miss, or it may name that tree's unrelated node. Holding ids across
+//! trees is a logic error; the tag that would catch it needs either
+//! global state or an address-derived value, and both are barred here
+//! for reasons older than this crate.
+//!
+//! **Bounds.** [`UiLimits`] fixes the arena's size at construction. A
+//! full tree refuses insertion with [`UiRefused::Full`]; nothing here
+//! grows, and nothing here panics on data.
+
+// The simulation's crates deny float arithmetic wholesale (the closure
+// rule checks every crate in a simulation's shipping graph); the tree
+// is pure structure and needs no arithmetic at all beyond indices.
+#![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
+
+/// Nothing here: the marker every slot uses for "no neighbour". One
+/// value, not an `Option<u32>`, so a slot stays eight words no matter
+/// how many links are empty.
+const NIL: u32 = u32::MAX;
+
+/// Capacities for one [`Ui`], fixed at construction.
+///
+/// One field today; later steps add their own ceilings (text bytes,
+/// style tables) beside it. The struct is plain on purpose — the crate
+/// is `bootstrap`, and growing a field is cheaper than a builder.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UiLimits {
+    /// The most nodes the tree will hold, root included. Zero is
+    /// clamped to one: a tree exists to hold at least its root.
+    pub nodes: u32,
+}
+
+/// Why the tree refused an operation.
+///
+/// Refusals are data, not faults: a full tree and a vanished parent
+/// are both things a running game can cause and must be able to hear
+/// about.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UiRefused {
+    /// The tree already holds [`UiLimits::nodes`] nodes.
+    Full,
+    /// The named parent is not live: removed since the id was taken.
+    MissingParent,
+}
+
+impl core::fmt::Display for UiRefused {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Full => write!(f, "the tree is at its node limit"),
+            Self::MissingParent => write!(f, "the parent node is not live"),
+        }
+    }
+}
+
+impl core::error::Error for UiRefused {}
+
+/// A node's address: slot index plus the generation the slot carried
+/// when this node was created.
+///
+/// Copyable and order-free on purpose: an id can be stored anywhere,
+/// for any length of time, and — **on the tree that issued it** — the
+/// worst it can do later is miss. It does not remember which tree that
+/// was (see the crate doc): on any other tree it is meaningless and
+/// undetected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct NodeId {
+    index: u32,
+    generation: u64,
+}
+
+/// One arena slot. Free slots keep their links meaningless except
+/// `next_sibling`, which threads the free list.
+#[derive(Clone, Copy, Debug)]
+struct Slot {
+    /// Bumped on every removal, so old ids miss. Sixty-four bits so
+    /// the bump can never cycle in a physical run — "stays stale
+    /// forever" is a claim about this counter, and a u32 makes it
+    /// false after 2^32 recycles of one slot. Tracked beside an
+    /// explicit `live` flag rather than encoded in parity — parity is
+    /// the kind of cleverness that is wrong once and then wrong
+    /// forever.
+    generation: u64,
+    live: bool,
+    parent: u32,
+    first_child: u32,
+    last_child: u32,
+    prev_sibling: u32,
+    next_sibling: u32,
+}
+
+impl Slot {
+    const EMPTY: Self = Self {
+        generation: 0,
+        live: false,
+        parent: NIL,
+        first_child: NIL,
+        last_child: NIL,
+        prev_sibling: NIL,
+        next_sibling: NIL,
+    };
+}
+
+/// The retained widget tree.
+///
+/// Construction allocates everything the tree will ever hold; no later
+/// operation allocates, which is what lets the steady-state gate assert
+/// exactly zero.
+#[derive(Debug)]
+pub struct Ui {
+    slots: Vec<Slot>,
+    /// Head of the free list, threaded through `next_sibling`.
+    free: u32,
+    live: u32,
+    limits: UiLimits,
+}
+
+impl Ui {
+    /// A tree holding only its root, with room for `limits.nodes` nodes
+    /// in total.
+    #[must_use]
+    pub fn new(limits: UiLimits) -> Self {
+        let capacity = limits.nodes.max(1);
+        let mut slots = vec![Slot::EMPTY; capacity as usize];
+        // The root occupies slot zero from birth. Generation starts at
+        // one so the all-zeroes NodeId a caller might conjure from
+        // nowhere never names anything.
+        slots[0].generation = 1;
+        slots[0].live = true;
+        // The remaining slots thread the free list in index order.
+        for (index, slot) in slots.iter_mut().enumerate().skip(1) {
+            slot.generation = 1;
+            let next = index + 1;
+            slot.next_sibling = if next < capacity as usize {
+                // Bounded by capacity, which is a u32.
+                u32::try_from(next).unwrap_or(NIL)
+            } else {
+                NIL
+            };
+        }
+        let free = if capacity > 1 { 1 } else { NIL };
+        Self {
+            slots,
+            free,
+            live: 1,
+            limits: UiLimits { nodes: capacity },
+        }
+    }
+
+    /// The root: created with the tree, never removable.
+    #[must_use]
+    pub fn root(&self) -> NodeId {
+        NodeId {
+            index: 0,
+            generation: self.slots[0].generation,
+        }
+    }
+
+    /// The limits the tree was built with (with zero already clamped).
+    #[must_use]
+    pub fn limits(&self) -> UiLimits {
+        self.limits
+    }
+
+    /// How many nodes are live, root included.
+    #[must_use]
+    pub fn live(&self) -> u32 {
+        self.live
+    }
+
+    /// Whether `node` still names a live node of this tree.
+    #[must_use]
+    pub fn is_live(&self, node: NodeId) -> bool {
+        self.slot_of(node).is_some()
+    }
+
+    /// Append a new node as `parent`'s last child.
+    ///
+    /// # Errors
+    ///
+    /// [`UiRefused::Full`] when the tree already holds its limit;
+    /// [`UiRefused::MissingParent`] when `parent` is stale. Either way
+    /// the tree is unchanged.
+    pub fn insert(&mut self, parent: NodeId) -> Result<NodeId, UiRefused> {
+        let parent_index = self.slot_of(parent).ok_or(UiRefused::MissingParent)?;
+        if self.free == NIL {
+            return Err(UiRefused::Full);
+        }
+        let index = self.free;
+        let slot = &mut self.slots[index as usize];
+        self.free = slot.next_sibling;
+        let generation = slot.generation;
+        *slot = Slot {
+            generation,
+            live: true,
+            parent: parent_index,
+            ..Slot::EMPTY
+        };
+        self.link_last(parent_index, index);
+        self.live += 1;
+        Ok(NodeId { index, generation })
+    }
+
+    /// Remove `node` and its whole subtree.
+    ///
+    /// Answers whether anything was removed: `false` is the miss for a
+    /// stale id — and for the root, which is structural and lives as
+    /// long as the tree.
+    pub fn remove(&mut self, node: NodeId) -> bool {
+        let Some(index) = self.slot_of(node) else {
+            return false;
+        };
+        if index == 0 {
+            return false;
+        }
+        self.unlink(index);
+        self.free_subtree(index);
+        true
+    }
+
+    /// The parent of `node`; `None` for the root and for stale ids.
+    #[must_use]
+    pub fn parent(&self, node: NodeId) -> Option<NodeId> {
+        let index = self.slot_of(node)?;
+        let parent = self.slots[index as usize].parent;
+        (parent != NIL).then(|| self.id_at(parent))
+    }
+
+    /// The children of `node`, in insertion order — document order,
+    /// the order layout and drawing will walk. Empty for stale ids.
+    pub fn children(&self, node: NodeId) -> impl Iterator<Item = NodeId> + '_ {
+        let first = self
+            .slot_of(node)
+            .map_or(NIL, |index| self.slots[index as usize].first_child);
+        Children {
+            ui: self,
+            at: first,
+        }
+    }
+
+    /// The live slot index behind `node`, if the id still names one.
+    fn slot_of(&self, node: NodeId) -> Option<u32> {
+        let slot = self.slots.get(node.index as usize)?;
+        (slot.live && slot.generation == node.generation).then_some(node.index)
+    }
+
+    /// The id currently naming `index`. Only called for live slots.
+    fn id_at(&self, index: u32) -> NodeId {
+        NodeId {
+            index,
+            generation: self.slots[index as usize].generation,
+        }
+    }
+
+    /// Append `index` to `parent`'s child list.
+    fn link_last(&mut self, parent: u32, index: u32) {
+        let last = self.slots[parent as usize].last_child;
+        if last == NIL {
+            self.slots[parent as usize].first_child = index;
+        } else {
+            self.slots[last as usize].next_sibling = index;
+            self.slots[index as usize].prev_sibling = last;
+        }
+        self.slots[parent as usize].last_child = index;
+    }
+
+    /// Detach `index` from its parent's child list. The subtree below
+    /// it stays attached to it.
+    fn unlink(&mut self, index: u32) {
+        let Slot {
+            parent,
+            prev_sibling,
+            next_sibling,
+            ..
+        } = self.slots[index as usize];
+        if prev_sibling == NIL {
+            self.slots[parent as usize].first_child = next_sibling;
+        } else {
+            self.slots[prev_sibling as usize].next_sibling = next_sibling;
+        }
+        if next_sibling == NIL {
+            self.slots[parent as usize].last_child = prev_sibling;
+        } else {
+            self.slots[next_sibling as usize].prev_sibling = prev_sibling;
+        }
+    }
+
+    /// Free `index` and everything below it, bumping generations so
+    /// every id into the subtree goes stale at once.
+    ///
+    /// Iterative with the free list itself as the work list: freed
+    /// slots are pushed as they are visited, and children are walked
+    /// before their parent's links are overwritten. No recursion — a
+    /// document is data, and data must not choose the stack depth.
+    fn free_subtree(&mut self, index: u32) {
+        // The pending stack borrows `prev_sibling` of already-detached
+        // slots, which nothing else reads between here and the free
+        // push: a slot enters pending exactly once and leaves freed.
+        let mut pending = index;
+        self.slots[index as usize].prev_sibling = NIL;
+        while pending != NIL {
+            let current = pending;
+            pending = self.slots[current as usize].prev_sibling;
+            // Push every child onto pending.
+            let mut child = self.slots[current as usize].first_child;
+            while child != NIL {
+                let next = self.slots[child as usize].next_sibling;
+                self.slots[child as usize].prev_sibling = pending;
+                pending = child;
+                child = next;
+            }
+            // Free the slot: bump the generation, thread the free
+            // list. Wrapping spelled for the overflow lint's sake only
+            // — a 64-bit recycle counter cannot wrap in a physical run.
+            let slot = &mut self.slots[current as usize];
+            slot.generation = slot.generation.wrapping_add(1);
+            slot.live = false;
+            slot.parent = NIL;
+            slot.first_child = NIL;
+            slot.last_child = NIL;
+            slot.next_sibling = self.free;
+            slot.prev_sibling = NIL;
+            self.free = current;
+            self.live -= 1;
+        }
+    }
+}
+
+/// Sibling-walk iterator over one node's children.
+struct Children<'a> {
+    ui: &'a Ui,
+    at: u32,
+}
+
+impl Iterator for Children<'_> {
+    type Item = NodeId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.at == NIL {
+            return None;
+        }
+        let id = self.ui.id_at(self.at);
+        self.at = self.ui.slots[self.at as usize].next_sibling;
+        Some(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn small() -> Ui {
+        Ui::new(UiLimits { nodes: 8 })
+    }
+
+    /// The tree is born holding its root and nothing else, and the
+    /// zero limit is clamped rather than obeyed into absurdity.
+    #[test]
+    fn a_new_tree_is_a_root_alone() {
+        let ui = small();
+        assert_eq!(ui.live(), 1);
+        assert!(ui.is_live(ui.root()));
+        assert_eq!(ui.parent(ui.root()), None);
+        assert_eq!(ui.children(ui.root()).count(), 0);
+        assert_eq!(Ui::new(UiLimits { nodes: 0 }).limits().nodes, 1);
+    }
+
+    /// Children come back in insertion order — document order, which
+    /// is the order everything downstream will walk.
+    #[test]
+    fn children_keep_document_order() {
+        let mut ui = small();
+        let root = ui.root();
+        let a = ui.insert(root).expect("room");
+        let b = ui.insert(root).expect("room");
+        let c = ui.insert(root).expect("room");
+        assert_eq!(ui.children(root).collect::<Vec<_>>(), vec![a, b, c]);
+        assert_eq!(ui.parent(b), Some(root));
+    }
+
+    /// A full tree refuses with `Full` and is left unchanged.
+    #[test]
+    fn a_full_tree_refuses_and_stands_still() {
+        let mut ui = Ui::new(UiLimits { nodes: 2 });
+        let root = ui.root();
+        let only = ui.insert(root).expect("one slot beyond the root");
+        assert_eq!(ui.insert(root), Err(UiRefused::Full));
+        assert_eq!(ui.live(), 2);
+        assert!(ui.is_live(only));
+    }
+
+    /// A stale parent refuses with `MissingParent` — a miss, not a
+    /// panic, and not a lie about capacity.
+    #[test]
+    fn a_stale_parent_is_a_miss() {
+        let mut ui = small();
+        let root = ui.root();
+        let gone = ui.insert(root).expect("room");
+        assert!(ui.remove(gone));
+        assert_eq!(ui.insert(gone), Err(UiRefused::MissingParent));
+        assert!(!ui.is_live(gone));
+        assert_eq!(ui.parent(gone), None);
+        assert_eq!(ui.children(gone).count(), 0);
+        assert!(!ui.remove(gone), "a second removal is a miss too");
+    }
+
+    /// Removing a node takes its whole subtree, stales every id into
+    /// it at once, and returns every slot to use.
+    #[test]
+    fn removal_is_the_whole_subtree() {
+        let mut ui = small();
+        let root = ui.root();
+        let branch = ui.insert(root).expect("room");
+        let leaf = ui.insert(branch).expect("room");
+        let twig = ui.insert(leaf).expect("room");
+        let sibling = ui.insert(root).expect("room");
+        assert!(ui.remove(branch));
+        assert_eq!(ui.live(), 2);
+        for stale in [branch, leaf, twig] {
+            assert!(!ui.is_live(stale));
+        }
+        assert!(ui.is_live(sibling));
+        assert_eq!(ui.children(root).collect::<Vec<_>>(), vec![sibling]);
+        // The three freed slots are usable again, to the exact limit.
+        for _ in 0..6 {
+            ui.insert(root).expect("freed slots must come back");
+        }
+        assert_eq!(ui.insert(root), Err(UiRefused::Full));
+    }
+
+    /// A recycled slot's new tenant is not reachable through the old
+    /// tenant's id: generations, not indices, are the address.
+    #[test]
+    fn a_recycled_slot_does_not_answer_to_its_old_name() {
+        let mut ui = small();
+        let root = ui.root();
+        let old = ui.insert(root).expect("room");
+        assert!(ui.remove(old));
+        let new = ui.insert(root).expect("room");
+        assert!(!ui.is_live(old));
+        assert!(ui.is_live(new));
+        assert_ne!(old, new);
+    }
+
+    /// The root refuses removal: it is structural, not content.
+    #[test]
+    fn the_root_is_not_removable() {
+        let mut ui = small();
+        let root = ui.root();
+        assert!(!ui.remove(root));
+        assert!(ui.is_live(root));
+        assert_eq!(ui.live(), 1);
+    }
+
+    /// A deep chain frees without recursion: depth equal to the whole
+    /// arena neither overflows nor leaks a slot.
+    #[test]
+    fn a_chain_as_deep_as_the_arena_frees_completely() {
+        let mut ui = Ui::new(UiLimits { nodes: 1024 });
+        let root = ui.root();
+        let mut at = root;
+        let mut top = None;
+        for _ in 0..1023 {
+            at = ui.insert(at).expect("room");
+            top.get_or_insert(at);
+        }
+        assert_eq!(ui.live(), 1024);
+        assert!(ui.remove(top.expect("the chain has a first link")));
+        assert_eq!(ui.live(), 1);
+    }
+
+    /// Every refusal says what happened in words a reader can act on.
+    #[test]
+    fn refusals_say_what_they_are() {
+        assert!(UiRefused::Full.to_string().contains("limit"));
+        assert!(UiRefused::MissingParent.to_string().contains("parent"));
+    }
+
+    /// Everything the tree promises, checked from the outside: the
+    /// public API alone must be able to see a sound tree, because the
+    /// public API is all any consumer gets.
+    fn assert_sound(ui: &Ui, ever_issued: &[NodeId]) {
+        // Every node reachable from the root agrees with its children
+        // about the relationship, and the reachable count is exactly
+        // what `live()` reports.
+        let mut seen = vec![ui.root()];
+        let mut at = 0;
+        while at < seen.len() {
+            let node = seen[at];
+            for child in ui.children(node) {
+                assert_eq!(ui.parent(child), Some(node), "a child must name its parent");
+                assert!(ui.is_live(child), "a listed child must be live");
+                seen.push(child);
+            }
+            at += 1;
+        }
+        assert_eq!(
+            seen.len(),
+            ui.live() as usize,
+            "every live node hangs off the root, and none hangs twice"
+        );
+        // Every id ever issued either still names a reachable node or
+        // misses everywhere at once.
+        for &id in ever_issued {
+            if ui.is_live(id) {
+                assert!(
+                    seen.contains(&id),
+                    "a live id must be reachable from the root"
+                );
+            } else {
+                assert_eq!(ui.parent(id), None);
+                assert_eq!(ui.children(id).count(), 0);
+            }
+        }
+    }
+
+    proptest::proptest! {
+        /// Any sequence of inserts and removals leaves a sound tree:
+        /// reachability matches the live count, children and parents
+        /// agree, and stale ids miss everywhere. The ops draw their
+        /// targets from every id ever issued — including stale ones —
+        /// so the miss paths are exercised as heavily as the hits.
+        #[test]
+        fn any_operation_sequence_keeps_the_tree_sound(
+            ops in proptest::collection::vec((0u8..=1, 0usize..1024), 1..256)
+        ) {
+            let mut ui = Ui::new(UiLimits { nodes: 24 });
+            let mut issued = vec![ui.root()];
+            for (op, pick) in ops {
+                let target = issued[pick % issued.len()];
+                if op == 0 {
+                    if let Ok(id) = ui.insert(target) {
+                        issued.push(id);
+                    }
+                } else {
+                    ui.remove(target);
+                }
+                assert_sound(&ui, &issued);
+            }
+        }
+
+        /// Capacity is a wall, not a suggestion: however the tree got
+        /// full, one more insert refuses, and a removal opens exactly
+        /// the freed room back up.
+        #[test]
+        fn full_means_full_and_freed_means_free(extra in 1u32..16) {
+            let mut ui = Ui::new(UiLimits { nodes: extra + 1 });
+            let root = ui.root();
+            let mut last = root;
+            for _ in 0..extra {
+                last = ui.insert(root).expect("under the limit");
+            }
+            proptest::prop_assert_eq!(ui.insert(root), Err(UiRefused::Full));
+            proptest::prop_assert!(ui.remove(last));
+            proptest::prop_assert!(ui.insert(root).is_ok());
+            proptest::prop_assert_eq!(ui.insert(root), Err(UiRefused::Full));
+        }
+    }
+}

--- a/crates/ui/tests/zero_alloc.rs
+++ b/crates/ui/tests/zero_alloc.rs
@@ -1,0 +1,51 @@
+//! Mechanical enforcement of the tree's allocation contract: after
+//! construction, the steady state — insert, remove, walk — performs no
+//! heap allocation through the global allocator.
+//!
+//! Shipped with the crate's first commit rather than after it, because
+//! a gate that arrives later measures whatever the code has grown into
+//! rather than what it promised. Non-vacuous by construction: the
+//! measured window works a tree that genuinely churns, and the test
+//! asserts the churn happened.
+
+use renew_memory::{CountingAllocator, counters};
+use renew_ui::{Ui, UiLimits};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_steady_state_allocates_nothing() {
+    // Everything that may allocate happens out here: the arena, once.
+    let mut ui = Ui::new(UiLimits { nodes: 256 });
+    let root = ui.root();
+
+    // Warmup: one full churn cycle, so any one-time lazy initialization
+    // lands before the window opens.
+    let first = ui.insert(root).expect("an empty tree has room");
+    assert!(ui.remove(first));
+
+    // The measured window: fill a branch to a real depth and width,
+    // walk it, tear it down, repeatedly. Insert pops the free list,
+    // remove pushes it back, the walk follows intrusive links — none
+    // of it may touch the heap.
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            let branch = ui.insert(root).expect("room for the branch");
+            for _ in 0..31 {
+                let limb = ui.insert(branch).expect("room under the limit");
+                ui.insert(limb).expect("room for a leaf");
+            }
+            assert_eq!(ui.live(), 64, "the churn must really build the tree");
+            let walked = ui.children(branch).count();
+            assert_eq!(walked, 31, "the walk must really see the children");
+            assert!(ui.remove(branch));
+            assert_eq!(ui.live(), 1, "teardown must return every slot");
+        }
+    });
+    verdict.expect("the tree's steady state stays heap-silent");
+}


### PR DESCRIPTION
A new crate: `renew-ui`, an arena of generationally addressed nodes with capacities fixed at construction. This is the simulation-side ground the UI stands on — layout, input, and state digestion arrive as their own steps and all walk the tree built here.

**Shape.** Nodes link intrusively (parent, first/last child, prev/next sibling), so no node owns a collection and the steady state allocates nothing: insertion pops a free slot, removal pushes one back, and a counting-allocator test holds the churn to exactly zero. Children keep document order — the order every later consumer (layout, drawing, hit-testing) walks.

**Addressing, honestly scoped.** A `NodeId` is a slot index plus a 64-bit generation: removal stales every id into the subtree at once, and no physical run recycles a slot often enough to see the counter repeat. The promise is scoped to the issuing tree — ids carry no tree identity, and the docs say so plainly rather than claiming a detection the representation cannot deliver. Refusals are data (`Full`, `MissingParent`); nothing panics on input. Subtree teardown is iterative — a document is data, and data must not choose the stack depth; a chain as deep as the whole arena is a unit test.

**Tests.** Eleven unit tests, two property suites (random op sequences with targets drawn from every id ever issued, so miss paths are exercised as heavily as hits, against a public-API-only soundness oracle), and the zero-allocation gate. The crate-local lint tripwires match the strictest sibling's — no clock, no filesystem by method or by type, no threads, no self-seeding containers, no environment reads.

**Wiring.** Workspace member; a new build-matrix cell proves the workspace whole without the crate; the optional-crate list and the nightly instrumented-run feature list both grow by one.
