### PR TITLE
feat(ui): input, decisions, and the digest they feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-ui --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -283,9 +283,10 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-camera $sel
           cargo build $sel
           cargo test $sel
-      # The widget tree: pure structure with no dependencies and no
-      # consumers yet — the UI's later layers and their first embedding
-      # game grow this list when they arrive.
+      # The widget tree: structure, layout, and interaction over the
+      # fixed-point and digest crates, no consumers yet — the UI's
+      # presentation crate and its first embedding game grow this list
+      # when they arrive.
       - name: Build and test without the widget tree
         run: |
           sel="--workspace --exclude renew-ui"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "renew-fixed",
+ "renew-frame",
  "renew-memory",
 ]
 

--- a/crates/core/math/src/lib.rs
+++ b/crates/core/math/src/lib.rs
@@ -1,8 +1,9 @@
 //! Linear algebra value types: vectors, a column-major matrix, a
 //! quaternion, and an axis-aligned bounding box, all `f32` — plus
-//! [`Alpha`], the render interpolation factor, which lives here because
-//! this is the crate a simulation is mechanically forbidden from
-//! reaching.
+//! [`Alpha`], the render interpolation factor, and
+//! [`quantize_pointer`], the pointer's float-to-integer seam — both
+//! live here because this is the crate a simulation is mechanically
+//! forbidden from reaching.
 //!
 //! # Contract
 //!
@@ -27,11 +28,13 @@
 mod aabb;
 mod alpha;
 mod mat4;
+mod quantize;
 mod quat;
 mod vec;
 
 pub use aabb::Aabb3;
 pub use alpha::Alpha;
 pub use mat4::Mat4;
+pub use quantize::quantize_pointer;
 pub use quat::Quat;
 pub use vec::{Vec2, Vec3, Vec4};

--- a/crates/core/math/src/quantize.rs
+++ b/crates/core/math/src/quantize.rs
@@ -1,0 +1,81 @@
+//! The pointer quantization seam: `f64` window coordinates become the
+//! integers a simulation may hear.
+//!
+//! Pointer events arrive from the window system as `f64` physical
+//! pixels. Simulation crates are mechanically forbidden from computing
+//! with floats, so somewhere a float must become an integer — and that
+//! somewhere must be *one* documented function, applied by every
+//! windowed driver and by the replay harness alike, or two callers
+//! quantize two ways and a replayed trace stops reproducing the run it
+//! recorded.
+//!
+//! This is that function. It lives here for [`crate::Alpha`]'s reason:
+//! this is the crate a simulation is mechanically forbidden from
+//! reaching, which makes it the one safe home for the exact float
+//! seams the engine's edges need.
+
+/// One axis of a pointer position, floored to the pixel it is inside
+/// and saturated to the representable range.
+///
+/// Floor rather than round or truncate: a pointer at x = 3.7 is inside
+/// pixel 3, and truncation would disagree for negative coordinates
+/// (−0.5 is inside pixel −1, not pixel 0). The operations are IEEE
+/// exact — `floor` on any finite `f64` and a saturating cast — so the
+/// result is bit-identical on every target, which is what lets a
+/// recorded `f64` trace replay into the same integers everywhere.
+///
+/// Edges, all deliberate: exact integers stay themselves; infinities
+/// saturate to the corresponding extreme; NaN — a pointer coordinate
+/// no window system should ever send — quantizes to zero, the cast's
+/// defined answer, rather than to a panic in the input path.
+#[must_use]
+pub fn quantize_pointer(coordinate: f64) -> i32 {
+    // `as` from a float saturates and maps NaN to zero by definition
+    // (Rust 1.45's float-to-int semantics) — the cast IS the clamp.
+    #[allow(clippy::cast_possible_truncation)]
+    let quantized = coordinate.floor() as i32;
+    quantized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quantize_pointer;
+
+    /// The interior cases: floor, not round, not truncate.
+    #[test]
+    fn a_pointer_is_inside_the_pixel_below_it() {
+        assert_eq!(quantize_pointer(3.7), 3);
+        assert_eq!(quantize_pointer(3.0), 3);
+        assert_eq!(quantize_pointer(0.999_999), 0);
+        assert_eq!(quantize_pointer(0.0), 0);
+        assert_eq!(
+            quantize_pointer(-0.5),
+            -1,
+            "truncation would say 0, wrongly"
+        );
+        assert_eq!(quantize_pointer(-1.0), -1);
+        assert_eq!(quantize_pointer(-1.000_001), -2);
+    }
+
+    /// The edges: saturation at both ends, zero for NaN, and the
+    /// boundary where an f64 stops being representable as i32.
+    #[test]
+    fn the_edges_saturate_and_nan_is_zero() {
+        assert_eq!(quantize_pointer(f64::from(i32::MAX) + 0.7), i32::MAX);
+        assert_eq!(quantize_pointer(f64::from(i32::MIN) - 0.7), i32::MIN);
+        assert_eq!(quantize_pointer(f64::INFINITY), i32::MAX);
+        assert_eq!(quantize_pointer(f64::NEG_INFINITY), i32::MIN);
+        assert_eq!(quantize_pointer(f64::NAN), 0);
+        assert_eq!(quantize_pointer(f64::from(i32::MAX)), i32::MAX);
+        assert_eq!(quantize_pointer(f64::from(i32::MIN)), i32::MIN);
+    }
+
+    /// Bit-exactness in the form a replay depends on: the same f64
+    /// always answers the same integer, including awkward negatives.
+    #[test]
+    fn the_same_coordinate_always_answers_the_same_pixel() {
+        for raw in [0.1_f64, -2.9, 1e9, -1e9, 1_234.499_999_999_9] {
+            assert_eq!(quantize_pointer(raw), quantize_pointer(raw));
+        }
+    }
+}

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "The simulation-side widget tree and its Q47.16 flex-subset layout solver: an arena of generationally addressed nodes with capacities fixed by UiLimits at construction, refusing rather than growing, solved into pixel rectangles behind a dirty flag. Input and state digestion arrive in later steps."
+purpose = "The simulation-side widget tree, its Q47.16 flex-subset layout solver, and its integer-only interaction surface: generationally addressed nodes solved into pixel rectangles behind a dirty flag, hit-tested for hover/press/focus decisions that fold into the engine state fingerprint."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -22,6 +22,9 @@ workspace = true
 # The layout solver's arithmetic: Q47.16, saturating, bit-identical on
 # every target — the crate simulation numbers are written in.
 renew-fixed = { path = "../fixed" }
+# The digest the tree's decisions fold into — the same explicit-order
+# fingerprint every simulation state answers with.
+renew-frame = { path = "../frame" }
 
 # Property tests for the tree's invariants — the containers row of the
 # testing table — and the engine's counting allocator for the

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -1,10 +1,13 @@
 # renew-ui
 
-The retained widget tree and its fixed-point layout solver: an arena
-of generationally addressed nodes, capacities fixed at construction,
-solved into pixel rectangles by a trimmed flexbox subset over Q47.16.
-This crate is the simulation-side half of the UI — input handling and
-state digestion arrive as their own steps and walk what is built here.
+The retained widget tree, its fixed-point layout solver, and its
+integer-only interaction surface: an arena of generationally
+addressed nodes, capacities fixed at construction, solved into pixel
+rectangles by a trimmed flexbox subset over Q47.16, hit-tested into
+hover, press, and focus decisions that fold into the engine's state
+fingerprint. This crate is the simulation-side half of the UI;
+presentation arrives as its own crate and draws what is decided
+here.
 
 Machine-readable facts — maturity, dependencies, core status — live in
 this crate's manifest metadata (`Cargo.toml`, `[package.metadata.renew]`).
@@ -59,8 +62,8 @@ with the rest of flexbox landing when a real document needs it.
 Everything is `Fixed` (Q47.16), so a solve is integer arithmetic
 under the hood, the same on every target by construction. A test
 builds the same tree twice and compares every rectangle to the bit;
-the cross-target lane that turns that claim into evidence arrives
-with state digestion. Leftover space
+the cross-target determinism-lane scenario that turns that claim
+into three-platform evidence stands as its own step, next. Leftover space
 among growers is shared by largest remainder over raw fixed-point
 units — shares sum to the leftover exactly, property-tested, with
 ties breaking toward the earlier sibling. Both passes are iterative
@@ -70,3 +73,30 @@ nothing — the same counting-allocator gate holds both promises.
 Solving is retained behind one dirty flag: a clean tree with an
 unchanged viewport returns without walking. Exact per-node damage
 arrives with the compiled style tables.
+
+## Input and decisions
+
+The event surface is integer-only: pointer coordinates arrive as
+`i32` physical pixels through `Ui::handle`, and the one documented
+float-to-integer seam (`quantize_pointer`, in the maths crate beside
+the render interpolation factor) is applied by windowed drivers and
+the replay harness before events get here — so a recorded trace
+replays into the same integers everywhere, and no float exists in
+this crate for a digest to see.
+
+The v0 vocabulary is hover, press/release activation, and focus.
+Hit-testing walks the retained rectangles topmost-first (children
+over parents, later siblings over earlier); a press remembers its
+node, a release on the same node activates it — queueing
+`UiOutput::Activated` and moving focus there — and a release
+anywhere else abandons the press, the way every toolkit lets a
+mis-click be dragged off a button. The output queue is bounded by
+the node count; past that, decisions are dropped and counted, never
+silently lost.
+
+`Ui::absorb` folds the discrete decisions into the engine's state
+fingerprint: pointer, pressed, focus, the activation ordinal, and
+the overflow count. What it leaves out is named in the source beside
+it — hover is derived, geometry reaches the digest only by changing
+a decision, and a test pins exactly that: a padding tweak with no
+press between digests identically.

--- a/crates/ui/src/input.rs
+++ b/crates/ui/src/input.rs
@@ -1,0 +1,608 @@
+//! Input and interaction state: the integer events a tree hears, the
+//! decisions it makes, and the digest those decisions feed.
+//!
+//! **The surface is integer-only, deliberately.** Pointer coordinates
+//! arrive as `i32` physical pixels; the one documented float-to-integer
+//! seam (`quantize_pointer`) lives in the maths crate, applied by
+//! windowed drivers and the replay harness before events reach
+//! [`crate::Ui::handle`]. No float enters this crate, so nothing here
+//! can put one where a digest sees it.
+//!
+//! **The v0 interaction vocabulary** is hover, press/release
+//! activation, and focus — focus follows activation, because the first
+//! consumer is a menu and a clicked button is the focused one. Keyboard
+//! traversal, scroll, and text input are cut until a consumer needs
+//! them; each returns with its own quantization rule where floats are
+//! involved.
+//!
+//! **Hit-testing walks the retained rectangles** of the last
+//! [`crate::Ui::solve`], topmost first: children draw over their
+//! parents and later siblings draw over earlier ones, so the test
+//! descends to the deepest, latest node containing the point. A tree
+//! that was never solved hit-tests against zero-sized rectangles,
+//! which contain no point at all under half-open edges — solve first,
+//! or every event lands on nothing.
+
+use renew_frame::StateHash;
+
+use crate::{NIL, NodeId, Ui};
+
+/// One event the tree can hear. Integers only — see the module doc.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UiEvent {
+    /// The pointer moved to these physical pixels, in the same space
+    /// the solver's rectangles live in.
+    PointerMoved { x: i32, y: i32 },
+    /// The primary button went down at the current pointer position.
+    PointerPressed,
+    /// The primary button came up at the current pointer position.
+    PointerReleased,
+}
+
+/// One decision the tree made, queued for the host to drain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UiOutput {
+    /// A press and release landed on the same node: the click
+    /// happened, and the node now holds focus.
+    Activated(NodeId),
+}
+
+/// The interaction state one [`Ui`] carries between events.
+#[derive(Debug, Default)]
+pub(crate) struct Interaction {
+    /// The last pointer position, in physical pixels. Kept because a
+    /// press decides against the position of the moment, not the
+    /// position of the last move event.
+    pub pointer: (i32, i32),
+    /// The node the primary button went down on, until release.
+    pub pressed: Option<NodeId>,
+    /// The node that holds focus: the last activated one.
+    pub focus: Option<NodeId>,
+    /// How many activations this tree has ever made — the ordinal the
+    /// digest folds, so a replayed run that clicks twice can never
+    /// digest like one that clicked once.
+    pub activations: u64,
+    /// A running fold of every activated id, in order — the sequence
+    /// record the ordinal alone cannot be. Two runs that activated
+    /// different nodes, or the same nodes in a different order, hold
+    /// different folds even after their queues drain.
+    pub decisions: u64,
+    /// Decisions dropped because the output queue was full. Absorbed
+    /// into the digest: a dropped decision is a behaviour difference,
+    /// and a counter is how it stays visible rather than silent.
+    pub overflowed: u64,
+}
+
+impl Ui {
+    /// Feed one event through the tree's interaction state.
+    ///
+    /// Hover is refreshed against the retained rectangles of the last
+    /// [`Self::solve`] on every event — a moved pointer, a press, and
+    /// a release all decide against where things are *now*. A press
+    /// remembers the node it landed on; a release on that same node
+    /// activates it, queues [`UiOutput::Activated`], and moves focus
+    /// there. A release anywhere else abandons the press, which is how
+    /// every toolkit lets a mis-click be dragged off a button.
+    pub fn handle(&mut self, event: UiEvent) {
+        match event {
+            UiEvent::PointerMoved { x, y } => {
+                self.interaction.pointer = (x, y);
+            }
+            UiEvent::PointerPressed => {
+                let (x, y) = self.interaction.pointer;
+                self.interaction.pressed = self.hit_test(x, y);
+            }
+            UiEvent::PointerReleased => {
+                let (x, y) = self.interaction.pointer;
+                let released_on = self.hit_test(x, y);
+                if let Some(node) = self.interaction.pressed
+                    && released_on == Some(node)
+                {
+                    self.interaction.activations += 1;
+                    // Chain the id into the running decision fold: the
+                    // previous fold seeds the next, so the sequence —
+                    // not just the count and the last — is the record.
+                    self.interaction.decisions = StateHash::new()
+                        .absorb_u64(self.interaction.decisions)
+                        .absorb_u32(node.index())
+                        .absorb_u64(node.generation())
+                        .finish();
+                    self.interaction.focus = Some(node);
+                    // Bounded by the declared limit, not by whatever
+                    // the allocator happened to hand the queue.
+                    if self.outputs.len() < self.limits.nodes as usize {
+                        self.outputs.push(UiOutput::Activated(node));
+                    } else {
+                        self.interaction.overflowed += 1;
+                    }
+                }
+                self.interaction.pressed = None;
+            }
+        }
+    }
+
+    /// The queued decisions, drained oldest first. The queue holds as
+    /// many decisions as the tree holds nodes; past that, decisions
+    /// are dropped and counted, never silently lost — the digest folds
+    /// the count.
+    pub fn drain_outputs(&mut self) -> impl Iterator<Item = UiOutput> + '_ {
+        self.outputs.drain(..)
+    }
+
+    /// The node under the pointer, against the rectangles of the last
+    /// [`Self::solve`] — computed fresh on every ask, so a re-solve
+    /// that moved a box under a stationary pointer answers the new
+    /// truth, never a cached one.
+    #[must_use]
+    pub fn hover(&self) -> Option<NodeId> {
+        let (x, y) = self.interaction.pointer;
+        self.hit_test(x, y)
+    }
+
+    /// The node the primary button is currently down on.
+    #[must_use]
+    pub fn pressed(&self) -> Option<NodeId> {
+        self.interaction.pressed.filter(|&node| self.is_live(node))
+    }
+
+    /// The node holding focus: the last activated one, while it lives.
+    #[must_use]
+    pub fn focus(&self) -> Option<NodeId> {
+        self.interaction.focus.filter(|&node| self.is_live(node))
+    }
+
+    /// Fold this tree's discrete decisions into `hash`.
+    ///
+    /// **What is absorbed:** the pointer position (input echo — it
+    /// decides the next press), the pressed and focus ids, the
+    /// activation ordinal, the running fold of every activated id in
+    /// order, and the overflow count. Ids absorb as slot index plus
+    /// generation, with the index `NIL` standing for none — a
+    /// collision-free sentinel, since no real slot carries `NIL` and
+    /// no generation is zero.
+    ///
+    /// **What is left out, and why — named here because an unstated
+    /// exclusion is how a digest goes quietly vacuous:**
+    /// - *Hover*: not stored at all. Every decision path re-derives it
+    ///   from the absorbed pointer and the current rectangles at the
+    ///   moment of the press or release, and the accessor recomputes
+    ///   on every ask — there is no cached value to go stale or to
+    ///   escape this digest.
+    /// - *Solved rectangles and wanted sizes*: geometry. A layout
+    ///   change reaches this digest only by changing a decision — a
+    ///   press that hits a different node — which is exactly when it
+    ///   should.
+    /// - *Styles and the tree structure*: authoring data, same road.
+    /// - *The output queue*: its contents are exactly the activated
+    ///   ids in order, and the decision fold above records that
+    ///   sequence — so two states with equal digests hand their hosts
+    ///   the same drained decisions.
+    #[must_use]
+    pub fn absorb(&self, hash: StateHash) -> StateHash {
+        let hash = hash
+            .absorb_u32(self.interaction.pointer.0.cast_unsigned())
+            .absorb_u32(self.interaction.pointer.1.cast_unsigned());
+        let hash = absorb_id(hash, self.interaction.pressed);
+        let hash = absorb_id(hash, self.interaction.focus);
+        hash.absorb_u64(self.interaction.activations)
+            .absorb_u64(self.interaction.decisions)
+            .absorb_u64(self.interaction.overflowed)
+    }
+
+    /// The deepest, latest node containing the point, or `None` when
+    /// even the root does not.
+    ///
+    /// Paint order is document order — parents under children, earlier
+    /// siblings under later ones — so the test starts at the root and
+    /// repeatedly descends into the *last* child containing the point.
+    fn hit_test(&self, x: i32, y: i32) -> Option<NodeId> {
+        if !self.contains(0, x, y) {
+            return None;
+        }
+        let mut at = 0u32;
+        loop {
+            let mut descended = false;
+            let mut child = self.slots[at as usize].first_child;
+            let mut topmost = NIL;
+            while child != NIL {
+                if self.contains(child, x, y) {
+                    topmost = child;
+                }
+                child = self.slots[child as usize].next_sibling;
+            }
+            if topmost != NIL {
+                at = topmost;
+                descended = true;
+            }
+            if !descended {
+                return Some(self.id_at(at));
+            }
+        }
+    }
+
+    /// Whether `index`'s solved rectangle contains the point.
+    /// Half-open on both axes: a point on the right or bottom edge is
+    /// outside, so adjacent rectangles never both claim it.
+    fn contains(&self, index: u32, x: i32, y: i32) -> bool {
+        let rect = self.layout[index as usize].rect;
+        let x = renew_fixed::Fixed::from_int(x);
+        let y = renew_fixed::Fixed::from_int(y);
+        x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
+    }
+}
+
+/// Absorb an optional id: slot index (`NIL` for none) then generation.
+fn absorb_id(hash: StateHash, id: Option<NodeId>) -> StateHash {
+    match id {
+        Some(node) => hash.absorb_u32(node.index()).absorb_u64(node.generation()),
+        None => hash.absorb_u32(NIL).absorb_u64(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Edges, Size, Style, UiLimits};
+    use renew_fixed::Fixed;
+
+    fn f(value: i32) -> Fixed {
+        Fixed::from_int(value)
+    }
+
+    fn px(value: i32) -> Size {
+        Size::Px(f(value))
+    }
+
+    /// A solved two-button column, the fixture most tests share:
+    /// buttons at y 0..10 and y 10..20, both x 0..40.
+    fn two_buttons() -> (Ui, NodeId, NodeId) {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                direction: crate::Direction::Column,
+                ..Style::default()
+            },
+        );
+        let first = ui.insert(root).expect("room");
+        ui.set_style(
+            first,
+            Style {
+                width: px(40),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        let second = ui.insert(root).expect("room");
+        ui.set_style(
+            second,
+            Style {
+                width: px(40),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        (ui, first, second)
+    }
+
+    /// The deepest node under the pointer wins, edges are half-open,
+    /// and outside the root is nobody.
+    #[test]
+    fn hit_testing_finds_the_deepest_node_and_respects_edges() {
+        let (mut ui, first, second) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        assert_eq!(ui.hover(), Some(first));
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 15 });
+        assert_eq!(ui.hover(), Some(second));
+        // y = 10 is the second button's first row, not the first's
+        // last: half-open edges mean neighbours never share a point.
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 10 });
+        assert_eq!(ui.hover(), Some(second));
+        // x = 40 is past both buttons' right edge but inside the root.
+        ui.handle(UiEvent::PointerMoved { x: 40, y: 5 });
+        assert_eq!(ui.hover(), Some(ui.root()));
+        // Outside the viewport is outside everything.
+        ui.handle(UiEvent::PointerMoved { x: 200, y: 5 });
+        assert_eq!(ui.hover(), None);
+    }
+
+    /// Later siblings draw on top, so an overlapping later sibling
+    /// takes the hit.
+    #[test]
+    fn a_later_sibling_overlapping_an_earlier_one_is_on_top() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let under = ui.insert(root).expect("room");
+        ui.set_style(
+            under,
+            Style {
+                width: px(30),
+                height: px(30),
+                ..Style::default()
+            },
+        );
+        let over = ui.insert(root).expect("room");
+        ui.set_style(
+            over,
+            Style {
+                width: px(30),
+                height: px(30),
+                margin: Edges {
+                    left: f(-30),
+                    ..Edges::default()
+                },
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.rect(under),
+            ui.rect(over),
+            "the fixture needs the two boxes coincident"
+        );
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        assert_eq!(ui.hover(), Some(over), "paint order decides the hit");
+    }
+
+    /// Press and release on the same node activates it, queues the
+    /// decision, and moves focus; the press then ends.
+    #[test]
+    fn a_click_activates_and_focuses() {
+        let (mut ui, first, _) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerPressed);
+        assert_eq!(ui.pressed(), Some(first));
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.pressed(), None, "release ends the press");
+        assert_eq!(ui.focus(), Some(first), "focus follows activation");
+        let outputs: Vec<_> = ui.drain_outputs().collect();
+        assert_eq!(outputs, vec![UiOutput::Activated(first)]);
+        assert_eq!(
+            ui.drain_outputs().count(),
+            0,
+            "draining is consuming: the queue empties"
+        );
+    }
+
+    /// Dragging off a button abandons the press: no activation, no
+    /// focus, nothing queued.
+    #[test]
+    fn releasing_elsewhere_abandons_the_press() {
+        let (mut ui, first, _) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerPressed);
+        assert_eq!(ui.pressed(), Some(first));
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 15 });
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.focus(), None, "an abandoned press focuses nothing");
+        assert_eq!(ui.drain_outputs().count(), 0);
+    }
+
+    /// A release with no press, and a press on nothing, both decide
+    /// nothing — the pairing is a pairing.
+    #[test]
+    fn unpaired_halves_decide_nothing() {
+        let (mut ui, _, _) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.drain_outputs().count(), 0, "release without press");
+        ui.handle(UiEvent::PointerMoved { x: 200, y: 200 });
+        ui.handle(UiEvent::PointerPressed);
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.drain_outputs().count(), 0, "press on nothing");
+    }
+
+    /// The replay shape: one recorded event sequence, applied to two
+    /// identically built trees, digests identically at every step —
+    /// and differently from a sequence that decided differently.
+    #[test]
+    fn a_replayed_sequence_digests_identically() {
+        use renew_frame::StateHash;
+        let script = [
+            UiEvent::PointerMoved { x: 5, y: 5 },
+            UiEvent::PointerPressed,
+            UiEvent::PointerReleased,
+            UiEvent::PointerMoved { x: 5, y: 15 },
+            UiEvent::PointerPressed,
+            UiEvent::PointerMoved { x: 5, y: 5 },
+            UiEvent::PointerReleased,
+        ];
+        let run = || {
+            let (mut ui, _, _) = two_buttons();
+            let mut digests = Vec::new();
+            for &event in &script {
+                ui.handle(event);
+                digests.push(ui.absorb(StateHash::new()).finish());
+            }
+            digests
+        };
+        assert_eq!(run(), run(), "same trace, same digests, every step");
+
+        // A run that activated a different button — and then parked
+        // the pointer on the same final pixel — must digest
+        // differently: the decision is the difference.
+        let (mut other, _, second) = two_buttons();
+        other.handle(UiEvent::PointerMoved { x: 5, y: 15 });
+        other.handle(UiEvent::PointerPressed);
+        other.handle(UiEvent::PointerReleased);
+        other.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        assert_eq!(other.focus(), Some(second), "the fixture decided");
+        assert_ne!(
+            run().last().copied(),
+            Some(other.absorb(StateHash::new()).finish()),
+            "different decisions may not share a digest"
+        );
+    }
+
+    /// The load-bearing exclusion, pinned: geometry that changes no
+    /// decision changes no digest. A padding tweak moves rectangles,
+    /// but with no press between, the digest stands still.
+    #[test]
+    fn geometry_reaches_the_digest_only_through_decisions() {
+        use renew_frame::StateHash;
+        let (mut ui, _, _) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        let before = ui.absorb(StateHash::new()).finish();
+        let root = ui.root();
+        let mut style = ui.style(root).expect("root is live");
+        style.padding = Edges::all(f(2));
+        ui.set_style(root, style);
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.absorb(StateHash::new()).finish(),
+            before,
+            "a padding tweak with no decision between must not redden a digest"
+        );
+    }
+
+    /// One button clicked `clicks` times in a tree sized `nodes`, for
+    /// the overflow comparison below.
+    fn clicked(nodes: u32, clicks: u32) -> Ui {
+        let mut ui = Ui::new(UiLimits { nodes });
+        let root = ui.root();
+        let button = ui.insert(root).expect("room");
+        ui.set_style(
+            button,
+            Style {
+                width: px(10),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        for _ in 0..clicks {
+            ui.handle(UiEvent::PointerPressed);
+            ui.handle(UiEvent::PointerReleased);
+        }
+        ui
+    }
+
+    /// The queue is bounded by the node count; past that, decisions
+    /// are counted rather than silently lost — and the count alone
+    /// separates the digests, because the comparison runs make the
+    /// same activations in the same order and differ only in room.
+    #[test]
+    fn overflowed_decisions_are_counted_not_lost() {
+        use renew_frame::StateHash;
+        let mut cramped = clicked(2, 3);
+        let mut roomy = clicked(4, 3);
+        assert_eq!(cramped.drain_outputs().count(), 2, "two fit, one dropped");
+        assert_eq!(roomy.drain_outputs().count(), 3, "all three fit");
+        assert_ne!(
+            cramped.absorb(StateHash::new()).finish(),
+            roomy.absorb(StateHash::new()).finish(),
+            "the dropped decision must be visible in the digest, and only \
+             the overflow counter distinguishes these two runs"
+        );
+    }
+
+    /// A second press without a release simply re-decides: the first
+    /// press is overwritten, and the release pairs with the newest.
+    #[test]
+    fn a_second_press_replaces_the_first() {
+        let (mut ui, _, second) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerPressed);
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 15 });
+        ui.handle(UiEvent::PointerPressed);
+        assert_eq!(ui.pressed(), Some(second), "the newest press holds");
+        ui.handle(UiEvent::PointerReleased);
+        let outputs: Vec<_> = ui.drain_outputs().collect();
+        assert_eq!(outputs, vec![UiOutput::Activated(second)]);
+    }
+
+    /// A recycled slot under the pointer does not inherit the old
+    /// tenant's press: the generation refuses the pairing.
+    #[test]
+    fn a_recycled_slot_does_not_inherit_a_press() {
+        let (mut ui, first, _) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerPressed);
+        assert_eq!(ui.pressed(), Some(first));
+        assert!(ui.remove(first));
+        let replacement = ui.insert(ui.root()).expect("the freed slot returns");
+        ui.set_style(
+            replacement,
+            Style {
+                width: px(40),
+                height: px(10),
+                ..Style::default()
+            },
+        );
+        ui.solve(f(100), f(100));
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(
+            ui.drain_outputs().count(),
+            0,
+            "the new tenant under the same pixels is not the node that was pressed"
+        );
+        assert_eq!(ui.focus(), None);
+    }
+
+    /// An unsolved tree hits nothing at all: zero-sized rectangles
+    /// contain no point under half-open edges, the origin included.
+    #[test]
+    fn an_unsolved_tree_hits_nothing() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        ui.handle(UiEvent::PointerMoved { x: 0, y: 0 });
+        assert_eq!(ui.hover(), None);
+        ui.handle(UiEvent::PointerPressed);
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.drain_outputs().count(), 0);
+    }
+
+    /// The decision fold records the sequence, not the summary: two
+    /// runs with the same activation count, the same final focus, and
+    /// the same parked pointer — differing only in WHICH node was
+    /// activated first — digest differently.
+    #[test]
+    fn the_decision_fold_separates_equal_summaries() {
+        use renew_frame::StateHash;
+        let click = |ui: &mut Ui, y: i32| {
+            ui.handle(UiEvent::PointerMoved { x: 5, y });
+            ui.handle(UiEvent::PointerPressed);
+            ui.handle(UiEvent::PointerReleased);
+        };
+        let (mut one, _, _) = two_buttons();
+        click(&mut one, 5);
+        click(&mut one, 15);
+        let (mut two, _, _) = two_buttons();
+        click(&mut two, 15);
+        click(&mut two, 15);
+        // Same count, same focus, same pointer; only history differs.
+        assert_eq!(one.focus(), two.focus());
+        assert_ne!(
+            one.absorb(StateHash::new()).finish(),
+            two.absorb(StateHash::new()).finish(),
+            "the digest must remember which node was activated, not just how many times"
+        );
+    }
+
+    /// Interaction state follows liveness: focus dies with its node,
+    /// and hover — computed fresh — answers what is really under the
+    /// pointer, before and after the re-solve.
+    #[test]
+    fn removed_nodes_leave_the_interaction_state() {
+        let (mut ui, first, second) = two_buttons();
+        ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+        ui.handle(UiEvent::PointerPressed);
+        ui.handle(UiEvent::PointerReleased);
+        assert_eq!(ui.focus(), Some(first));
+        assert!(ui.remove(first));
+        assert_eq!(ui.focus(), None, "focus does not outlive its node");
+        assert_eq!(
+            ui.hover(),
+            Some(ui.root()),
+            "with the button gone and the tree unsolved, the pointer rests on the root"
+        );
+        ui.solve(f(100), f(100));
+        assert_eq!(
+            ui.hover(),
+            Some(second),
+            "after the re-solve, on the sibling that moved up"
+        );
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,13 +1,14 @@
 //! The retained widget tree: an arena of generationally addressed
 //! nodes, capacities fixed at construction.
 //!
-//! This crate is the simulation-side half of the UI: the tree, and
-//! the fixed-point solver (the [`layout`] module vocabulary) that
-//! turns its styles into pixel rectangles. Input handling and state
-//! digestion arrive as their own steps; what they will share is here —
-//! a tree whose nodes are stable to address, cheap to add and remove,
-//! and bounded by an explicit limit rather than by whatever the heap
-//! allows.
+//! This crate is the simulation-side half of the UI: the tree, the
+//! fixed-point solver (the [`layout`] module vocabulary) that turns
+//! its styles into pixel rectangles, and the integer-only interaction
+//! surface ([`Ui::handle`], [`Ui::absorb`]) that turns events into
+//! decisions and decisions into digests. Under all three sits the
+//! same ground — a tree whose nodes are stable to address, cheap to
+//! add and remove, and bounded by an explicit limit rather than by
+//! whatever the heap allows.
 //!
 //! **Shape.** Nodes live in one arena, linked intrusively: parent,
 //! first and last child, previous and next sibling. Children keep
@@ -44,8 +45,11 @@
 // anywhere in this crate would be a value a digest could see.
 #![deny(clippy::print_stdout, clippy::print_stderr, clippy::float_arithmetic)]
 
+mod input;
 mod layout;
 
+use input::Interaction;
+pub use input::{UiEvent, UiOutput};
 pub use layout::{Align, Direction, Edges, Rect, Size, Style};
 use layout::{LayoutSlot, Scratch, Solve};
 use renew_fixed::Fixed;
@@ -105,6 +109,18 @@ pub struct NodeId {
     generation: u64,
 }
 
+impl NodeId {
+    /// The slot index, for the digest's explicit absorption order.
+    pub(crate) fn index(self) -> u32 {
+        self.index
+    }
+
+    /// The generation, likewise.
+    pub(crate) fn generation(self) -> u64 {
+        self.generation
+    }
+}
+
 /// One arena slot. Free slots keep their links meaningless except
 /// `next_sibling`, which threads the free list.
 #[derive(Clone, Copy, Debug)]
@@ -155,6 +171,10 @@ pub struct Ui {
     dirty: bool,
     /// The viewport the current rectangles were solved for.
     solved_for: (Fixed, Fixed),
+    /// Pointer, hover, press, focus, and the decision counters.
+    interaction: Interaction,
+    /// Decisions waiting for the host, capacity fixed with the arena.
+    outputs: Vec<UiOutput>,
     /// Head of the free list, threaded through `next_sibling`.
     free: u32,
     live: u32,
@@ -191,6 +211,8 @@ impl Ui {
             scratch: Scratch::with_capacity(capacity),
             dirty: true,
             solved_for: (Fixed::ZERO, Fixed::ZERO),
+            interaction: Interaction::default(),
+            outputs: Vec::with_capacity(capacity as usize),
             free,
             live: 1,
             limits: UiLimits { nodes: capacity },

--- a/crates/ui/tests/zero_alloc.rs
+++ b/crates/ui/tests/zero_alloc.rs
@@ -10,7 +10,7 @@
 
 use renew_fixed::Fixed;
 use renew_memory::{CountingAllocator, counters};
-use renew_ui::{Size, Style, Ui, UiLimits};
+use renew_ui::{Size, Style, Ui, UiEvent, UiLimits};
 
 #[global_allocator]
 static ALLOCATOR: CountingAllocator = CountingAllocator;
@@ -88,4 +88,27 @@ fn the_steady_state_allocates_nothing() {
         }
     });
     verdict.expect("re-solving stays heap-silent");
+
+    // The interaction half: moving, clicking, and draining decisions
+    // works the preallocated queue and the retained rectangles, never
+    // the heap. One click first as warmup, then the window clicks and
+    // drains and asserts the decisions really flowed.
+    ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+    ui.handle(UiEvent::PointerPressed);
+    ui.handle(UiEvent::PointerReleased);
+    assert_eq!(ui.drain_outputs().count(), 1, "the warmup click must land");
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            ui.handle(UiEvent::PointerMoved { x: 5, y: 5 });
+            ui.handle(UiEvent::PointerPressed);
+            ui.handle(UiEvent::PointerMoved { x: 6, y: 6 });
+            ui.handle(UiEvent::PointerReleased);
+            assert_eq!(
+                ui.drain_outputs().count(),
+                1,
+                "every windowed click must decide"
+            );
+        }
+    });
+    verdict.expect("interaction stays heap-silent");
 }


### PR DESCRIPTION
The interaction half of the widget tree, and the seam that keeps it honest.

**Integer-only by construction.** Pointer events reach the tree as `i32` physical pixels. The one float-to-integer seam — floor, then the saturating cast that floor makes exact — lands in the maths crate beside the render interpolation factor (`quantize_pointer`, with edge tests for the interior floor, both saturations, infinities, and NaN), applied by drivers and the replay harness before events get here. A recorded trace replays into the same integers everywhere, and no float exists in the widget crate for a digest to see.

**The vocabulary** is hover, press/release activation, and focus. Hit-testing walks the retained rectangles topmost-first with half-open edges; hover is computed fresh on every ask — no cached value to go stale across a re-solve. A press remembers its node, a release on the same node activates it and moves focus there, a release anywhere else abandons the press, and a recycled slot does not inherit the old tenant's press — the generation refuses the pairing.

**The digest.** Decisions fold into the engine's state fingerprint: pointer, pressed, focus, the activation ordinal, a running fold of every activated id in order — two runs that activated different nodes can never digest alike, even after their queues drain — and the count of decisions dropped by the bounded queue (sized by the declared node limit, not by whatever the allocator handed the vector). The exclusions are named in the source beside the absorption, and a test pins the load-bearing one: a padding tweak with no press between digests identically. A replay-shaped test applies one recorded sequence to two trees and compares digests at every step.

Forty lib tests, a third allocation-gate window (click-and-drain churn), and the structure checks all green; the build matrix's without-frame cell names its new dependent.
