### PR TITLE
feat(ui): the presenter — snapshots blended at display rate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-ui --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
+          sel="--workspace --exclude renew-frame --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel
@@ -212,7 +212,7 @@ jobs:
       # other side.
       - name: Build and test without the rendering crate
         run: |
-          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-render3d --exclude renew-sample-cube --exclude renew-sample-hello-triangle --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-render3d --exclude renew-ui-render --exclude renew-sample-cube --exclude renew-sample-hello-triangle --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rhi $sel
           cargo build $sel
           cargo test $sel
@@ -284,20 +284,29 @@ jobs:
           cargo build $sel
           cargo test $sel
       # The widget tree: structure, layout, and interaction over the
-      # fixed-point and digest crates, no consumers yet — the UI's
-      # presentation crate and its first embedding game grow this list
-      # when they arrive.
+      # fixed-point and digest crates. Its one consumer is the UI
+      # presenter; the first embedding game grows this list when its
+      # menu lands.
       - name: Build and test without the widget tree
         run: |
-          sel="--workspace --exclude renew-ui"
+          sel="--workspace --exclude renew-ui --exclude renew-ui-render"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui $sel
+          cargo build $sel
+          cargo test $sel
+      # The UI presenter: snapshots over the widget tree, emitted
+      # through the 2D renderer; no consumers yet — the first embedding
+      # game grows this list when its menu lands.
+      - name: Build and test without the UI presenter
+        run: |
+          sel="--workspace --exclude renew-ui-render"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui-render $sel
           cargo build $sel
           cargo test $sel
       # The 2D renderer: policy over the rendering crate, no consumers
       # yet -- the windowed game grows this list when it draws sprites.
       - name: Build and test without the 2D renderer
         run: |
-          sel="--workspace --exclude renew-render2d --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-render2d --exclude renew-ui-render --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d $sel
           cargo build $sel
           cargo test $sel
@@ -346,7 +355,7 @@ jobs:
       # each went red here until the cell named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -413,7 +422,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel
@@ -559,6 +568,10 @@ jobs:
         run: |
           cargo clippy -p renew-particles --features render --all-targets -- -D warnings
           cargo test --package renew-particles --features render
+          # The UI presenter's computed image oracle rides the same
+          # pinned rasterizer for the same reason: a skip here is a
+          # failure, so the oracle can never pass by not running.
+          cargo test --package renew-ui-render
       # The sprite renderer's oracles on the same pinned rasterizer,
       # under the same rule: its computed-image test must run exactly
       # here too, and its committed golden is only compared on this

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-ui-render"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-fixed",
+ "renew-math",
+ "renew-memory",
+ "renew-render2d",
+ "renew-rhi",
+ "renew-ui",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
-    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "crates/ui", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/ui-render/Cargo.toml
+++ b/crates/ui-render/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "renew-ui-render"
+description = "Presentation for the widget tree: retained snapshots blended at display rate, clipped on the CPU, emitted as sprites"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "The presentation half of the UI: snapshot pairs of the solved widget tree, blended at display rate by the ratified interpolation factor, clipped to ancestor boxes on the CPU, and emitted as premultiplied sprites through the 2D renderer from one generated atlas."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# The tree being presented: rectangles, styles, and the (slot,
+# generation) identity the snapshot pair is keyed by.
+renew-ui = { path = "../ui" }
+# The display-rate half: the interpolation factor and float vectors —
+# the crate a simulation is forbidden from reaching, which is exactly
+# why the presenter may.
+renew-math = { path = "../core/math" }
+# The emission surface: sprites over one atlas, one buffer, one item.
+renew-render2d = { path = "../render2d" }
+
+# The golden oracle needs a device; the counting allocator gates the
+# steady state; property tests drive the clipper.
+[dev-dependencies]
+proptest = "1.11"
+renew-memory = { path = "../core/memory" }
+renew-rhi = { path = "../rhi", default-features = false }
+renew-fixed = { path = "../fixed" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under instrumented allocators.
+[features]
+sanitized = []

--- a/crates/ui-render/README.md
+++ b/crates/ui-render/README.md
@@ -1,0 +1,49 @@
+# renew-ui-render
+
+Presentation for the widget tree: retained snapshots blended at
+display rate, clipped on the CPU, emitted as sprites through the 2D
+renderer. The tree solves at the fixed timestep; frames arrive faster;
+this crate is the seam between the two.
+
+Machine-readable facts — maturity, dependencies, core status — live in
+this crate's manifest metadata (`Cargo.toml`, `[package.metadata.renew]`).
+
+## The snapshot pair
+
+`UiPresenter::advance` captures the solved tree once per simulation
+tick; every frame until the next capture blends the two most recent by
+the ratified interpolation factor. The blend is keyed by
+(slot, generation), so a node is only ever blended with *itself*: a
+recycled slot's new tenant never inherits the old tenant's motion.
+Nodes with one known tick draw unlerped at it — a newborn at the
+current tick, a dying node once more at the previous, underneath the
+living — so nothing vanishes mid-blend; what can change abruptly is
+stacking, never existence.
+
+## Frames as data
+
+`UiPresenter::frame` answers one frame as an iterator of quads —
+position, size, premultiplied tint — with clipping applied and
+invisible quads dropped. Quads are in the solver's pixel space, so
+the sprite renderer's canvas must match the viewport the tree solves
+at, and one frame can hold up to `max_quads` of them — twice the node
+limit, because a bulk replace draws every dying node once more under
+every newborn. Every decision the presenter makes is
+observable there without a device, which is where the unit and
+property tests hold it; `emit` is a thin adapter pushing each quad as
+a sprite. Clipping is rectangle intersection against the ancestor
+chain, computed at capture and blended with the rest; the one sampled
+atlas region is a uniform white texel, so clipping the rectangle is
+clipping the image — the proportional-UV half arrives with the first
+non-uniform region.
+
+## Atlas and evidence
+
+The atlas is generated — a white fill tile and a chrome border tile
+reserved for later — and tested against its own regions. A computed
+image oracle draws a solved tree offscreen and compares byte-exactly
+against pixels the test derives from the solver's own answers,
+inheriting the 2D renderer's exactness argument and its recorded
+sunset (the move to a linear working space re-decides the test). After
+construction the presenter allocates nothing: capture and frame churn
+run inside a counting-allocator window on every push.

--- a/crates/ui-render/clippy.toml
+++ b/crates/ui-render/clippy.toml
@@ -1,0 +1,39 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: a presenter is a pure function of the snapshots it took
+# and the blend factor it was handed — it never reads a clock, never
+# touches the filesystem, never spawns a thread. Floats are its medium
+# on purpose: this crate is presentation-side, and the structure
+# checker's float fence is what keeps it out of every simulation
+# crate's closure.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a presenter is advanced by the caller at the cadence the caller owns" },
+    { path = "std::time::SystemTime::now", reason = "a presenter is advanced by the caller at the cadence the caller owns" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "a presenter holds no randomness at all, and nothing self-seeding may suggest otherwise" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "self-seeding entropy has no place behind a reproducibility contract" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/ui-render/proptest-regressions/lib.txt
+++ b/crates/ui-render/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 24cda75ce4359fa20aaeab284a334d94d58fd6c13a08fdd5cdc9842e1b7ad675 # shrinks to rect = [-29.371904, 0.0, -66.170815, 45.944168], clip_a = [-43.535595, 0.0, 67.08066, 82.20785], clip_b = [-45.26216, 0.0, -52.094357, 63.585453]

--- a/crates/ui-render/src/atlas.rs
+++ b/crates/ui-render/src/atlas.rs
@@ -1,0 +1,107 @@
+//! The UI atlas, generated: a file would be a dependency with a
+//! licence, and a function has a test.
+//!
+//! Two eight-texel tiles side by side. The **fill tile** is solid
+//! white — every background is this tile under a premultiplied tint,
+//! and the sampled region sits two texels inside it so linear
+//! filtering can never blend an edge in. The **chrome tile** is a
+//! white one-texel border over transparency, reserved for the panel
+//! and button borders that arrive with the compiled style tables; it
+//! ships now so the atlas layout is settled before anything samples
+//! it.
+
+use renew_render2d::Region;
+
+/// Atlas width in texels: two tiles of eight.
+pub const WIDTH: u32 = 16;
+/// Atlas height in texels: one tile row.
+pub const HEIGHT: u32 = 8;
+
+/// The atlas bytes, premultiplied RGBA, row-major.
+#[must_use]
+pub fn pixels() -> Vec<u8> {
+    let mut bytes = Vec::with_capacity((WIDTH * HEIGHT * 4) as usize);
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let texel: [u8; 4] = if x < 8 {
+                // The fill tile: white everywhere.
+                [255, 255, 255, 255]
+            } else {
+                // The chrome tile: a one-texel white border over
+                // nothing.
+                let inner_x = x - 8;
+                let border = inner_x == 0 || inner_x == 7 || y == 0 || y == HEIGHT - 1;
+                if border {
+                    [255, 255, 255, 255]
+                } else {
+                    [0, 0, 0, 0]
+                }
+            };
+            bytes.extend_from_slice(&texel);
+        }
+    }
+    bytes
+}
+
+/// The region every background samples: the middle of the fill tile,
+/// two texels in from every edge, so filtering never reaches a
+/// neighbour.
+#[must_use]
+pub fn white() -> Region {
+    Region {
+        x: 2,
+        y: 2,
+        width: 4,
+        height: 4,
+    }
+}
+
+/// The chrome tile, whole: reserved for borders; nothing samples it
+/// in v0, and the region exists so the layout is a published fact
+/// rather than a magic number in a later change.
+#[must_use]
+pub fn chrome() -> Region {
+    Region {
+        x: 8,
+        y: 0,
+        width: 8,
+        height: 8,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The atlas is the declared size, the fill tile is uniformly
+    /// white, the sampled region sits strictly inside it, and the
+    /// chrome tile is a border over transparency.
+    #[test]
+    fn the_atlas_is_what_the_regions_promise() {
+        let bytes = pixels();
+        assert_eq!(bytes.len(), (WIDTH * HEIGHT * 4) as usize);
+        let texel = |x: u32, y: u32| {
+            let at = ((y * WIDTH + x) * 4) as usize;
+            [bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]
+        };
+        for y in 0..HEIGHT {
+            for x in 0..8 {
+                assert_eq!(
+                    texel(x, y),
+                    [255; 4],
+                    "the fill tile is white at ({x}, {y})"
+                );
+            }
+        }
+        let white = white();
+        assert!(white.x >= 1 && white.x + white.width <= 7);
+        assert!(white.y >= 1 && white.y + white.height <= 7);
+        let chrome = chrome();
+        assert_eq!(texel(chrome.x, chrome.y), [255; 4], "the border is ink");
+        assert_eq!(
+            texel(chrome.x + 3, chrome.y + 3),
+            [0; 4],
+            "the middle is nothing"
+        );
+    }
+}

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -1,0 +1,536 @@
+//! Presentation for the widget tree: retained snapshots, blended at
+//! display rate, clipped on the CPU, emitted as sprites.
+//!
+//! **The split this crate lives on.** The tree solves at the fixed
+//! timestep; frames arrive faster. The presenter captures a snapshot
+//! of the solved rectangles each tick and blends the last two by the
+//! ratified interpolation factor, keyed by (slot, generation) so a
+//! node is only ever blended with *itself*: a recycled slot's new
+//! tenant never inherits the old tenant's motion. Nodes with one known
+//! tick draw unlerped at it — a newborn at the current tick, a dying
+//! node at the previous — so nothing vanishes mid-blend. (Paint order
+//! puts the dying underneath the living, so what CAN change abruptly
+//! is stacking, never existence.)
+//!
+//! **Clipping is CPU rectangle intersection.** Every node clips to the
+//! intersection of its ancestors' boxes, computed at capture and
+//! blended with the rest. The one atlas region v0 samples is a uniform
+//! white texel, so clipping the rectangle *is* clipping the image —
+//! the proportional-UV half of the job arrives with the first
+//! non-uniform region, where texel granularity has to be answered.
+//!
+//! **Emission is sprites.** One generated atlas (a white fill tile and
+//! a chrome tile beside it, reserved for borders), one premultiplied
+//! tint per node from its integer background colour, pushed through
+//! the 2D renderer's own preallocated buffer. Quads are in the
+//! solver's pixel space: the sprite renderer's canvas must match the
+//! viewport the tree solves at, and a frame can hold up to twice the
+//! node limit in quads — a bulk replace legitimately draws every old
+//! node once more under every new one — so size the sprite capacity
+//! by [`UiPresenter::max_quads`], not by the node count. After
+//! construction the presenter allocates nothing: both snapshots and
+//! the capture stack are sized at construction, and `advance` asserts
+//! the tree fits them.
+
+// A presenter draws pictures, not terminal lines: the standard
+// output macros are banned by construction, not convention.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+use renew_math::Alpha;
+use renew_render2d::{Sprite, SpriteRenderer};
+use renew_ui::{NodeId, Ui};
+
+pub mod atlas;
+
+/// One captured node: everything a frame needs to draw it.
+#[derive(Clone, Copy, Debug, Default)]
+struct Entry {
+    present: bool,
+    generation: u64,
+    /// Solved box, in canvas pixels: x, y, width, height.
+    rect: [f32; 4],
+    /// The ancestor intersection this node may not draw outside:
+    /// left, top, right, bottom.
+    clip: [f32; 4],
+    /// Premultiplied tint from the node's integer background.
+    tint: [f32; 4],
+}
+
+/// One tick's captured tree: slot-indexed entries plus paint order.
+#[derive(Debug)]
+struct Snapshot {
+    entries: Vec<Entry>,
+    /// Live slots in paint order — parents before children, siblings
+    /// in document order, exactly the walk the solver promises.
+    order: Vec<u32>,
+}
+
+impl Snapshot {
+    fn with_capacity(nodes: u32) -> Self {
+        Self {
+            entries: vec![Entry::default(); nodes as usize],
+            order: Vec::with_capacity(nodes as usize),
+        }
+    }
+
+    /// Forget everything, keeping the allocations.
+    fn clear(&mut self) {
+        self.entries.fill(Entry::default());
+        self.order.clear();
+    }
+}
+
+/// The presenter: two snapshots and the blend between them.
+#[derive(Debug)]
+pub struct UiPresenter {
+    previous: Snapshot,
+    current: Snapshot,
+    /// Capture scratch: the walk stack of (node, inherited clip).
+    stack: Vec<(NodeId, [f32; 4])>,
+}
+
+impl UiPresenter {
+    /// A presenter sized for trees of up to `nodes` nodes — normally
+    /// the same limit the tree itself was built with.
+    #[must_use]
+    pub fn new(nodes: u32) -> Self {
+        let nodes = nodes.max(1);
+        Self {
+            previous: Snapshot::with_capacity(nodes),
+            current: Snapshot::with_capacity(nodes),
+            stack: Vec::with_capacity(nodes as usize),
+        }
+    }
+
+    /// Capture the tree's solved state as the new current snapshot,
+    /// retiring the old current to previous. Call once per simulation
+    /// tick, after the solve; every frame until the next call blends
+    /// between the two most recent captures.
+    ///
+    /// The blend never asks how old a capture is: a host that stops
+    /// advancing a hidden tree and resumes on reshow will blend one
+    /// interval from wherever it left off. A host that wants a reshow
+    /// to cut rather than slide advances twice.
+    ///
+    /// # Panics
+    ///
+    /// When the tree's limit exceeds the presenter's capacity — a
+    /// construction mismatch, asserted by name rather than left to an
+    /// index bound.
+    pub fn advance(&mut self, ui: &Ui) {
+        assert!(
+            ui.limits().nodes as usize <= self.current.entries.len(),
+            "the presenter must be sized for the tree it presents: the tree \
+             holds up to {} nodes, the presenter {}",
+            ui.limits().nodes,
+            self.current.entries.len()
+        );
+        core::mem::swap(&mut self.previous, &mut self.current);
+        self.current.clear();
+        self.stack.clear();
+        self.stack
+            .push((ui.root(), [f32::MIN, f32::MIN, f32::MAX, f32::MAX]));
+        while let Some((node, inherited)) = self.stack.pop() {
+            let index = node.index();
+            let Some(rect) = ui.rect(node) else {
+                continue;
+            };
+            let Some(style) = ui.style(node) else {
+                continue;
+            };
+            let rect = [
+                to_f32(rect.x),
+                to_f32(rect.y),
+                to_f32(rect.width),
+                to_f32(rect.height),
+            ];
+            let clip = intersect(inherited, edges_of(rect));
+            let slot = &mut self.current.entries[index as usize];
+            slot.present = true;
+            slot.generation = node.generation();
+            slot.rect = rect;
+            slot.clip = clip;
+            slot.tint = tint_of(style.background);
+            self.current.order.push(index);
+            // Children push in reverse document order so the stack
+            // pops them forward: paint order is document order.
+            let children: &mut Vec<_> = &mut self.stack;
+            let before = children.len();
+            for child in ui.children(node) {
+                children.push((child, clip));
+            }
+            children[before..].reverse();
+        }
+    }
+
+    /// One frame's quads: the current snapshot blended `alpha` of the
+    /// way from the previous, dying nodes first — underneath the
+    /// living, at their last known place — everything clipped to its
+    /// ancestors, invisible and empty quads already dropped.
+    ///
+    /// This is the whole of what a frame draws, as data: every
+    /// decision the presenter makes is observable here without a
+    /// device, which is where the tests hold it.
+    pub fn frame(&self, alpha: Alpha) -> impl Iterator<Item = Quad> + '_ {
+        let dying = self.previous.order.iter().filter_map(move |&index| {
+            let old = self.previous.entries[index as usize];
+            let successor = self.current.entries[index as usize];
+            if successor.present && successor.generation == old.generation {
+                return None;
+            }
+            clipped(old.rect, old.clip, old.tint)
+        });
+        let living = self.current.order.iter().filter_map(move |&index| {
+            let entry = self.current.entries[index as usize];
+            let old = self.previous.entries[index as usize];
+            let (rect, clip) = if old.present && old.generation == entry.generation {
+                (
+                    lerp4(old.rect, entry.rect, alpha),
+                    lerp4(old.clip, entry.clip, alpha),
+                )
+            } else {
+                (entry.rect, entry.clip)
+            };
+            clipped(rect, clip, entry.tint)
+        });
+        dying.chain(living)
+    }
+
+    /// The most quads one frame can hold: twice the capacity, because
+    /// a bulk replace legitimately draws every dying node once more
+    /// underneath every newborn. Size the sprite renderer by this,
+    /// never by the node count alone.
+    #[must_use]
+    pub fn max_quads(&self) -> u32 {
+        u32::try_from(self.current.entries.len().saturating_mul(2)).unwrap_or(u32::MAX)
+    }
+
+    /// Push one frame's quads as sprites — up to [`Self::max_quads`]
+    /// of them, in the solver's pixel space, so the renderer's canvas
+    /// must match the solve viewport. The caller owns `begin` and
+    /// `item`: a presenter is one source of sprites among possibly
+    /// several in a frame.
+    pub fn emit(&self, alpha: Alpha, sprites: &mut SpriteRenderer) {
+        for quad in self.frame(alpha) {
+            sprites.push(
+                &Sprite::new(atlas::white(), quad.x, quad.y)
+                    .size(quad.width, quad.height)
+                    .tint(quad.tint),
+            );
+        }
+    }
+}
+
+/// One drawn rectangle: everything presentation decides about a node,
+/// after blending and clipping.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Quad {
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    /// Premultiplied RGBA.
+    pub tint: [f32; 4],
+}
+
+/// Clip `rect` to `clip`: the visible quad, or `None` when nothing
+/// remains or the tint draws nothing at all.
+fn clipped(rect: [f32; 4], clip: [f32; 4], tint: [f32; 4]) -> Option<Quad> {
+    if tint == [0.0, 0.0, 0.0, 0.0] {
+        return None;
+    }
+    let [x, y, width, height] = rect;
+    let left = x.max(clip[0]);
+    let top = y.max(clip[1]);
+    let right = (x + width).min(clip[2]);
+    let bottom = (y + height).min(clip[3]);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    Some(Quad {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+        tint,
+    })
+}
+
+/// A rectangle's edges: left, top, right, bottom.
+fn edges_of(rect: [f32; 4]) -> [f32; 4] {
+    [rect[0], rect[1], rect[0] + rect[2], rect[1] + rect[3]]
+}
+
+/// The intersection of two edge rectangles. May be empty (right below
+/// left); the emitter treats empty as nothing to draw.
+fn intersect(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
+    [
+        a[0].max(b[0]),
+        a[1].max(b[1]),
+        a[2].min(b[2]),
+        a[3].min(b[3]),
+    ]
+}
+
+/// Component lerp of two rectangles by the frame's blend factor. At
+/// zero this is exactly `from`, because `from + 0 × d` is `from` in
+/// IEEE arithmetic for every finite value.
+fn lerp4(from: [f32; 4], to: [f32; 4], alpha: Alpha) -> [f32; 4] {
+    let t = alpha.get();
+    [
+        from[0] + (to[0] - from[0]) * t,
+        from[1] + (to[1] - from[1]) * t,
+        from[2] + (to[2] - from[2]) * t,
+        from[3] + (to[3] - from[3]) * t,
+    ]
+}
+
+/// The premultiplied float tint of an integer background.
+fn tint_of(background: [u8; 4]) -> [f32; 4] {
+    [
+        f32::from(background[0]) / 255.0,
+        f32::from(background[1]) / 255.0,
+        f32::from(background[2]) / 255.0,
+        f32::from(background[3]) / 255.0,
+    ]
+}
+
+/// Canvas pixels from the solver's fixed-point. The i64 raw value
+/// casts through f32's 24-bit mantissa, so coordinates past 2^24 raw
+/// units — 256 canvas pixels of magnitude — already round to the
+/// nearest representable float. That is sub-pixel error at any
+/// on-screen magnitude, growing with distance off-screen; the picture
+/// degrades, nothing else does.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "rounding is sub-pixel on screen and only the picture degrades off it"
+)]
+fn to_f32(value: renew_ui::Fixed) -> f32 {
+    value.to_bits() as f32 / 65536.0
+}
+
+#[cfg(test)]
+mod tests {
+    // Every float comparison below is between values produced by the
+    // same IEEE expressions the assertion names — bit equality IS the
+    // claim (alpha zero is exactly the previous tick, a capture is
+    // exactly its solve), so approximate comparison would weaken the
+    // tests into passing when the arithmetic drifts.
+    #![expect(
+        clippy::float_cmp,
+        reason = "bit equality is the claim these tests make"
+    )]
+
+    use super::*;
+    use renew_ui::{Fixed, Size, Style, UiLimits};
+
+    fn f(value: i32) -> Fixed {
+        Fixed::from_int(value)
+    }
+
+    fn px(value: i32) -> Size {
+        Size::Px(f(value))
+    }
+
+    const INK: [u8; 4] = [255, 128, 64, 255];
+
+    fn coloured(width: i32, height: i32) -> Style {
+        Style {
+            width: px(width),
+            height: px(height),
+            background: INK,
+            ..Style::default()
+        }
+    }
+
+    /// A solved tree captures into quads at its solved places, in
+    /// paint order, with transparent nodes (the unstyled root) absent.
+    #[test]
+    fn a_capture_draws_what_was_solved() {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        let first = ui.insert(root).expect("room");
+        ui.set_style(first, coloured(20, 10));
+        let second = ui.insert(root).expect("room");
+        ui.set_style(second, coloured(30, 10));
+        ui.solve(f(100), f(100));
+
+        let mut presenter = UiPresenter::new(8);
+        presenter.advance(&ui);
+        let quads: Vec<Quad> = presenter.frame(Alpha::ZERO).collect();
+        assert_eq!(quads.len(), 2, "two coloured nodes, no transparent root");
+        assert_eq!((quads[0].x, quads[0].width), (0.0, 20.0));
+        assert_eq!((quads[1].x, quads[1].width), (20.0, 30.0));
+        assert_eq!(quads[0].tint, [1.0, 128.0 / 255.0, 64.0 / 255.0, 1.0]);
+    }
+
+    /// The blend moves a surviving node between its two captures: at
+    /// zero it stands at the previous tick, midway it stands midway.
+    #[test]
+    fn a_surviving_node_blends_between_its_ticks() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let node = ui.insert(root).expect("room");
+        ui.set_style(
+            node,
+            Style {
+                margin: renew_ui::Edges {
+                    left: f(10),
+                    ..renew_ui::Edges::default()
+                },
+                ..coloured(20, 10)
+            },
+        );
+        ui.solve(f(100), f(100));
+        let mut presenter = UiPresenter::new(4);
+        presenter.advance(&ui);
+
+        let mut style = ui.style(node).expect("live");
+        style.margin.left = f(50);
+        ui.set_style(node, style);
+        ui.solve(f(100), f(100));
+        presenter.advance(&ui);
+
+        let at_zero: Vec<Quad> = presenter.frame(Alpha::ZERO).collect();
+        assert_eq!(
+            at_zero[0].x, 10.0,
+            "alpha zero is exactly the previous tick"
+        );
+        let midway: Vec<Quad> = presenter
+            .frame(Alpha::new(1, core::num::NonZeroU64::new(2).expect("two")))
+            .collect();
+        assert_eq!(midway[0].x, 30.0, "halfway between 10 and 50");
+    }
+
+    /// A newborn draws unlerped at its one known tick, and a dying
+    /// node draws once more at its last known place, underneath.
+    #[test]
+    fn newborns_and_dying_nodes_draw_at_their_one_known_tick() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let old = ui.insert(root).expect("room");
+        ui.set_style(old, coloured(20, 10));
+        ui.solve(f(100), f(100));
+        let mut presenter = UiPresenter::new(4);
+        presenter.advance(&ui);
+
+        assert!(ui.remove(old));
+        let newborn = ui.insert(root).expect("the freed slot returns");
+        ui.set_style(newborn, coloured(40, 10));
+        ui.solve(f(100), f(100));
+        presenter.advance(&ui);
+
+        let half = Alpha::new(1, core::num::NonZeroU64::new(2).expect("two"));
+        let quads: Vec<Quad> = presenter.frame(half).collect();
+        assert_eq!(quads.len(), 2, "the dying node and the newborn");
+        assert_eq!(
+            quads[0].width, 20.0,
+            "the dying node stands at its last known size, first — underneath"
+        );
+        assert_eq!(
+            quads[1].width, 40.0,
+            "the newborn stands unlerped at its only tick — a recycled slot's \
+             new tenant never inherits the old tenant's motion"
+        );
+    }
+
+    /// Children clip to their ancestors: what pokes out is cut, what
+    /// is fully outside vanishes.
+    #[test]
+    fn children_clip_to_their_ancestors() {
+        let mut ui = Ui::new(UiLimits { nodes: 4 });
+        let root = ui.root();
+        let panel = ui.insert(root).expect("room");
+        ui.set_style(panel, coloured(50, 50));
+        let poker = ui.insert(panel).expect("room");
+        // Wider than the panel: the overflow spills right and is cut.
+        ui.set_style(poker, coloured(80, 10));
+        ui.solve(f(200), f(200));
+        let mut presenter = UiPresenter::new(4);
+        presenter.advance(&ui);
+        let quads: Vec<Quad> = presenter.frame(Alpha::ZERO).collect();
+        assert_eq!(quads.len(), 2);
+        assert_eq!(
+            quads[1].width, 50.0,
+            "the child is cut at the panel's right edge"
+        );
+    }
+
+    /// Two captures of the same solved tree produce identical frames
+    /// at every alpha: presentation is a pure function of its inputs.
+    #[test]
+    fn presentation_is_a_pure_function() {
+        let build = || {
+            let mut ui = Ui::new(UiLimits { nodes: 8 });
+            let root = ui.root();
+            for nth in 1..4 {
+                let node = ui.insert(root).expect("room");
+                ui.set_style(node, coloured(10 * nth, 8));
+            }
+            ui.solve(f(100), f(100));
+            let mut presenter = UiPresenter::new(8);
+            presenter.advance(&ui);
+            presenter.advance(&ui);
+            let half = Alpha::new(1, core::num::NonZeroU64::new(2).expect("two"));
+            presenter.frame(half).collect::<Vec<Quad>>()
+        };
+        assert_eq!(build(), build());
+    }
+
+    proptest::proptest! {
+        /// However rectangles and clips fall, a clipped quad sits
+        /// inside both and clipping is stable — to within a few
+        /// rounding steps, because the quad stores a width whose
+        /// subtraction rounds once and whose `x + width` re-derivation
+        /// rounds again, each at the magnitude of the operands rather
+        /// than of the edge. The permitted spill is bounded well below
+        /// anything a rasterizer can see; the property pins that it
+        /// never grows past that.
+        #[test]
+        fn clipping_contains_and_is_stable(
+            rect in proptest::array::uniform4(-100.0f32..100.0),
+            clip_a in proptest::array::uniform4(-100.0f32..100.0),
+            clip_b in proptest::array::uniform4(-100.0f32..100.0),
+        ) {
+            let close = |a: f32, b: f32| {
+                (a - b).abs() <= f32::EPSILON * 4.0 * (1.0 + a.abs() + b.abs())
+            };
+            let within = |value: f32, bound: f32| value <= bound || close(value, bound);
+            let rect = [rect[0], rect[1], rect[2].abs(), rect[3].abs()];
+            let clip = intersect(
+                [clip_a[0], clip_a[1], clip_a[0] + clip_a[2].abs(), clip_a[1] + clip_a[3].abs()],
+                [clip_b[0], clip_b[1], clip_b[0] + clip_b[2].abs(), clip_b[1] + clip_b[3].abs()],
+            );
+            let tint = [1.0, 1.0, 1.0, 1.0];
+            if let Some(quad) = clipped(rect, clip, tint) {
+                proptest::prop_assert!(quad.x >= rect[0]);
+                proptest::prop_assert!(quad.x >= clip[0]);
+                proptest::prop_assert!(within(quad.x + quad.width, rect[0] + rect[2]));
+                proptest::prop_assert!(within(quad.x + quad.width, clip[2]));
+                proptest::prop_assert!(quad.y >= clip[1]);
+                proptest::prop_assert!(within(quad.y + quad.height, clip[3]));
+                proptest::prop_assert!(quad.width > 0.0 && quad.height > 0.0);
+                // Stable: clipping the clipped quad moves nothing by
+                // more than the one rounding step above.
+                let again = clipped([quad.x, quad.y, quad.width, quad.height], clip, tint)
+                    .expect("a visible quad stays visible");
+                proptest::prop_assert!(close(again.x, quad.x));
+                proptest::prop_assert!(close(again.y, quad.y));
+                proptest::prop_assert!(close(again.width, quad.width));
+                proptest::prop_assert!(close(again.height, quad.height));
+            }
+        }
+
+        /// A transparent background never reaches the frame.
+        #[test]
+        fn transparent_draws_nothing(
+            rect in proptest::array::uniform4(0.0f32..50.0),
+        ) {
+            let clip = [f32::MIN, f32::MIN, f32::MAX, f32::MAX];
+            proptest::prop_assert_eq!(
+                clipped([rect[0], rect[1], rect[2] + 1.0, rect[3] + 1.0], clip, [0.0; 4]),
+                None
+            );
+        }
+    }
+}

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -132,12 +132,12 @@ impl UiPresenter {
             .push((ui.root(), [f32::MIN, f32::MIN, f32::MAX, f32::MAX]));
         while let Some((node, inherited)) = self.stack.pop() {
             let index = node.index();
-            let Some(rect) = ui.rect(node) else {
-                continue;
-            };
-            let Some(style) = ui.style(node) else {
-                continue;
-            };
+            // Both answers are Some for every id this walk can hold —
+            // the tree only hands out live children — and the defaults
+            // are the no-op answer if that invariant ever bent: a zero
+            // rectangle draws nothing.
+            let rect = ui.rect(node).unwrap_or_default();
+            let style = ui.style(node).unwrap_or_default();
             let rect = [
                 to_f32(rect.x),
                 to_f32(rect.y),
@@ -343,10 +343,22 @@ mod tests {
         }
     }
 
+    /// A presenter smaller than its tree refuses by name, not by a
+    /// bare slice index.
+    #[test]
+    #[should_panic(expected = "the presenter must be sized for the tree")]
+    fn a_undersized_presenter_refuses_by_name() {
+        let ui = Ui::new(UiLimits { nodes: 8 });
+        let mut presenter = UiPresenter::new(4);
+        presenter.advance(&ui);
+    }
+
     /// A solved tree captures into quads at its solved places, in
-    /// paint order, with transparent nodes (the unstyled root) absent.
+    /// paint order, with transparent nodes (the unstyled root) absent —
+    /// and one frame can never need more than twice the capacity.
     #[test]
     fn a_capture_draws_what_was_solved() {
+        assert_eq!(UiPresenter::new(8).max_quads(), 16);
         let mut ui = Ui::new(UiLimits { nodes: 8 });
         let root = ui.root();
         let first = ui.insert(root).expect("room");

--- a/crates/ui-render/tests/golden.rs
+++ b/crates/ui-render/tests/golden.rs
@@ -1,0 +1,188 @@
+//! The presenter's image oracle: computed, exact on every adapter.
+//!
+//! The same argument the 2D renderer's own golden makes, inherited
+//! deliberately: opaque backgrounds at texel-aligned positions over a
+//! solid clear. With alpha 1 the premultiplied blend degenerates to
+//! replacement, texel-aligned edges land on pixel boundaries, and the
+//! sampled region is uniform white — so a sprite's pixels are exactly
+//! its tint, the expected image is computable in the test, and the
+//! comparison is byte-exact with no committed artifact. The recorded
+//! fallback is scoping this to the software rasterizer on the first
+//! divergence report — no debate — and the scheduled sunset is the
+//! move to a linear working space, which re-decides this test the way
+//! the 2D renderer's own Testing notes record.
+
+use renew_math::Alpha;
+use renew_render2d::{AtlasDesc, Canvas, SpriteRenderer, attachment};
+use renew_rhi::{
+    Color, Device, DeviceDesc, DeviceError, Extent, Pass, RenderDesc, TargetFormat, Validation,
+};
+use renew_ui::{Edges, Fixed, Size, Style, Ui, UiLimits};
+use renew_ui_render::{UiPresenter, atlas};
+
+const SIZE: u32 = 64;
+/// 51/255, 102/255, 153/255: unambiguous UNORM conversions.
+const CLEAR: Color = Color {
+    r: 51.0 / 255.0,
+    g: 102.0 / 255.0,
+    b: 153.0 / 255.0,
+    a: 1.0,
+};
+const CLEAR_BYTES: [u8; 4] = [51, 102, 153, 255];
+const RED: [u8; 4] = [255, 0, 0, 255];
+const BLUE: [u8; 4] = [0, 0, 255, 255];
+
+fn strict() -> bool {
+    std::env::var_os("RENEW_GOLDEN").is_some_and(|v| v == "1")
+}
+
+/// `Ok(None)` is the graceful skip; under `RENEW_GOLDEN=1` a skip is a
+/// failure and validation must be active — the lane's oracle can never
+/// go silently vacuous. The same harness as the 2D renderer's goldens;
+/// the copy is deliberate, and a fourth copy is the cue to extract a
+/// shared one.
+fn device_or_skip() -> Result<Option<Device>, DeviceError> {
+    match Device::new(&DeviceDesc {
+        app_name: "renew-ui-render-golden-tests",
+        validation: Validation::IfAvailable,
+    }) {
+        Ok(device) => {
+            assert!(
+                device.validation_active() || !strict(),
+                "RENEW_GOLDEN=1 but the validation layer is not active"
+            );
+            Ok(Some(device))
+        }
+        Err(DeviceError::LoaderUnavailable { message }) if !strict() => {
+            eprintln!("SKIP: no Vulkan runtime: {message}");
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Paint `color` over a rectangle of the expected image — the same
+/// replacement an opaque sprite performs.
+fn paint(image: &mut [u8], x: u32, y: u32, width: u32, height: u32, color: [u8; 4]) {
+    for row in y..y + height {
+        for column in x..x + width {
+            let at = ((row * SIZE + column) * 4) as usize;
+            image[at..at + 4].copy_from_slice(&color);
+        }
+    }
+}
+
+/// **The presenter's whole road, held to computed bytes:** a solved
+/// tree with two opaque texel-aligned backgrounds captures, emits, and
+/// lands exactly where the solver put it, in exactly its background
+/// colours, twice identically.
+#[test]
+fn a_presented_tree_lands_in_computed_pixels() {
+    let Some(device) = device_or_skip().expect("device creation failed for a non-skip reason")
+    else {
+        return;
+    };
+
+    // The tree: two opaque panels at (8,8) and (32,8), 16 px square,
+    // placed by margins so the solver's own arithmetic chooses the
+    // texel-aligned spots the oracle expects.
+    let mut ui = Ui::new(UiLimits { nodes: 8 });
+    let root = ui.root();
+    let panel = |margin_left: i32, background: [u8; 4]| Style {
+        width: Size::Px(Fixed::from_int(16)),
+        height: Size::Px(Fixed::from_int(16)),
+        margin: Edges {
+            left: Fixed::from_int(margin_left),
+            top: Fixed::from_int(8),
+            ..Edges::default()
+        },
+        background,
+        ..Style::default()
+    };
+    let red = ui.insert(root).expect("room");
+    ui.set_style(red, panel(8, RED));
+    let blue = ui.insert(root).expect("room");
+    ui.set_style(blue, panel(8, BLUE));
+    ui.solve(Fixed::from_int(64), Fixed::from_int(64));
+
+    let mut presenter = UiPresenter::new(8);
+    presenter.advance(&ui);
+
+    let canvas = Canvas::new(SIZE, SIZE).expect("nonzero canvas");
+    let capacity = core::num::NonZeroU32::new(8).expect("nonzero capacity");
+    let mut sprites = SpriteRenderer::new(
+        &device,
+        &AtlasDesc::new(
+            Extent {
+                width: atlas::WIDTH,
+                height: atlas::HEIGHT,
+            },
+            &atlas::pixels(),
+        ),
+        canvas,
+        TargetFormat::Rgba8Unorm,
+        capacity,
+    )
+    .expect("sprite renderer");
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: SIZE,
+            height: SIZE,
+        })
+        .expect("offscreen target");
+
+    sprites.begin();
+    presenter.emit(Alpha::ZERO, &mut sprites);
+    assert_eq!(sprites.sprites(), 2, "two panels, no transparent root");
+    let color = [attachment(CLEAR)];
+    let items = [sprites.item()];
+    let passes = [Pass::new(&color, &items)];
+    target.render(&RenderDesc::new(&passes)).expect("render");
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+
+    let mut expected = Vec::with_capacity((SIZE * SIZE * 4) as usize);
+    for _ in 0..SIZE * SIZE {
+        expected.extend_from_slice(&CLEAR_BYTES);
+    }
+    // Painted from the rectangles the solver itself answers, so the
+    // oracle and the picture share one source of truth; the corner
+    // pins below keep the solver honest about where that is.
+    for (node, colour) in [(red, RED), (blue, BLUE)] {
+        let rect = ui.rect(node).expect("solved");
+        let x = u32::try_from(rect.x.trunc_int()).expect("on-canvas");
+        let y = u32::try_from(rect.y.trunc_int()).expect("on-canvas");
+        let width = u32::try_from(rect.width.trunc_int()).expect("on-canvas");
+        let height = u32::try_from(rect.height.trunc_int()).expect("on-canvas");
+        paint(&mut expected, x, y, width, height, colour);
+    }
+    assert_eq!(
+        ui.rect(red).expect("solved").x,
+        Fixed::from_int(8),
+        "the fixture's arithmetic: red's margin puts it at x 8"
+    );
+    assert_eq!(
+        ui.rect(blue).expect("solved").x,
+        Fixed::from_int(32),
+        "and blue follows red's outer edge plus its own margin"
+    );
+    assert_eq!(
+        pixels, expected,
+        "the presented tree must land exactly where the solver put it"
+    );
+
+    // Determinism self-check: the same frame twice is the same bytes.
+    target.render(&RenderDesc::new(&passes)).expect("again");
+    let mut second = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut second);
+    assert_eq!(pixels, second, "same frame rendered twice diverged");
+
+    drop(target);
+    drop(sprites);
+    let report = device.validation_report();
+    assert_eq!(
+        report.errors, 0,
+        "validation errors; first messages: {:?}",
+        report.first_messages
+    );
+}

--- a/crates/ui-render/tests/zero_alloc.rs
+++ b/crates/ui-render/tests/zero_alloc.rs
@@ -1,0 +1,65 @@
+//! Mechanical enforcement of the presenter's allocation contract:
+//! after construction, capturing and framing allocate exactly nothing.
+//!
+//! Shipped with the crate's first commit rather than after it. The
+//! measured window advances the presenter across a real style change
+//! and walks every frame quad, asserting the quads really flowed —
+//! non-vacuous by construction.
+
+use renew_math::Alpha;
+use renew_memory::{CountingAllocator, counters};
+use renew_ui::{Fixed, Size, Style, Ui, UiLimits};
+use renew_ui_render::UiPresenter;
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_steady_state_allocates_nothing() {
+    // Everything that may allocate happens out here: the tree, the
+    // presenter, and one warmup pass through capture and frame.
+    let mut ui = Ui::new(UiLimits { nodes: 64 });
+    let root = ui.root();
+    let mut nodes = Vec::new();
+    for nth in 1..32 {
+        let node = ui.insert(root).expect("room under the limit");
+        ui.set_style(
+            node,
+            Style {
+                width: Size::Px(Fixed::from_int(4 + nth)),
+                height: Size::Px(Fixed::from_int(6)),
+                background: [200, 180, 160, 255],
+                ..Style::default()
+            },
+        );
+        nodes.push(node);
+    }
+    ui.solve(Fixed::from_int(640), Fixed::from_int(360));
+    let mut presenter = UiPresenter::new(64);
+    presenter.advance(&ui);
+    let half = Alpha::new(1, core::num::NonZeroU64::new(2).expect("two"));
+    assert_eq!(presenter.frame(half).count(), 31, "the warmup really drew");
+
+    // The measured window: a style change, a re-solve, a capture, and
+    // a full frame walk, repeatedly — the presenter's whole per-tick
+    // and per-frame life, heap-silent.
+    let mut wide = false;
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            wide = !wide;
+            let width = if wide { 40 } else { 20 };
+            let mut style = ui.style(nodes[0]).expect("live");
+            style.width = Size::Px(Fixed::from_int(width));
+            assert!(ui.set_style(nodes[0], style));
+            ui.solve(Fixed::from_int(640), Fixed::from_int(360));
+            presenter.advance(&ui);
+            let drawn = presenter.frame(half).count();
+            assert_eq!(drawn, 31, "every windowed frame must really draw");
+        }
+    });
+    verdict.expect("the presenter's steady state stays heap-silent");
+}

--- a/crates/ui/README.md
+++ b/crates/ui/README.md
@@ -38,7 +38,14 @@ That promise is scoped to the tree that issued the id. A `NodeId`
 carries no memory of its tree: two trees issue the same id sequence,
 so an id used on the wrong tree is not detected — it may miss, or it
 may name an unrelated node. Holding ids across trees is a logic
-error.
+error. The raw halves of the address are public for presentation,
+which keys its snapshots by them; they are never a serialization.
+
+Styles carry one visual field — an integer premultiplied background,
+transparent by default — which presentation converts to its own
+vocabulary; richer visuals arrive with the compiled style tables.
+The solver's arithmetic type is re-exported as `Fixed`, because the
+API speaks it.
 
 ## Bounds
 

--- a/crates/ui/src/layout.rs
+++ b/crates/ui/src/layout.rs
@@ -111,6 +111,13 @@ pub struct Style {
     pub justify: Align,
     /// Where each child sits along the cross axis.
     pub align_cross: Align,
+    /// The fill behind this node, as premultiplied RGBA bytes — an
+    /// integer, because this crate's numbers must be. All zeros — the
+    /// default — draws nothing at all; presentation converts everything
+    /// else to its own vocabulary. Richer visuals (borders, images,
+    /// text) arrive with the compiled style tables, not as more fields
+    /// here.
+    pub background: [u8; 4],
 }
 
 /// A solved box: absolute position and size, in pixels.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -52,7 +52,9 @@ use input::Interaction;
 pub use input::{UiEvent, UiOutput};
 pub use layout::{Align, Direction, Edges, Rect, Size, Style};
 use layout::{LayoutSlot, Scratch, Solve};
-use renew_fixed::Fixed;
+/// Re-exported because the API speaks it: rectangles, styles, and the
+/// solver's whole vocabulary are in this arithmetic.
+pub use renew_fixed::Fixed;
 
 /// Nothing here: the marker every slot uses for "no neighbour". One
 /// value, not an `Option<u32>`, so a slot stays eight words no matter
@@ -110,13 +112,18 @@ pub struct NodeId {
 }
 
 impl NodeId {
-    /// The slot index, for the digest's explicit absorption order.
-    pub(crate) fn index(self) -> u32 {
+    /// The raw slot index. Public for presentation, which keys its
+    /// snapshot pairs by (slot, generation); not meaningful across
+    /// trees, and not a stable serialization — an id is an address,
+    /// never data to store outside the process.
+    #[must_use]
+    pub fn index(self) -> u32 {
         self.index
     }
 
-    /// The generation, likewise.
-    pub(crate) fn generation(self) -> u64 {
+    /// The generation half of the address, likewise.
+    #[must_use]
+    pub fn generation(self) -> u64 {
         self.generation
     }
 }


### PR DESCRIPTION
A new crate: `renew-ui-render`, presentation for the widget tree. The tree solves at the fixed timestep; frames arrive faster; this crate is the seam between the two.

**The snapshot pair.** Each tick captures the solved rectangles; every frame blends the two most recent captures by the ratified interpolation factor, keyed by (slot, generation) so a node is only ever blended with *itself* — a recycled slot's new tenant never inherits the old tenant's motion. Nodes with one known tick draw unlerped at it: newborns at the current tick, dying nodes once more at the previous, underneath the living.

**Frames are data first.** One frame is an iterator of clipped, blended, tinted quads in the solver's pixel space — every presentation decision observable without a device, which is where the unit and property tests hold it; sprite emission is a thin adapter. The clipping property suite pinned its own honesty: storing a width rounds, so stability is promised to within a few invisible ulps rather than claimed exactly. A capacity mismatch between presenter and tree asserts by name, and a frame can hold up to twice the node limit in quads — `max_quads` exists to size the sprite renderer by, because a bulk replace legitimately draws every dying node once more under every newborn.

**The widget tree's additions.** An integer premultiplied background per style (transparent default; presentation converts — the simulation crate stays float-free), public raw address halves on node ids for the snapshot keying, and the fixed-point re-export its API speaks.

**Evidence.** The generated atlas is tested against its own regions; a computed image oracle paints its expected pixels from the solver's own answers and compares byte-exactly on a real GPU, twice, with zero validation errors, and the pinned software rasterizer runs it strictly. The counting-allocator gate holds capture-and-frame churn to zero heap. The build matrix gains the presenter's own removability cell, and five existing cells name their new dependent — every crate this one touches gained a dependent the moment it landed.
