### PR TITLE
feat(ui): the fixed-point flex solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,14 +337,15 @@ jobs:
           cargo test $sel
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-png -p renew-sample-cube
           cargo build -p renew-sample-cube
-      # The fixed-point arithmetic, and the collision crate written in it.
-      # This cell was a single leaf when it landed, with a comment saying
-      # the first crate to depend on it should discover the obligation
-      # from a red lane rather than from nobody. It did: physics arrived
-      # and this cell went red until it named the dependent.
+      # The fixed-point arithmetic, and the crates written in it. This
+      # cell was a single leaf when it landed, with a comment saying the
+      # first crate to depend on it should discover the obligation from
+      # a red lane rather than from nobody. It has now worked twice:
+      # physics arrived, and later the widget tree's layout solver, and
+      # each went red here until the cell named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,7 @@ name = "renew-ui"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "renew-fixed",
  "renew-memory",
 ]
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renew-ui"
-description = "The retained widget tree: arena-backed nodes with generational ids, capacities fixed at construction"
+description = "The retained widget tree and its fixed-point layout solver: arena-backed nodes solved into pixel rectangles, capacities fixed at construction"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "The simulation-side widget tree: an arena of generationally addressed nodes with capacities fixed by UiLimits at construction, refusing rather than growing. Layout, input, and state digestion arrive in later steps; the tree is their common ground."
+purpose = "The simulation-side widget tree and its Q47.16 flex-subset layout solver: an arena of generationally addressed nodes with capacities fixed by UiLimits at construction, refusing rather than growing, solved into pixel rectangles behind a dirty flag. Input and state digestion arrive in later steps."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -19,6 +19,9 @@ simulation = true
 workspace = true
 
 [dependencies]
+# The layout solver's arithmetic: Q47.16, saturating, bit-identical on
+# every target — the crate simulation numbers are written in.
+renew-fixed = { path = "../fixed" }
 
 # Property tests for the tree's invariants — the containers row of the
 # testing table — and the engine's counting allocator for the

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -1,10 +1,10 @@
 # renew-ui
 
-The retained widget tree: an arena of generationally addressed nodes,
-capacities fixed at construction. This crate is the simulation-side
-ground the rest of the UI stands on — layout solving, input handling,
-and state digestion arrive as their own steps and all walk the tree
-built here.
+The retained widget tree and its fixed-point layout solver: an arena
+of generationally addressed nodes, capacities fixed at construction,
+solved into pixel rectangles by a trimmed flexbox subset over Q47.16.
+This crate is the simulation-side half of the UI — input handling and
+state digestion arrive as their own steps and walk what is built here.
 
 Machine-readable facts — maturity, dependencies, core status — live in
 this crate's manifest metadata (`Cargo.toml`, `[package.metadata.renew]`).
@@ -47,3 +47,26 @@ error vocabulary, and property tests drive random operation sequences
 against the tree's invariants: reachability matches the live count,
 children and parents agree, capacity is a wall, and stale ids miss
 everywhere at once.
+
+## Layout
+
+`solve` turns styles into absolute rectangles, the root filling the
+viewport. The v0 surface is deliberately small — row and column
+containers; pixel or content-driven sizes; start, centre, and end
+placement on both axes; margin, padding, gap; and integer `grow` —
+with the rest of flexbox landing when a real document needs it.
+
+Everything is `Fixed` (Q47.16), so a solve is integer arithmetic
+under the hood, the same on every target by construction. A test
+builds the same tree twice and compares every rectangle to the bit;
+the cross-target lane that turns that claim into evidence arrives
+with state digestion. Leftover space
+among growers is shared by largest remainder over raw fixed-point
+units — shares sum to the leftover exactly, property-tested, with
+ties breaking toward the earlier sibling. Both passes are iterative
+(the tree is data, and data must not choose the stack depth), run in
+scratch buffers sized at construction, and re-solving allocates
+nothing — the same counting-allocator gate holds both promises.
+Solving is retained behind one dirty flag: a clean tree with an
+unchanged viewport returns without walking. Exact per-node damage
+arrives with the compiled style tables.

--- a/crates/ui/src/layout.rs
+++ b/crates/ui/src/layout.rs
@@ -1,0 +1,1005 @@
+//! The fixed-point flex solver: a trimmed flexbox subset over Q47.16.
+//!
+//! **The v0 surface, and why it is this small.** Row and column
+//! containers; sizes in pixels or from content; start, centre, and end
+//! placement on both axes; margin, padding, and gap; integer `grow`
+//! that shares leftover space exactly. Percent sizes, min/max bounds,
+//! shrink, wrapping, and space-between land when a real document needs
+//! them — an interface with no consumer is the smell the defaults name.
+//!
+//! **Two passes, both iterative.** Measurement walks children before
+//! parents to answer every `Auto` from content; arrangement walks
+//! parents before children to place each child inside its parent's
+//! content box. Neither recurses: the tree is data, and data must not
+//! choose the stack depth. Both walks and the grow bookkeeping run in
+//! scratch buffers sized once at construction, so re-solving allocates
+//! exactly nothing — the same gate the tree itself sits behind.
+//!
+//! **Exact arithmetic, exactly shared.** All positions and sizes are
+//! [`Fixed`]: every operation is integer arithmetic under the hood and
+//! bit-identical on every target. Leftover space among growers is
+//! shared by largest remainder over raw fixed-point units — shares sum
+//! to the leftover *exactly*, never one unit over or under — and ties
+//! break toward the earlier sibling, so the same tree always solves to
+//! the same bits. At the far edge of the range, [`Fixed`]'s saturation
+//! applies: sizes summing past ±2^47 pixels clamp rather than wrap,
+//! deterministically, and children past the clamp stack at the edge.
+
+use renew_fixed::Fixed;
+
+/// Which way a container lays its children.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Direction {
+    /// Children advance along x; the cross axis is y.
+    #[default]
+    Row,
+    /// Children advance along y; the cross axis is x.
+    Column,
+}
+
+/// One dimension of a node's size.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Size {
+    /// Whatever the content needs: children plus padding, or nothing.
+    #[default]
+    Auto,
+    /// Exactly this many pixels.
+    Px(Fixed),
+}
+
+/// Where children sit along an axis when space is left over.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Align {
+    /// Packed toward the axis origin.
+    #[default]
+    Start,
+    /// Centred; an odd leftover's extra raw unit lands before the
+    /// run — the halving rounds to nearest, ties away from zero.
+    Center,
+    /// Packed toward the axis end.
+    End,
+}
+
+/// Space on each side of a box, in pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Edges {
+    pub left: Fixed,
+    pub right: Fixed,
+    pub top: Fixed,
+    pub bottom: Fixed,
+}
+
+impl Edges {
+    /// The same amount on every side.
+    #[must_use]
+    pub fn all(amount: Fixed) -> Self {
+        Self {
+            left: amount,
+            right: amount,
+            top: amount,
+            bottom: amount,
+        }
+    }
+}
+
+/// Everything layout knows about one node.
+///
+/// Plain fields on purpose: the crate is `bootstrap`, and the document
+/// compiler that will author these offline wants a struct it can fill,
+/// not a builder it must thread. Negative pixels are expressible and
+/// not validated here — the arithmetic simply follows them; the
+/// compiler is where authoring validation belongs, with the untrusted
+/// blob parser it arrives with.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Style {
+    /// How this node lays out its own children.
+    pub direction: Direction,
+    /// This node's width, before margins.
+    pub width: Size,
+    /// This node's height, before margins.
+    pub height: Size,
+    /// Space outside this node's box, claimed from the parent.
+    pub margin: Edges,
+    /// Space inside this node's box, before its children.
+    pub padding: Edges,
+    /// Space between consecutive children, along the main axis.
+    pub gap: Fixed,
+    /// This node's share of the parent's leftover main-axis space.
+    /// Zero — the default — takes none.
+    pub grow: u32,
+    /// Where the run of children sits along the main axis.
+    pub justify: Align,
+    /// Where each child sits along the cross axis.
+    pub align_cross: Align,
+}
+
+/// A solved box: absolute position and size, in pixels.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Rect {
+    pub x: Fixed,
+    pub y: Fixed,
+    pub width: Fixed,
+    pub height: Fixed,
+}
+
+/// The per-slot layout state the [`crate::Ui`] arena carries.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct LayoutSlot {
+    pub style: Style,
+    pub rect: Rect,
+    /// Content-driven size from the measure pass: the box this node
+    /// wants (padding included, margin excluded) before the parent has
+    /// its say.
+    pub wanted_width: Fixed,
+    pub wanted_height: Fixed,
+}
+
+/// The solver's reusable workspace, sized once for the whole arena.
+#[derive(Debug)]
+pub(crate) struct Scratch {
+    /// Traversal order (parents before children), rebuilt per solve.
+    order: Vec<u32>,
+    /// Largest-remainder bookkeeping, one entry per child of the node
+    /// being arranged, in child order: (remainder, share so far).
+    shares: Vec<(i64, i64)>,
+}
+
+impl Scratch {
+    pub fn with_capacity(nodes: u32) -> Self {
+        Self {
+            order: Vec::with_capacity(nodes as usize),
+            shares: Vec::with_capacity(nodes as usize),
+        }
+    }
+}
+
+/// The solver itself, generic over the arena through a small view so
+/// the tree module keeps its links private.
+pub(crate) struct Solve<'a> {
+    /// Read-only on purpose: the solver walks links and never touches
+    /// them, and the borrow proves it.
+    pub slots: &'a [crate::Slot],
+    pub layout: &'a mut [LayoutSlot],
+    pub scratch: &'a mut Scratch,
+}
+
+impl Solve<'_> {
+    /// Solve the whole tree into absolute rectangles, with the root
+    /// filling `viewport` at the origin.
+    pub fn run(&mut self, viewport_width: Fixed, viewport_height: Fixed) {
+        self.collect_order();
+
+        // Measure: children before parents, so every Auto has its
+        // content's answer by the time the parent asks.
+        for position in (0..self.scratch.order.len()).rev() {
+            let index = self.scratch.order[position];
+            self.measure(index);
+        }
+
+        // The root's box is the viewport, whatever its style says: a
+        // document fills the screen it is given.
+        self.layout[0].rect = Rect {
+            x: Fixed::ZERO,
+            y: Fixed::ZERO,
+            width: viewport_width,
+            height: viewport_height,
+        };
+
+        // Arrange: parents before children, each placing its children
+        // inside its own already-known rect.
+        for position in 0..self.scratch.order.len() {
+            let index = self.scratch.order[position];
+            self.arrange(index);
+        }
+    }
+
+    /// Fill `scratch.order` with every live slot, parents first, in
+    /// document order — one preallocated list serves both passes, read
+    /// forward to arrange and backward to measure.
+    fn collect_order(&mut self) {
+        self.scratch.order.clear();
+        self.scratch.order.push(0);
+        let mut at = 0;
+        while at < self.scratch.order.len() {
+            let index = self.scratch.order[at];
+            let mut child = self.slots[index as usize].first_child;
+            while child != crate::NIL {
+                self.scratch.order.push(child);
+                child = self.slots[child as usize].next_sibling;
+            }
+            at += 1;
+        }
+    }
+
+    /// What `index` wants to be, from its style and its children.
+    fn measure(&mut self, index: u32) {
+        let style = self.layout[index as usize].style;
+        let (main_sum, cross_max) = self.content_extent(index, style);
+
+        let content_width = match style.direction {
+            Direction::Row => main_sum,
+            Direction::Column => cross_max,
+        };
+        let content_height = match style.direction {
+            Direction::Row => cross_max,
+            Direction::Column => main_sum,
+        };
+
+        let slot = &mut self.layout[index as usize];
+        slot.wanted_width = match style.width {
+            Size::Px(width) => width,
+            Size::Auto => content_width + style.padding.left + style.padding.right,
+        };
+        slot.wanted_height = match style.height {
+            Size::Px(height) => height,
+            Size::Auto => content_height + style.padding.top + style.padding.bottom,
+        };
+    }
+
+    /// The children's combined extent: outer sizes plus gaps along the
+    /// main axis, and the tallest outer size across it.
+    fn content_extent(&self, index: u32, style: Style) -> (Fixed, Fixed) {
+        let mut main_sum = Fixed::ZERO;
+        let mut cross_max = Fixed::ZERO;
+        let mut count = 0u32;
+        let mut child = self.slots[index as usize].first_child;
+        while child != crate::NIL {
+            let outer = self.outer_wanted(child, style.direction);
+            main_sum = main_sum + outer.0;
+            cross_max = cross_max.max(outer.1);
+            count += 1;
+            child = self.slots[child as usize].next_sibling;
+        }
+        if count > 1 {
+            // One gap between each consecutive pair. The count fits an
+            // i32 long before an arena of this many slots would fit in
+            // memory; the saturation is the type conversion's honesty,
+            // not a reachable path.
+            let gaps = i32::try_from(count - 1).unwrap_or(i32::MAX);
+            main_sum = main_sum + style.gap * Fixed::from_int(gaps);
+        }
+        (main_sum, cross_max)
+    }
+
+    /// A child's wanted size plus its margins, as (main, cross) for
+    /// the parent's direction.
+    fn outer_wanted(&self, child: u32, direction: Direction) -> (Fixed, Fixed) {
+        let slot = &self.layout[child as usize];
+        let margin = slot.style.margin;
+        let outer_width = slot.wanted_width + margin.left + margin.right;
+        let outer_height = slot.wanted_height + margin.top + margin.bottom;
+        match direction {
+            Direction::Row => (outer_width, outer_height),
+            Direction::Column => (outer_height, outer_width),
+        }
+    }
+
+    /// Place `index`'s children inside its solved rect.
+    fn arrange(&mut self, index: u32) {
+        let style = self.layout[index as usize].style;
+        let rect = self.layout[index as usize].rect;
+
+        // The content box: the node's rect minus its padding.
+        let content_x = rect.x + style.padding.left;
+        let content_y = rect.y + style.padding.top;
+        let content_width = rect.width - style.padding.left - style.padding.right;
+        let content_height = rect.height - style.padding.top - style.padding.bottom;
+        let (content_main, content_cross) = match style.direction {
+            Direction::Row => (content_width, content_height),
+            Direction::Column => (content_height, content_width),
+        };
+
+        let (occupied, _) = self.content_extent(index, style);
+        let leftover = content_main - occupied;
+        self.plan_growth(index, leftover);
+
+        // Growers consume the leftover; whatever they leave is what
+        // justification places. With any grower the run fills the box
+        // and justification has nothing to move.
+        let grown: i64 = self.scratch.shares.iter().map(|entry| entry.1).sum();
+        let free = leftover - Fixed::from_bits(grown);
+        let mut cursor = content_main_offset(style.justify, free);
+
+        let mut child = self.slots[index as usize].first_child;
+        let mut nth = 0usize;
+        while child != crate::NIL {
+            let (outer_main, outer_cross) = self.outer_wanted(child, style.direction);
+            let growth = self
+                .scratch
+                .shares
+                .get(nth)
+                .map_or(Fixed::ZERO, |entry| Fixed::from_bits(entry.1));
+            let child_style = self.layout[child as usize].style;
+            let cross_free = content_cross - outer_cross;
+            let cross_offset = content_main_offset(style.align_cross, cross_free);
+
+            let (width, height, x, y) = match style.direction {
+                Direction::Row => (
+                    self.layout[child as usize].wanted_width + growth,
+                    self.layout[child as usize].wanted_height,
+                    content_x + cursor + child_style.margin.left,
+                    content_y + cross_offset + child_style.margin.top,
+                ),
+                Direction::Column => (
+                    self.layout[child as usize].wanted_width,
+                    self.layout[child as usize].wanted_height + growth,
+                    content_x + cross_offset + child_style.margin.left,
+                    content_y + cursor + child_style.margin.top,
+                ),
+            };
+            self.layout[child as usize].rect = Rect {
+                x,
+                y,
+                width,
+                height,
+            };
+            cursor = cursor + outer_main + growth + style.gap;
+            nth += 1;
+            child = self.slots[child as usize].next_sibling;
+        }
+    }
+
+    /// Share `leftover` among `index`'s growing children by largest
+    /// remainder over raw fixed-point units, ties to the earlier
+    /// sibling. Fills `scratch.shares` with one entry per child, in
+    /// child order; non-growers hold zero. Shares sum to the leftover
+    /// exactly — that exactness is property-tested, not assumed.
+    fn plan_growth(&mut self, index: u32, leftover: Fixed) {
+        self.scratch.shares.clear();
+        // The sum cannot overflow an i64 for any arena that fits in
+        // memory: each grow is at most 2^32 and each child costs tens
+        // of bytes of slot, so 2^31 children — the count that could
+        // push the sum past 2^63 — needs more memory than a machine
+        // has. The same argument the gap count makes, made here
+        // because this code is the one place raw sums leave `Fixed`'s
+        // saturation behind.
+        let mut total_grow: i64 = 0;
+        let mut child = self.slots[index as usize].first_child;
+        while child != crate::NIL {
+            let grow = i64::from(self.layout[child as usize].style.grow);
+            total_grow += grow;
+            self.scratch.shares.push((grow, 0));
+            child = self.slots[child as usize].next_sibling;
+        }
+        let leftover_raw = leftover.to_bits();
+        if total_grow == 0 || leftover_raw <= 0 {
+            return;
+        }
+
+        // Integer base shares first; the division truncates toward
+        // zero, and what it truncated away is the remainder that ranks
+        // who gets the leftover units. The products run in i128 — a
+        // large viewport times a large grow overflows an i64 for
+        // inputs a caller can actually write, and wrapped arithmetic
+        // here would hand the top-up loop a nonsense shortfall. The
+        // narrowing back cannot fail: a base share is at most the
+        // leftover and a remainder is less than the total, both i64;
+        // the fallbacks are the conversion's honesty, not a path.
+        let mut distributed: i64 = 0;
+        for entry in &mut self.scratch.shares {
+            let grow = i128::from(entry.0);
+            let product = i128::from(leftover_raw) * grow;
+            let base = i64::try_from(product / i128::from(total_grow)).unwrap_or(i64::MAX);
+            let remainder = i64::try_from(product % i128::from(total_grow)).unwrap_or(i64::MAX);
+            entry.0 = remainder;
+            entry.1 = base;
+            distributed += base;
+        }
+        let mut short = leftover_raw - distributed;
+
+        // One extra raw unit each to the largest remainders, earlier
+        // siblings first on ties. The list is already in child order,
+        // so a stable pass that picks the maximum `short` times keeps
+        // the tiebreak by construction without sorting.
+        while short > 0 {
+            let mut best = 0;
+            for (position, entry) in self.scratch.shares.iter().enumerate() {
+                if entry.0 > self.scratch.shares[best].0 {
+                    best = position;
+                }
+            }
+            self.scratch.shares[best].0 = -1;
+            self.scratch.shares[best].1 += 1;
+            short -= 1;
+        }
+    }
+}
+
+/// Where a run starts along an axis with `free` space left over: at
+/// the origin, centred, or at the end. Negative free space — overflow —
+/// keeps the start placement, so overflowing content spills toward the
+/// axis end rather than in both directions.
+fn content_main_offset(align: Align, free: Fixed) -> Fixed {
+    if free <= Fixed::ZERO {
+        return Fixed::ZERO;
+    }
+    match align {
+        Align::Start => Fixed::ZERO,
+        Align::Center => free / Fixed::from_int(2),
+        Align::End => free,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Ui, UiLimits};
+
+    fn px(value: i32) -> Size {
+        Size::Px(Fixed::from_int(value))
+    }
+
+    fn f(value: i32) -> Fixed {
+        Fixed::from_int(value)
+    }
+
+    /// A row with padding and gap places its children where a reader
+    /// doing the arithmetic by hand would put them.
+    #[test]
+    fn a_row_places_children_after_padding_and_gap() {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                padding: Edges::all(f(10)),
+                gap: f(5),
+                ..Style::default()
+            },
+        );
+        let first = ui.insert(root).expect("room");
+        ui.set_style(
+            first,
+            Style {
+                width: px(20),
+                height: px(30),
+                ..Style::default()
+            },
+        );
+        let second = ui.insert(root).expect("room");
+        ui.set_style(
+            second,
+            Style {
+                width: px(40),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(200), f(100));
+        assert_eq!(
+            ui.rect(first),
+            Some(Rect {
+                x: f(10),
+                y: f(10),
+                width: f(20),
+                height: f(30)
+            })
+        );
+        assert_eq!(
+            ui.rect(second),
+            Some(Rect {
+                x: f(35),
+                y: f(10),
+                width: f(40),
+                height: f(10)
+            })
+        );
+    }
+
+    /// A column advances along y with the same rules turned sideways.
+    #[test]
+    fn a_column_advances_downward() {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                direction: Direction::Column,
+                gap: f(4),
+                ..Style::default()
+            },
+        );
+        let first = ui.insert(root).expect("room");
+        ui.set_style(
+            first,
+            Style {
+                width: px(10),
+                height: px(6),
+                ..Style::default()
+            },
+        );
+        let second = ui.insert(root).expect("room");
+        ui.set_style(
+            second,
+            Style {
+                width: px(10),
+                height: px(6),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(ui.rect(first).expect("solved").y, f(0));
+        assert_eq!(ui.rect(second).expect("solved").y, f(10));
+    }
+
+    /// Centre and end placement put the leftover where they promise.
+    #[test]
+    fn justification_places_the_leftover() {
+        for (justify, expected_x) in [
+            (Align::Start, f(0)),
+            (Align::Center, f(45)),
+            (Align::End, f(90)),
+        ] {
+            let mut ui = Ui::new(UiLimits { nodes: 4 });
+            let root = ui.root();
+            ui.set_style(
+                root,
+                Style {
+                    justify,
+                    ..Style::default()
+                },
+            );
+            let child = ui.insert(root).expect("room");
+            ui.set_style(
+                child,
+                Style {
+                    width: px(10),
+                    height: px(10),
+                    ..Style::default()
+                },
+            );
+            ui.solve(f(100), f(100));
+            assert_eq!(ui.rect(child).expect("solved").x, expected_x, "{justify:?}");
+        }
+    }
+
+    /// The cross axis obeys the container's alignment the same way.
+    #[test]
+    fn cross_alignment_places_each_child() {
+        for (align_cross, expected_y) in [
+            (Align::Start, f(0)),
+            (Align::Center, f(45)),
+            (Align::End, f(90)),
+        ] {
+            let mut ui = Ui::new(UiLimits { nodes: 4 });
+            let root = ui.root();
+            ui.set_style(
+                root,
+                Style {
+                    align_cross,
+                    ..Style::default()
+                },
+            );
+            let child = ui.insert(root).expect("room");
+            ui.set_style(
+                child,
+                Style {
+                    width: px(10),
+                    height: px(10),
+                    ..Style::default()
+                },
+            );
+            ui.solve(f(100), f(100));
+            assert_eq!(
+                ui.rect(child).expect("solved").y,
+                expected_y,
+                "{align_cross:?}"
+            );
+        }
+    }
+
+    /// Margins claim space from the parent: the box shifts in by its
+    /// margin, and the next sibling starts past it.
+    #[test]
+    fn margins_claim_space() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let first = ui.insert(root).expect("room");
+        ui.set_style(
+            first,
+            Style {
+                width: px(20),
+                height: px(10),
+                margin: Edges {
+                    left: f(7),
+                    right: f(3),
+                    top: f(2),
+                    bottom: Fixed::ZERO,
+                },
+                ..Style::default()
+            },
+        );
+        let second = ui.insert(root).expect("room");
+        ui.set_style(
+            second,
+            Style {
+                width: px(5),
+                height: px(5),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        let first_rect = ui.rect(first).expect("solved");
+        assert_eq!((first_rect.x, first_rect.y), (f(7), f(2)));
+        assert_eq!(ui.rect(second).expect("solved").x, f(30));
+    }
+
+    /// An Auto box is its content plus its padding, measured from the
+    /// bottom of the tree up.
+    #[test]
+    fn auto_wraps_content_plus_padding() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let wrapper = ui.insert(root).expect("room");
+        ui.set_style(
+            wrapper,
+            Style {
+                padding: Edges::all(f(4)),
+                ..Style::default()
+            },
+        );
+        let leaf = ui.insert(wrapper).expect("room");
+        ui.set_style(
+            leaf,
+            Style {
+                width: px(10),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        let rect = ui.rect(wrapper).expect("solved");
+        assert_eq!((rect.width, rect.height), (f(18), f(18)));
+        let inner = ui.rect(leaf).expect("solved");
+        assert_eq!((inner.x, inner.y), (f(4), f(4)));
+    }
+
+    /// Growth shares the leftover exactly, one raw unit at a time,
+    /// earlier siblings first: seventy pixels among three growers is
+    /// twice 23.333 and once 23.333 plus one raw unit, on the first.
+    #[test]
+    fn growth_is_exact_and_ties_break_early() {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        let mut children = Vec::new();
+        for _ in 0..3 {
+            let child = ui.insert(root).expect("room");
+            ui.set_style(
+                child,
+                Style {
+                    width: px(10),
+                    height: px(10),
+                    grow: 1,
+                    ..Style::default()
+                },
+            );
+            children.push(child);
+        }
+        ui.solve(f(100), f(100));
+        let widths: Vec<i64> = children
+            .iter()
+            .map(|&child| ui.rect(child).expect("solved").width.to_bits())
+            .collect();
+        let seventy_thirds = f(70).to_bits() / 3;
+        assert_eq!(widths[0], f(10).to_bits() + seventy_thirds + 1);
+        assert_eq!(widths[1], f(10).to_bits() + seventy_thirds);
+        assert_eq!(widths[2], f(10).to_bits() + seventy_thirds);
+        assert_eq!(
+            widths.iter().sum::<i64>(),
+            f(100).to_bits(),
+            "the grown run must fill the container to the bit"
+        );
+    }
+
+    /// The same operations build the same picture: two trees, one
+    /// script, bit-identical rectangles.
+    #[test]
+    fn the_same_operations_solve_to_the_same_bits() {
+        let build = || {
+            let mut ui = Ui::new(UiLimits { nodes: 16 });
+            let root = ui.root();
+            ui.set_style(
+                root,
+                Style {
+                    direction: Direction::Column,
+                    padding: Edges::all(f(3)),
+                    gap: f(2),
+                    ..Style::default()
+                },
+            );
+            let mut ids = vec![root];
+            for nth in 0..6i32 {
+                let child = ui.insert(root).expect("room");
+                ui.set_style(
+                    child,
+                    Style {
+                        width: if nth % 2 == 0 { px(20) } else { Size::Auto },
+                        height: px(5 + nth),
+                        grow: (nth % 3).unsigned_abs(),
+                        ..Style::default()
+                    },
+                );
+                ids.push(child);
+            }
+            ui.solve(f(320), f(200));
+            ids.iter().map(|&id| ui.rect(id)).collect::<Vec<_>>()
+        };
+        assert_eq!(build(), build());
+    }
+
+    /// An odd leftover's extra raw unit lands before a centred run:
+    /// the halving rounds to nearest, ties away from zero, and this
+    /// pins the arm so the doc cannot drift from the arithmetic.
+    #[test]
+    fn a_centred_odd_leftover_puts_its_extra_unit_before() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                justify: Align::Center,
+                ..Style::default()
+            },
+        );
+        let child = ui.insert(root).expect("room");
+        ui.set_style(
+            child,
+            Style {
+                width: Size::Px(Fixed::from_bits(2)),
+                height: Size::Px(Fixed::from_bits(2)),
+                ..Style::default()
+            },
+        );
+        // Five raw units of free space: three land before, two after.
+        ui.solve(Fixed::from_bits(7), Fixed::from_bits(7));
+        assert_eq!(ui.rect(child).expect("solved").x.to_bits(), 3);
+    }
+
+    /// An overflowing run refuses to grow: with no leftover there is
+    /// nothing to share, and the growers keep their asked-for sizes.
+    #[test]
+    fn an_overflowing_run_grows_nothing() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let mut children = Vec::new();
+        for _ in 0..2 {
+            let child = ui.insert(root).expect("room");
+            ui.set_style(
+                child,
+                Style {
+                    width: px(80),
+                    height: px(10),
+                    grow: 3,
+                    ..Style::default()
+                },
+            );
+            children.push(child);
+        }
+        ui.solve(f(100), f(100));
+        for &child in &children {
+            assert_eq!(
+                ui.rect(child).expect("solved").width,
+                f(80),
+                "negative leftover must not shrink or grow anyone"
+            );
+        }
+    }
+
+    /// A column grower stretches along y, not x: growth follows the
+    /// container's main axis.
+    #[test]
+    fn a_column_grower_stretches_downward() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                direction: Direction::Column,
+                ..Style::default()
+            },
+        );
+        let child = ui.insert(root).expect("room");
+        ui.set_style(
+            child,
+            Style {
+                width: px(10),
+                height: px(10),
+                grow: 1,
+                ..Style::default()
+            },
+        );
+        ui.solve(f(50), f(200));
+        let rect = ui.rect(child).expect("solved");
+        assert_eq!(rect.width, f(10), "the cross axis is not the grower's");
+        assert_eq!(rect.height, f(200), "the main axis is");
+    }
+
+    /// Editing the tree after a solve reaches the next picture: both
+    /// removal and insertion invalidate the retained rectangles.
+    #[test]
+    fn structural_edits_invalidate_the_solve() {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        let first = ui.insert(root).expect("room");
+        ui.set_style(
+            first,
+            Style {
+                width: px(10),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        let second = ui.insert(root).expect("room");
+        ui.set_style(
+            second,
+            Style {
+                width: px(10),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(ui.rect(second).expect("solved").x, f(10));
+
+        assert!(ui.remove(first));
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.rect(second).expect("solved").x,
+            f(0),
+            "a removal must reach the next solve"
+        );
+
+        let third = ui.insert(root).expect("room");
+        ui.set_style(
+            third,
+            Style {
+                width: px(5),
+                height: px(5),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.rect(third).expect("solved").x,
+            f(10),
+            "an insertion must reach the next solve"
+        );
+    }
+
+    /// A clean tree keeps its rectangles: solving is retained, and a
+    /// style change is what invalidates.
+    #[test]
+    fn solving_is_retained_until_something_changes() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let child = ui.insert(root).expect("room");
+        ui.set_style(
+            child,
+            Style {
+                width: px(10),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        let before = ui.rect(child);
+        ui.solve(f(100), f(100));
+        assert_eq!(ui.rect(child), before, "a clean solve moves nothing");
+        ui.set_style(
+            child,
+            Style {
+                width: px(30),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.rect(child).expect("solved").width,
+            f(30),
+            "a style change must reach the picture"
+        );
+    }
+
+    proptest::proptest! {
+        /// Children that fit stay inside their parent's content box.
+        #[test]
+        fn fitting_children_are_contained(
+            sizes in proptest::collection::vec((1i32..20, 1i32..20), 1..6),
+            pad in 0i32..10,
+            gap in 0i32..5,
+        ) {
+            let mut ui = Ui::new(UiLimits { nodes: 16 });
+            let root = ui.root();
+            ui.set_style(root, Style {
+                padding: Edges::all(f(pad)),
+                gap: f(gap),
+                ..Style::default()
+            });
+            let mut children = Vec::new();
+            for &(width, height) in &sizes {
+                let child = ui.insert(root).expect("room");
+                ui.set_style(child, Style {
+                    width: px(width),
+                    height: px(height),
+                    ..Style::default()
+                });
+                children.push(child);
+            }
+            ui.solve(f(500), f(500));
+            let content_right = f(500) - f(pad);
+            let content_bottom = f(500) - f(pad);
+            for &child in &children {
+                let rect = ui.rect(child).expect("solved");
+                proptest::prop_assert!(rect.x >= f(pad));
+                proptest::prop_assert!(rect.y >= f(pad));
+                proptest::prop_assert!(rect.x + rect.width <= content_right);
+                proptest::prop_assert!(rect.y + rect.height <= content_bottom);
+            }
+        }
+
+        /// However grow factors fall, growers fill the container to
+        /// the exact bit — never one raw unit over or under.
+        #[test]
+        fn growth_sums_exactly(
+            grows in proptest::collection::vec(0u32..5, 1..8),
+            viewport in 50i32..400,
+        ) {
+            let mut ui = Ui::new(UiLimits { nodes: 16 });
+            let root = ui.root();
+            let mut children = Vec::new();
+            for &grow in &grows {
+                let child = ui.insert(root).expect("room");
+                ui.set_style(child, Style {
+                    width: px(5),
+                    height: px(5),
+                    grow,
+                    ..Style::default()
+                });
+                children.push(child);
+            }
+            ui.solve(f(viewport), f(100));
+            let occupied: i64 = children
+                .iter()
+                .map(|&child| ui.rect(child).expect("solved").width.to_bits())
+                .sum();
+            let base: i64 = f(5).to_bits() * i64::try_from(children.len()).unwrap_or(0);
+            if grows.iter().all(|&grow| grow == 0) {
+                proptest::prop_assert_eq!(occupied, base, "no grower, no growth");
+            } else {
+                proptest::prop_assert_eq!(
+                    occupied,
+                    f(viewport).to_bits(),
+                    "growers must absorb the leftover exactly"
+                );
+            }
+        }
+
+        /// Solving twice is the same picture: the solver is a pure
+        /// function of the tree, not of how often it ran.
+        #[test]
+        fn solving_is_idempotent(
+            sizes in proptest::collection::vec((1i32..30, 1i32..30, 0u32..3), 1..8),
+        ) {
+            let mut ui = Ui::new(UiLimits { nodes: 16 });
+            let root = ui.root();
+            let mut children = vec![root];
+            for &(width, height, grow) in &sizes {
+                let child = ui.insert(root).expect("room");
+                ui.set_style(child, Style {
+                    width: px(width),
+                    height: px(height),
+                    grow,
+                    ..Style::default()
+                });
+                children.push(child);
+            }
+            ui.solve(f(300), f(300));
+            let first: Vec<_> = children.iter().map(|&id| ui.rect(id)).collect();
+            ui.set_style(root, ui.style(root).expect("root is live"));
+            ui.solve(f(300), f(300));
+            let second: Vec<_> = children.iter().map(|&id| ui.rect(id)).collect();
+            proptest::prop_assert_eq!(first, second);
+        }
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,9 +1,10 @@
 //! The retained widget tree: an arena of generationally addressed
 //! nodes, capacities fixed at construction.
 //!
-//! This crate is the simulation-side ground the rest of the UI stands
-//! on. Layout solving, input handling, and state digestion arrive as
-//! their own steps; what ships here is the structure they all share —
+//! This crate is the simulation-side half of the UI: the tree, and
+//! the fixed-point solver (the [`layout`] module vocabulary) that
+//! turns its styles into pixel rectangles. Input handling and state
+//! digestion arrive as their own steps; what they will share is here —
 //! a tree whose nodes are stable to address, cheap to add and remove,
 //! and bounded by an explicit limit rather than by whatever the heap
 //! allows.
@@ -38,14 +39,21 @@
 //! grows, and nothing here panics on data.
 
 // The simulation's crates deny float arithmetic wholesale (the closure
-// rule checks every crate in a simulation's shipping graph); the tree
-// is pure structure and needs no arithmetic at all beyond indices.
+// rule checks every crate in a simulation's shipping graph); the
+// solver's numbers are Fixed — integers under the hood — and a float
+// anywhere in this crate would be a value a digest could see.
 #![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
+
+mod layout;
+
+pub use layout::{Align, Direction, Edges, Rect, Size, Style};
+use layout::{LayoutSlot, Scratch, Solve};
+use renew_fixed::Fixed;
 
 /// Nothing here: the marker every slot uses for "no neighbour". One
 /// value, not an `Option<u32>`, so a slot stays eight words no matter
 /// how many links are empty.
-const NIL: u32 = u32::MAX;
+pub(crate) const NIL: u32 = u32::MAX;
 
 /// Capacities for one [`Ui`], fixed at construction.
 ///
@@ -100,7 +108,7 @@ pub struct NodeId {
 /// One arena slot. Free slots keep their links meaningless except
 /// `next_sibling`, which threads the free list.
 #[derive(Clone, Copy, Debug)]
-struct Slot {
+pub(crate) struct Slot {
     /// Bumped on every removal, so old ids miss. Sixty-four bits so
     /// the bump can never cycle in a physical run — "stays stale
     /// forever" is a claim about this counter, and a u32 makes it
@@ -111,10 +119,10 @@ struct Slot {
     generation: u64,
     live: bool,
     parent: u32,
-    first_child: u32,
+    pub(crate) first_child: u32,
     last_child: u32,
     prev_sibling: u32,
-    next_sibling: u32,
+    pub(crate) next_sibling: u32,
 }
 
 impl Slot {
@@ -137,6 +145,16 @@ impl Slot {
 #[derive(Debug)]
 pub struct Ui {
     slots: Vec<Slot>,
+    /// Per-slot layout state: style in, solved rectangle out.
+    layout: Vec<LayoutSlot>,
+    /// The solver's reusable workspace, sized with the arena.
+    scratch: Scratch,
+    /// Whether anything changed since the last solve — structure,
+    /// style, or viewport. One flag for the whole tree in v0: exact
+    /// damage arrives with the compiled style tables.
+    dirty: bool,
+    /// The viewport the current rectangles were solved for.
+    solved_for: (Fixed, Fixed),
     /// Head of the free list, threaded through `next_sibling`.
     free: u32,
     live: u32,
@@ -169,6 +187,10 @@ impl Ui {
         let free = if capacity > 1 { 1 } else { NIL };
         Self {
             slots,
+            layout: vec![LayoutSlot::default(); capacity as usize],
+            scratch: Scratch::with_capacity(capacity),
+            dirty: true,
+            solved_for: (Fixed::ZERO, Fixed::ZERO),
             free,
             live: 1,
             limits: UiLimits { nodes: capacity },
@@ -226,6 +248,8 @@ impl Ui {
         };
         self.link_last(parent_index, index);
         self.live += 1;
+        self.layout[index as usize] = LayoutSlot::default();
+        self.dirty = true;
         Ok(NodeId { index, generation })
     }
 
@@ -243,6 +267,7 @@ impl Ui {
         }
         self.unlink(index);
         self.free_subtree(index);
+        self.dirty = true;
         true
     }
 
@@ -264,6 +289,56 @@ impl Ui {
             ui: self,
             at: first,
         }
+    }
+
+    /// Give `node` a new style. Answers whether it landed: `false` is
+    /// the miss for a stale id. Any change marks the tree for
+    /// re-solving; setting the same style again does too, and the
+    /// solve it provokes is idempotent, so the cost is a no-op walk
+    /// rather than a wrong picture.
+    pub fn set_style(&mut self, node: NodeId, style: Style) -> bool {
+        let Some(index) = self.slot_of(node) else {
+            return false;
+        };
+        self.layout[index as usize].style = style;
+        self.dirty = true;
+        true
+    }
+
+    /// The style `node` currently holds; `None` for stale ids.
+    #[must_use]
+    pub fn style(&self, node: NodeId) -> Option<Style> {
+        let index = self.slot_of(node)?;
+        Some(self.layout[index as usize].style)
+    }
+
+    /// Solve the tree into absolute rectangles, the root filling the
+    /// viewport at the origin.
+    ///
+    /// Retained: when nothing changed since the last solve — no edit,
+    /// no style, same viewport — this returns without walking. The
+    /// walk itself allocates nothing; construction sized everything.
+    pub fn solve(&mut self, viewport_width: Fixed, viewport_height: Fixed) {
+        if !self.dirty && self.solved_for == (viewport_width, viewport_height) {
+            return;
+        }
+        Solve {
+            slots: &mut self.slots,
+            layout: &mut self.layout,
+            scratch: &mut self.scratch,
+        }
+        .run(viewport_width, viewport_height);
+        self.dirty = false;
+        self.solved_for = (viewport_width, viewport_height);
+    }
+
+    /// The rectangle the last [`Self::solve`] gave `node`; `None` for
+    /// stale ids. Meaningful only after a solve — before one, every
+    /// rectangle is the zero default.
+    #[must_use]
+    pub fn rect(&self, node: NodeId) -> Option<Rect> {
+        let index = self.slot_of(node)?;
+        Some(self.layout[index as usize].rect)
     }
 
     /// The live slot index behind `node`, if the id still names one.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -505,6 +505,12 @@ mod tests {
         assert_eq!(ui.parent(gone), None);
         assert_eq!(ui.children(gone).count(), 0);
         assert!(!ui.remove(gone), "a second removal is a miss too");
+        assert!(
+            !ui.set_style(gone, Style::default()),
+            "styling a stale id is a miss, not a landing"
+        );
+        assert_eq!(ui.style(gone), None);
+        assert_eq!(ui.rect(gone), None);
     }
 
     /// Removing a node takes its whole subtree, stales every id into

--- a/crates/ui/tests/zero_alloc.rs
+++ b/crates/ui/tests/zero_alloc.rs
@@ -8,8 +8,9 @@
 //! measured window works a tree that genuinely churns, and the test
 //! asserts the churn happened.
 
+use renew_fixed::Fixed;
 use renew_memory::{CountingAllocator, counters};
-use renew_ui::{Ui, UiLimits};
+use renew_ui::{Size, Style, Ui, UiLimits};
 
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
@@ -48,4 +49,43 @@ fn the_steady_state_allocates_nothing() {
         }
     });
     verdict.expect("the tree's steady state stays heap-silent");
+
+    // The solver's half of the promise: styling and re-solving a real
+    // tree — dirtied every time, so every pass walks — reaches the
+    // heap exactly as often as the tree does. Built (and solved once,
+    // for the same warmup reason) before the window opens.
+    let wide = ui.insert(root).expect("room for the solver's subject");
+    for _ in 0..16 {
+        ui.insert(wide).expect("room for a row child");
+    }
+    ui.solve(Fixed::from_int(640), Fixed::from_int(360));
+    // Two styles alternated so every pass provably re-solves: the
+    // rectangle must flip between the two widths, which a retained or
+    // skipped solve could not produce.
+    let narrow = Style {
+        width: Size::Px(Fixed::from_int(20)),
+        height: Size::Px(Fixed::from_int(10)),
+        ..Style::default()
+    };
+    let wide_style = Style {
+        width: Size::Px(Fixed::from_int(40)),
+        ..narrow
+    };
+    let verdict = counters::quiet_window(5, || {
+        for pass in 0..8u32 {
+            let (style, expected) = if pass % 2 == 0 {
+                (narrow, Fixed::from_int(20))
+            } else {
+                (wide_style, Fixed::from_int(40))
+            };
+            assert!(ui.set_style(wide, style), "the subject must be live");
+            ui.solve(Fixed::from_int(640), Fixed::from_int(360));
+            assert_eq!(
+                ui.rect(wide).expect("the subject must be live").width,
+                expected,
+                "the re-solve must really lay the tree out"
+            );
+        }
+    });
+    verdict.expect("re-solving stays heap-silent");
 }


### PR DESCRIPTION
The layout half of the widget tree: a trimmed flexbox subset over Q47.16 that turns styles into absolute pixel rectangles, the root filling the viewport. Row and column containers; pixel or content-driven sizes; start, centre, and end placement on both axes; margin, padding, gap; and integer grow — the rest of flexbox lands when a real document needs it.

**Two passes, both iterative** over one preallocated order list: measurement walks children before parents so every content-driven size has its answer; arrangement walks parents before children into solved boxes. Re-solving allocates nothing, and the counting-allocator gate proves it with a window that alternates two styles and asserts the rectangle flips — a skipped or retained solve could not produce the flip.

**Exact growth.** Leftover space among growers is shared by largest remainder over raw fixed-point units, in 128-bit intermediates so writable inputs can never wrap the bookkeeping. Shares sum to the leftover exactly — property-tested, never one raw unit over or under — and ties break toward the earlier sibling; a unit test pins seventy pixels across three growers landing its odd raw unit on the first sibling.

**Retained solving.** One dirty flag; structure, style, and viewport changes each invalidate, and tests hold all three to it. The same operations solve to the same bits, compared rectangle by rectangle. Twenty-seven lib tests (unit + five property suites), the two-window allocation gate, and the structure checks all green; the fixed-point arithmetic crate joins the dependency list, keeping the float-free closure intact.
