### PR TITLE
bench(ui): the widget tree's frame costs, timed at a thousand nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,9 @@ jobs:
       #
       # renew-bench appears in several exclude lists because its bench
       # targets reach the crates they time (jobs, frame, rng, ecs,
-      # particles); each crate's cell excludes it alongside the crate.
+      # particles, ui, ui-render) and, through those, what they build
+      # on (render2d, rhi, fixed); every cell that removes a crate in
+      # that closure excludes the suite alongside it.
       - name: Build and test without the job system
         run: |
           sel="--workspace --exclude renew-jobs --exclude renew-bench"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       # other side.
       - name: Build and test without the rendering crate
         run: |
-          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-render3d --exclude renew-ui-render --exclude renew-sample-cube --exclude renew-sample-hello-triangle --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-rhi --exclude renew-render2d --exclude renew-render3d --exclude renew-ui-render --exclude renew-sample-cube --exclude renew-sample-hello-triangle --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rhi $sel
           cargo build $sel
           cargo test $sel
@@ -285,20 +285,21 @@ jobs:
           cargo test $sel
       # The widget tree: structure, layout, and interaction over the
       # fixed-point and digest crates. Its consumers are the UI
-      # presenter and the windowed game whose pause menu embeds it —
-      # the growth this comment once promised.
+      # presenter, the windowed game whose pause menu embeds it, and
+      # the bench suite that times its solve from its bench targets.
       - name: Build and test without the widget tree
         run: |
-          sel="--workspace --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui $sel
           cargo build $sel
           cargo test $sel
       # The UI presenter: snapshots over the widget tree, emitted
-      # through the 2D renderer. Its one consumer is the windowed game
-      # whose pause menu it draws.
+      # through the 2D renderer. Its consumers are the windowed game
+      # whose pause menu it draws and the bench suite that times its
+      # snapshot copy from its bench targets.
       - name: Build and test without the UI presenter
         run: |
-          sel="--workspace --exclude renew-ui-render --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ui-render $sel
           cargo build $sel
           cargo test $sel
@@ -308,7 +309,7 @@ jobs:
       # yet -- the windowed game grows this list when it draws sprites.
       - name: Build and test without the 2D renderer
         run: |
-          sel="--workspace --exclude renew-render2d --exclude renew-ui-render --exclude renew-sample-glide"
+          sel="--workspace --exclude renew-render2d --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d $sel
           cargo build $sel
           cargo test $sel
@@ -357,7 +358,7 @@ jobs:
       # each went red here until the cell named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world"
+          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,8 @@ dependencies = [
  "renew-particles",
  "renew-platform",
  "renew-rng",
+ "renew-ui",
+ "renew-ui-render",
 ]
 
 [[package]]

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles, widget tree — paired with exact allocation-count assertions."
+purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles, widget tree and its presenter — paired with exact allocation-count assertions."
 maturity = "bootstrap"
 core = false
 extension_points = []

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles — paired with exact allocation-count assertions."
+purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles, widget tree — paired with exact allocation-count assertions."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -41,6 +41,11 @@ renew-ecs = { path = "../../crates/ecs" }
 # Bench-target-only: the pool's allocation behaviour is gated in its
 # own crate; this suite only times it.
 renew-particles = { path = "../../crates/particles" }
+# Bench-target-only, and the same shape again: the tree and the
+# presenter gate their allocations in their own crates; this suite
+# times the solve, the re-solve, and the snapshot copy.
+renew-ui = { path = "../../crates/ui" }
+renew-ui-render = { path = "../../crates/ui-render" }
 
 [lints]
 workspace = true
@@ -79,4 +84,8 @@ harness = false
 
 [[bench]]
 name = "particles"
+harness = false
+
+[[bench]]
+name = "ui"
 harness = false

--- a/bench/suite/benches/ui.rs
+++ b/bench/suite/benches/ui.rs
@@ -32,10 +32,11 @@ const PER_ROW: u32 = (NODES - 1 - ROWS) / ROWS;
 /// The viewport every solve answers for.
 const VIEW: (i32, i32) = (1280, 720);
 
-/// A tree of exactly [`NODES`] nodes, styled so every solver feature
-/// pays its way: rows grow by weight, children mix fixed and content
-/// sizing, gaps and centring exercise arrangement. Built dirty; the
-/// caller decides when the first solve happens.
+/// A tree of exactly [`NODES`] nodes, styled so the solver's paths
+/// all run: rows grow by weight into the column's leftover height,
+/// leaves grow into their row's fixed width, sizes mix fixed and
+/// content, gaps and cross-axis centring exercise arrangement. Built
+/// dirty; the caller decides when the first solve happens.
 fn build_tree() -> Ui {
     let mut ui = Ui::new(UiLimits { nodes: NODES });
     let root = ui.root();
@@ -44,7 +45,6 @@ fn build_tree() -> Ui {
         Style {
             direction: Direction::Column,
             gap: Fixed::from_int(2),
-            justify: Align::Center,
             ..Style::default()
         },
     );
@@ -59,7 +59,10 @@ fn build_tree() -> Ui {
             Style {
                 direction: Direction::Row,
                 // Alternating weights so the largest-remainder split
-                // has remainders to hand out.
+                // has remainders to hand out, and a width wide enough
+                // past the leaves' content that their own growers get
+                // leftover to split too.
+                width: Size::Px(Fixed::from_int(1000)),
                 grow: 1 + row % 3,
                 gap: Fixed::from_int(1),
                 align_cross: Align::Center,
@@ -103,12 +106,16 @@ fn last_leaf(ui: &Ui) -> renew_ui::NodeId {
 fn ui_benches(c: &mut Criterion) {
     // Solving a freshly built tree: the cost of showing a document
     // for the first time. The build is setup, not measurement.
-    c.bench_function("ui_solve_cold_1k", |b| {
+    c.bench_function("ui_solve_cold_1024", |b| {
         b.iter_batched_ref(
             build_tree,
             |ui| {
                 solve(ui);
-                black_box(ui.rect(ui.root()));
+                // The root is pinned to the viewport whatever the tree
+                // does; a leaf's rectangle is an answer the solve had
+                // to compute.
+                let leaf = last_leaf(ui);
+                black_box(ui.rect(leaf));
             },
             criterion::BatchSize::LargeInput,
         );
@@ -117,7 +124,7 @@ fn ui_benches(c: &mut Criterion) {
     // One node's layout changes, the tree re-solves. Two widths
     // alternate so every iteration provably lays out rather than
     // early-outing on a clean flag.
-    c.bench_function("ui_re_solve_one_dirty_1k", |b| {
+    c.bench_function("ui_re_solve_one_dirty_1024", |b| {
         let mut ui = build_tree();
         solve(&mut ui);
         let leaf = last_leaf(&ui);
@@ -141,10 +148,10 @@ fn ui_benches(c: &mut Criterion) {
 
     // A colour-only flip: geometry is untouched, and today the tree
     // re-solves anyway — one dirty flag, no damage classes. This
-    // number exists to be compared against `re_solve_one_dirty_1k`
+    // number exists to be compared against `re_solve_one_dirty_1024`
     // now (they should match) and against itself when styling stops
     // dirtying layout (it should collapse).
-    c.bench_function("ui_state_flip_colour_1k", |b| {
+    c.bench_function("ui_state_flip_colour_1024", |b| {
         let mut ui = build_tree();
         solve(&mut ui);
         let leaf = last_leaf(&ui);
@@ -173,7 +180,7 @@ fn ui_benches(c: &mut Criterion) {
     // The snapshot copy: capturing a solved tree into the presenter's
     // pair. This is presentation's per-tick cost, paid whether or not
     // anything moved.
-    c.bench_function("ui_snapshot_advance_1k", |b| {
+    c.bench_function("ui_snapshot_advance_1024", |b| {
         let mut ui = build_tree();
         solve(&mut ui);
         let mut presenter = UiPresenter::new(NODES);

--- a/bench/suite/benches/ui.rs
+++ b/bench/suite/benches/ui.rs
@@ -1,0 +1,188 @@
+//! Widget-tree timings: what a frame pays for layout and for the
+//! snapshot copy behind presentation, at a thousand nodes — a tree an
+//! order of magnitude past any menu the samples draw, so the numbers
+//! bound a real document rather than flatter a toy.
+//!
+//! Four costs, in the order a running game meets them: solving a tree
+//! from cold, re-solving after one node's layout changed, re-solving
+//! after a colour-only flip (today identical to the layout re-solve,
+//! recorded so the state-table work can show the drop when colour
+//! stops dirtying layout), and capturing the solved tree into the
+//! presenter's snapshot pair.
+//!
+//! The allocation gates for these paths do not live here: the tree
+//! commits to zero steady-state allocation in its own crate's
+//! `tests/zero_alloc.rs` (solve, re-solve, input, digest), and the
+//! presenter does the same for `advance` and `frame`. This file only
+//! times what those tests already gate.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_ui::{Align, Direction, Fixed, Size, Style, Ui, UiLimits};
+use renew_ui_render::UiPresenter;
+
+/// Nodes in the benched tree: one root, `ROWS` rows, the rest split
+/// evenly among them.
+const NODES: u32 = 1024;
+const ROWS: u32 = 31;
+/// Children per row: (1024 - 1 - 31) / 31 = 32, exactly.
+const PER_ROW: u32 = (NODES - 1 - ROWS) / ROWS;
+
+/// The viewport every solve answers for.
+const VIEW: (i32, i32) = (1280, 720);
+
+/// A tree of exactly [`NODES`] nodes, styled so every solver feature
+/// pays its way: rows grow by weight, children mix fixed and content
+/// sizing, gaps and centring exercise arrangement. Built dirty; the
+/// caller decides when the first solve happens.
+fn build_tree() -> Ui {
+    let mut ui = Ui::new(UiLimits { nodes: NODES });
+    let root = ui.root();
+    ui.set_style(
+        root,
+        Style {
+            direction: Direction::Column,
+            gap: Fixed::from_int(2),
+            justify: Align::Center,
+            ..Style::default()
+        },
+    );
+    // Successes are counted and asserted below rather than each
+    // insert unwrapped: one guard, at the size the name claims.
+    let mut built = 1;
+    for row in 0..ROWS {
+        let Ok(panel) = ui.insert(root) else { continue };
+        built += 1;
+        ui.set_style(
+            panel,
+            Style {
+                direction: Direction::Row,
+                // Alternating weights so the largest-remainder split
+                // has remainders to hand out.
+                grow: 1 + row % 3,
+                gap: Fixed::from_int(1),
+                align_cross: Align::Center,
+                background: [20, 20, 30, 255],
+                ..Style::default()
+            },
+        );
+        for child in 0..PER_ROW {
+            let Ok(leaf) = ui.insert(panel) else { continue };
+            built += 1;
+            ui.set_style(
+                leaf,
+                Style {
+                    width: Size::Px(Fixed::from_int(8 + i32::try_from(child % 5).unwrap_or(0))),
+                    height: Size::Px(Fixed::from_int(10)),
+                    grow: child % 2,
+                    background: [40, 44, 52, 230],
+                    ..Style::default()
+                },
+            );
+        }
+    }
+    assert_eq!(built, NODES, "the tree must be the size the name claims");
+    ui
+}
+
+fn solve(ui: &mut Ui) {
+    ui.solve(Fixed::from_int(VIEW.0), Fixed::from_int(VIEW.1));
+}
+
+/// The deepest, last-inserted leaf: the one whose restyle dirties the
+/// whole tree today.
+fn last_leaf(ui: &Ui) -> renew_ui::NodeId {
+    let root = ui.root();
+    // The fallbacks are unreachable past build_tree's size assert;
+    // root merely keeps this total without unwrapping.
+    let row = ui.children(root).last().unwrap_or(root);
+    ui.children(row).last().unwrap_or(root)
+}
+
+fn ui_benches(c: &mut Criterion) {
+    // Solving a freshly built tree: the cost of showing a document
+    // for the first time. The build is setup, not measurement.
+    c.bench_function("ui_solve_cold_1k", |b| {
+        b.iter_batched_ref(
+            build_tree,
+            |ui| {
+                solve(ui);
+                black_box(ui.rect(ui.root()));
+            },
+            criterion::BatchSize::LargeInput,
+        );
+    });
+
+    // One node's layout changes, the tree re-solves. Two widths
+    // alternate so every iteration provably lays out rather than
+    // early-outing on a clean flag.
+    c.bench_function("ui_re_solve_one_dirty_1k", |b| {
+        let mut ui = build_tree();
+        solve(&mut ui);
+        let leaf = last_leaf(&ui);
+        let mut wide = false;
+        b.iter(|| {
+            wide = !wide;
+            let width = if wide { 24 } else { 8 };
+            ui.set_style(
+                leaf,
+                Style {
+                    width: Size::Px(Fixed::from_int(width)),
+                    height: Size::Px(Fixed::from_int(10)),
+                    background: [40, 44, 52, 230],
+                    ..Style::default()
+                },
+            );
+            solve(&mut ui);
+            black_box(ui.rect(leaf));
+        });
+    });
+
+    // A colour-only flip: geometry is untouched, and today the tree
+    // re-solves anyway — one dirty flag, no damage classes. This
+    // number exists to be compared against `re_solve_one_dirty_1k`
+    // now (they should match) and against itself when styling stops
+    // dirtying layout (it should collapse).
+    c.bench_function("ui_state_flip_colour_1k", |b| {
+        let mut ui = build_tree();
+        solve(&mut ui);
+        let leaf = last_leaf(&ui);
+        let mut lit = false;
+        b.iter(|| {
+            lit = !lit;
+            let background = if lit {
+                [90, 120, 200, 255]
+            } else {
+                [40, 44, 52, 230]
+            };
+            ui.set_style(
+                leaf,
+                Style {
+                    width: Size::Px(Fixed::from_int(8)),
+                    height: Size::Px(Fixed::from_int(10)),
+                    background,
+                    ..Style::default()
+                },
+            );
+            solve(&mut ui);
+            black_box(ui.rect(leaf));
+        });
+    });
+
+    // The snapshot copy: capturing a solved tree into the presenter's
+    // pair. This is presentation's per-tick cost, paid whether or not
+    // anything moved.
+    c.bench_function("ui_snapshot_advance_1k", |b| {
+        let mut ui = build_tree();
+        solve(&mut ui);
+        let mut presenter = UiPresenter::new(NODES);
+        presenter.advance(&ui);
+        b.iter(|| {
+            presenter.advance(black_box(&ui));
+        });
+    });
+}
+
+criterion_group!(benches, ui_benches);
+criterion_main!(benches);

--- a/crates/ui/tests/zero_alloc.rs
+++ b/crates/ui/tests/zero_alloc.rs
@@ -9,6 +9,7 @@
 //! asserts the churn happened.
 
 use renew_fixed::Fixed;
+use renew_frame::StateHash;
 use renew_memory::{CountingAllocator, counters};
 use renew_ui::{Size, Style, Ui, UiEvent, UiLimits};
 
@@ -111,4 +112,21 @@ fn the_steady_state_allocates_nothing() {
         }
     });
     verdict.expect("interaction stays heap-silent");
+
+    // The digest half: folding the tree's structure and decisions into
+    // a hash reads retained state only. Warmed once outside the
+    // window; asserted stable inside it, because a fold that read
+    // nothing would also be quiet — identical digests of an unchanged
+    // tree are what show the fold really ran over real state.
+    let baseline = ui.absorb(StateHash::new()).finish();
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            assert_eq!(
+                ui.absorb(StateHash::new()).finish(),
+                baseline,
+                "an unchanged tree must digest identically"
+            );
+        }
+    });
+    verdict.expect("the digest stays heap-silent");
 }


### PR DESCRIPTION
Four numbers a running game pays, at 1,024 nodes (root + 31 growing rows × 32 mixed leaves, solved at 1280×720) — an order of magnitude past any current menu, so they bound a real document rather than flatter a toy.

Measured medians on the recording machine (Intel 10th-gen, Windows 10, rustc 1.97.1): cold solve 61.5 µs, one-leaf re-solve 61.8 µs, colour-only flip 61.7 µs, snapshot capture 15.3 µs. A full re-solve plus capture is ~77 µs — under half a percent of a 60 Hz frame.

The colour flip is deliberately its own line even though it matches the layout re-solve today: the tree carries one dirty flag and no damage classes, so styling pays for geometry it never touched. When state tables split that, this line is the before.

Allocation gates stay where they live — the tree and the presenter each assert zero steady-state allocation in their own crates; this suite only times what those tests already hold. The suite's bench targets now reach the tree and the presenter, so the five removability cells that remove them (or anything beneath them) exclude the suite alongside, as the particle pool's cell already does.
