### PR TITLE
fix(ui-render): the clipping property forgives rounding where it happens

### DIFF
--- a/crates/ui-render/proptest-regressions/lib.txt
+++ b/crates/ui-render/proptest-regressions/lib.txt
@@ -4,4 +4,14 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
+#
+# Provenance, so nobody reads these as clip-code defects. Both are
+# failures of the property's own tolerance: the containment allowance
+# scaled with the edge being compared while the rounding it forgives
+# happens at the magnitude of the operands the edge was derived from,
+# so a small edge cut from a large rectangle failed on a legal
+# one-step spill. The first was found by a local run during
+# development; the second by a remote run. The clip code was correct
+# for both; the assertion was not.
 cc 24cda75ce4359fa20aaeab284a334d94d58fd6c13a08fdd5cdc9842e1b7ad675 # shrinks to rect = [-29.371904, 0.0, -66.170815, 45.944168], clip_a = [-43.535595, 0.0, 67.08066, 82.20785], clip_b = [-45.26216, 0.0, -52.094357, 63.585453]
+cc 285fab3ff485940fbf80cf67d28ac07c9277436ebe96cb02899bd95c41c5838d # as generated remotely: rect = [0.0, -31.56227, -97.60441, 93.57196], clip_a = [0.0, -70.84951, 86.24885, -75.53496], clip_b = [0.0, -98.04869, -76.44562, 99.42183]

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -537,10 +537,15 @@ mod tests {
             clip_a in proptest::array::uniform4(-100.0f32..100.0),
             clip_b in proptest::array::uniform4(-100.0f32..100.0),
         ) {
-            let close = |a: f32, b: f32| {
-                (a - b).abs() <= f32::EPSILON * 4.0 * (1.0 + a.abs() + b.abs())
-            };
-            let within = |value: f32, bound: f32| value <= bound || close(value, bound);
+            // The allowance scales with the values a sum passes
+            // through, not with the edge that comes out: a small edge
+            // derived from large operands carries the operands'
+            // rounding error, and a bound scaled only to the edge
+            // rejects a legal one-step spill whenever the operands
+            // dwarf it — the committed regression seeds are exactly
+            // such cases. A real containment defect spills by
+            // fractions of the overlap, orders of magnitude past this.
+            let step = |magnitude: f32| f32::EPSILON * 4.0 * (1.0 + magnitude);
             let rect = [rect[0], rect[1], rect[2].abs(), rect[3].abs()];
             let clip = intersect(
                 [clip_a[0], clip_a[1], clip_a[0] + clip_a[2].abs(), clip_a[1] + clip_a[3].abs()],
@@ -548,6 +553,10 @@ mod tests {
             );
             let tint = [1.0, 1.0, 1.0, 1.0];
             if let Some(quad) = clipped(rect, clip, tint) {
+                let mag =
+                    quad.x.abs() + quad.y.abs() + quad.width.abs() + quad.height.abs();
+                let within = |value: f32, bound: f32| value <= bound + step(mag + bound.abs());
+                let close = |a: f32, b: f32| (a - b).abs() <= step(mag);
                 proptest::prop_assert!(quad.x >= rect[0]);
                 proptest::prop_assert!(quad.x >= clip[0]);
                 proptest::prop_assert!(within(quad.x + quad.width, rect[0] + rect[2]));


### PR DESCRIPTION
A remote run tripped `clipping_contains_and_is_stable` on a legal input: a small clipped edge cut from a large rectangle. The one rounding step the quad legitimately carries happens at the magnitude of the operands the edge was derived from; the assertion's allowance scaled only with the edge being compared, so it rejected a one-step spill the property's own doc comment explicitly permits. The clip code was correct; the assertion was not.

The allowance now scales with the quad the sums pass through. Both known failing inputs — one found locally during development, one remotely — are committed as regression seeds with provenance notes, so every run replays them before generating novel cases. Twenty thousand fresh cases pass on top of the two seeds.
