### PR TITLE
feat(glide): a pause menu built on the widget tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,12 +888,15 @@ jobs:
             --headless --input-trace walk
           xvfb-run -a cargo llvm-cov --no-report run -p renew-sample-input-echo --bin input_echo -- \
             --frames 30
-          # The game's two committed traces: one that plays, one that
-          # falls. Both are pure headless runs, so they execute anywhere.
+          # The game's three committed traces: one that plays, one that
+          # falls, one that pauses and restarts through the menu. All
+          # are pure headless runs, so they execute anywhere.
           cargo llvm-cov --no-report run -p renew-sample-glide --bin glide -- \
             --input-trace soar --frames 600
           cargo llvm-cov --no-report run -p renew-sample-glide --bin glide -- \
             --input-trace sink --frames 600
+          cargo llvm-cov --no-report run -p renew-sample-glide --bin glide -- \
+            --input-trace menu --frames 600
           # The game's windowed feature, in two instrumented pieces: the
           # feature-gated unit tests (display-less-safe -- they open no
           # window), and the windowed arm live under the virtual display.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,24 +284,26 @@ jobs:
           cargo build $sel
           cargo test $sel
       # The widget tree: structure, layout, and interaction over the
-      # fixed-point and digest crates. Its one consumer is the UI
-      # presenter; the first embedding game grows this list when its
-      # menu lands.
+      # fixed-point and digest crates. Its consumers are the UI
+      # presenter and the windowed game whose pause menu embeds it —
+      # the growth this comment once promised.
       - name: Build and test without the widget tree
         run: |
-          sel="--workspace --exclude renew-ui --exclude renew-ui-render"
+          sel="--workspace --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui $sel
           cargo build $sel
           cargo test $sel
       # The UI presenter: snapshots over the widget tree, emitted
-      # through the 2D renderer; no consumers yet — the first embedding
-      # game grows this list when its menu lands.
+      # through the 2D renderer. Its one consumer is the windowed game
+      # whose pause menu it draws.
       - name: Build and test without the UI presenter
         run: |
-          sel="--workspace --exclude renew-ui-render"
+          sel="--workspace --exclude renew-ui-render --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui-render $sel
           cargo build $sel
           cargo test $sel
+          RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui-render -p renew-sample-glide
+          cargo build -p renew-sample-glide
       # The 2D renderer: policy over the rendering crate, no consumers
       # yet -- the windowed game grows this list when it draws sprites.
       - name: Build and test without the 2D renderer
@@ -355,7 +357,7 @@ jobs:
       # each went red here until the cell named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "renew-event",
  "renew-frame",
  "renew-input",
+ "renew-math",
  "renew-platform",
  "renew-png",
  "renew-render2d",
@@ -1839,6 +1840,8 @@ dependencies = [
  "renew-rhi",
  "renew-sample-glide-world",
  "renew-trace",
+ "renew-ui",
+ "renew-ui-render",
 ]
 
 [[package]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -133,3 +133,8 @@ reason = "Delivering raw device motion. No lane has a mouse - the windowed runs 
 file = "crates/ui/src/bin/ui_digest.rs"
 lines = [33, 34, 41, 42]
 reason = "The scenario binary's two refusal arms: the argument guard (a drifted pinned-run row must fail loudly rather than run a different scenario under the same name) and the impossible-construction arm (reachable only if a four-insert scenario overflows a sixteen-node limit; a vacuous zero digest must never reach the comparison). Each is two lines - a message and a nonzero exit - and an exiting process does not reliably flush its coverage counters, so exercising them under the instrumented lane would hinge on an exit-path implementation detail rather than prove anything. The happy path is executed by the lane's own run of the binary."
+
+[[exempt]]
+file = "samples/glide/src/windowed.rs"
+lines = [392, 393, 394, 395, 396, 397, 398]
+reason = "The menu-open half of the draw: the presenter's snapshots advanced and emitted, and a label placed per button. The lane's windowed run is keyboardless under a virtual display, so nothing there ever opens the menu, and no test reaches draw at all - drawing needs the bring-up's live target. Everything the block decides is covered without it: the advance/emit pair by the presentation crate's own tests, the placement arithmetic by a unit test on label_origin (the block's only computation), and the routing, pausing, restarting and rescaling behind it by constructed-event tests on the seam. Deliberately narrow: the is_open check the frame evaluates every draw is measured and not exempt."

--- a/samples/glide/Cargo.toml
+++ b/samples/glide/Cargo.toml
@@ -30,10 +30,18 @@ renew-frame = { path = "../../crates/frame" }
 renew-input = { path = "../../crates/input" }
 renew-platform = { path = "../../crates/core/platform", default-features = false }
 renew-render2d = { path = "../../crates/render2d", optional = true }
+# The menu's presentation: snapshots and glyphs over the 2D renderer.
+renew-ui-render = { path = "../../crates/ui-render", optional = true }
 renew-audio = { path = "../../crates/audio", optional = true }
 renew-replay = { path = "../../crates/replay" }
 renew-rhi = { path = "../../crates/rhi", default-features = false, optional = true }
 renew-sample-glide-world = { path = "world" }
+# The pointer seam: the one documented quantization the drivers and
+# the replay harness apply before events reach the tree.
+renew-math = { path = "../../crates/core/math" }
+# The pause menu: a real retained widget tree, folded into the
+# session digest — a menu that can restart the run is gameplay.
+renew-ui = { path = "../../crates/ui" }
 renew-trace = { path = "../../crates/trace" }
 
 [features]
@@ -42,6 +50,7 @@ renew-trace = { path = "../../crates/trace" }
 # a player runs headless carries none of it.
 window = [
     "renew-platform/window",
+    "dep:renew-ui-render",
     "dep:renew-rhi",
     "renew-rhi/present",
     "dep:renew-render2d",

--- a/samples/glide/README.md
+++ b/samples/glide/README.md
@@ -129,6 +129,34 @@ nothing to write with. A log that ends mid-run, with a nonzero exit and
 no failure line, is itself the finding — it says the fault was below the
 engine rather than in it.
 
+## The pause menu, and why the digest moved
+
+Escape pauses. The menu is a real retained widget tree — the same
+arena, solver, and hit-tester every future document will use — with
+two buttons sized from their labels by an integer advance table.
+While it is open the world stands still and the session keeps
+counting: events index by session tick, so every trace recorded
+before the menu existed replays unchanged, and a trace that pauses
+carries events at ticks the world never stepped.
+
+The reported digest is the session's, not just the world's: the
+world's own fold first, then whether the menu is open — a bit that
+decides if the world steps at all — then every decision the tree
+made, in order. A menu that can restart the run is gameplay, and a
+digest that ignored it would call two different sessions the same.
+That is why the reported hash changed when the menu landed: not a
+regression, but coverage arriving. The world's own digest is
+untouched, and its frozen pin still stands.
+
+The `menu` trace exercises the whole road: it flies, pauses to
+resume, pauses again to restart, and flies the new run; a test pins
+the world's tick count mid-trace and after the restart, so a pause
+that leaked steps or a restart that kept the old world would move an
+integer the suite watches. Clicks route to exactly one listener: the
+menu hears everything, gameplay hears an event only if the menu was
+closed as it arrived, so the click that presses Resume never also
+flaps.
+
 ## Shape
 
 Two crates. `world/` is the simulation — a pure fixed-step function of

--- a/samples/glide/src/cli.rs
+++ b/samples/glide/src/cli.rs
@@ -219,6 +219,20 @@ pub struct Report {
     pub source: String,
     pub stats: FrameStats,
     pub world: World,
+    /// The session digest: the world's own fold, then the menu's —
+    /// the pause bit and every decision the tree made. A menu that
+    /// can restart the run is gameplay, so the reported hash covers
+    /// it; the world's own digest stays what it always was.
+    ///
+    /// **What the fold leaves out, named so the exclusion cannot go
+    /// quietly vacuous:** the input map's latch state and the
+    /// windowed driver's pending-flap counter. Both change future
+    /// behaviour mid-run, and both are excluded soundly only because
+    /// this fold is terminal — it happens once, when the run is over
+    /// and no future remains. A mid-run session checkpoint would
+    /// have to absorb them or inherit the gap; this sentence is where
+    /// that obligation is written.
+    pub session_hash: u64,
 }
 
 impl Report {
@@ -251,7 +265,7 @@ impl Report {
             self.world.score(),
             self.world.alive(),
             self.stats.schedule_hash(),
-            self.world.digest().finish(),
+            self.session_hash,
         )
     }
 
@@ -270,7 +284,7 @@ impl Report {
             self.world.score(),
             u8::from(self.world.alive()),
             self.stats.schedule_hash(),
-            self.world.digest().finish(),
+            self.session_hash,
         )
     }
 }

--- a/samples/glide/src/lib.rs
+++ b/samples/glide/src/lib.rs
@@ -7,6 +7,9 @@
 //! what lets the cross-process determinism gate compare runs by their
 //! one output line; a windowed run rides the real clock and marks its
 //! digest line `source=window` so nothing ever compares the two.
+//! `ticks=` counts planned sessions; while the pause menu holds the
+//! world still, the world's own tick count lags behind it, and the
+//! two agree only in a run that never pauses.
 //!
 //! # Indexing
 //!
@@ -17,6 +20,7 @@
 
 mod cli;
 mod error;
+pub mod menu;
 pub mod scene;
 // The sound derivation is pure and testable with no device, no
 // window, and no audio crate in the graph, so it compiles always;

--- a/samples/glide/src/menu.rs
+++ b/samples/glide/src/menu.rs
@@ -1,0 +1,300 @@
+//! The pause menu: the widget tree's first embedding.
+//!
+//! The menu owns a [`Ui`] — a real retained tree, solved by the
+//! fixed-point solver, hit-tested by the same code every future
+//! document will use — and the game folds the tree's decisions into
+//! its reported digest, because a menu that can restart the run is
+//! gameplay, not chrome. The world's own digest never learns the menu
+//! exists; the *session's* digest is the fold of both, which is why
+//! the reported hash moved when this file landed.
+//!
+//! **Event routing is the driver's, pausing is here.** The menu hears
+//! every window event: the pause key toggles it, and pointer events
+//! reach the tree only while it is open — quantized through the one
+//! documented seam, so a recorded trace replays into the same
+//! integers. The driver checks [`Menu::is_open`] *before* handing the
+//! same event to gameplay input, so the click that presses Resume
+//! never also flaps the bird.
+
+use renew_event::{KeyCode, PointerButton, WindowEvent};
+use renew_frame::StateHash;
+use renew_math::quantize_pointer;
+use renew_sample_glide_world::{VIEW_HEIGHT, VIEW_WIDTH};
+use renew_ui::{
+    Align, Direction, Fixed, NodeId, Size, Style, Ui, UiEvent, UiLimits, UiOutput, text,
+};
+
+/// A decision the menu made this frame, for the driver to act on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MenuAction {
+    /// Play on: the menu has already closed itself.
+    Resume,
+    /// Start over from the same seed: the menu has closed, and the
+    /// driver owns making the world new.
+    Restart,
+}
+
+/// The pause menu: a tree, its two buttons, and whether it is shown.
+#[derive(Debug)]
+pub struct Menu {
+    ui: Ui,
+    resume: NodeId,
+    restart: NodeId,
+    open: bool,
+}
+
+/// Space around a button label, in pixels.
+const PAD_X: i32 = 12;
+const PAD_Y: i32 = 5;
+
+impl Menu {
+    /// Build and solve the tree once: the menu's layout is static,
+    /// and the buttons size themselves from their labels through the
+    /// same integer measurement the digest never fears.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut ui = Ui::new(UiLimits { nodes: 8 });
+        let root = ui.root();
+        ui.set_style(
+            root,
+            Style {
+                direction: Direction::Column,
+                justify: Align::Center,
+                align_cross: Align::Center,
+                gap: Fixed::from_int(8),
+                ..Style::default()
+            },
+        );
+        let resume = button(&mut ui, root, "Resume");
+        let restart = button(&mut ui, root, "Restart");
+        ui.solve(
+            Fixed::from_int(i32::try_from(VIEW_WIDTH).unwrap_or(i32::MAX)),
+            Fixed::from_int(i32::try_from(VIEW_HEIGHT).unwrap_or(i32::MAX)),
+        );
+        Self {
+            ui,
+            resume,
+            restart,
+            open: false,
+        }
+    }
+
+    /// Whether the menu is currently shown — the driver's cue to
+    /// pause the world and to route events here instead of gameplay.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Feed one window event. The pause key toggles visibility from
+    /// either state; everything else reaches the tree only while the
+    /// menu is open, as the integers the seam makes of it.
+    pub fn handle(&mut self, event: &WindowEvent) {
+        if let WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        } = event
+        {
+            self.open = !self.open;
+            // A press left dangling across a toggle must not pair
+            // with a release from a later episode: park the pointer
+            // outside the tree and release, which the tree treats as
+            // an abandoned press — no activation, nothing pending.
+            self.ui.handle(UiEvent::PointerMoved { x: -1, y: -1 });
+            self.ui.handle(UiEvent::PointerReleased);
+            return;
+        }
+        if !self.open {
+            return;
+        }
+        match event {
+            WindowEvent::PointerMoved { x, y } => {
+                self.ui.handle(UiEvent::PointerMoved {
+                    x: quantize_pointer(*x),
+                    y: quantize_pointer(*y),
+                });
+            }
+            WindowEvent::PointerButton {
+                button: PointerButton::Left,
+                pressed,
+            } => {
+                self.ui.handle(if *pressed {
+                    UiEvent::PointerPressed
+                } else {
+                    UiEvent::PointerReleased
+                });
+            }
+            _ => {}
+        }
+    }
+
+    /// The decisions since the last drain, applied: an activated
+    /// button closes the menu, and the caller learns what to do next.
+    pub fn drain(&mut self) -> impl Iterator<Item = MenuAction> + '_ {
+        let resume = self.resume;
+        let restart = self.restart;
+        let open = &mut self.open;
+        self.ui.drain_outputs().filter_map(move |output| {
+            let UiOutput::Activated(node) = output;
+            if node == resume {
+                *open = false;
+                Some(MenuAction::Resume)
+            } else if node == restart {
+                *open = false;
+                Some(MenuAction::Restart)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Fold the menu into a digest: whether it is open — a bit that
+    /// decides whether the world steps, so it must be visible — then
+    /// every discrete decision the tree holds.
+    #[must_use]
+    pub fn absorb(&self, hash: StateHash) -> StateHash {
+        self.ui.absorb(hash.absorb_u32(u32::from(self.open)))
+    }
+
+    /// The tree, for presentation: the presenter snapshots it and the
+    /// labels draw at its solved rectangles.
+    #[must_use]
+    pub fn ui(&self) -> &Ui {
+        &self.ui
+    }
+
+    /// The buttons and their labels, in draw order, for the label
+    /// pass: each label centres inside its button's solved rectangle.
+    #[must_use]
+    pub fn labels(&self) -> [(NodeId, &'static str); 2] {
+        [(self.resume, "Resume"), (self.restart, "Restart")]
+    }
+}
+
+impl Default for Menu {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One button: sized from its label by the integer advance table,
+/// padded, dark until the compiled style tables bring richer looks.
+fn button(ui: &mut Ui, parent: NodeId, label: &str) -> NodeId {
+    let node = ui.insert(parent).unwrap_or(parent);
+    let width = text::measure(label) + Fixed::from_int(2 * PAD_X);
+    let line = i32::try_from(text::LINE_HEIGHT).unwrap_or(16);
+    let height = Fixed::from_int(line + 2 * PAD_Y);
+    ui.set_style(
+        node,
+        Style {
+            width: Size::Px(width),
+            height: Size::Px(height),
+            background: [40, 44, 52, 230],
+            ..Style::default()
+        },
+    );
+    node
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press_at(menu: &mut Menu, x: f64, y: f64) {
+        menu.handle(&WindowEvent::PointerMoved { x, y });
+        menu.handle(&WindowEvent::PointerButton {
+            button: PointerButton::Left,
+            pressed: true,
+        });
+        menu.handle(&WindowEvent::PointerButton {
+            button: PointerButton::Left,
+            pressed: false,
+        });
+    }
+
+    fn centre_of(menu: &Menu, node: NodeId) -> (f64, f64) {
+        let rect = menu.ui().rect(node).expect("solved");
+        let x = rect.x + rect.width / Fixed::from_int(2);
+        let y = rect.y + rect.height / Fixed::from_int(2);
+        // A centre well inside a button fits an i32 with room to
+        // spare; the widening to f64 is exact.
+        let px = |value: Fixed| f64::from(i32::try_from(value.trunc_int()).unwrap_or(0));
+        (px(x), px(y))
+    }
+
+    /// The pause key toggles; pointer events reach the tree only
+    /// while open — a closed menu decides nothing however hard it is
+    /// clicked.
+    #[test]
+    fn a_closed_menu_hears_only_the_pause_key() {
+        let mut menu = Menu::new();
+        let (x, y) = centre_of(&menu, menu.resume);
+        press_at(&mut menu, x, y);
+        assert_eq!(menu.drain().count(), 0, "a closed menu decides nothing");
+        menu.handle(&WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+        assert!(menu.is_open());
+    }
+
+    /// Clicking Resume closes and says so; clicking Restart closes
+    /// and says so; the two are different decisions.
+    #[test]
+    fn the_buttons_decide_and_close() {
+        let mut menu = Menu::new();
+        menu.handle(&WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+        let (x, y) = centre_of(&menu, menu.resume);
+        press_at(&mut menu, x, y);
+        let actions: Vec<_> = menu.drain().collect();
+        assert_eq!(actions, vec![MenuAction::Resume]);
+        assert!(!menu.is_open(), "an activated button closes the menu");
+
+        menu.handle(&WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+        let (x, y) = centre_of(&menu, menu.restart);
+        press_at(&mut menu, x, y);
+        let actions: Vec<_> = menu.drain().collect();
+        assert_eq!(actions, vec![MenuAction::Restart]);
+    }
+
+    /// The digest sees the open bit and the decisions: pausing alone
+    /// moves it, and the same session twice digests identically.
+    #[test]
+    fn the_menu_digests_its_decisions() {
+        let closed = Menu::new().absorb(StateHash::new()).finish();
+        let mut paused = Menu::new();
+        paused.handle(&WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+        assert_ne!(
+            paused.absorb(StateHash::new()).finish(),
+            closed,
+            "whether the world steps must be visible in the digest"
+        );
+        let run = || {
+            let mut menu = Menu::new();
+            menu.handle(&WindowEvent::Key {
+                code: KeyCode::Escape,
+                pressed: true,
+                repeat: false,
+            });
+            let (x, y) = centre_of(&menu, menu.resume);
+            press_at(&mut menu, x, y);
+            let _ = menu.drain().count();
+            menu.absorb(StateHash::new()).finish()
+        };
+        assert_eq!(run(), run());
+    }
+}

--- a/samples/glide/src/menu.rs
+++ b/samples/glide/src/menu.rs
@@ -297,4 +297,28 @@ mod tests {
         };
         assert_eq!(run(), run());
     }
+
+    /// The default menu is the new menu: closed, solved, ready.
+    #[test]
+    fn the_default_menu_starts_closed() {
+        assert!(!Menu::default().is_open());
+    }
+
+    /// A click on empty space activates the root, which is not a
+    /// button: drain maps it to nothing, and the menu stays open.
+    #[test]
+    fn empty_space_decides_nothing() {
+        let mut menu = Menu::new();
+        menu.handle(&WindowEvent::Key {
+            code: KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+        press_at(&mut menu, 2.0, 2.0);
+        assert_eq!(menu.drain().count(), 0, "the root decides nothing");
+        assert!(
+            menu.is_open(),
+            "an empty-space click does not close the menu"
+        );
+    }
 }

--- a/samples/glide/src/scripted.rs
+++ b/samples/glide/src/scripted.rs
@@ -50,9 +50,14 @@ pub fn close_recording(
     report: &Report,
     recorder: Recorder,
 ) -> Result<renew_trace::Trace, SampleError> {
+    // The header's length is the SESSION's, not the world's: with a
+    // pause menu the world can stand still while frames keep coming,
+    // and a recorded event's tick is a session tick. In a run that
+    // never pauses the two counts are equal, which is why this line
+    // could say world.tick() for as long as it did.
     let header = renew_trace::TraceHeader::new(
         "glide",
-        report.world.tick(),
+        report.stats.ticks(),
         FRAME_INTERVAL_NS,
         StepBudget::DEFAULT.get().get(),
     )
@@ -128,8 +133,13 @@ fn replay_to(recorded: &renew_trace::Trace, frames: Option<u64>) -> Result<Repor
     ))
 }
 
-/// The loop itself. Events for tick `k` are delivered before step `k` —
-/// the loader's own indexing, no shift anywhere.
+/// The loop itself. Events for session tick `k` are delivered before
+/// frame `k` — the loader's own indexing, no shift anywhere. The
+/// session tick is the frame counter, not the world's: while the
+/// pause menu is open the world stands still and the session keeps
+/// counting, so events keep arriving. In a run that never pauses the
+/// two counters are equal, which is why every trace recorded before
+/// the menu existed replays unchanged.
 fn drive(
     seed: u64,
     frames: u64,
@@ -138,6 +148,7 @@ fn drive(
     mut recorder: Option<&mut Recorder>,
 ) -> Report {
     let mut world = World::new(seed);
+    let mut menu = crate::menu::Menu::new();
     let mut input = input_map();
     let mut frame = FrameLoop::new(
         Timestep::HZ_60,
@@ -147,12 +158,31 @@ fn drive(
     let mut stats = FrameStats::new();
 
     for index in 1..=frames {
+        let session_tick = index - 1;
         for (at, event) in events {
-            if *at == world.tick() {
+            if *at == session_tick {
                 if let Some(recorder) = recorder.as_deref_mut() {
-                    recorder.event(world.tick(), *event);
+                    recorder.event(session_tick, *event);
                 }
-                input.handle(*event);
+                // The menu hears everything; gameplay hears an event
+                // only when the menu was closed as it arrived, so the
+                // click that presses Resume never also flaps.
+                let was_open = menu.is_open();
+                menu.handle(event);
+                if !was_open && menu.is_open() {
+                    // Opening releases gameplay input: a key held into
+                    // the pause must not wedge the map with a press
+                    // whose release the menu will swallow.
+                    input.release_all();
+                }
+                if !was_open {
+                    input.handle(*event);
+                }
+            }
+        }
+        for action in menu.drain() {
+            if action == crate::menu::MenuAction::Restart {
+                world = World::new(seed);
             }
         }
         let now = Timestamp::from_nanos(FRAME_INTERVAL_NS.saturating_mul(index));
@@ -167,23 +197,46 @@ fn drive(
         );
         let flap = input.state(Action::Flap).just_pressed;
         for _step in plan.steps() {
-            world.step(flap);
+            // An open menu pauses the world: the session advances,
+            // the world does not, and the pause bit is digested.
+            if !menu.is_open() {
+                world.step(flap);
+            }
         }
         input.advance();
         stats.absorb(&plan);
     }
 
+    let session_hash = menu.absorb(world.digest()).finish();
     Report {
         seed,
         source,
         stats,
         world,
+        session_hash,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The menu trace's structure, pinned: the pause really pauses
+    /// and the restart really restarts, visible in the world's own
+    /// tick count. At session 240 the world has stepped 228 times —
+    /// 240 minus the twelve frames the first pause held it (opened by
+    /// the escape at session 120, closed by the Resume release at
+    /// 132). At session 320 it has stepped 8 — a NEW world, made by
+    /// the Restart click at session 312, stepped once per session
+    /// since. Wrong routing (a click that also flaps), a pause that
+    /// leaks steps, or a restart that keeps the old world each move
+    /// one of these two integers.
+    #[test]
+    fn the_menu_trace_pauses_and_restarts_the_world() {
+        let mid = world_at("menu", 240).expect("trace runs").tick();
+        let after = world_at("menu", 320).expect("trace runs").tick();
+        assert_eq!((mid, after), (228, 8));
+    }
 
     #[test]
     fn both_bindings_resolve_to_the_one_action() {

--- a/samples/glide/src/trace.rs
+++ b/samples/glide/src/trace.rs
@@ -30,6 +30,11 @@ const SCRIPTED: &[Scripted] = &[
         summary: "no input at all — gravity wins",
         text: include_str!("../traces/sink.trace"),
     },
+    Scripted {
+        name: "menu",
+        summary: "flies, pauses to resume, pauses again to restart, flies the new run",
+        text: include_str!("../traces/menu.trace"),
+    },
 ];
 
 /// A loaded trace: events by tick from zero, exactly as stored.

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -163,6 +163,24 @@ fn relabel_into<const N: usize>(
 }
 
 /// The game as the window seam sees it.
+// Sprites reserved for HUD and label text beyond the menu's own
+// quads: enough for the score line and both button labels.
+const UI_TEXT_SPRITES: u32 = 64;
+// Opaque white ink for the HUD score.
+const HUD_INK: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+// Slightly warm ink for button labels.
+const LABEL_INK: [f32; 4] = [0.92, 0.94, 1.0, 1.0];
+
+/// Canvas pixels from the solver's fixed-point, for label placement.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "label coordinates are tens of pixels, exact in an f32"
+)]
+fn fixed_px(value: renew_ui::Fixed) -> f32 {
+    value.to_bits() as f32 / 65536.0
+}
+
+/// The game as the window seam sees it.
 pub struct GlideApp {
     clock: Clock,
     seed: u64,
@@ -177,7 +195,18 @@ pub struct GlideApp {
     /// extend this or lose its edges.
     pending_flaps: u8,
     stats: FrameStats,
+    /// The pause menu: a real widget tree, folded into the session
+    /// digest. Pausing gates the world's steps; the menu decides.
+    menu: crate::menu::Menu,
+    /// The menu's snapshot pair, advanced per redraw while the menu
+    /// is open.
+    presenter: renew_ui_render::UiPresenter,
+    /// The UI's own sprite renderer over the UI atlas — the second
+    /// texture in the frame, drawn as its own item in the same pass.
+    ui_sprites: Option<renew_render2d::SpriteRenderer>,
     scene_scratch: Vec<SceneSprite>,
+    /// The HUD's score line, formatted in place each frame.
+    hud_score: String,
     title: Title,
     /// The score last written into the title, so relabeling happens on
     /// change only. Death changes the suffix, tracked beside it.
@@ -220,7 +249,11 @@ impl GlideApp {
             #[cfg(feature = "audio")]
             muted: None,
             stats: FrameStats::new(),
+            menu: crate::menu::Menu::new(),
+            presenter: renew_ui_render::UiPresenter::new(8),
+            ui_sprites: None,
             scene_scratch: Vec::new(),
+            hud_score: String::with_capacity(24),
             title: Title::new(),
             titled: None,
             frame: None,
@@ -280,9 +313,30 @@ impl GlideApp {
             capacity,
         )
         .map_err(|error| SampleError::failed("building the sprite renderer", &error))?;
+        // The UI's own renderer: a second texture in the frame,
+        // carried as its own whole pipeline and its own item — the
+        // tolerated shape until the frame model revisits descriptors.
+        let ui_capacity =
+            core::num::NonZeroU32::new(self.presenter.max_quads().saturating_add(UI_TEXT_SPRITES))
+                .ok_or_else(|| SampleError::Failed("zero UI sprite capacity".to_string()))?;
+        let ui_sprites = SpriteRenderer::new(
+            &device,
+            &AtlasDesc::new(
+                renew_rhi::Extent {
+                    width: renew_ui_render::atlas::WIDTH,
+                    height: renew_ui_render::atlas::HEIGHT,
+                },
+                &renew_ui_render::atlas::pixels(),
+            ),
+            canvas,
+            target.format(),
+            ui_capacity,
+        )
+        .map_err(|error| SampleError::failed("building the UI sprite renderer", &error))?;
         self.device = Some(device);
         self.target = Some(target);
         self.renderer = Some(renderer);
+        self.ui_sprites = Some(ui_sprites);
         #[cfg(feature = "audio")]
         {
             // A machine with no sound card is a machine that plays in
@@ -298,7 +352,9 @@ impl GlideApp {
 
     /// Draw the world as it stands.
     fn draw(&mut self) {
-        let (Some(target), Some(renderer)) = (&mut self.target, &mut self.renderer) else {
+        let (Some(target), Some(renderer), Some(ui_sprites)) =
+            (&mut self.target, &mut self.renderer, &mut self.ui_sprites)
+        else {
             return;
         };
         scene(&self.world, &mut self.scene_scratch);
@@ -311,13 +367,62 @@ impl GlideApp {
             renderer
                 .push(&Sprite::new(region, sprite.x, sprite.y).size(sprite.width, sprite.height));
         }
+        // The UI over the world: the score always, the menu when
+        // open — panels from the presenter's snapshots, labels
+        // centred in the buttons' solved rectangles by the same
+        // integer advances the tree measured them with.
+        ui_sprites.begin();
+        self.hud_score.clear();
+        let _ = core::fmt::Write::write_fmt(
+            &mut self.hud_score,
+            format_args!("Score {}", self.world.score()),
+        );
+        renew_ui_render::emit_text(ui_sprites, 6.0, 4.0, &self.hud_score, HUD_INK);
+        if self.menu.is_open() {
+            self.presenter.advance(self.menu.ui());
+            self.presenter.emit(renew_math::Alpha::ZERO, ui_sprites);
+            for (node, label) in self.menu.labels() {
+                if let Some(rect) = self.menu.ui().rect(node) {
+                    let text_width = renew_ui::text::measure(label);
+                    let line = renew_ui::Fixed::from_int(
+                        i32::try_from(renew_ui::text::LINE_HEIGHT).unwrap_or(16),
+                    );
+                    let two = renew_ui::Fixed::from_int(2);
+                    let x = rect.x + (rect.width - text_width) / two;
+                    let y = rect.y + (rect.height - line) / two;
+                    renew_ui_render::emit_text(
+                        ui_sprites,
+                        fixed_px(x),
+                        fixed_px(y),
+                        label,
+                        LABEL_INK,
+                    );
+                }
+            }
+        }
         // The frame, composed on this stack; the borrows end at the
-        // render call.
+        // render call. Two items: the world's atlas, then the UI's.
         let color = [renew_render2d::attachment(SKY)];
-        let items = [renderer.item()];
+        let items = [renderer.item(), ui_sprites.item()];
         let passes = [Pass::new(&color, &items)];
         let outcome = target.render(&RenderDesc::new(&passes));
         self.record_draw(outcome);
+    }
+
+    /// A window event with any pointer position rescaled from
+    /// physical surface pixels into the 320x240 canvas the menu
+    /// solved in. Everything else passes through untouched.
+    fn to_canvas(&self, event: WindowEvent) -> WindowEvent {
+        if let WindowEvent::PointerMoved { x, y } = event {
+            let sx = f64::from(VIEW_WIDTH) / f64::from(self.size.width.max(1));
+            let sy = f64::from(VIEW_HEIGHT) / f64::from(self.size.height.max(1));
+            WindowEvent::PointerMoved {
+                x: x * sx,
+                y: y * sy,
+            }
+        } else {
+            event
+        }
     }
 
     /// What a draw outcome means for the run — split from [`Self::draw`]
@@ -396,10 +501,22 @@ impl GlideApp {
             self.pending_flaps = self
                 .pending_flaps
                 .saturating_add(u8::from(self.input.state(Action::Flap).just_pressed));
+            for action in self.menu.drain() {
+                if action == crate::menu::MenuAction::Restart {
+                    self.world = World::new(self.seed);
+                    self.pending_flaps = 0;
+                }
+            }
+            let paused = self.menu.is_open();
             for _step in plan.steps() {
                 // Readings around the tick: the world exposes no
                 // events, so the difference across a step is what
                 // happened in it.
+                // An open menu pauses the world: frames keep coming,
+                // steps do not, and the pause bit is digested.
+                if paused {
+                    continue;
+                }
                 let flap_passed = self.pending_flaps > 0;
                 let before_alive = self.world.alive();
                 let before_score = self.world.score();
@@ -487,11 +604,13 @@ impl GlideApp {
                 eprintln!("sound: the device stopped mid-run; the rest was silent");
             }
         }
+        let session_hash = self.menu.absorb(self.world.digest()).finish();
         Ok(Report {
             seed: self.seed,
             source: "window".to_string(),
             stats: self.stats,
             world: self.world,
+            session_hash,
         })
     }
 }
@@ -517,7 +636,32 @@ impl WindowApp for GlideApp {
             WindowEvent::Resized { width, height } => self.resize(Extent { width, height }),
             WindowEvent::CloseRequested => self.close_requested = true,
             WindowEvent::Focused(false) => self.input.release_all(),
-            other => self.input.handle(other),
+            other => {
+                // Pointer coordinates arrive in physical window
+                // pixels; the menu solved in canvas pixels, and the
+                // sprite renderer stretches that canvas over the whole
+                // surface — so the driver maps positions into canvas
+                // space BEFORE the tree hears them, or the menu would
+                // draw in one place and hit-test in another. The
+                // mapping is part of the input seam: scripted traces
+                // speak canvas coordinates directly, and this is the
+                // one place a window's pixels become those.
+                let other = self.to_canvas(other);
+                // The menu hears everything; gameplay hears an event
+                // only when the menu was closed as it arrived, so the
+                // click that presses Resume never also flaps. Opening
+                // releases gameplay input: a key held into the pause
+                // must not wedge the map with a press whose release
+                // the menu will swallow.
+                let was_open = self.menu.is_open();
+                self.menu.handle(&other);
+                if !was_open && self.menu.is_open() {
+                    self.input.release_all();
+                }
+                if !was_open {
+                    self.input.handle(other);
+                }
+            }
         }
     }
 

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -162,7 +162,6 @@ fn relabel_into<const N: usize>(
     true
 }
 
-/// The game as the window seam sees it.
 // Sprites reserved for HUD and label text beyond the menu's own
 // quads: enough for the score line and both button labels.
 const UI_TEXT_SPRITES: u32 = 64;
@@ -178,6 +177,17 @@ const LABEL_INK: [f32; 4] = [0.92, 0.94, 1.0, 1.0];
 )]
 fn fixed_px(value: renew_ui::Fixed) -> f32 {
     value.to_bits() as f32 / 65536.0
+}
+
+/// Where a label starts inside its button: centred both ways by the
+/// same integer advances the tree measured the button with.
+fn label_origin(rect: &renew_ui::Rect, label: &str) -> (f32, f32) {
+    let text_width = renew_ui::text::measure(label);
+    let line = renew_ui::Fixed::from_int(i32::try_from(renew_ui::text::LINE_HEIGHT).unwrap_or(16));
+    let two = renew_ui::Fixed::from_int(2);
+    let x = rect.x + (rect.width - text_width) / two;
+    let y = rect.y + (rect.height - line) / two;
+    (fixed_px(x), fixed_px(y))
 }
 
 /// The game as the window seam sees it.
@@ -383,20 +393,8 @@ impl GlideApp {
             self.presenter.emit(renew_math::Alpha::ZERO, ui_sprites);
             for (node, label) in self.menu.labels() {
                 if let Some(rect) = self.menu.ui().rect(node) {
-                    let text_width = renew_ui::text::measure(label);
-                    let line = renew_ui::Fixed::from_int(
-                        i32::try_from(renew_ui::text::LINE_HEIGHT).unwrap_or(16),
-                    );
-                    let two = renew_ui::Fixed::from_int(2);
-                    let x = rect.x + (rect.width - text_width) / two;
-                    let y = rect.y + (rect.height - line) / two;
-                    renew_ui_render::emit_text(
-                        ui_sprites,
-                        fixed_px(x),
-                        fixed_px(y),
-                        label,
-                        LABEL_INK,
-                    );
+                    let (x, y) = label_origin(&rect, label);
+                    renew_ui_render::emit_text(ui_sprites, x, y, label, LABEL_INK);
                 }
             }
         }
@@ -497,10 +495,15 @@ impl GlideApp {
             // Capture the edge before it retires, count it, spend one
             // per step: a press on a zero-step frame survives to the
             // next frame's first step, and two presses with two due
-            // steps deliver two flaps.
-            self.pending_flaps = self
-                .pending_flaps
-                .saturating_add(u8::from(self.input.state(Action::Flap).just_pressed));
+            // steps deliver two flaps. An edge banks only while the
+            // menu is closed: a press racing the pause is abandoned,
+            // exactly as the scripted loop abandons it when the paused
+            // step never runs and the frame's advance retires it.
+            if !self.menu.is_open() {
+                self.pending_flaps = self
+                    .pending_flaps
+                    .saturating_add(u8::from(self.input.state(Action::Flap).just_pressed));
+            }
             for action in self.menu.drain() {
                 if action == crate::menu::MenuAction::Restart {
                     self.world = World::new(self.seed);
@@ -716,6 +719,133 @@ mod tests {
             pressed: false,
             repeat: false,
         });
+    }
+
+    fn escape(app: &mut GlideApp) {
+        app.event(WindowEvent::Key {
+            code: renew_event::KeyCode::Escape,
+            pressed: true,
+            repeat: false,
+        });
+    }
+
+    /// A click in physical window pixels, routed through the seam:
+    /// the driver rescales it into canvas space before the menu
+    /// hears it.
+    fn click_physical(app: &mut GlideApp, x: f64, y: f64) {
+        app.event(WindowEvent::PointerMoved { x, y });
+        app.event(WindowEvent::PointerButton {
+            button: renew_event::PointerButton::Left,
+            pressed: true,
+        });
+        app.event(WindowEvent::PointerButton {
+            button: renew_event::PointerButton::Left,
+            pressed: false,
+        });
+    }
+
+    /// A button's centre in canvas pixels, from the same solved
+    /// rectangle the menu hit-tests with.
+    fn centre_of(app: &GlideApp, index: usize) -> (f64, f64) {
+        let (node, _) = app.menu.labels()[index];
+        let rect = app.menu.ui().rect(node).expect("solved");
+        let two = renew_ui::Fixed::from_int(2);
+        let x = rect.x + rect.width / two;
+        let y = rect.y + rect.height / two;
+        let px = |value: renew_ui::Fixed| f64::from(i32::try_from(value.trunc_int()).unwrap_or(0));
+        (px(x), px(y))
+    }
+
+    #[test]
+    fn opening_the_menu_pauses_the_world_and_releases_input() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        // A key held into the pause: opening releases it, and the
+        // release the menu later swallows can no longer wedge the map.
+        press(&mut app);
+        escape(&mut app);
+        assert!(app.menu.is_open());
+        app.update_at(Timestamp::from_nanos(3 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 0, "an open menu holds the world still");
+        release(&mut app);
+        escape(&mut app);
+        assert!(!app.menu.is_open());
+        press(&mut app);
+        app.update_at(Timestamp::from_nanos(4 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 1, "resuming lets the world step again");
+        assert_eq!(app.pending_flaps, 0, "the fresh press was a clean edge");
+    }
+
+    #[test]
+    fn a_restart_click_lands_through_the_physical_to_canvas_seam() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        app.update_at(Timestamp::from_nanos(5 * STEP), &mut control);
+        assert_eq!(app.world.tick(), 5, "the run has an age to lose");
+        escape(&mut app);
+        // The window is twice the canvas in each direction: the click
+        // arrives in physical pixels and must still land, because the
+        // driver rescales positions before the tree hears them.
+        app.size = Extent {
+            width: 2 * VIEW_WIDTH,
+            height: 2 * VIEW_HEIGHT,
+        };
+        let (x, y) = centre_of(&app, 1);
+        click_physical(&mut app, 2.0 * x, 2.0 * y);
+        app.update_at(Timestamp::from_nanos(6 * STEP), &mut control);
+        assert!(!app.menu.is_open(), "an activated button closes the menu");
+        assert_eq!(
+            app.world.tick(),
+            1,
+            "the restart made the world new; one step has run since"
+        );
+        assert_eq!(app.pending_flaps, 0, "a restart abandons pending flaps");
+    }
+
+    #[test]
+    fn a_resume_click_plays_on_from_where_it_paused() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        app.update_at(Timestamp::from_nanos(5 * STEP), &mut control);
+        escape(&mut app);
+        // A window exactly the canvas size: the rescale is identity.
+        app.size = Extent {
+            width: VIEW_WIDTH,
+            height: VIEW_HEIGHT,
+        };
+        let (x, y) = centre_of(&app, 0);
+        click_physical(&mut app, x, y);
+        app.update_at(Timestamp::from_nanos(6 * STEP), &mut control);
+        assert!(!app.menu.is_open());
+        assert_eq!(
+            app.world.tick(),
+            6,
+            "resume keeps the world; a restart would have reset it"
+        );
+    }
+
+    /// The placement arithmetic behind the exempt draw block: every
+    /// label starts strictly inside its own button.
+    #[test]
+    fn labels_centre_inside_their_buttons() {
+        let app = app();
+        for (node, label) in app.menu.labels() {
+            let rect = app.menu.ui().rect(node).expect("solved");
+            let (x, y) = label_origin(&rect, label);
+            assert!(
+                fixed_px(rect.x) < x,
+                "{label} starts right of its left edge"
+            );
+            assert!(
+                x < fixed_px(rect.x + rect.width),
+                "{label} starts left of its right edge"
+            );
+            assert!(fixed_px(rect.y) < y, "{label} starts below its top edge");
+            assert!(
+                y < fixed_px(rect.y + rect.height),
+                "{label} starts above its bottom edge"
+            );
+        }
     }
 
     #[test]

--- a/samples/glide/tests/cli_determinism.rs
+++ b/samples/glide/tests/cli_determinism.rs
@@ -165,3 +165,57 @@ fn the_json_face_carries_the_same_digests_as_the_line() {
         "hashes must be quoted strings: {object}"
     );
 }
+
+/// The menu trace: the same session twice is the same digest — the
+/// tree's decisions replay bit for bit through the recorded pointer
+/// events and the one quantization seam.
+#[test]
+fn the_menu_session_reproduces() {
+    let first = digest_line(&["--input-trace", "menu", "--frames", "600"]);
+    let second = digest_line(&["--input-trace", "menu", "--frames", "600"]);
+    assert_eq!(first, second);
+    let soar = digest_line(&["--input-trace", "soar", "--frames", "600"]);
+    assert_ne!(
+        first, soar,
+        "a paused-and-restarted run is not an ordinary one"
+    );
+}
+
+/// Recording the menu session and replaying the recording answer the
+/// same digest: pointer events and pauses survive the trace format.
+#[test]
+fn the_menu_session_survives_a_record_replay_round_trip() {
+    let dir = std::env::temp_dir().join("renew-glide-menu-roundtrip");
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let path = dir.join("menu-rt.trace");
+    let path_text = path.to_str().expect("utf-8 temp path");
+    let recorded = digest_line(&[
+        "--input-trace",
+        "menu",
+        "--frames",
+        "600",
+        "--record-trace",
+        path_text,
+    ]);
+    let replayed = digest_line(&["--replay-trace", path_text]);
+    // The whole tail after the source field, not just the hash:
+    // comparing only the endpoint would let a schedule or length
+    // divergence hide behind an agreeing state hash.
+    let tail = |line: &str| {
+        line.split(" frames=")
+            .nth(1)
+            .expect("a frames field")
+            .to_string()
+    };
+    assert_eq!(tail(&recorded), tail(&replayed));
+    // And the recording IS the committed file, byte for byte: the
+    // hand-authored trace is already in canonical form, so it enjoys
+    // the same own-golden property the recorded traces do.
+    let rerecorded = std::fs::read_to_string(&path).expect("the recording exists");
+    assert_eq!(
+        rerecorded,
+        include_str!("../traces/menu.trace"),
+        "re-recording the menu trace must reproduce its committed bytes"
+    );
+    let _ = std::fs::remove_file(&path);
+}

--- a/samples/glide/traces/menu.trace
+++ b/samples/glide/traces/menu.trace
@@ -1,0 +1,25 @@
+renew-trace 0 sample=glide ticks=600 timestep_ns=16666667 budget=5 seed=7
+e 37 key space down
+e 38 key space up
+e 75 key space down
+e 76 key space up
+e 120 key escape down
+e 121 key escape up
+e 125 pointer 0x4064000000000000 0x4059c00000000000
+e 130 button left down
+e 132 button left up
+e 170 key space down
+e 171 key space up
+e 220 key space down
+e 221 key space up
+e 300 key escape down
+e 301 key escape up
+e 305 pointer 0x4064000000000000 0x4061000000000000
+e 310 button left down
+e 312 button left up
+e 350 key space down
+e 351 key space up
+e 420 key space down
+e 421 key space up
+e 480 key space down
+e 481 key space up


### PR DESCRIPTION
The widget tree's first embedding. Escape pauses; the menu is a real retained tree — the same arena, solver, and hit-tester every future document will use — with two buttons sized from their labels by the integer advance table, drawn by the snapshot presenter, labels centred by the same advances the tree measured them with.

**The digest moves, deliberately.** The reported hash is now the session's: the world's own fold, then the pause bit (it decides whether the world steps), then every decision the tree made in order. A menu that can restart the run is gameplay, and a digest that ignored it would call two different sessions the same. The world's own digest and its frozen pin are untouched; what the session fold leaves out is named where the field is declared, with the terminal-fold argument that makes the exclusion sound.

**Pausing splits session ticks from world ticks.** Events index by session; the world steps only when unpaused; every pre-menu trace replays unchanged because the two counts are equal in a run that never pauses. The recording header now carries the session length — the round-trip test caught it stamping the world's count, which a paused recording refused as past-the-end.

**Evidence.** A committed trace flies, pauses to resume, pauses again to restart, and flies the new run. Tests pin the world's tick count mid-trace (228: twelve paused frames) and after the restart (8: a new world), replay the recording to the same digest tail, and hold the committed file byte-for-byte against its own re-recording. The windowed driver maps physical pixels into the canvas the tree solved in — the review caught the menu drawing in one space and hit-testing in another — and opening releases gameplay input so a held key cannot wedge the map. Three removability cells name their new dependent. 197 workspace suites green; the windowed run observed live on real hardware.
