### PR TITLE
refactor(rhi): one sampled-binding layout, owned where identity lives

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -81,7 +81,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1088, 1089, 1090]
+lines = [1068, 1069, 1070]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/crates/rhi/src/vk/device.rs
+++ b/crates/rhi/src/vk/device.rs
@@ -88,6 +88,13 @@ pub(crate) struct DeviceShared {
     /// target creation; queried once because format support is a static
     /// property of the physical device.
     pub(crate) depth_format: Option<vk::Format>,
+    /// The one descriptor-set layout every sampled binding shares: a
+    /// single combined image sampler at binding zero, fragment stage.
+    /// Owned here because layout identity is what makes any written
+    /// set compatible with any pipeline that declares the slot — one
+    /// object, created at bring-up, destroyed at teardown before the
+    /// device.
+    pub(crate) sampled_set_layout: vk::DescriptorSetLayout,
     /// `maxImageDimension2D`, read once at bring-up.
     ///
     /// Kept for the same reason `depth_format` is: it is a static
@@ -142,6 +149,8 @@ impl Drop for DeviceShared {
         // no resource object can outlive this struct (each holds an Rc
         // to it).
         unsafe {
+            self.device
+                .destroy_descriptor_set_layout(self.sampled_set_layout, Some(&self.alloc_cbs()));
             self.device.destroy_device(Some(&self.alloc_cbs()));
             if let Some((utils, messenger)) = self.debug.take() {
                 utils.destroy_debug_utils_messenger(messenger, Some(&self.alloc_cbs()));
@@ -395,6 +404,35 @@ impl Device {
         // declared in the create info above.
         let queue = unsafe { device.get_device_queue(queue_family, 0) };
 
+        // The crate's one sampled-binding set layout, created with the
+        // device because it lives and dies with it.
+        let bindings = [vk::DescriptorSetLayoutBinding::default()
+            .binding(0)
+            .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
+            .descriptor_count(1)
+            .stage_flags(vk::ShaderStageFlags::FRAGMENT)];
+        let layout_info = vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
+        // SAFETY: category 2: device live; the binding array is a local
+        // outliving the call.
+        let sampled_set_layout = unsafe {
+            device.create_descriptor_set_layout(
+                &layout_info,
+                Some(&crate::vk::alloc::callbacks(&ledger)),
+            )
+        }
+        .map_err(|code| {
+            // SAFETY: device live, created just above with these same
+            // callbacks; nothing else references it yet.
+            unsafe { device.destroy_device(Some(&crate::vk::alloc::callbacks(&ledger))) };
+            teardown_early(&instance, debug.as_ref(), &ledger);
+            match code {
+                vk::Result::ERROR_OUT_OF_HOST_MEMORY => DeviceError::OutOfHostMemory {
+                    call: "vkCreateDescriptorSetLayout",
+                },
+                other => creation("vkCreateDescriptorSetLayout", other),
+            }
+        })?;
+
         renew_diag::info!(
             target: "renew-rhi",
             "device up: {} ({:?}), depth format {}",
@@ -414,6 +452,7 @@ impl Device {
                 entry,
                 adapter,
                 depth_format,
+                sampled_set_layout,
                 max_image_dimension_2d,
                 lost: PoisonFlag::default(),
                 validation: validation_counters,

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -610,6 +610,15 @@ impl AddressMode {
     }
 }
 
+/// The sampler's owning half, split like the texture's and for the
+/// same reason: a future binding object holds the inner alive while
+/// callers pass borrows. The contract lives on [`Sampler`], where its
+/// reader is.
+pub(crate) struct SamplerInner {
+    pub(crate) shared: Rc<DeviceShared>,
+    pub(crate) sampler: vk::Sampler,
+}
+
 /// A sampler. Holds its device alive; destroyed on drop.
 ///
 /// # Contract
@@ -624,14 +633,6 @@ impl AddressMode {
 /// only run once the pipeline has released its clone, which happens
 /// inside `RenderPipeline`'s own `Drop`, after that has waited for the
 /// device to go idle and destroyed the pool.
-/// The sampler's owning half, split like the texture's and for the
-/// same reason: a future binding object holds the inner alive while
-/// callers pass borrows.
-pub(crate) struct SamplerInner {
-    pub(crate) shared: Rc<DeviceShared>,
-    pub(crate) sampler: vk::Sampler,
-}
-
 pub struct Sampler {
     pub(crate) inner: Rc<SamplerInner>,
 }

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -624,9 +624,16 @@ impl AddressMode {
 /// only run once the pipeline has released its clone, which happens
 /// inside `RenderPipeline`'s own `Drop`, after that has waited for the
 /// device to go idle and destroyed the pool.
-pub struct Sampler {
+/// The sampler's owning half, split like the texture's and for the
+/// same reason: a future binding object holds the inner alive while
+/// callers pass borrows.
+pub(crate) struct SamplerInner {
     pub(crate) shared: Rc<DeviceShared>,
     pub(crate) sampler: vk::Sampler,
+}
+
+pub struct Sampler {
+    pub(crate) inner: Rc<SamplerInner>,
 }
 
 impl fmt::Debug for Sampler {
@@ -635,7 +642,7 @@ impl fmt::Debug for Sampler {
     }
 }
 
-impl Drop for Sampler {
+impl Drop for SamplerInner {
     fn drop(&mut self) {
         // SAFETY: category 2 (ash dispatch): device live via the spine
         // Rc; the handle was created with these callbacks; the owner of
@@ -659,28 +666,25 @@ impl Drop for Sampler {
 /// holding the moment sets are allocated per frame.
 #[derive(Clone, Copy)]
 struct Descriptors {
-    set_layout: vk::DescriptorSetLayout,
     pool: vk::DescriptorPool,
     set: vk::DescriptorSet,
 }
 
 impl Descriptors {
-    /// Destroy the pool and the layout. The set is freed with the pool
-    /// and must not be freed separately.
+    /// Destroy the pool; the set is freed with it and must not be
+    /// freed separately. The set layout is the device spine's one
+    /// shared object and is not this struct's to destroy.
     ///
     /// # Safety
     ///
     /// No submit referencing the set may still be running.
     unsafe fn destroy(self, shared: &DeviceShared) {
-        // SAFETY: forwarded to the caller; both handles were created by
+        // SAFETY: forwarded to the caller; the pool was created by
         // `create_descriptors` with these callbacks.
         unsafe {
             shared
                 .device
                 .destroy_descriptor_pool(self.pool, Some(&shared.alloc_cbs()));
-            shared
-                .device
-                .destroy_descriptor_set_layout(self.set_layout, Some(&shared.alloc_cbs()));
         }
     }
 }
@@ -826,50 +830,28 @@ fn create_descriptors(
         "texture and pipeline come from different devices"
     );
     debug_assert!(
-        core::ptr::eq(shared, Rc::as_ptr(&sampler.shared)),
+        core::ptr::eq(shared, Rc::as_ptr(&sampler.inner.shared)),
         "sampler and pipeline come from different devices"
     );
-    let bindings = [vk::DescriptorSetLayoutBinding::default()
-        .binding(0)
-        .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
-        .descriptor_count(1)
-        .stage_flags(vk::ShaderStageFlags::FRAGMENT)];
-    let layout_info = vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings);
-    // SAFETY: category 2 (ash dispatch): device live via the spine; the
-    // binding array is a local outliving the call. (The same argument
-    // covers every dispatch call in this function.)
-    let set_layout = unsafe {
-        shared
-            .device
-            .create_descriptor_set_layout(&layout_info, Some(&shared.alloc_cbs()))
-    }
-    .map_err(|code| creation("vkCreateDescriptorSetLayout", code))?;
-
     let sizes = [vk::DescriptorPoolSize::default()
         .ty(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
         .descriptor_count(1)];
     let pool_info = vk::DescriptorPoolCreateInfo::default()
         .max_sets(1)
         .pool_sizes(&sizes);
-    // SAFETY: device live; the size array is a local.
-    let pool = match unsafe {
+    // SAFETY: category 2 (ash dispatch): device live via the spine; the
+    // size array is a local outliving the call. (The same argument
+    // covers every dispatch call in this function.)
+    let pool = unsafe {
         shared
             .device
             .create_descriptor_pool(&pool_info, Some(&shared.alloc_cbs()))
-    } {
-        Ok(pool) => pool,
-        Err(code) => {
-            // SAFETY: layout live, nothing retained it.
-            unsafe {
-                shared
-                    .device
-                    .destroy_descriptor_set_layout(set_layout, Some(&shared.alloc_cbs()));
-            }
-            return Err(creation("vkCreateDescriptorPool", code));
-        }
-    };
+    }
+    .map_err(|code| creation("vkCreateDescriptorPool", code))?;
 
-    let set_layouts = [set_layout];
+    // The spine's one shared layout: identity is what makes this set
+    // compatible with every pipeline that declares the slot.
+    let set_layouts = [shared.sampled_set_layout];
     let alloc_info = vk::DescriptorSetAllocateInfo::default()
         .descriptor_pool(pool)
         .set_layouts(&set_layouts);
@@ -885,7 +867,6 @@ fn create_descriptors(
     };
     let Some(set) = set else {
         let partial = Descriptors {
-            set_layout,
             pool,
             set: vk::DescriptorSet::null(),
         };
@@ -896,8 +877,8 @@ fn create_descriptors(
     };
 
     let image_info = [vk::DescriptorImageInfo::default()
-        .sampler(sampler.sampler)
-        .image_view(texture.view)
+        .sampler(sampler.inner.sampler)
+        .image_view(texture.inner.view)
         // The upload left the image in this layout and nothing changes
         // it afterwards, immutability being the texture contract.
         .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)];
@@ -912,11 +893,7 @@ fn create_descriptors(
     // the call.
     unsafe { shared.device.update_descriptor_sets(&writes, &[]) };
 
-    Ok(Descriptors {
-        set_layout,
-        pool,
-        set,
-    })
+    Ok(Descriptors { pool, set })
 }
 
 fn creation(call: &'static str, code: vk::Result) -> PipelineError {
@@ -1052,8 +1029,10 @@ impl Device {
         }
         .map_err(|code| creation("vkCreateSampler", code))?;
         Ok(Sampler {
-            shared: Rc::clone(shared),
-            sampler,
+            inner: Rc::new(SamplerInner {
+                shared: Rc::clone(shared),
+                sampler,
+            }),
         })
     }
 
@@ -1153,7 +1132,7 @@ impl Device {
         // An untextured pipeline keeps the empty layout it has always
         // had; a textured one declares the single set the crate defines.
         let set_layouts: &[vk::DescriptorSetLayout] = match &descriptors {
-            Some(descriptors) => core::slice::from_ref(&descriptors.set_layout),
+            Some(_) => core::slice::from_ref(&shared.sampled_set_layout),
             None => &[],
         };
         // One vertex-stage range at offset zero, present exactly when

--- a/crates/rhi/src/vk/texture.rs
+++ b/crates/rhi/src/vk/texture.rs
@@ -222,37 +222,45 @@ impl Drop for Partial<'_> {
 /// A texture whose pixels change — an animated or glyph atlas — breaks
 /// that argument rather than extending it, and needs a type that states
 /// its own rule about when a write is legal.
-pub struct Texture {
-    shared: Rc<DeviceShared>,
+/// The texture's owning half, behind the handle the caller holds —
+/// the mesh split, applied here so a future binding object can keep
+/// the image alive with an `Rc` clone while callers pass plain
+/// borrows and drop whenever they like.
+pub(crate) struct TextureInner {
+    pub(crate) shared: Rc<DeviceShared>,
     image: vk::Image,
     memory: vk::DeviceMemory,
     pub(crate) view: vk::ImageView,
     extent: Extent,
 }
 
+pub struct Texture {
+    pub(crate) inner: Rc<TextureInner>,
+}
+
 impl Texture {
     /// The texture's size in texels.
     #[must_use]
     pub fn extent(&self) -> Extent {
-        self.extent
+        self.inner.extent
     }
 
     /// The device spine this texture belongs to, for the cross-device
     /// contract check the pipeline makes before writing a descriptor.
     pub(crate) fn shared(&self) -> &Rc<DeviceShared> {
-        &self.shared
+        &self.inner.shared
     }
 }
 
 impl core::fmt::Debug for Texture {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Texture")
-            .field("extent", &self.extent)
+            .field("extent", &self.inner.extent)
             .finish_non_exhaustive()
     }
 }
 
-impl Drop for Texture {
+impl Drop for TextureInner {
     fn drop(&mut self) {
         // SAFETY: category 2 (ash dispatch): device live via the spine
         // `Rc`; all three handles were created here with these callbacks
@@ -639,11 +647,13 @@ fn upload(
     partial.memory = None;
     partial.view = None;
     Ok(Texture {
-        shared: Rc::clone(shared),
-        image,
-        memory,
-        view,
-        extent: desc.extent,
+        inner: Rc::new(TextureInner {
+            shared: Rc::clone(shared),
+            image,
+            memory,
+            view,
+            extent: desc.extent,
+        }),
     })
 }
 

--- a/crates/rhi/src/vk/texture.rs
+++ b/crates/rhi/src/vk/texture.rs
@@ -203,6 +203,19 @@ impl Drop for Partial<'_> {
     }
 }
 
+/// The texture's owning half, behind the handle the caller holds —
+/// the mesh split, applied here so a future binding object can keep
+/// the image alive with an `Rc` clone while callers pass plain
+/// borrows and drop whenever they like. The contract lives on
+/// [`Texture`], where its reader is.
+pub(crate) struct TextureInner {
+    pub(crate) shared: Rc<DeviceShared>,
+    image: vk::Image,
+    memory: vk::DeviceMemory,
+    pub(crate) view: vk::ImageView,
+    extent: Extent,
+}
+
 /// An image the GPU can sample. Holds its device alive; destroyed on
 /// drop.
 ///
@@ -222,18 +235,6 @@ impl Drop for Partial<'_> {
 /// A texture whose pixels change — an animated or glyph atlas — breaks
 /// that argument rather than extending it, and needs a type that states
 /// its own rule about when a write is legal.
-/// The texture's owning half, behind the handle the caller holds —
-/// the mesh split, applied here so a future binding object can keep
-/// the image alive with an `Rc` clone while callers pass plain
-/// borrows and drop whenever they like.
-pub(crate) struct TextureInner {
-    pub(crate) shared: Rc<DeviceShared>,
-    image: vk::Image,
-    memory: vk::DeviceMemory,
-    pub(crate) view: vk::ImageView,
-    extent: Extent,
-}
-
 pub struct Texture {
     pub(crate) inner: Rc<TextureInner>,
 }

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -1256,6 +1256,23 @@ fn every_driver_failure_ladder_behaves() {
             )),
         },
     ));
+    // E12 fails after the device exists: the unwinder has the device
+    // itself to take back down beside the instance and messenger.
+    verdicts.push(bringup_case(
+        "E12 sampled-set-layout/initialization-failed",
+        "vkCreateDescriptorSetLayout=ERROR_INITIALIZATION_FAILED",
+        |got| match got {
+            Err(DeviceError::Creation {
+                call: "vkCreateDescriptorSetLayout",
+                ..
+            }) => Ok(()),
+            other => Err(wrong(
+                "",
+                "Creation(vkCreateDescriptorSetLayout)",
+                &other.map(|_| "a device"),
+            )),
+        },
+    ));
     // E3 fails between the instance and the device: the unwinder has an
     // instance (and possibly a messenger) to take back down.
     verdicts.push(bringup_case(

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -362,20 +362,6 @@ fn every_driver_failure_ladder_behaves() {
         },
     ));
     verdicts.push(bringup_case(
-        "A5 sampled-set-layout/out-of-host-memory",
-        "vkCreateDescriptorSetLayout=ERROR_OUT_OF_HOST_MEMORY",
-        |got| match got {
-            Err(DeviceError::OutOfHostMemory {
-                call: "vkCreateDescriptorSetLayout",
-            }) => Ok(()),
-            other => Err(wrong(
-                "",
-                "OutOfHostMemory(vkCreateDescriptorSetLayout)",
-                &other.map(|_| "a device"),
-            )),
-        },
-    ));
-    verdicts.push(bringup_case(
         "A4 create-device/out-of-host-memory",
         "vkCreateDevice=ERROR_OUT_OF_HOST_MEMORY",
         |got| match got {
@@ -385,6 +371,20 @@ fn every_driver_failure_ladder_behaves() {
             other => Err(wrong(
                 "",
                 "OutOfHostMemory(vkCreateDevice)",
+                &other.map(|_| "a device"),
+            )),
+        },
+    ));
+    verdicts.push(bringup_case(
+        "A5 sampled-set-layout/out-of-host-memory",
+        "vkCreateDescriptorSetLayout=ERROR_OUT_OF_HOST_MEMORY",
+        |got| match got {
+            Err(DeviceError::OutOfHostMemory {
+                call: "vkCreateDescriptorSetLayout",
+            }) => Ok(()),
+            other => Err(wrong(
+                "",
+                "OutOfHostMemory(vkCreateDescriptorSetLayout)",
                 &other.map(|_| "a device"),
             )),
         },
@@ -646,7 +646,7 @@ fn every_driver_failure_ladder_behaves() {
         },
     ));
 
-    // ---- C6-C8 · descriptor ladder ---------------------------------
+    // ---- C7-C10 · descriptor ladder ---------------------------------
     // A textured pipeline is the only thing that allocates descriptors,
     // so these arm the fault and then build one. Each is a distinct
     // creation call inside `create_pipeline`, and each must leave the

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -362,6 +362,20 @@ fn every_driver_failure_ladder_behaves() {
         },
     ));
     verdicts.push(bringup_case(
+        "A5 sampled-set-layout/out-of-host-memory",
+        "vkCreateDescriptorSetLayout=ERROR_OUT_OF_HOST_MEMORY",
+        |got| match got {
+            Err(DeviceError::OutOfHostMemory {
+                call: "vkCreateDescriptorSetLayout",
+            }) => Ok(()),
+            other => Err(wrong(
+                "",
+                "OutOfHostMemory(vkCreateDescriptorSetLayout)",
+                &other.map(|_| "a device"),
+            )),
+        },
+    ));
+    verdicts.push(bringup_case(
         "A4 create-device/out-of-host-memory",
         "vkCreateDevice=ERROR_OUT_OF_HOST_MEMORY",
         |got| match got {
@@ -637,12 +651,11 @@ fn every_driver_failure_ladder_behaves() {
     // so these arm the fault and then build one. Each is a distinct
     // creation call inside `create_pipeline`, and each must leave the
     // device able to build the same pipeline on a second attempt.
+    // C6 (descriptor-set-layout creation) moved to the bring-up
+    // ladder as A5: the layout is the device spine's one shared
+    // object now, created with the device, so arming that call fails
+    // bring-up rather than pipeline creation.
     let descriptor_ladder: &[(&str, &str, &str)] = &[
-        (
-            "C6",
-            "vkCreateDescriptorSetLayout=ERROR_OUT_OF_HOST_MEMORY",
-            "vkCreateDescriptorSetLayout",
-        ),
         (
             "C7",
             "vkCreateDescriptorPool=ERROR_OUT_OF_HOST_MEMORY",


### PR DESCRIPTION
Every textured pipeline used to create its own descriptor-set layout — identical objects, one per pipeline, each destroyed with it. The layout now lives on the device spine: one object, created at bring-up, destroyed at teardown before the device. Layout identity is what makes a written set compatible with a pipeline, and one shared object makes that compatibility structural rather than checked. Pipeline creation keeps its pool and set exactly as they were; only the layout they answer to moved, and its creation-failure path unwinds precisely as the device-creation path beside it does.

The fault scenario for layout creation moves with it: arming that call now fails device bring-up rather than pipeline creation, so the scenario leaves the pipeline ladder and joins the bring-up ladder — in call order, with the failure shape bring-up refusals carry. The pool and set-allocation scenarios stay where they were, and the suite ran with the layer armed on the recording machine.

Texture and Sampler take the split the mesh already has: an owning inner half behind the handle the caller holds, so a future object can keep either alive with a clone while callers pass plain borrows. Their public contracts stay on the public types, where their readers are. No public signature changes; every golden is byte-identical.
