### PR TITLE
feat(ui): the menu scenario joins the cross-platform comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,13 @@ jobs:
           # gate measures nothing of it. The lavapipe driver above makes
           # its golden run for real here.
           cargo llvm-cov --no-report test -p renew-particles --features render
+          # The widget tree's scenario binary: the comparison legs run
+          # it for real elsewhere; here it runs once so the entry
+          # point's lines are executed by the suite that measures them.
+          # Its two refusal arms are exempted by name — an exiting
+          # process does not reliably flush its counters, so covering
+          # them here would hinge on an exit-path detail.
+          cargo llvm-cov --no-report run -p renew-ui
           cargo llvm-cov --no-report test -p renew-sample-glide --features window
           cargo llvm-cov --no-report test -p renew-sample-cube --features window
           # The voxel game's three views, one run each. The line above

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -128,3 +128,8 @@ reason = "A test double's required method that cannot be called: its argument bo
 file = "crates/core/platform/src/window.rs"
 lines = [404, 405, 406, 407, 408, 409, 410, 411, 412, 413]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run."
+
+[[exempt]]
+file = "crates/ui/src/bin/ui_digest.rs"
+lines = [33, 34, 41, 42]
+reason = "The scenario binary's two refusal arms: the argument guard (a drifted pinned-run row must fail loudly rather than run a different scenario under the same name) and the impossible-construction arm (reachable only if a four-insert scenario overflows a sixteen-node limit; a vacuous zero digest must never reach the comparison). Each is two lines - a message and a nonzero exit - and an exiting process does not reliably flush its coverage counters, so exercising them under the instrumented lane would hinge on an exit-path implementation detail rather than prove anything. The happy path is executed by the lane's own run of the binary."

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -101,12 +101,12 @@ reason = "The arm that clears a voice whose sound index is missing. A voice is o
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [80, 81, 82, 1090, 1091, 1092, 1093, 1099, 1100, 1102, 1103, 1104, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1117, 1118, 1119, 1120, 1121, 1122, 1123, 1124, 1125, 1129, 1130, 1131, 1132, 1133, 1134, 1135, 1136, 1137, 1138, 1139, 1140, 1142, 1146, 1147]
-reason = "The emit half of determinism: it spawns nine cargo runs across four samples and reads what they printed, so reaching it from a test would mean building and running whole samples under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
+lines = [80, 81, 82, 1095, 1096, 1097, 1098, 1104, 1105, 1107, 1108, 1109, 1114, 1115, 1116, 1117, 1118, 1119, 1120, 1122, 1123, 1124, 1125, 1126, 1127, 1128, 1129, 1130, 1134, 1135, 1136, 1137, 1138, 1139, 1140, 1141, 1142, 1143, 1144, 1145, 1147, 1151, 1152]
+reason = "The emit half of determinism: it spawns a cargo run per pinned scenario and reads what they printed, so reaching it from a test would mean building and running whole samples under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [1153]
+lines = [1158]
 reason = "The comparison refusing to start because no workspace root is above it. Every other subcommand carries the same arm and reaches it the same way -- never, from a test, because a test runs inside the workspace it is testing. Reaching it would mean invoking the binary from outside any cargo project, which is a property of where a caller stands rather than of anything this code does."
 
 [[exempt]]

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -61,9 +61,9 @@ with the rest of flexbox landing when a real document needs it.
 
 Everything is `Fixed` (Q47.16), so a solve is integer arithmetic
 under the hood, the same on every target by construction. A test
-builds the same tree twice and compares every rectangle to the bit;
-the cross-target determinism-lane scenario that turns that claim
-into three-platform evidence stands as its own step, next. Leftover space
+builds the same tree twice and compares every rectangle to the bit,
+and the `ui_digest` scenario below carries the claim to the
+cross-target comparison lane. Leftover space
 among growers is shared by largest remainder over raw fixed-point
 units — shares sum to the leftover exactly, property-tested, with
 ties breaking toward the earlier sibling. Both passes are iterative
@@ -95,8 +95,15 @@ the node count; past that, decisions are dropped and counted, never
 silently lost.
 
 `Ui::absorb` folds the discrete decisions into the engine's state
-fingerprint: pointer, pressed, focus, the activation ordinal, and
-the overflow count. What it leaves out is named in the source beside
-it — hover is derived, geometry reaches the digest only by changing
-a decision, and a test pins exactly that: a padding tweak with no
-press between digests identically.
+fingerprint: pointer, pressed, focus, the activation ordinal, a
+running fold of every activated id in order, and the overflow count.
+What it leaves out is named in the source beside it — hover is
+computed fresh rather than stored, geometry reaches the digest only
+by changing a decision, and a test pins exactly that: a padding
+tweak with no press between digests identically.
+
+The crate's one binary, `ui_digest`, runs a fixed scripted menu
+session headless and prints its digest as one JSON line — the
+scenario the cross-platform comparison lane holds against itself on
+every target, so the integer-arithmetic claim above is three
+machines agreeing rather than one machine asserting.

--- a/crates/ui/src/bin/ui_digest.rs
+++ b/crates/ui/src/bin/ui_digest.rs
@@ -157,10 +157,7 @@ fn run() -> Option<(u64, usize, u64)> {
 /// The lane witness wants what the gameplay digest deliberately
 /// excludes: a one-raw-unit solver divergence must be visible here.
 fn fold_geometry(ui: &Ui, mut hash: StateHash, nodes: &[renew_ui::NodeId]) -> StateHash {
-    for &node in nodes {
-        let Some(rect) = ui.rect(node) else {
-            continue;
-        };
+    for rect in nodes.iter().filter_map(|&node| ui.rect(node)) {
         for part in [rect.x, rect.y, rect.width, rect.height] {
             hash = hash.absorb_u64(part.to_bits().cast_unsigned());
         }

--- a/crates/ui/src/bin/ui_digest.rs
+++ b/crates/ui/src/bin/ui_digest.rs
@@ -1,0 +1,194 @@
+//! The widget tree's headless determinism scenario: one scripted menu
+//! session, digested, printed as a single JSON line.
+//!
+//! This binary exists for the cross-platform comparison: three targets
+//! run the same script and their digests are held against each other,
+//! never against a committed constant — agreement between machines is
+//! the only evidence that the machine did not matter. The script is
+//! fixed in this file; changing it changes the digest on every target
+//! at once, which the comparison forgives, and on one target alone,
+//! which it exists to catch.
+//!
+//! The session exercises the surfaces a divergence could hide in: the
+//! solver (mixed pixel and content sizes, growth, a mid-script restyle
+//! whose re-solve moves a later click onto a different button),
+//! hit-testing (moves across every button, a boundary-exact corner, a
+//! miss outside the tree), and the decision fold (activations, an
+//! abandoned press, a click on nothing). Unlike the tree's own
+//! `absorb` — whose geometry exclusion serves gameplay gates — this
+//! witness folds the solved rectangles too, to the raw fixed-point
+//! bit: a lane scenario wants maximum sensitivity, and a one-unit
+//! solver divergence must move this digest even though it would not
+//! move a game's.
+
+use renew_fixed::Fixed;
+use renew_frame::StateHash;
+use renew_ui::{Align, Direction, Edges, Size, Style, Ui, UiEvent, UiLimits};
+
+fn main() {
+    // The scenario takes no arguments; being handed one means the
+    // pinned-run table drifted, and a drifted invocation must fail
+    // rather than run a different scenario under the same name.
+    if std::env::args().len() > 1 {
+        eprintln!("ui_digest takes no arguments; the scenario is fixed in its source");
+        std::process::exit(2);
+    }
+    let Some((digest, events, activations)) = run() else {
+        // Unreachable while the file's own limits hold; if it ever
+        // fires, a nonzero exit makes the lane leg fail by name
+        // rather than contribute a vacuous digest that all targets
+        // would agree on.
+        eprintln!("the scenario could not build its own tree; nothing was digested");
+        std::process::exit(1);
+    };
+    // One line, machine-readable, schema-versioned: the lane's whole
+    // interface to this binary.
+    println!(
+        "{{\"schema_version\":1,\"sample\":\"ui\",\"script\":\"menu\",\"events\":{events},\"activations\":{activations},\"digest\":\"0x{digest:016x}\"}}"
+    );
+}
+
+/// The scripted session: build the menu, solve it, walk the script,
+/// folding the tree's digest after every event and the solved
+/// geometry after every solve. `None` only if the tree refuses its
+/// own construction, which the limits above make impossible.
+fn run() -> Option<(u64, usize, u64)> {
+    let mut ui = Ui::new(UiLimits { nodes: 16 });
+    let root = ui.root();
+    ui.set_style(
+        root,
+        Style {
+            direction: Direction::Column,
+            padding: Edges::all(Fixed::from_int(8)),
+            gap: Fixed::from_int(4),
+            align_cross: Align::Center,
+            ..Style::default()
+        },
+    );
+    // A title strip and three menu buttons, the middle one growing.
+    // A refused insert is impossible under this file's own limits;
+    // the `?` road ends in main's nonzero exit, never in a digest.
+    let title = ui.insert(root).ok()?;
+    ui.set_style(
+        title,
+        Style {
+            width: Size::Px(Fixed::from_int(120)),
+            height: Size::Px(Fixed::from_int(24)),
+            ..Style::default()
+        },
+    );
+    let mut buttons = [title; 3];
+    for (nth, slot) in buttons.iter_mut().enumerate() {
+        let button = ui.insert(root).ok()?;
+        ui.set_style(
+            button,
+            Style {
+                width: Size::Px(Fixed::from_int(100)),
+                height: Size::Px(Fixed::from_int(20)),
+                grow: u32::from(nth == 1),
+                ..Style::default()
+            },
+        );
+        *slot = button;
+    }
+    ui.solve(Fixed::from_int(320), Fixed::from_int(200));
+    let mut hash = StateHash::new();
+    hash = fold_geometry(
+        &ui,
+        hash,
+        &[root, title, buttons[0], buttons[1], buttons[2]],
+    );
+
+    // The script: coordinates chosen against the solved layout above —
+    // the buttons sit centred at x 110..210, stacked from y 36 with a
+    // 4px gap, the middle one grown. Every kind of gesture appears at
+    // least once, and one move lands exactly on the first button's
+    // top-left corner, where the half-open convention decides the hit.
+    let script = [
+        UiEvent::PointerMoved { x: 110, y: 36 },
+        UiEvent::PointerMoved { x: 160, y: 40 },
+        UiEvent::PointerPressed,
+        UiEvent::PointerReleased, // activate the first button
+        UiEvent::PointerMoved { x: 160, y: 100 },
+        UiEvent::PointerPressed,
+        UiEvent::PointerMoved { x: 5, y: 5 },
+        UiEvent::PointerReleased, // abandoned: dragged off before release
+        UiEvent::PointerMoved { x: 400, y: 300 },
+        UiEvent::PointerPressed,
+        UiEvent::PointerReleased, // click on nothing at all
+        UiEvent::PointerMoved { x: 160, y: 180 },
+        UiEvent::PointerPressed,
+        UiEvent::PointerReleased, // activate the last button
+    ];
+    for &event in &script {
+        ui.handle(event);
+        hash = ui.absorb(hash);
+    }
+
+    // Mid-session restyle: the growing button stops growing, the tree
+    // re-solves, and the pixel that hit the middle button before the
+    // restyle now hits the last one — the coda click activates a
+    // DIFFERENT node than it would have a moment earlier, so a
+    // re-solve that diverged or silently never ran changes the
+    // decision fold, not just the geometry fold.
+    let mut style = ui.style(buttons[1])?;
+    style.grow = 0;
+    ui.set_style(buttons[1], style);
+    ui.solve(Fixed::from_int(320), Fixed::from_int(200));
+    hash = fold_geometry(
+        &ui,
+        hash,
+        &[root, title, buttons[0], buttons[1], buttons[2]],
+    );
+    let coda = [
+        UiEvent::PointerMoved { x: 160, y: 100 },
+        UiEvent::PointerPressed,
+        UiEvent::PointerReleased,
+    ];
+    for &event in &coda {
+        ui.handle(event);
+        hash = ui.absorb(hash);
+    }
+    let activations = ui.drain_outputs().count() as u64;
+    Some((hash.finish(), script.len() + coda.len(), activations))
+}
+
+/// Fold the solved rectangles of `nodes`, to the raw fixed-point bit.
+/// The lane witness wants what the gameplay digest deliberately
+/// excludes: a one-raw-unit solver divergence must be visible here.
+fn fold_geometry(ui: &Ui, mut hash: StateHash, nodes: &[renew_ui::NodeId]) -> StateHash {
+    for &node in nodes {
+        let Some(rect) = ui.rect(node) else {
+            continue;
+        };
+        for part in [rect.x, rect.y, rect.width, rect.height] {
+            hash = hash.absorb_u64(part.to_bits().cast_unsigned());
+        }
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+
+    /// The scenario is a pure function: two runs in one process agree
+    /// exactly. The cross-machine half of the claim belongs to the
+    /// comparison lane, which is the point of the binary existing.
+    #[test]
+    fn the_scenario_reproduces_in_process() {
+        assert_eq!(run(), run());
+    }
+
+    /// The script really decides things: two activations before the
+    /// restyle and one after, counted from the drained queue — a
+    /// scenario that stopped deciding could never pass this, however
+    /// stable its digest.
+    #[test]
+    fn the_scenario_actually_activates() {
+        let (digest, events, activations) = run().expect("the scenario builds its own tree");
+        assert_eq!(events, 17);
+        assert_eq!(activations, 3, "the script activates exactly three times");
+        assert_ne!(digest, 0);
+    }
+}

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -369,8 +369,8 @@ fn escape(text: &str) -> String {
 ///
 /// The pure half of `--emit`: everything between "a child process wrote
 /// some bytes" and "the report holds two digests". Separated from the
-/// orchestration around it because the orchestration spawns four cargo
-/// runs and cannot be reached by a unit test, while every way this can go
+/// orchestration around it because the orchestration spawns a cargo run
+/// per pinned scenario and cannot be reached by a unit test, while every way this can go
 /// wrong can be — a run that printed nothing, printed something that is
 /// not JSON, or printed JSON missing a hash the comparison needs.
 ///

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1004,11 +1004,16 @@ type PinnedRun = (
     &'static [&'static str],
 );
 
-/// Glide reports two hashes; the samples added since report one each.
+/// Glide reports two hashes; every run added since reports one.
 const GLIDE_FIELDS: &[&str] = &["schedule_hash", "state_hash"];
 const ONE_DIGEST: &[&str] = &["digest"];
 
-const PINNED_RUNS: [PinnedRun; 9] = [
+const PINNED_RUNS: [PinnedRun; 10] = [
+    // The widget tree: a scripted menu session through the fixed-point
+    // solver, the hit-tester, and the decision fold. Everything in it
+    // is integer arithmetic, and this row is what turns that claim
+    // into three targets agreeing rather than one target asserting.
+    ("ui/menu-16", "renew-ui", &[], ONE_DIGEST),
     (
         "glide/seed-7-600",
         "renew-sample-glide",
@@ -1084,9 +1089,9 @@ const PINNED_RUNS: [PinnedRun; 9] = [
 ///
 /// Each run contributes whichever digests its own report carries — two for
 /// the glide sample, which computes a frame-schedule hash beside its world
-/// hash, and one for the three added since. A lane that assumed one shape
-/// would tell the others their report was missing a field, which is true and
-/// useless.
+/// hash, and one apiece for every run added since. A lane that assumed one
+/// shape would tell the others their report was missing a field, which is
+/// true and useless.
 fn run_determinism_emit(output_path: &str, json_mode: bool) -> ExitCode {
     let runner = match Runner::anchored("determinism", json_mode) {
         Ok(runner) => runner,


### PR DESCRIPTION
The widget tree gains its one binary: `ui_digest`, a headless scripted menu session printed as a single schema-versioned JSON line. The pinned-run table grows a tenth row, and because both comparison legs share the same emit path, the scenario joins every target with no workflow change — three machines agreeing is the only evidence that the machine did not matter.

**What the script covers.** The solver with growth and a mid-session restyle whose re-solve moves a later click onto a *different button* — a re-solve that diverged or silently never ran changes which node activates, not just where boxes sit. Hit-tests across every button, one landing exactly on a corner where the half-open convention decides the hit. An abandoned press, a click on nothing, and the decision fold throughout.

**Why it folds geometry.** Unlike the tree's own digest — whose geometry exclusion exists so a padding tweak cannot redden a gameplay gate — this witness folds every solved rectangle to the raw fixed-point bit after each solve: a lane scenario wants maximum sensitivity, and a one-raw-unit solver divergence must move it even though it would not move a game's digest.

**Honest failure modes.** The binary rejects arguments, so a drifted table row fails loudly instead of running a different scenario under the same name; an impossible construction failure exits nonzero rather than contributing a deterministic zero digest that every target would vacuously agree on; and the tests pin the activation count the script actually earns (three), not just a nonzero hash.
