### PR TITLE
feat(rhi): passes gain image identity, and one walk plans every barrier

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -71,12 +71,12 @@ reason = "The width guards on the pack's own header fields. Reaching one needs m
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [665]
+lines = [680]
 reason = "The unreachable arm of the walk's surface-depth barrier: a depth-carrying surface pass on a depthless target was already refused by the DepthUnsupported check before recording began, so the walk cannot hand this site a depth use with no depth image. The arm exists so the guaranteed-Some is stated without a banned expect; driving it would require breaking the refusal it stands behind."
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [711]
+lines = [730]
 reason = "The unreachable arm behind the sample-before-write refusal: the assert immediately above proved the entry exists, and the let-else restates it without a banned expect. No frame can drive it."
 
 [[exempt]]
@@ -85,33 +85,28 @@ lines = [228, 229, 230, 231]
 reason = "The format-feature pre-check's refusal: every measuring lane's adapter reports SAMPLED_IMAGE and the attachment feature for both kinds' formats, and vkGetPhysicalDeviceFormatProperties is a void query no fault layer can mutate - the same unreachability the depthless-adapter exemptions record. The refusal exists for adapters the lanes do not have."
 
 [[exempt]]
-file = "crates/rhi/src/vk/pass.rs"
-lines = [622]
-reason = "The unreachable arm of the walk's entry lookup: entry_index either returns the index of the slot it just filled or asserted the ceiling, so the slot is occupied by construction. Stated as let-else-unreachable rather than a banned expect; no frame can drive it."
-
-[[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
 lines = [383]
 reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs — so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [498, 499, 500]
+lines = [509, 510, 511]
 reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless adapter. Same unreachability as the creation arm above: every measuring lane's adapter offers a depth format, and the query that decides it cannot be faulted. The error construction is driven by the display test in the error module; the branch condition's false side runs on every depth-carrying frame."
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1050, 1051, 1052]
+lines = [1058, 1059, 1060]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]
 file = "crates/rhi/src/vk/swapchain.rs"
-lines = [508, 509, 510]
+lines = [519, 520, 521]
 reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless adapter, window side - same unreachability as the offscreen twin: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]
 file = "crates/rhi/src/vk/swapchain.rs"
-lines = [1344]
+lines = [1359]
 reason = "The depthless-adapter side of chain population, where no per-slot depth images are built. Unreachable wherever a depth format exists, which is every measuring lane's adapter."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -71,17 +71,37 @@ reason = "The width guards on the pack's own header fields. Reaching one needs m
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [379]
+lines = [665]
+reason = "The unreachable arm of the walk's surface-depth barrier: a depth-carrying surface pass on a depthless target was already refused by the DepthUnsupported check before recording began, so the walk cannot hand this site a depth use with no depth image. The arm exists so the guaranteed-Some is stated without a banned expect; driving it would require breaking the refusal it stands behind."
+
+[[exempt]]
+file = "crates/rhi/src/vk/pass.rs"
+lines = [711]
+reason = "The unreachable arm behind the sample-before-write refusal: the assert immediately above proved the entry exists, and the let-else restates it without a banned expect. No frame can drive it."
+
+[[exempt]]
+file = "crates/rhi/src/vk/render_image.rs"
+lines = [228, 229, 230, 231]
+reason = "The format-feature pre-check's refusal: every measuring lane's adapter reports SAMPLED_IMAGE and the attachment feature for both kinds' formats, and vkGetPhysicalDeviceFormatProperties is a void query no fault layer can mutate - the same unreachability the depthless-adapter exemptions record. The refusal exists for adapters the lanes do not have."
+
+[[exempt]]
+file = "crates/rhi/src/vk/pass.rs"
+lines = [622]
+reason = "The unreachable arm of the walk's entry lookup: entry_index either returns the index of the slot it just filled or asserted the ceiling, so the slot is occupied by construction. Stated as let-else-unreachable rather than a banned expect; no frame can drive it."
+
+[[exempt]]
+file = "crates/rhi/src/vk/offscreen.rs"
+lines = [383]
 reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs — so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
-lines = [494, 495, 496]
+lines = [498, 499, 500]
 reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless adapter. Same unreachability as the creation arm above: every measuring lane's adapter offers a depth format, and the query that decides it cannot be faulted. The error construction is driven by the display test in the error module; the branch condition's false side runs on every depth-carrying frame."
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [993, 994, 995]
+lines = [1050, 1051, 1052]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]
@@ -91,7 +111,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/swapchain.rs"
-lines = [1272]
+lines = [1344]
 reason = "The depthless-adapter side of chain population, where no per-slot depth images are built. Unreachable wherever a depth format exists, which is every measuring lane's adapter."
 
 [[exempt]]

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -54,14 +54,29 @@ display server, and the golden-image tests attest the bytes.
   billboard, and the mesh pairs (sources and compile record in
   [shaders/](shaders/README.md)).
 - `Binding` — one written descriptor set behind the device's one
-  canonical layout (a combined image sampler at binding 0): a texture,
-  the sampler that reads it, and shared ownership of both. Written
-  once at creation, never rewritten — the write-while-outstanding rule
-  a mutable set would need does not exist here. Items name bindings
-  per draw in slot order (slot *i* is set *i*); a mismatch against the
-  pipeline's declared count is a named refusal before any GPU call,
-  and a binding named by several items costs one retention slot, like
-  a mesh.
+  canonical layout (a combined image sampler at binding 0): a texture
+  or render image, the sampler that reads it, and shared ownership of
+  both. Written once at creation, never rewritten — the
+  write-while-outstanding rule a mutable set would need does not exist
+  here. Items name bindings per draw in slot order (slot *i* is set
+  *i*); a mismatch against the pipeline's declared count is a named
+  refusal before any GPU call, and a binding named by several items
+  costs one retention slot, like a mesh.
+- `RenderImage` — what one pass renders into and a later pass samples:
+  one physical image, kinded Color (`Rgba8Unorm`) or Depth (the
+  device's chosen format) at creation, with the format pre-checked
+  against the adapter's own sampled/attachment features. Its
+  **contents are frame-scoped** — every frame's first use starts
+  undefined, enforced by the same walk that plans its barriers — while
+  the image itself is retained by any frame that names it. A pass
+  renders into one via `Pass::render_to` (the image's kind decides the
+  pass shape, so a mismatch is unrepresentable), and items sample it
+  through an ordinary binding. The per-frame identity rules — write
+  before read, no feedback within a pass, no re-targeting after
+  sampling, Store before a later sample, at most 4 distinct images —
+  are named refusals before any GPU call. Depth-kinded images draw
+  through `PipelineDesc::depth_mesh` pipelines: no fragment stage, no
+  color attachment, `TargetFormat::DepthOnly`.
 - `Mesh` — vertex and index bytes written once at creation and read-only
   to the GPU thereafter, in one allocation. Indices are `&[u32]`, and
   **every index is checked against the vertex count at creation**: an
@@ -105,7 +120,8 @@ display server, and the golden-image tests attest the bytes.
 Every resource holds the device spine alive (`Rc`), so drop order is
 free for consumers, and each `Drop` destroys in exact reverse creation
 order. The targets and the pipeline quiesce the GPU first (best-effort
-wait-idle); `Texture`, `Sampler` and `Binding` deliberately do not.
+wait-idle); `Texture`, `Sampler`, `Binding` and `RenderImage`
+deliberately do not.
 The binding holds shared ownership of its texture and sampler, so
 their `Drop` cannot run while a set still points at them — and the
 binding itself is held by the retention table of any frame that named
@@ -127,12 +143,13 @@ presents frames where a display exists.
 ## Status
 
 Early-stage: the surface is exactly device + two target kinds + the
-pass vocabulary + two pipeline shapes + per-draw sampled bindings +
-geometry — per-vertex and per-instance input, vertex-stage push
-constants, indexed draws and target-owned depth exist; no MSAA, no
-image identity on attachments, one fixed descriptor-set layout (a
-combined image sampler at binding 0, repeated per declared slot) —
-grown only when a consumer demands it. Mesh memory is
+pass vocabulary + three pipeline shapes + per-draw sampled bindings +
+render images + geometry — per-vertex and per-instance input,
+vertex-stage push constants, indexed draws, target-owned depth, and
+render-to-texture with one shared barrier walk exist; no MSAA, no
+multiple render targets, one fixed descriptor-set layout (a combined
+image sampler at binding 0, repeated per declared slot) — grown only
+when a consumer demands it. Mesh memory is
 host-visible rather than device-local, which is a recorded decision with
 a written reopening trigger (a real-GPU frame-time measurement showing
 vertex fetch matters) and not an oversight. The `[package.metadata.renew]` table

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -2,10 +2,10 @@
 
 The engine's only doorway to the GPU: device bring-up, render targets,
 and the v0 draw path, over Vulkan. A frame is described, not scripted:
-the caller composes a `RenderDesc` — a list of `Pass`es, each with one
-color attachment, an optional depth attachment, and `Item`s (a pipeline,
-optionally the geometry it walks, optionally this frame's bytes) drawn in
-order — on its own stack, and
+the caller composes a `RenderDesc` — a list of `Pass`es, each rendering
+into the target's surface or a render image, with `Item`s (a pipeline,
+optionally the geometry it walks, optionally this frame's bytes,
+optionally the bindings it samples) drawn in order — on its own stack, and
 hands it to a target's `render`. Correctness is provable headless — the
 offscreen target renders and reads back pixels without a window or a
 display server, and the golden-image tests attest the bytes.
@@ -30,13 +30,17 @@ display server, and the golden-image tests attest the bytes.
   into, sized and owned by the target. An `Item` may name geometry
   (`Item::mesh`), which makes its draw indexed, and may carry push data
   (`Item::push_data`) for a pipeline that declares a range. Malformed
-  frames — no passes, a first-pass `Load`, a clear value of the wrong
-  kind, a depth-testing pipeline in a depthless pass, two items naming
-  one per-frame buffer, an item whose geometry and whose pipeline's
-  per-vertex input disagree, a mesh whose stride the pipeline does not
-  pack to, push data missing or mis-sized against the declared range —
-  are refused by named assertions before any GPU call.
-- `RenderPipeline` — two SPIR-V stages, optional per-vertex and
+  frames — no passes, no surface pass, a first-use `Load` on any
+  attachment identity, a clear value of the wrong kind, a
+  depth-testing pipeline in a depthless pass, two items carrying
+  different data for one per-frame buffer, an item whose geometry and
+  whose pipeline's per-vertex input disagree, a mesh whose stride the
+  pipeline does not pack to, push data or bindings missing or
+  mis-counted against the declaration, a frame that reads a render
+  image it never wrote or discarded — are refused by named assertions
+  before any GPU call.
+- `RenderPipeline` — two SPIR-V stages (or one, for the depth-only
+  shape), optional per-vertex and
   per-instance input, an optional vertex-stage push-constant range (at
   most 128 bytes, the guaranteed device minimum; items then carry
   exactly that many bytes per draw), optional sampled-binding slots
@@ -44,11 +48,14 @@ display server, and the golden-image tests attest the bytes.
   which is how N textures share one pipeline), and optional
   `DepthState` (test/write, compare fixed
   `GREATER_OR_EQUAL` — depth is reversed: nearer is larger, the far
-  plane is zero, depth clears to zero). Two pipeline shapes: `PipelineDesc::new` takes
+  plane is zero, depth clears to zero). Three pipeline shapes: `PipelineDesc::new` takes
   `Shaders`, whose stages write their own vertex list and carry the
   count they generate; `PipelineDesc::mesh` takes `MeshShaders` and a
   per-vertex layout, and has no count at all because the geometry
-  supplies it. `builtin` carries the embedded shader bundles — a colored
+  supplies it; `PipelineDesc::depth_mesh` takes one vertex stage over a
+  per-vertex layout — no fragment stage, no color attachment,
+  `TargetFormat::DepthOnly` — for pipelines that draw only into
+  depth-kinded render images. `builtin` carries the embedded shader bundles — a colored
   triangle, textured full-target quads over one and two sampled slots,
   instanced quads with and without per-instance depth, the particle
   billboard, and the mesh pairs (sources and compile record in

--- a/crates/rhi/src/error.rs
+++ b/crates/rhi/src/error.rs
@@ -82,10 +82,11 @@ pub enum TargetError {
     OutOfDeviceMemory {
         call: &'static str,
     },
-    /// A pass asked for depth on an adapter that offers no format in
-    /// the chain — the environment declined, not the caller, so this is
-    /// a result rather than an assertion. Depth-free rendering on the
-    /// same target keeps working.
+    /// A pass, or a depth render image's creation, asked for depth on
+    /// an adapter that offers no format in the chain — the environment
+    /// declined, not the caller, so this is a result rather than an
+    /// assertion. Depth-free rendering on the same target keeps
+    /// working.
     DepthUnsupported {
         /// The refused format chain, for the diagnostic.
         chain: &'static str,

--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -77,11 +77,15 @@ pub use vk::buffer::{Buffer, BufferUsage};
 pub use vk::device::{Device, HostAllocationStats, ValidationReport};
 pub use vk::mesh::{Mesh, MeshDesc};
 pub use vk::offscreen::OffscreenTarget;
-pub use vk::pass::{Attachment, Bindings, ClearValue, Item, LoadOp, Pass, RenderDesc, StoreOp};
+pub use vk::pass::{
+    Attachment, Bindings, ClearValue, Item, LoadOp, MAX_FRAME_RENDER_IMAGES, Pass, PassTarget,
+    RenderDesc, StoreOp,
+};
 pub use vk::pipeline::{
     AddressMode, Blend, DepthState, Filter, FrameData, MAX_PUSH_CONSTANT_BYTES, MeshShaders,
     PipelineDesc, RenderPipeline, Sampler, SamplerDesc, Shaders, TargetFormat, VertexAttribute,
 };
+pub use vk::render_image::{RenderImage, RenderImageDesc, RenderImageKind};
 #[cfg(feature = "present")]
 pub use vk::swapchain::{PresentOutcome, WindowTarget};
 pub use vk::texture::{Texture, TextureDesc};

--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -1,7 +1,7 @@
 //! The engine's only doorway to the GPU: device bring-up, render
 //! targets, and the v0 draw path — multi-pass frames composed by the
-//! caller, instanced draws, sampled textures, target-owned depth —
-//! over Vulkan.
+//! caller, instanced draws, sampled textures, target-owned depth, and
+//! render-to-texture through kinded render images — over Vulkan.
 //!
 //! # Contract
 //!

--- a/crates/rhi/src/vk.rs
+++ b/crates/rhi/src/vk.rs
@@ -21,6 +21,7 @@ pub mod mesh;
 pub mod offscreen;
 pub mod pass;
 pub mod pipeline;
+pub mod render_image;
 #[cfg(feature = "present")]
 pub mod swapchain;
 pub mod texture;

--- a/crates/rhi/src/vk/binding.rs
+++ b/crates/rhi/src/vk/binding.rs
@@ -16,6 +16,7 @@ use ash::vk;
 use crate::error::PipelineError;
 use crate::vk::device::{Device, DeviceShared};
 use crate::vk::pipeline::{Sampler, SamplerInner, creation};
+use crate::vk::render_image::{RenderImage, RenderImageInner};
 use crate::vk::texture::{Texture, TextureInner};
 
 /// How many sampled-binding slots one pipeline may declare, and so the
@@ -32,14 +33,21 @@ pub const MAX_SAMPLED_BINDINGS: usize = 4;
 
 /// What a binding reads.
 ///
-/// An input enum, so `#[non_exhaustive]`: the render-image arm arrives
-/// with render-to-texture and must not break downstream matchers when
-/// it does.
+/// An input enum, so `#[non_exhaustive]`: a later source class must
+/// not break downstream matchers when it arrives.
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum BindingSource<'a> {
     /// A host-filled immutable texture.
     Texture(&'a Texture),
+    /// A render image some pass in each frame renders into.
+    ///
+    /// The set is still written once, here at creation — what changes
+    /// per frame is the image's *contents*, which no set write ever
+    /// carries. The frame contract is what refuses sampling an image
+    /// this frame has not rendered, so a binding over a render image
+    /// is only as fresh as the frame that draws with it.
+    Image(&'a RenderImage),
 }
 
 /// Everything a binding needs: what it reads, and how.
@@ -67,6 +75,15 @@ impl<'a> BindingDesc<'a> {
     }
 }
 
+/// Shared ownership of whichever source the set points at — the hold
+/// is what matters, not the kind, so release sites never match on it.
+pub(crate) enum SourceHold {
+    /// The handles are never read through — the hold keeps the sampled
+    /// image alive across a submit; the walk reads only which image.
+    Texture(#[allow(dead_code, reason = "held for its Drop alone")] Rc<TextureInner>),
+    Image(Rc<RenderImageInner>),
+}
+
 /// The binding's owning half: the pool, the set allocated from it, and
 /// shared ownership of everything the set points at.
 ///
@@ -80,11 +97,24 @@ pub(crate) struct BindingInner {
     pub(crate) shared: Rc<DeviceShared>,
     pool: vk::DescriptorPool,
     pub(crate) set: vk::DescriptorSet,
-    /// Never read through — held so the view the set points at outlives
-    /// the set, without the caller sequencing drops.
-    _source: Rc<TextureInner>,
+    /// Held so the view the set points at outlives the set, without
+    /// the caller sequencing drops; read only to tell the frame walk
+    /// which render image, if any, this set samples.
+    source: SourceHold,
     /// As above, for the sampler handle.
     _sampler: Rc<SamplerInner>,
+}
+
+impl BindingInner {
+    /// The render image this binding samples, if its source is one --
+    /// how the frame walk learns which images a pass reads without
+    /// matching on the hold anywhere else.
+    pub(crate) fn sampled_render_image(&self) -> Option<&Rc<RenderImageInner>> {
+        match &self.source {
+            SourceHold::Image(inner) => Some(inner),
+            SourceHold::Texture(_) => None,
+        }
+    }
 }
 
 impl Drop for BindingInner {
@@ -139,15 +169,30 @@ impl Device {
     /// error.
     pub fn create_binding(&self, desc: &BindingDesc<'_>) -> Result<Binding, PipelineError> {
         let shared = &self.shared;
-        let BindingSource::Texture(texture) = desc.source;
-        // Handles from another device would be written into this
-        // device's set and read by it — undefined behaviour that no
-        // return value can report, so it asserts, as the targets do for
-        // a pipeline built on a foreign device.
-        debug_assert!(
-            Rc::ptr_eq(shared, texture.shared()),
-            "texture and binding come from different devices"
-        );
+        // One (view, hold) pair per source class; everything after this
+        // is class-blind. Handles from another device would be written
+        // into this device's set and read by it — undefined behaviour
+        // that no return value can report, so each arm asserts, as the
+        // targets do for a pipeline built on a foreign device.
+        let (view, source_hold) = match desc.source {
+            BindingSource::Texture(texture) => {
+                debug_assert!(
+                    Rc::ptr_eq(shared, texture.shared()),
+                    "texture and binding come from different devices"
+                );
+                (
+                    texture.inner.view,
+                    SourceHold::Texture(Rc::clone(&texture.inner)),
+                )
+            }
+            BindingSource::Image(image) => {
+                debug_assert!(
+                    Rc::ptr_eq(shared, &image.inner.shared),
+                    "render image and binding come from different devices"
+                );
+                (image.inner.view, SourceHold::Image(Rc::clone(&image.inner)))
+            }
+        };
         debug_assert!(
             Rc::ptr_eq(shared, &desc.sampler.inner.shared),
             "sampler and binding come from different devices"
@@ -198,10 +243,11 @@ impl Device {
 
         let image_info = [vk::DescriptorImageInfo::default()
             .sampler(desc.sampler.inner.sampler)
-            .image_view(texture.inner.view)
-            // The upload left the image in this layout and nothing
-            // changes it afterwards, immutability being the texture
-            // contract.
+            .image_view(view)
+            // The layout every sampled read sees. A texture's upload
+            // left it here and immutability keeps it; a render image is
+            // *brought* here by the frame walk's sampling transition
+            // before any draw recorded against this set runs.
             .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)];
         let writes = [vk::WriteDescriptorSet::default()
             .dst_set(set)
@@ -219,7 +265,7 @@ impl Device {
                 shared: Rc::clone(shared),
                 pool,
                 set,
-                _source: Rc::clone(&texture.inner),
+                source: source_hold,
                 _sampler: Rc::clone(&desc.sampler.inner),
             }),
         })

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -12,7 +12,7 @@ use crate::vk::depth::{self, DepthResources};
 use crate::vk::device::{Device, DeviceShared, FENCE_TIMEOUT_NS};
 use crate::vk::pass::{self, MAX_RETAINED_RESOURCES, RenderDesc, Retained};
 use crate::vk::pipeline::{INSTANCE_BINDING, TargetFormat, VERTEX_BINDING};
-use crate::vk::transition::{self, ImageUse};
+use crate::vk::transition;
 
 /// Bytes per pixel of the fixed RGBA8 format.
 pub(crate) const BPP: u64 = 4;
@@ -223,7 +223,9 @@ fn build(
 ) -> Result<OffscreenTarget, TargetError> {
     let image_info = vk::ImageCreateInfo::default()
         .image_type(vk::ImageType::TYPE_2D)
-        .format(TargetFormat::Rgba8Unorm.to_vk())
+        // TargetFormat::Rgba8Unorm's one Vulkan spelling — the
+        // offscreen target's format is a static fact of this module.
+        .format(vk::Format::R8G8B8A8_UNORM)
         .extent(vk::Extent3D {
             width: extent.width,
             height: extent.height,
@@ -280,7 +282,9 @@ fn build(
     let view_info = vk::ImageViewCreateInfo::default()
         .image(image)
         .view_type(vk::ImageViewType::TYPE_2D)
-        .format(TargetFormat::Rgba8Unorm.to_vk())
+        // TargetFormat::Rgba8Unorm's one Vulkan spelling — the
+        // offscreen target's format is a static fact of this module.
+        .format(vk::Format::R8G8B8A8_UNORM)
         .subresource_range(color_range());
     // SAFETY: image live and bound.
     let view = unsafe {
@@ -496,13 +500,17 @@ impl OffscreenTarget {
             });
         }
         for pass in desc.passes {
+            let surface_pass = matches!(pass.target, pass::PassTarget::Surface);
             for item in pass.items {
                 debug_assert!(
                     Rc::ptr_eq(&self.shared, &item.pipeline.shared),
                     "pipeline and target come from different devices"
                 );
+                // Image passes matched their format against their image
+                // in the contract; the surface's own format is this
+                // target's to assert.
                 debug_assert!(
-                    item.pipeline.format == TargetFormat::Rgba8Unorm,
+                    !surface_pass || item.pipeline.format == TargetFormat::Rgba8Unorm,
                     "pipeline targets {:?}, offscreen is Rgba8Unorm",
                     item.pipeline.format
                 );
@@ -518,6 +526,16 @@ impl OffscreenTarget {
         }
         let mut retained_count = 0usize;
         for pass in desc.passes {
+            // A pass-target image is retained by the pass itself: the
+            // recorded attachment references it whether or not any item
+            // samples it, so the pass walk is where its hold begins.
+            if let pass::PassTarget::Image(image, _) = &pass.target {
+                let resource = Retained::Image(Rc::clone(&image.inner));
+                if !pass::already_retained(&resource, &self.retained[..retained_count]) {
+                    self.retained[retained_count] = Some(resource);
+                    retained_count += 1;
+                }
+            }
             for item in pass.items {
                 if let Some(mesh) = item.mesh {
                     debug_assert!(
@@ -607,65 +625,79 @@ impl OffscreenTarget {
                 )
                 .map_err(|code| creation("vkBeginCommandBuffer", code))?;
 
-            let area = vk::Rect2D {
-                offset: vk::Offset2D { x: 0, y: 0 },
-                extent: vk::Extent2D {
-                    width: self.extent.width,
-                    height: self.extent.height,
-                },
-            };
             // The walk: for each pass, its boundary barriers from the
-            // pure core, then its attachments, then its items in slice
-            // order. Depth transitions from UNDEFINED once per frame —
-            // frame-local layout state, nothing carried across frames.
-            let mut depth_in_use = false;
+            // shared frame walk (the same state machine the contract
+            // already proved this frame against), then its attachments,
+            // then its items in slice order — every one of them
+            // following the pass's target.
+            let mut walk = pass::FrameWalk::new();
             for (index, pass) in desc.passes.iter().enumerate() {
-                let color_masks = if index == 0 {
-                    transition::pass_boundary(
-                        ImageUse::ColorAttachmentFirstUse,
-                        ImageUse::ColorAttachment,
-                    )
-                } else {
-                    transition::pass_boundary(ImageUse::ColorAttachment, ImageUse::ColorAttachment)
-                };
-                let mut barriers = [vk::ImageMemoryBarrier2::default(); 2];
-                let mut barrier_count = 1;
-                barriers[0] = vk::ImageMemoryBarrier2::default()
-                    .src_stage_mask(color_masks.src_stage)
-                    .src_access_mask(color_masks.src_access)
-                    .dst_stage_mask(color_masks.dst_stage)
-                    .dst_access_mask(color_masks.dst_access)
-                    .old_layout(color_masks.old_layout)
-                    .new_layout(color_masks.new_layout)
-                    .image(self.image)
-                    .subresource_range(color_range());
-                // Total by the depth-availability check at the top: a
-                // depth-carrying frame on a depthless target already
-                // returned `DepthUnsupported` before the walk began.
-                let depth_pass = pass.depth.as_ref().zip(self.depth.as_ref());
-                if let Some((_, depth_resources)) = depth_pass {
-                    let depth_masks = if depth_in_use {
-                        transition::pass_boundary(
-                            ImageUse::DepthAttachment,
-                            ImageUse::DepthAttachment,
-                        )
-                    } else {
-                        transition::pass_boundary(
-                            ImageUse::DepthAttachmentFirstUse,
-                            ImageUse::DepthAttachment,
-                        )
+                let uses = walk.advance_target(index, pass);
+                let mut barriers = [vk::ImageMemoryBarrier2::default(); pass::MAX_PASS_BARRIERS];
+                let mut barrier_count = 0usize;
+                if let Some((from, to)) = uses.color {
+                    let masks = transition::pass_boundary(from, to);
+                    let image = match &pass.target {
+                        pass::PassTarget::Surface => self.image,
+                        pass::PassTarget::Image(image, _) => image.inner.image,
                     };
-                    depth_in_use = true;
-                    barriers[1] = vk::ImageMemoryBarrier2::default()
-                        .src_stage_mask(depth_masks.src_stage)
-                        .src_access_mask(depth_masks.src_access)
-                        .dst_stage_mask(depth_masks.dst_stage)
-                        .dst_access_mask(depth_masks.dst_access)
-                        .old_layout(depth_masks.old_layout)
-                        .new_layout(depth_masks.new_layout)
-                        .image(depth_resources.image)
-                        .subresource_range(depth::barrier_range(depth_resources.format));
-                    barrier_count = 2;
+                    barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
+                        .src_stage_mask(masks.src_stage)
+                        .src_access_mask(masks.src_access)
+                        .dst_stage_mask(masks.dst_stage)
+                        .dst_access_mask(masks.dst_access)
+                        .old_layout(masks.old_layout)
+                        .new_layout(masks.new_layout)
+                        .image(image)
+                        .subresource_range(color_range());
+                    barrier_count += 1;
+                }
+                if let Some((from, to)) = uses.depth {
+                    let masks = transition::pass_boundary(from, to);
+                    // Total by the depth-availability check at the top
+                    // for surface passes; an image pass carries its own
+                    // depth image in its target.
+                    let (image, format) = match &pass.target {
+                        pass::PassTarget::Surface => match self.depth.as_ref() {
+                            Some(depth_resources) => {
+                                (depth_resources.image, depth_resources.format)
+                            }
+                            None => unreachable!(
+                                "a depth-carrying surface pass on a depthless target was \
+                                 refused before recording began"
+                            ),
+                        },
+                        pass::PassTarget::Image(image, _) => {
+                            (image.inner.image, image.inner.format)
+                        }
+                    };
+                    barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
+                        .src_stage_mask(masks.src_stage)
+                        .src_access_mask(masks.src_access)
+                        .dst_stage_mask(masks.dst_stage)
+                        .dst_access_mask(masks.dst_access)
+                        .old_layout(masks.old_layout)
+                        .new_layout(masks.new_layout)
+                        .image(image)
+                        .subresource_range(depth::barrier_range(format));
+                    barrier_count += 1;
+                }
+                // The sampling transitions this pass forces: each
+                // rendered-then-read image crosses to SHADER_READ_ONLY
+                // at the first reading pass's boundary, once.
+                let (samples, sample_count) = walk.advance_sampling(index, pass);
+                for sample in samples.iter().take(sample_count).flatten() {
+                    let masks = transition::pass_boundary(sample.uses.0, sample.uses.1);
+                    barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
+                        .src_stage_mask(masks.src_stage)
+                        .src_access_mask(masks.src_access)
+                        .dst_stage_mask(masks.dst_stage)
+                        .dst_access_mask(masks.dst_access)
+                        .old_layout(masks.old_layout)
+                        .new_layout(masks.new_layout)
+                        .image(sample.image)
+                        .subresource_range(sample.range);
+                    barrier_count += 1;
                 }
                 device.cmd_pipeline_barrier2(
                     self.cmd,
@@ -673,26 +705,69 @@ impl OffscreenTarget {
                         .image_memory_barriers(&barriers[..barrier_count]),
                 );
 
-                let color = &pass.color[0];
-                let color_attachment = vk::RenderingAttachmentInfo::default()
-                    .image_view(self.view)
-                    .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                    .load_op(color.load.to_vk())
-                    .store_op(color.store.to_vk())
-                    .clear_value(pass::vk_clear_color(color));
-                let color_attachments = [color_attachment];
-                let depth_attachment = depth_pass.map(|(attachment, depth_resources)| {
-                    vk::RenderingAttachmentInfo::default()
-                        .image_view(depth_resources.view)
-                        .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                        .load_op(attachment.load.to_vk())
-                        .store_op(attachment.store.to_vk())
-                        .clear_value(pass::vk_clear_depth(attachment))
-                });
+                // Attachments and geometry follow the target: a surface
+                // pass renders into this target's own images at its
+                // extent; an image pass renders into the image at the
+                // image's.
+                let mut color_attachments: [vk::RenderingAttachmentInfo<'_>; 1] =
+                    [vk::RenderingAttachmentInfo::default()];
+                let mut color_attachment_count = 0usize;
+                let mut depth_attachment = None;
+                let extent = match &pass.target {
+                    pass::PassTarget::Surface => {
+                        let color = &pass.color[0];
+                        color_attachments[0] = vk::RenderingAttachmentInfo::default()
+                            .image_view(self.view)
+                            .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                            .load_op(color.load.to_vk())
+                            .store_op(color.store.to_vk())
+                            .clear_value(pass::vk_clear_color(color));
+                        color_attachment_count = 1;
+                        depth_attachment = pass.depth.as_ref().zip(self.depth.as_ref()).map(
+                            |(attachment, depth_resources)| {
+                                vk::RenderingAttachmentInfo::default()
+                                    .image_view(depth_resources.view)
+                                    .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+                                    .load_op(attachment.load.to_vk())
+                                    .store_op(attachment.store.to_vk())
+                                    .clear_value(pass::vk_clear_depth(attachment))
+                            },
+                        );
+                        self.extent
+                    }
+                    pass::PassTarget::Image(image, attachment) => {
+                        if image.kind() == crate::RenderImageKind::Depth {
+                            depth_attachment = Some(
+                                vk::RenderingAttachmentInfo::default()
+                                    .image_view(image.inner.view)
+                                    .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+                                    .load_op(attachment.load.to_vk())
+                                    .store_op(attachment.store.to_vk())
+                                    .clear_value(pass::vk_clear_depth(attachment)),
+                            );
+                        } else {
+                            color_attachments[0] = vk::RenderingAttachmentInfo::default()
+                                .image_view(image.inner.view)
+                                .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                                .load_op(attachment.load.to_vk())
+                                .store_op(attachment.store.to_vk())
+                                .clear_value(pass::vk_clear_color(attachment));
+                            color_attachment_count = 1;
+                        }
+                        image.extent()
+                    }
+                };
+                let area = vk::Rect2D {
+                    offset: vk::Offset2D { x: 0, y: 0 },
+                    extent: vk::Extent2D {
+                        width: extent.width,
+                        height: extent.height,
+                    },
+                };
                 let mut rendering_info = vk::RenderingInfo::default()
                     .render_area(area)
                     .layer_count(1)
-                    .color_attachments(&color_attachments);
+                    .color_attachments(&color_attachments[..color_attachment_count]);
                 if let Some(depth_attachment) = &depth_attachment {
                     rendering_info = rendering_info.depth_attachment(depth_attachment);
                 }
@@ -704,8 +779,8 @@ impl OffscreenTarget {
                     let viewport = vk::Viewport {
                         x: 0.0,
                         y: 0.0,
-                        width: self.extent.width as f32,
-                        height: self.extent.height as f32,
+                        width: extent.width as f32,
+                        height: extent.height as f32,
                         min_depth: 0.0,
                         max_depth: 1.0,
                     };

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -452,23 +452,34 @@ impl OffscreenTarget {
     /// # Panics
     ///
     /// The frame-shape contract is asserted before any GPU call —
-    /// among its refusals: a frame needs at least one pass; a pass
-    /// carries exactly one color attachment; `LoadOp::Load` is refused
-    /// on an attachment's first use in the frame; clear values must
-    /// match their attachment's kind and a depth clear its documented
-    /// range; an item's pipeline depth state must match its pass; one
-    /// buffer feeds at most one item per frame; an item names geometry
-    /// exactly when its pipeline declares per-vertex input, and a mesh's
-    /// vertex stride equals the stride that pipeline's layout packs to;
-    /// an item names bindings exactly when its pipeline declares
-    /// sampled slots, and exactly as many as it declares; and a frame
-    /// carries at most the retention table's width of distinct
-    /// resources — per-frame buffers, meshes and bindings together,
-    /// the repeatable classes counting once however many items name
-    /// them. Frame data longer than its buffer's per-frame capacity
-    /// also panics through a retained assertion: the length bounds a
-    /// copy into mapped device memory, which makes it a memory-safety
-    /// boundary rather than a contract nicety.
+    /// among its refusals: a frame needs at least one pass, and at
+    /// least one surface pass; a surface pass carries exactly one
+    /// color attachment, an image pass none (its one attachment rides
+    /// its target); `LoadOp::Load` is refused on each identity's first
+    /// use in the frame, and on a render image whose last targeting
+    /// pass discarded; clear values must match their attachment's kind
+    /// and a depth clear its documented range; an item's pipeline
+    /// depth state must match its pass, its format an image pass's
+    /// kind, and a depth-only pipeline draws only into depth images;
+    /// one buffer carries one `FrameData` per frame
+    /// (pointer-identical data may repeat across items; differing data
+    /// is refused); an item names geometry exactly when its pipeline
+    /// declares per-vertex input, and a mesh's vertex stride equals
+    /// the stride that pipeline's layout packs to; an item names
+    /// bindings exactly when its pipeline declares sampled slots, and
+    /// exactly as many as it declares; the per-image walk is one-way —
+    /// a frame writes an image before reading it, never in the same
+    /// pass, never re-targeting after a read, storing whatever a later
+    /// pass loads or samples — over at most
+    /// [`MAX_FRAME_RENDER_IMAGES`](crate::MAX_FRAME_RENDER_IMAGES)
+    /// distinct images; and a frame carries at most the retention
+    /// table's width of distinct resources — per-frame buffers,
+    /// meshes, bindings and pass-target images together, the
+    /// repeatable classes counting once however many mentions. Frame
+    /// data longer than its buffer's per-frame capacity also panics
+    /// through a retained assertion: the length bounds a copy into
+    /// mapped device memory, which makes it a memory-safety boundary
+    /// rather than a contract nicety.
     ///
     /// # Errors
     ///
@@ -530,6 +541,10 @@ impl OffscreenTarget {
             // recorded attachment references it whether or not any item
             // samples it, so the pass walk is where its hold begins.
             if let pass::PassTarget::Image(image, _) = &pass.target {
+                debug_assert!(
+                    Rc::ptr_eq(&image.inner.shared, &self.shared),
+                    "render image and target come from different devices"
+                );
                 let resource = Retained::Image(Rc::clone(&image.inner));
                 if !pass::already_retained(&resource, &self.retained[..retained_count]) {
                     self.retained[retained_count] = Some(resource);

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -134,7 +134,9 @@ impl<'a> Pass<'a> {
         }
     }
 
-    /// Attach the target's depth image to this pass with `depth`'s ops.
+    /// Attach the target's depth image to this pass with `depth`'s
+    /// ops. Surface passes only — an image pass carries its one
+    /// attachment in its target, and the contract refuses the mix.
     #[must_use]
     pub fn depth(mut self, depth: Attachment) -> Self {
         self.depth = Some(depth);
@@ -169,9 +171,11 @@ impl Attachment {
 pub enum LoadOp {
     /// The attachment starts as `ClearValue`.
     Clear(ClearValue),
-    /// The attachment keeps the previous pass's contents. Refused on a
-    /// frame's first pass — every frame's first use of each attachment
-    /// starts from undefined contents.
+    /// The attachment keeps the previous pass's contents. Refused on
+    /// each identity's first use in the frame — the surface, the
+    /// target's depth image, and every render image all start a frame
+    /// from undefined contents — and on a render image whose last
+    /// targeting pass discarded.
     Load,
 }
 
@@ -213,9 +217,10 @@ pub struct Item<'a> {
     /// without geometry reads an unbound binding and geometry handed to
     /// a generative pipeline is silently ignored.
     ///
-    /// **Unlike per-frame bytes, a mesh may be named by any number of
-    /// items** — there is no copy to race, so the one-buffer-one-item
-    /// rule below does not reach it.
+    /// **A mesh may be named by any number of items** — there is no
+    /// copy to race at all, unlike per-frame bytes, whose repeats must
+    /// be pointer-identical under the one-buffer-one-`FrameData` rule
+    /// below.
     pub mesh: Option<&'a Mesh>,
     /// `FrameData` contained, not forked; room to grow (a
     /// first-instance or vertex-offset field) without touching existing
@@ -240,8 +245,8 @@ pub struct Item<'a> {
     /// is what lets N textures share one pipeline.
     ///
     /// **Like a mesh, a binding may be named by any number of items** —
-    /// nothing copies into it, so the one-buffer-one-item rule does not
-    /// reach it; each distinct binding costs one retention slot.
+    /// nothing copies into it, so the buffer rule does not reach it;
+    /// each distinct binding costs one retention slot.
     pub bindings: Option<Bindings<'a>>,
 }
 
@@ -506,6 +511,10 @@ struct ImageEntry {
     kind: RenderImageKind,
     targeted: bool,
     sampled: bool,
+    /// Whether the image's LAST targeting pass discarded its contents
+    /// — what decides both whether a later `Load` reads anything and
+    /// whether a later sample does.
+    discarded: bool,
 }
 
 /// What one pass does to its target identities, as [`ImageUse`] pairs
@@ -566,6 +575,7 @@ impl FrameWalk {
             kind,
             targeted: false,
             sampled: false,
+            discarded: false,
         });
         occupied
     }
@@ -623,7 +633,7 @@ impl FrameWalk {
                 };
                 assert!(
                     !entry.sampled,
-                    "pass {index}: this frame already sampled this render image -- the \
+                    "pass {index}: this frame already sampled this render image — the \
                      per-image walk is one-way (target, then sample), so every pass that \
                      writes an image must precede the first pass that reads it"
                 );
@@ -631,10 +641,19 @@ impl FrameWalk {
                 assert!(
                     !first_use || !matches!(attachment.load, LoadOp::Load),
                     "pass {index}: LoadOp::Load on a render image's first use this frame \
-                     loads undefined contents -- render-image contents are frame-scoped and \
+                     loads undefined contents — render-image contents are frame-scoped and \
                      start undefined every frame"
                 );
+                // Loading what the last targeting pass threw away is the
+                // same undefined read one pass later.
+                assert!(
+                    first_use || !matches!(attachment.load, LoadOp::Load) || !entry.discarded,
+                    "pass {index}: LoadOp::Load on a render image whose last targeting \
+                     pass discarded its contents loads undefined pixels — store what a \
+                     later pass loads"
+                );
                 entry.targeted = true;
+                entry.discarded = matches!(attachment.store, StoreOp::Discard);
                 match kind {
                     RenderImageKind::Color => TargetUses {
                         color: Some(if first_use {
@@ -704,12 +723,18 @@ impl FrameWalk {
                 assert!(
                     entry.is_some(),
                     "pass {index}: an item samples a render image no pass in this frame \
-                     has rendered -- render-image contents are frame-scoped, so a frame \
+                     has rendered — render-image contents are frame-scoped, so a frame \
                      that reads one must write it first"
                 );
                 let Some(entry) = entry else {
                     unreachable!("asserted just above")
                 };
+                assert!(
+                    !entry.discarded,
+                    "pass {index}: an item samples a render image whose last targeting \
+                     pass discarded its contents — a targeting pass whose image is read \
+                     later must Store"
+                );
                 if entry.sampled {
                     continue;
                 }
@@ -766,6 +791,20 @@ pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
         // with the record paths.
         let _ = walk.advance_target(index, pass);
         for item in pass.items {
+            // A depth-only pipeline draws only into depth images —
+            // anywhere else its zero-attachment shape disagrees with
+            // the pass's rendering instance, which is invalid usage the
+            // driver may answer with anything. Retained, unlike the
+            // surface format match: the consequence is not a channel
+            // swap but an undefined draw.
+            let depth_image_pass = matches!(
+                &pass.target,
+                PassTarget::Image(image, _) if image.kind() == RenderImageKind::Depth
+            );
+            assert!(
+                depth_image_pass || item.pipeline.format != crate::TargetFormat::DepthOnly,
+                "pass {index}: a depth-only pipeline draws only into depth-kinded render                  images — it has no fragment stage and no color attachment for any other                  pass shape to bind"
+            );
             // Image passes carry their format in their kind, so the
             // match is contract-checked here; a surface pass's format
             // is the target's own, asserted where the target knows it.
@@ -850,7 +889,6 @@ pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
          contents, and a frame that never touches the surface defines nothing to present \
          or read back"
     );
-    check_store_before_sample(desc);
     check_retention_bound(desc);
 }
 
@@ -934,45 +972,6 @@ pub(crate) fn pass_has_depth(pass: &Pass<'_>) -> bool {
     }
 }
 
-/// Whether any of `pass`'s items sample the render image behind `key`.
-fn pass_samples(pass: &Pass<'_>, key: *const u8) -> bool {
-    pass.items.iter().any(|item| {
-        item.bindings.as_ref().is_some_and(|bindings| {
-            bindings.iter().any(|binding| {
-                binding
-                    .inner
-                    .sampled_render_image()
-                    .is_some_and(|inner| Rc::as_ptr(inner).cast::<u8>() == key)
-            })
-        })
-    })
-}
-
-/// A targeting pass whose image a later pass samples must store: a
-/// discarded attachment leaves the sampled contents undefined, which
-/// renders as plausible garbage rather than failing. A second scan
-/// rather than walk state, because the refusal needs to name the
-/// writing pass and the reading pass together.
-fn check_store_before_sample(desc: &RenderDesc<'_>) {
-    for (index, pass) in desc.passes.iter().enumerate() {
-        let PassTarget::Image(image, attachment) = &pass.target else {
-            continue;
-        };
-        if matches!(attachment.store, StoreOp::Store) {
-            continue;
-        }
-        let key = Rc::as_ptr(&image.inner).cast::<u8>();
-        for (later_index, later) in desc.passes.iter().enumerate().skip(index + 1) {
-            assert!(
-                !pass_samples(later, key),
-                "pass {index} discards its render image's contents, but pass \
-                 {later_index} samples them — a targeting pass whose image is sampled \
-                 later must Store"
-            );
-        }
-    }
-}
-
 /// The push-data rules again, for sampled slots: a declared slot never
 /// filled samples an unbound set, and bindings on a slotless pipeline
 /// bind sets its layout does not declare — invalid usage either way,
@@ -1034,7 +1033,7 @@ fn check_retention_bound(desc: &RenderDesc<'_>) {
             assert!(
                 *count < MAX_RETAINED_RESOURCES,
                 "a frame carries at most {MAX_RETAINED_RESOURCES} distinct resources \
-                 (per-frame buffers, meshes and bindings together)"
+                 (per-frame buffers, meshes, bindings and pass-target images together)"
             );
             seen[*count] = Some(key);
             *count += 1;
@@ -1098,11 +1097,12 @@ fn count_matters(records: &[Option<BufferRecord>; MAX_RETAINED_RESOURCES]) -> us
 
 /// How many distinct resources one frame may keep alive, per target slot
 /// — the hard bound that keeps retention tables fixed-width and the frame
-/// path allocation-free. Per-frame buffers, meshes and bindings share it,
-/// because they share one table. The seventeenth distinct resource is
-/// refused by name in [`check_frame_contract`]. Sixteen, doubled from
-/// eight when bindings joined the table: every draw's sampled slots now
-/// spend from the same budget its geometry does.
+/// path allocation-free. Per-frame buffers, meshes, bindings and
+/// pass-target render images share it, because they share one table. The
+/// seventeenth distinct resource is refused by name in
+/// [`check_frame_contract`]. Sixteen, doubled from eight when bindings
+/// joined the table: every draw's sampled slots now spend from the same
+/// budget its geometry does.
 pub(crate) const MAX_RETAINED_RESOURCES: usize = 16;
 
 impl LoadOp {

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -12,6 +12,17 @@ use crate::config::Color;
 use crate::vk::binding::{Binding, MAX_SAMPLED_BINDINGS};
 use crate::vk::mesh::Mesh;
 use crate::vk::pipeline::{FrameData, RenderPipeline};
+use crate::vk::render_image::{RenderImage, RenderImageKind};
+use crate::vk::transition::ImageUse;
+
+use std::rc::Rc;
+
+/// How many distinct render images one frame may touch — as targets,
+/// as sampled sources, or both. A fixed ceiling so the contract's walk
+/// table and the record paths' barrier arrays are stack-sized and the
+/// frame path allocates nothing; the fifth distinct image is refused
+/// by name before any GPU call.
+pub const MAX_FRAME_RENDER_IMAGES: usize = 4;
 
 /// Everything one frame needs, for either target: the passes, in order.
 ///
@@ -49,27 +60,76 @@ impl fmt::Debug for RenderDesc<'_> {
     }
 }
 
+/// What a pass renders into: the target's own surface, or a render
+/// image whose kind decides the pass's shape.
+///
+/// An input enum, so `#[non_exhaustive]`: a later target class must
+/// not break downstream matchers.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub enum PassTarget<'a> {
+    /// The target's own surface — what every pass named implicitly
+    /// before targets had identity, and the default [`Pass::new`]
+    /// still writes.
+    Surface,
+    /// A render image, with the ops for its one attachment.
+    ///
+    /// The ops ride the variant rather than the pass's slices because
+    /// an image pass has exactly one attachment and its kind is the
+    /// image's — a color list or a depth option would be two more ways
+    /// to state a shape the image already states.
+    Image(&'a RenderImage, Attachment),
+}
+
 /// One pass: what it renders into, and the draws it records.
 #[derive(Clone, Copy)]
 #[non_exhaustive]
 pub struct Pass<'a> {
-    /// v0: exactly one, naming the target's own surface implicitly; a
-    /// retained assert refuses zero or more-than-one until a later
-    /// change adds image identity.
+    /// Surface passes: exactly one, naming the target's own surface.
+    /// Image passes: empty — the image's ops ride [`Pass::target`].
+    /// Both shapes are refused by name when violated.
     pub color: &'a [Attachment],
-    /// The target's own depth image, when Some.
+    /// The target's own depth image, when Some. Surface passes only:
+    /// an image pass carries its one attachment in its target, and a
+    /// depth-kinded image *is* the depth attachment.
     pub depth: Option<Attachment>,
+    /// What this pass renders into.
+    pub target: PassTarget<'a>,
     /// Draws, executed in slice order.
     pub items: &'a [Item<'a>],
 }
 
 impl<'a> Pass<'a> {
-    /// A pass over `color`, drawing `items` in order, with no depth.
+    /// A surface pass over `color`, drawing `items` in order, with no
+    /// depth.
     #[must_use]
     pub fn new(color: &'a [Attachment], items: &'a [Item<'a>]) -> Self {
         Self {
             color,
             depth: None,
+            target: PassTarget::Surface,
+            items,
+        }
+    }
+
+    /// A pass rendering into `image` with `attachment`'s ops, drawing
+    /// `items` in order.
+    ///
+    /// The image's kind decides the pass shape — a color image is the
+    /// pass's one color attachment, a depth image its one depth
+    /// attachment with no color at all — so a kind/shape mismatch is
+    /// unrepresentable rather than refused. Render area, viewport and
+    /// scissor come from the image's extent.
+    #[must_use]
+    pub fn render_to(
+        image: &'a RenderImage,
+        attachment: Attachment,
+        items: &'a [Item<'a>],
+    ) -> Self {
+        Self {
+            color: &[],
+            depth: None,
+            target: PassTarget::Image(image, attachment),
             items,
         }
     }
@@ -336,24 +396,35 @@ pub(crate) enum Retained {
     /// mesh is — nothing copies into a binding, so items may share one
     /// freely.
     Binding(std::rc::Rc<crate::vk::binding::BindingInner>),
+    /// A render image some pass targets. Retained by the pass walk
+    /// rather than by any item — the recorded attachment references it
+    /// whether or not anything samples it. Read only to recognise an
+    /// image already retained this frame; a sampled-only image rides
+    /// its binding's hold instead.
+    Image(std::rc::Rc<crate::vk::render_image::RenderImageInner>),
 }
 
-/// Whether `resource` is already held in `held` — true only for the
-/// repeatable classes (meshes and bindings), which several items may
-/// name while spending one slot.
+/// Whether `resource` is already held in `held` — true for every
+/// class, so several mentions of one resource spend one slot.
 ///
 /// **One definition, consumed by both targets' fill loops**, so the
-/// recognition rule cannot drift between them. A per-frame buffer never
-/// matches: the contract's one-buffer-one-item rule means a duplicate
-/// cannot reach retention.
+/// recognition rule cannot drift between them. Buffers joined the
+/// recognised classes when the retention rule relaxed to
+/// one-buffer-one-`FrameData`: identical frame data may now repeat
+/// across items, so a repeated buffer can reach retention.
 pub(crate) fn already_retained(resource: &Retained, held: &[Option<Retained>]) -> bool {
     match resource {
-        Retained::Frame(_) => false,
+        Retained::Frame(buffer) => held.iter().any(|slot| {
+            matches!(slot, Some(Retained::Frame(seen)) if std::rc::Rc::ptr_eq(seen, buffer))
+        }),
         Retained::Mesh(mesh) => held.iter().any(|slot| {
             matches!(slot, Some(Retained::Mesh(seen)) if std::rc::Rc::ptr_eq(seen, mesh))
         }),
         Retained::Binding(binding) => held.iter().any(|slot| {
             matches!(slot, Some(Retained::Binding(seen)) if std::rc::Rc::ptr_eq(seen, binding))
+        }),
+        Retained::Image(image) => held.iter().any(|slot| {
+            matches!(slot, Some(Retained::Image(seen)) if std::rc::Rc::ptr_eq(seen, image))
         }),
     }
 }
@@ -412,6 +483,267 @@ pub(crate) fn retained_of(item: &Item<'_>) -> [Option<Retained>; MAX_ITEM_RESOUR
 /// the fill loops stay allocation-free.
 pub(crate) const MAX_ITEM_RESOURCES: usize = 2 + MAX_SAMPLED_BINDINGS;
 
+/// The frame's per-identity image walk: which attachment identities
+/// this frame has used, and how -- ONE definition read by the contract
+/// and by both record paths.
+///
+/// **The rules and the barrier pairs live in the same state machine,
+/// and that is the point.** The contract drives a walk over the whole
+/// frame before any GPU call, so every refusal below fires there, by
+/// name; each record path then drives a fresh walk over the same
+/// frame and reads the [`ImageUse`] pairs the contract already proved
+/// legal, feeding them to `transition::pass_boundary`. Two targets
+/// selecting masks independently is how barrier drift happens; two
+/// consumers of one walk cannot drift.
+pub(crate) struct FrameWalk {
+    surface_color_used: bool,
+    target_depth_used: bool,
+    images: [Option<ImageEntry>; MAX_FRAME_RENDER_IMAGES],
+}
+
+struct ImageEntry {
+    key: *const u8,
+    kind: RenderImageKind,
+    targeted: bool,
+    sampled: bool,
+}
+
+/// What one pass does to its target identities, as [`ImageUse`] pairs
+/// ready for `transition::pass_boundary`. `color` is `None` exactly
+/// for depth-image passes, which have no color attachment at all.
+pub(crate) struct TargetUses {
+    pub(crate) color: Option<(ImageUse, ImageUse)>,
+    pub(crate) depth: Option<(ImageUse, ImageUse)>,
+}
+
+/// The most barriers one pass boundary can need: its color and depth
+/// attachments plus every image crossing to sampled at this boundary.
+/// Sizes both record paths' barrier arrays, so the frame path
+/// allocates nothing.
+pub(crate) const MAX_PASS_BARRIERS: usize = 2 + MAX_FRAME_RENDER_IMAGES;
+
+/// One sampling transition a pass forces: the image, its barrier
+/// subresource, and the use pair. Emitted once per image, at the first
+/// sampling pass's boundary.
+pub(crate) struct SampleUse {
+    pub(crate) image: ash::vk::Image,
+    pub(crate) range: ash::vk::ImageSubresourceRange,
+    pub(crate) uses: (ImageUse, ImageUse),
+}
+
+impl FrameWalk {
+    pub(crate) fn new() -> Self {
+        Self {
+            surface_color_used: false,
+            target_depth_used: false,
+            images: [const { None }; MAX_FRAME_RENDER_IMAGES],
+        }
+    }
+
+    /// The occupied slot for `key`, minting one on first mention.
+    ///
+    /// # Panics
+    ///
+    /// A fifth distinct image is refused by name.
+    fn entry_index(&mut self, key: *const u8, kind: RenderImageKind) -> usize {
+        let known = self
+            .images
+            .iter()
+            .position(|slot| matches!(slot, Some(entry) if entry.key == key));
+        if let Some(index) = known {
+            return index;
+        }
+        // Slots are minted densely, so the occupied count IS the first
+        // free index — and the ceiling refusal in one comparison.
+        let occupied = self.images.iter().flatten().count();
+        assert!(
+            occupied < MAX_FRAME_RENDER_IMAGES,
+            "a frame touches at most {MAX_FRAME_RENDER_IMAGES} distinct render images (as \
+             targets and sampled sources together)"
+        );
+        self.images[occupied] = Some(ImageEntry {
+            key,
+            kind,
+            targeted: false,
+            sampled: false,
+        });
+        occupied
+    }
+
+    /// Advance the walk over `pass`'s target, returning the use pairs
+    /// its attachments transition through.
+    ///
+    /// # Panics
+    ///
+    /// The identity rules, refused by name: a contents-preserving load
+    /// on any identity's first use of the frame; re-targeting a render
+    /// image after a pass sampled it; a fifth distinct image.
+    pub(crate) fn advance_target(&mut self, index: usize, pass: &Pass<'_>) -> TargetUses {
+        match &pass.target {
+            PassTarget::Surface => {
+                let color = &pass.color[0];
+                assert!(
+                    self.surface_color_used || !matches!(color.load, LoadOp::Load),
+                    "pass {index}: LoadOp::Load on the frame's first surface use loads \
+                     undefined contents -- every frame's first use of each attachment starts \
+                     undefined"
+                );
+                let color_pair = if self.surface_color_used {
+                    (ImageUse::ColorAttachment, ImageUse::ColorAttachment)
+                } else {
+                    (ImageUse::ColorAttachmentFirstUse, ImageUse::ColorAttachment)
+                };
+                self.surface_color_used = true;
+                let depth_pair = pass.depth.as_ref().map(|depth| {
+                    assert!(
+                        self.target_depth_used || !matches!(depth.load, LoadOp::Load),
+                        "pass {index}: LoadOp::Load on the frame's first depth use loads \
+                         undefined contents -- the depth image transitions from UNDEFINED at \
+                         its first carrying pass"
+                    );
+                    let pair = if self.target_depth_used {
+                        (ImageUse::DepthAttachment, ImageUse::DepthAttachment)
+                    } else {
+                        (ImageUse::DepthAttachmentFirstUse, ImageUse::DepthAttachment)
+                    };
+                    self.target_depth_used = true;
+                    pair
+                });
+                TargetUses {
+                    color: Some(color_pair),
+                    depth: depth_pair,
+                }
+            }
+            PassTarget::Image(image, attachment) => {
+                let key = Rc::as_ptr(&image.inner).cast::<u8>();
+                let kind = image.inner.kind;
+                let slot = self.entry_index(key, kind);
+                let Some(entry) = self.images[slot].as_mut() else {
+                    unreachable!("entry_index returns an occupied slot")
+                };
+                assert!(
+                    !entry.sampled,
+                    "pass {index}: this frame already sampled this render image -- the \
+                     per-image walk is one-way (target, then sample), so every pass that \
+                     writes an image must precede the first pass that reads it"
+                );
+                let first_use = !entry.targeted;
+                assert!(
+                    !first_use || !matches!(attachment.load, LoadOp::Load),
+                    "pass {index}: LoadOp::Load on a render image's first use this frame \
+                     loads undefined contents -- render-image contents are frame-scoped and \
+                     start undefined every frame"
+                );
+                entry.targeted = true;
+                match kind {
+                    RenderImageKind::Color => TargetUses {
+                        color: Some(if first_use {
+                            (ImageUse::RenderColorFirstUse, ImageUse::ColorAttachment)
+                        } else {
+                            (ImageUse::ColorAttachment, ImageUse::ColorAttachment)
+                        }),
+                        depth: None,
+                    },
+                    RenderImageKind::Depth => TargetUses {
+                        color: None,
+                        depth: Some(if first_use {
+                            (ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment)
+                        } else {
+                            (ImageUse::DepthAttachment, ImageUse::DepthAttachment)
+                        }),
+                    },
+                    // No rest arm: `#[non_exhaustive]` does not bind
+                    // inside the defining crate, so a new kind fails to
+                    // compile HERE -- the one place that must learn its
+                    // barriers -- rather than panicking at runtime.
+                }
+            }
+        }
+    }
+
+    /// Advance the walk over `pass`'s sampled render images, returning
+    /// the transitions the first sampling of each forces, in first-use
+    /// order.
+    ///
+    /// # Panics
+    ///
+    /// Sampling an image no pass in this frame has rendered, and
+    /// sampling the image the pass itself renders into -- both refused
+    /// by name.
+    pub(crate) fn advance_sampling(
+        &mut self,
+        index: usize,
+        pass: &Pass<'_>,
+    ) -> ([Option<SampleUse>; MAX_FRAME_RENDER_IMAGES], usize) {
+        let own_target = match &pass.target {
+            PassTarget::Image(image, _) => Some(Rc::as_ptr(&image.inner).cast::<u8>()),
+            PassTarget::Surface => None,
+        };
+        let mut out = [const { None }; MAX_FRAME_RENDER_IMAGES];
+        let mut count = 0usize;
+        for item in pass.items {
+            let Some(bindings) = &item.bindings else {
+                continue;
+            };
+            for binding in bindings.iter() {
+                let Some(inner) = binding.inner.sampled_render_image() else {
+                    continue;
+                };
+                let key = Rc::as_ptr(inner).cast::<u8>();
+                assert!(
+                    own_target != Some(key),
+                    "pass {index}: an item samples the render image this pass renders \
+                     into -- feedback within one pass is undefined; split it into a \
+                     writing pass and a reading pass"
+                );
+                let entry = self
+                    .images
+                    .iter_mut()
+                    .flatten()
+                    .find(|entry| entry.key == key && entry.targeted);
+                assert!(
+                    entry.is_some(),
+                    "pass {index}: an item samples a render image no pass in this frame \
+                     has rendered -- render-image contents are frame-scoped, so a frame \
+                     that reads one must write it first"
+                );
+                let Some(entry) = entry else {
+                    unreachable!("asserted just above")
+                };
+                if entry.sampled {
+                    continue;
+                }
+                entry.sampled = true;
+                out[count] = Some(SampleUse {
+                    image: inner.image,
+                    range: match entry.kind {
+                        RenderImageKind::Depth => crate::vk::depth::barrier_range(inner.format),
+                        _ => ash::vk::ImageSubresourceRange::default()
+                            .aspect_mask(ash::vk::ImageAspectFlags::COLOR)
+                            .base_mip_level(0)
+                            .level_count(1)
+                            .base_array_layer(0)
+                            .layer_count(1),
+                    },
+                    uses: match entry.kind {
+                        RenderImageKind::Depth => {
+                            (ImageUse::DepthAttachment, ImageUse::SampledInPass)
+                        }
+                        _ => (ImageUse::ColorAttachment, ImageUse::SampledInPass),
+                    },
+                });
+                count += 1;
+            }
+        }
+        (out, count)
+    }
+
+    /// Whether any pass so far targeted the surface.
+    pub(crate) fn surface_used(&self) -> bool {
+        self.surface_color_used
+    }
+}
+
 /// The frame-shape contract, asserted identically by both targets
 /// before any GPU call: the refusals that make a malformed frame a
 /// named panic instead of a validation stream or a quiet wrong image.
@@ -426,68 +758,34 @@ pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
         !desc.passes.is_empty(),
         "a frame needs at least one pass: an empty frame records nothing, and on the window          path would present contents nothing ever defined"
     );
-    let mut depth_used = false;
+    let mut walk = FrameWalk::new();
     for (index, pass) in desc.passes.iter().enumerate() {
-        assert!(
-            pass.color.len() == 1,
-            "pass {index}: v0 passes carry exactly one color attachment (the target's own \
-             surface), got {}",
-            pass.color.len()
-        );
-        let color = &pass.color[0];
-        if index == 0 {
-            assert!(
-                !matches!(color.load, LoadOp::Load),
-                "pass 0: LoadOp::Load on a frame's first pass loads undefined contents — \
-                 every frame's first use of the attachment starts undefined"
-            );
-        }
-        if let Some(depth) = &pass.depth {
-            // The color first-use is always pass 0 (every pass carries
-            // color); the depth first-use is the frame's first
-            // depth-CARRYING pass, whatever its index — that is where
-            // the walk transitions the image from UNDEFINED, so that is
-            // where a Load reads garbage.
-            if !depth_used {
+        check_pass_shape(index, pass);
+        // The identity rules: first-use loads, the one-way per-image
+        // walk, the distinct-image ceiling. One state machine, shared
+        // with the record paths.
+        let _ = walk.advance_target(index, pass);
+        for item in pass.items {
+            // Image passes carry their format in their kind, so the
+            // match is contract-checked here; a surface pass's format
+            // is the target's own, asserted where the target knows it.
+            if let PassTarget::Image(image, _) = &pass.target {
+                let expected = match image.kind() {
+                    RenderImageKind::Depth => crate::TargetFormat::DepthOnly,
+                    _ => crate::TargetFormat::Rgba8Unorm,
+                };
                 assert!(
-                    !matches!(depth.load, LoadOp::Load),
-                    "pass {index}: LoadOp::Load on the frame's first depth use loads \
-                     undefined contents — the depth image transitions from UNDEFINED at \
-                     its first carrying pass"
+                    item.pipeline.format == expected,
+                    "pass {index}: an item's pipeline format must match the image it \
+                     renders into — a color image draws {:?} pipelines, a depth image \
+                     {:?} ones; got {:?}",
+                    crate::TargetFormat::Rgba8Unorm,
+                    crate::TargetFormat::DepthOnly,
+                    item.pipeline.format
                 );
             }
-            depth_used = true;
-        }
-        if let LoadOp::Clear(value) = color.load {
             assert!(
-                matches!(value, ClearValue::Color(_)),
-                "pass {index}: a color attachment clears to ClearValue::Color, not \
-                 ClearValue::Depth"
-            );
-        }
-        if let Some(depth) = &pass.depth
-            && let LoadOp::Clear(value) = depth.load
-        {
-            // Kind and range in one refusal, so no arm is unreachable:
-            // a depth clear is valid exactly when it is a Depth value
-            // that is finite and in the documented range — anything
-            // else is invalid usage the driver may answer with
-            // anything.
-            let valid = match value {
-                ClearValue::Depth(depth_value) => {
-                    depth_value.is_finite() && (0.0..=1.0).contains(&depth_value)
-                }
-                _ => false,
-            };
-            assert!(
-                valid,
-                "pass {index}: a depth attachment clears to ClearValue::Depth, finite and \
-                 in [0, 1] — got {value:?}"
-            );
-        }
-        for item in pass.items {
-            assert!(
-                item.pipeline.depth == pass.depth.is_some(),
+                item.pipeline.depth == pass_has_depth(pass),
                 "pass {index}: an item's pipeline depth state must match the pass — a \
                  depth-testing pipeline in a depthless pass (or the reverse) draws \
                  differently than written"
@@ -544,8 +842,135 @@ pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
             }
             check_binding_contract(index, item);
         }
+        let _ = walk.advance_sampling(index, pass);
     }
+    assert!(
+        walk.surface_used(),
+        "a frame needs at least one surface pass: image passes render intermediate \
+         contents, and a frame that never touches the surface defines nothing to present \
+         or read back"
+    );
+    check_store_before_sample(desc);
     check_retention_bound(desc);
+}
+
+/// The pass's shape follows its target: a surface pass names the
+/// target's own surface as its one color attachment; an image pass
+/// carries its one attachment in the target itself, so its slices stay
+/// empty. Clear values must match the attachment's kind either way. A
+/// sibling of [`check_retention_bound`] for the same reason: one rule
+/// family, its own function.
+fn check_pass_shape(index: usize, pass: &Pass<'_>) {
+    match &pass.target {
+        PassTarget::Surface => {
+            assert!(
+                pass.color.len() == 1,
+                "pass {index}: a surface pass carries exactly one color attachment \
+                 (the target's own surface), got {}",
+                pass.color.len()
+            );
+            let color = &pass.color[0];
+            if let LoadOp::Clear(value) = color.load {
+                assert!(
+                    matches!(value, ClearValue::Color(_)),
+                    "pass {index}: a color attachment clears to ClearValue::Color, not \
+                     ClearValue::Depth"
+                );
+            }
+            if let Some(depth) = &pass.depth
+                && let LoadOp::Clear(value) = depth.load
+            {
+                // Kind and range in one refusal, so no arm is
+                // unreachable: a depth clear is valid exactly when it
+                // is a Depth value that is finite and in the documented
+                // range — anything else is invalid usage the driver may
+                // answer with anything.
+                let valid = match value {
+                    ClearValue::Depth(depth_value) => {
+                        depth_value.is_finite() && (0.0..=1.0).contains(&depth_value)
+                    }
+                    _ => false,
+                };
+                assert!(
+                    valid,
+                    "pass {index}: a depth attachment clears to ClearValue::Depth, \
+                     finite and in [0, 1] — got {value:?}"
+                );
+            }
+        }
+        PassTarget::Image(image, attachment) => {
+            assert!(
+                pass.color.is_empty() && pass.depth.is_none(),
+                "pass {index}: an image pass carries its one attachment in its \
+                 target — surface color slices and the target-depth option name \
+                 images this pass does not render into"
+            );
+            if let LoadOp::Clear(value) = attachment.load {
+                let valid = match (image.kind(), value) {
+                    (RenderImageKind::Color, ClearValue::Color(_)) => true,
+                    (RenderImageKind::Depth, ClearValue::Depth(depth_value)) => {
+                        depth_value.is_finite() && (0.0..=1.0).contains(&depth_value)
+                    }
+                    _ => false,
+                };
+                assert!(
+                    valid,
+                    "pass {index}: an image attachment clears to its kind's value — \
+                     Color to ClearValue::Color, Depth to a finite ClearValue::Depth \
+                     in [0, 1] — got {value:?}"
+                );
+            }
+        }
+    }
+}
+
+/// Whether a pass carries a depth attachment — the target's own depth
+/// image on a surface pass, or the image itself when it is
+/// depth-kinded.
+pub(crate) fn pass_has_depth(pass: &Pass<'_>) -> bool {
+    match &pass.target {
+        PassTarget::Surface => pass.depth.is_some(),
+        PassTarget::Image(image, _) => image.kind() == RenderImageKind::Depth,
+    }
+}
+
+/// Whether any of `pass`'s items sample the render image behind `key`.
+fn pass_samples(pass: &Pass<'_>, key: *const u8) -> bool {
+    pass.items.iter().any(|item| {
+        item.bindings.as_ref().is_some_and(|bindings| {
+            bindings.iter().any(|binding| {
+                binding
+                    .inner
+                    .sampled_render_image()
+                    .is_some_and(|inner| Rc::as_ptr(inner).cast::<u8>() == key)
+            })
+        })
+    })
+}
+
+/// A targeting pass whose image a later pass samples must store: a
+/// discarded attachment leaves the sampled contents undefined, which
+/// renders as plausible garbage rather than failing. A second scan
+/// rather than walk state, because the refusal needs to name the
+/// writing pass and the reading pass together.
+fn check_store_before_sample(desc: &RenderDesc<'_>) {
+    for (index, pass) in desc.passes.iter().enumerate() {
+        let PassTarget::Image(image, attachment) = &pass.target else {
+            continue;
+        };
+        if matches!(attachment.store, StoreOp::Store) {
+            continue;
+        }
+        let key = Rc::as_ptr(&image.inner).cast::<u8>();
+        for (later_index, later) in desc.passes.iter().enumerate().skip(index + 1) {
+            assert!(
+                !pass_samples(later, key),
+                "pass {index} discards its render image's contents, but pass \
+                 {later_index} samples them — a targeting pass whose image is sampled \
+                 later must Store"
+            );
+        }
+    }
 }
 
 /// The push-data rules again, for sampled slots: a declared slot never
@@ -582,16 +1007,23 @@ fn check_binding_contract(index: usize, item: &Item<'_>) {
 fn check_retention_bound(desc: &RenderDesc<'_>) {
     // Two rules, deliberately different:
     //
-    // - **One buffer, one item, per frame.** Two items naming one
-    //   per-frame buffer would have the second copy silently win before
-    //   either draws. Unchanged, in wording and in force.
-    // - **A mesh or a binding may repeat.** Nothing copies into either,
-    //   so there is no race for the rule above to prevent, and drawing
-    //   one voxel mesh — or one atlas binding — from several items is an
-    //   ordinary thing to want. Each distinct one costs one retention
-    //   slot however many items name it.
+    // - **One buffer, one `FrameData`, per frame.** Two items carrying
+    //   DIFFERENT data for one per-frame buffer would have the second
+    //   copy silently win before either draws — refused. Two items
+    //   carrying the POINTER-IDENTICAL data (same bytes, same count)
+    //   are one copy written twice: drawing the same instanced world
+    //   from two passes is an ordinary thing to want, and it costs one
+    //   retention slot.
+    // - **A mesh, a binding, or a pass-target image may repeat.**
+    //   Nothing copies into them, so there is no race at all; each
+    //   distinct one costs one retention slot however many mentions.
     let mut seen: [Option<*const u8>; MAX_RETAINED_RESOURCES] = [None; MAX_RETAINED_RESOURCES];
     let mut count = 0usize;
+    // Per-buffer FrameData signatures: (bytes pointer, length, count).
+    // Pointer identity, not content equality — the rule is about which
+    // copy wins, and two copies of one allocation cannot disagree.
+    let mut buffer_data: [Option<BufferRecord>; MAX_RETAINED_RESOURCES] =
+        [None; MAX_RETAINED_RESOURCES];
     // The repeatable classes share one recognise-or-count arm; the
     // pointer key spaces cannot collide across classes, because each is
     // the address of a distinct live allocation.
@@ -609,6 +1041,13 @@ fn check_retention_bound(desc: &RenderDesc<'_>) {
         }
     };
     for pass in desc.passes {
+        // A pass-target image is retained by the pass walk, exactly
+        // once however many passes target it — the mesh rule, one
+        // resource class over.
+        if let PassTarget::Image(image, _) = &pass.target {
+            let key = std::rc::Rc::as_ptr(&image.inner).cast::<u8>();
+            count_repeatable(&mut seen, &mut count, key);
+        }
         for item in pass.items {
             if let Some(mesh) = item.mesh {
                 let key = std::rc::Rc::as_ptr(&mesh.inner).cast::<u8>();
@@ -624,20 +1063,37 @@ fn check_retention_bound(desc: &RenderDesc<'_>) {
                 continue;
             };
             let key = std::rc::Rc::as_ptr(&data.buffer.inner).cast::<u8>();
-            assert!(
-                !seen[..count].contains(&Some(key)),
-                "one buffer, one item, per frame: two items name the same buffer, and the \
-                 second copy would silently win before either draws"
-            );
-            assert!(
-                count < MAX_RETAINED_RESOURCES,
-                "a frame carries at most {MAX_RETAINED_RESOURCES} distinct resources \
-                 (per-frame buffers, meshes and bindings together)"
-            );
-            seen[count] = Some(key);
-            count += 1;
+            let signature = (data.bytes.as_ptr(), data.bytes.len(), data.instances);
+            let prior = buffer_data[..count_matters(&buffer_data)]
+                .iter()
+                .flatten()
+                .find(|(prior_key, _)| *prior_key == key);
+            if let Some((_, prior_signature)) = prior {
+                assert!(
+                    *prior_signature == signature,
+                    "one buffer, one FrameData, per frame: two items carry different data \
+                     for the same buffer, and the second copy would silently win before \
+                     either draws (pointer-identical data may repeat)"
+                );
+            } else {
+                count_repeatable(&mut seen, &mut count, key);
+                let Some(slot) = buffer_data.iter_mut().find(|slot| slot.is_none()) else {
+                    unreachable!("the ceiling assert above bounds distinct buffers")
+                };
+                *slot = Some((key, signature));
+            }
         }
     }
+}
+
+/// One buffer's recorded claim: its key, then its `FrameData`
+/// signature — bytes pointer, length, instance count.
+type BufferRecord = (*const u8, (*const u8, usize, u32));
+
+/// How many leading buffer records are occupied — a helper the borrow
+/// checker demands, not a second counter.
+fn count_matters(records: &[Option<BufferRecord>; MAX_RETAINED_RESOURCES]) -> usize {
+    records.iter().take_while(|slot| slot.is_some()).count()
 }
 
 /// How many distinct resources one frame may keep alive, per target slot

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -1,15 +1,16 @@
-//! The v0 graphics pipeline: two SPIR-V stages, dynamic rendering into
-//! one color attachment, optionally sampled-binding slots filled per
-//! item, and optionally vertex input — per-vertex at binding 0,
-//! per-instance at binding 1.
+//! The v0 graphics pipeline: SPIR-V stages, dynamic rendering into one
+//! color attachment — or none, for the depth-only shape — optionally
+//! sampled-binding slots filled per item, and optionally vertex input:
+//! per-vertex at binding 0, per-instance at binding 1.
 //!
-//! **Two pipeline shapes, and which one a pipeline is decides where its
-//! vertex count comes from.** A generative pipeline's stages write their
+//! **Three pipeline shapes.** A generative pipeline's stages write their
 //! own vertex list, so the count belongs to the shader and travels with
 //! it in [`Shaders`]. A mesh pipeline reads a per-vertex stream, so the
 //! count belongs to the geometry and arrives at the draw — which is why
 //! its stages are a [`MeshShaders`] carrying no count at all rather than
-//! a `Shaders` carrying one that nothing reads.
+//! a `Shaders` carrying one that nothing reads. A depth-only pipeline is
+//! a mesh pipeline with no fragment stage and no color attachment,
+//! drawing geometry into a depth-kinded render image and nothing else.
 
 use std::fmt;
 use std::rc::Rc;
@@ -22,8 +23,10 @@ use crate::vk::buffer::Buffer;
 use crate::vk::device::{Device, DeviceShared};
 use crate::vk::pass::Bindings;
 
-/// The color format a pipeline renders into. Must match the target it
-/// is used with (checked as a contract in dev builds).
+/// What a pipeline renders into: a color format that must match its
+/// target's, or the color-free depth-only shape. Surface-pass matches
+/// are dev-build asserts beside each target; image-pass matches and
+/// depth-only placement are retained contract refusals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TargetFormat {
@@ -288,9 +291,11 @@ pub enum Blend {
 /// high and the stage indexes past the end of its own constant array.
 /// Bundled, the mismatch cannot be spelled.
 ///
-/// **A stage that *does* read a per-vertex buffer takes [`MeshShaders`]
-/// instead**, because its premise is the opposite one: the count belongs
-/// to the geometry, so there is none here to bundle.
+/// **A fragment-carrying pair that *does* read a per-vertex buffer
+/// takes [`MeshShaders`] instead**, because its premise is the opposite
+/// one: the count belongs to the geometry, so there is none here to
+/// bundle. (The depth-only shape reads a per-vertex stream too, and
+/// bundles nothing — one stage has no pair to carry.)
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct Shaders<'a> {
@@ -438,7 +443,10 @@ impl<'a> PipelineDesc<'a> {
     /// rasterization without a fragment stage still tests and writes
     /// depth — the whole draw. Depth state must still be declared (a
     /// builder call), because a depth-only pipeline that neither tests
-    /// nor writes depth does nothing at all; creation asserts it.
+    /// nor writes depth does nothing at all; creation asserts that,
+    /// and that this shape carries no fragment bytes. (The reverse —
+    /// empty fragment bytes on a color pipeline — stays the
+    /// recoverable `InvalidSpirv` refusal it has always been.)
     ///
     /// The vertex stage may write outputs no stage consumes — reusing a
     /// full mesh pair's vertex stage is expected, not clever.

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -27,17 +27,25 @@ use crate::vk::pass::Bindings;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TargetFormat {
-    /// The offscreen target's format.
+    /// The offscreen target's format, and every color render image's.
     Rgba8Unorm,
     /// The common swapchain format on desktop.
     Bgra8Unorm,
+    /// No color attachment at all: the format of a pipeline that draws
+    /// only into a depth-kinded render image. A depth-only pipeline
+    /// carries no fragment stage and must declare depth state — both
+    /// asserted at creation.
+    DepthOnly,
 }
 
 impl TargetFormat {
-    pub(crate) fn to_vk(self) -> vk::Format {
+    /// The color attachment format, `None` for the depth-only shape
+    /// whose color attachment list is empty.
+    pub(crate) fn to_vk(self) -> Option<vk::Format> {
         match self {
-            Self::Rgba8Unorm => vk::Format::R8G8B8A8_UNORM,
-            Self::Bgra8Unorm => vk::Format::B8G8R8A8_UNORM,
+            Self::Rgba8Unorm => Some(vk::Format::R8G8B8A8_UNORM),
+            Self::Bgra8Unorm => Some(vk::Format::B8G8R8A8_UNORM),
+            Self::DepthOnly => None,
         }
     }
 }
@@ -410,6 +418,39 @@ impl<'a> PipelineDesc<'a> {
             // Never read on this path: the draw takes its count from the
             // geometry. Zero rather than a sentinel because no caller can
             // supply it and nothing consults it.
+            vertex_count: 0,
+            blend: Blend::Opaque,
+            sampled_bindings: 0,
+            vertex_input: Some(layout),
+            instance_input: None,
+            depth_state: None,
+            push_constant_size: 0,
+        }
+    }
+
+    /// A depth-only mesh pipeline: one vertex stage over a per-vertex
+    /// stream, no fragment stage, no color attachment — the shape that
+    /// renders geometry into a depth-kinded render image and nothing
+    /// else.
+    ///
+    /// **No fragment shader parameter, and that is the point**: with no
+    /// color attachment there is nothing for one to write, and
+    /// rasterization without a fragment stage still tests and writes
+    /// depth — the whole draw. Depth state must still be declared (a
+    /// builder call), because a depth-only pipeline that neither tests
+    /// nor writes depth does nothing at all; creation asserts it.
+    ///
+    /// The vertex stage may write outputs no stage consumes — reusing a
+    /// full mesh pair's vertex stage is expected, not clever.
+    #[must_use]
+    pub fn depth_mesh(vertex_spirv: &'a [u8], layout: &'a [VertexAttribute]) -> Self {
+        Self {
+            vertex_spirv,
+            // Structurally absent rather than optional: the depth-only
+            // format is what licenses the emptiness, and creation
+            // asserts the pairing in both directions.
+            fragment_spirv: &[],
+            target_format: TargetFormat::DepthOnly,
             vertex_count: 0,
             blend: Blend::Opaque,
             sampled_bindings: 0,
@@ -983,6 +1024,22 @@ impl Device {
         // so the panic owns nothing.
         validate_sampled_bindings(desc.sampled_bindings);
         let sampled_slots = desc.sampled_bindings as usize;
+        // The depth-only pairing: the format is what licenses the
+        // missing fragment stage, and a depth-only pipeline without
+        // depth state does nothing at all. One direction only — an
+        // empty fragment slice on a color pipeline stays the
+        // recoverable InvalidSpirv refusal it has always been.
+        let depth_only = desc.target_format == TargetFormat::DepthOnly;
+        assert!(
+            !depth_only || desc.fragment_spirv.is_empty(),
+            "a depth-only pipeline carries no fragment stage — its color-attachment list \
+             is empty, so there is nothing for one to write"
+        );
+        assert!(
+            !depth_only || desc.depth_state.is_some(),
+            "a depth-only pipeline must declare depth state: with no color attachment and \
+             no depth test or write, the draw does nothing"
+        );
         // Checked before anything is created so this failure path owns
         // nothing. The environment declined, not the caller — a Result,
         // never an assert.
@@ -998,7 +1055,14 @@ impl Device {
             None => None,
         };
         let vs_words = crate::spirv::words_from_bytes("vertex", desc.vertex_spirv)?;
-        let fs_words = crate::spirv::words_from_bytes("fragment", desc.fragment_spirv)?;
+        let fs_words = if depth_only {
+            None
+        } else {
+            Some(crate::spirv::words_from_bytes(
+                "fragment",
+                desc.fragment_spirv,
+            )?)
+        };
 
         // SAFETY: category 2 (ash dispatch): device live via the spine;
         // the word slices outlive the calls; callbacks' ledger outlives
@@ -1010,37 +1074,42 @@ impl Device {
             )
         }
         .map_err(|code| creation("vkCreateShaderModule(vertex)", code))?;
-        // SAFETY: as above.
-        let fs = match unsafe {
-            shared.device.create_shader_module(
-                &vk::ShaderModuleCreateInfo::default().code(&fs_words),
-                Some(&shared.alloc_cbs()),
-            )
-        } {
-            Ok(module) => module,
-            Err(code) => {
-                // SAFETY: `vs` was just created, unused elsewhere.
-                unsafe {
-                    shared
-                        .device
-                        .destroy_shader_module(vs, Some(&shared.alloc_cbs()));
+        let fs = match &fs_words {
+            None => None,
+            // SAFETY: as above.
+            Some(fs_words) => match unsafe {
+                shared.device.create_shader_module(
+                    &vk::ShaderModuleCreateInfo::default().code(fs_words),
+                    Some(&shared.alloc_cbs()),
+                )
+            } {
+                Ok(module) => Some(module),
+                Err(code) => {
+                    // SAFETY: `vs` was just created, unused elsewhere.
+                    unsafe {
+                        shared
+                            .device
+                            .destroy_shader_module(vs, Some(&shared.alloc_cbs()));
+                    }
+                    return Err(creation("vkCreateShaderModule(fragment)", code));
                 }
-                return Err(creation("vkCreateShaderModule(fragment)", code));
-            }
+            },
         };
-        // Both modules exist past this point; this frees them on every
-        // exit (the pipeline retains what it needs — modules are only
-        // creation-time inputs).
+        // Every created module exists past this point; this frees them
+        // on every exit (the pipeline retains what it needs — modules
+        // are only creation-time inputs).
         let destroy_modules = || {
-            // SAFETY: both modules live and unused after pipeline
-            // creation resolves.
+            // SAFETY: modules live and unused after pipeline creation
+            // resolves.
             unsafe {
                 shared
                     .device
                     .destroy_shader_module(vs, Some(&shared.alloc_cbs()));
-                shared
-                    .device
-                    .destroy_shader_module(fs, Some(&shared.alloc_cbs()));
+                if let Some(fs) = fs {
+                    shared
+                        .device
+                        .destroy_shader_module(fs, Some(&shared.alloc_cbs()));
+                }
             }
         };
 
@@ -1075,16 +1144,18 @@ impl Device {
             }
         };
 
-        let stages = [
-            vk::PipelineShaderStageCreateInfo::default()
-                .stage(vk::ShaderStageFlags::VERTEX)
-                .module(vs)
-                .name(c"main"),
-            vk::PipelineShaderStageCreateInfo::default()
+        let mut stages = [vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::VERTEX)
+            .module(vs)
+            .name(c"main"); 2];
+        let mut stage_count = 1usize;
+        if let Some(fs) = fs {
+            stages[1] = vk::PipelineShaderStageCreateInfo::default()
                 .stage(vk::ShaderStageFlags::FRAGMENT)
                 .module(fs)
-                .name(c"main"),
-        ];
+                .name(c"main");
+            stage_count = 2;
+        }
         // With neither stream declared this stays the empty state every
         // generative pipeline was built with. The layout itself is a
         // pure function, so its cross-stream location numbering — the
@@ -1136,13 +1207,24 @@ impl Device {
                 .dst_alpha_blend_factor(vk::BlendFactor::ONE)
                 .alpha_blend_op(vk::BlendOp::ADD),
         }];
-        let color_blend =
-            vk::PipelineColorBlendStateCreateInfo::default().attachments(&blend_attachments);
+        // No color attachment, no blend entry: the blend list's length
+        // must equal the attachment count.
+        let blend_count = usize::from(!depth_only);
+        let color_blend = vk::PipelineColorBlendStateCreateInfo::default()
+            .attachments(&blend_attachments[..blend_count]);
         let dynamic_states = [vk::DynamicState::VIEWPORT, vk::DynamicState::SCISSOR];
         let dynamic = vk::PipelineDynamicStateCreateInfo::default().dynamic_states(&dynamic_states);
-        let formats = [desc.target_format.to_vk()];
-        let mut rendering =
-            vk::PipelineRenderingCreateInfo::default().color_attachment_formats(&formats);
+        // A depth-only pipeline's color list is empty — the same shape
+        // its passes render with. Everything else declares its one
+        // color format.
+        let mut formats = [vk::Format::UNDEFINED; 1];
+        let mut format_count = 0usize;
+        if let Some(format) = desc.target_format.to_vk() {
+            formats[0] = format;
+            format_count = 1;
+        }
+        let mut rendering = vk::PipelineRenderingCreateInfo::default()
+            .color_attachment_formats(&formats[..format_count]);
         if let Some(format) = depth_format {
             rendering = rendering.depth_attachment_format(format);
         }
@@ -1157,7 +1239,7 @@ impl Device {
         });
 
         let mut info = vk::GraphicsPipelineCreateInfo::default()
-            .stages(&stages)
+            .stages(&stages[..stage_count])
             .vertex_input_state(&vertex_input)
             .input_assembly_state(&input_assembly)
             .viewport_state(&viewport)

--- a/crates/rhi/src/vk/render_image.rs
+++ b/crates/rhi/src/vk/render_image.rs
@@ -1,0 +1,415 @@
+//! Render images: what one pass writes and a later pass samples.
+//!
+//! A [`RenderImage`] is one physical image with attachment and sampled
+//! usage, kinded Color or Depth at creation. Its *contents* are
+//! frame-scoped — nothing rendered into it survives a frame boundary,
+//! which is what keeps the frame contract pure — while the image
+//! itself lives as long as its handle does. It has no host path: no
+//! upload, no readback, no resize (recreate instead). What it is for
+//! arrives with pass targets; this module owns creation, ownership,
+//! and the format pre-check that refuses an unsampleable depth format
+//! by type before any frame exists to prove it.
+
+use std::rc::Rc;
+
+use ash::vk;
+
+use crate::config::Extent;
+use crate::error::TargetError;
+use crate::vk::device::{Device, DeviceShared};
+use crate::vk::offscreen::{creation, image_memory_type};
+
+/// What a render image is for: which attachment slot of a pass it can
+/// be, which decides its format and usage at creation.
+///
+/// An input enum, so `#[non_exhaustive]`: a later kind must not break
+/// downstream matchers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RenderImageKind {
+    /// A color target: `Rgba8Unorm`, drawable and sampleable.
+    Color,
+    /// A depth target: the device's chosen depth format, drawable by a
+    /// depth-only pass and sampleable by a later one.
+    Depth,
+}
+
+/// Everything a render image needs: its kind and its size.
+///
+/// `#[non_exhaustive]` with a constructor, per the descriptor pattern
+/// this crate uses everywhere.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct RenderImageDesc {
+    /// Which attachment slot this image can fill.
+    pub kind: RenderImageKind,
+    /// The image's size in pixels.
+    pub extent: Extent,
+}
+
+impl RenderImageDesc {
+    /// A render image of `kind`, sized `extent`.
+    ///
+    /// Positional because neither has a meaningful default: an image
+    /// with no kind has no format, and one with no size is not an
+    /// image.
+    #[must_use]
+    pub fn new(kind: RenderImageKind, extent: Extent) -> Self {
+        Self { kind, extent }
+    }
+}
+
+/// Refuse a malformed render-image extent. A pure function so both
+/// rules are unit-tested without a device, like the texture's own
+/// check.
+fn check_extent(extent: Extent, max_dimension: u32) -> Result<(), TargetError> {
+    if extent.width == 0 || extent.height == 0 {
+        return Err(TargetError::Creation {
+            call: "create_render_image(zero extent)",
+            code: 0,
+        });
+    }
+    if extent.width > max_dimension || extent.height > max_dimension {
+        return Err(TargetError::Creation {
+            call: "create_render_image(extent exceeds the device limit)",
+            code: 0,
+        });
+    }
+    Ok(())
+}
+
+/// The render image's owning half: the mesh split, applied here so the
+/// retention table and a binding can keep the image alive with `Rc`
+/// clones while callers pass plain borrows. The contract lives on
+/// [`RenderImage`], where its reader is.
+pub(crate) struct RenderImageInner {
+    pub(crate) shared: Rc<DeviceShared>,
+    pub(crate) image: vk::Image,
+    memory: vk::DeviceMemory,
+    pub(crate) view: vk::ImageView,
+    pub(crate) format: vk::Format,
+    pub(crate) kind: RenderImageKind,
+    extent: Extent,
+}
+
+impl Drop for RenderImageInner {
+    fn drop(&mut self) {
+        // SAFETY: category 2 (ash dispatch): device live via the spine
+        // Rc; every handle was created with these callbacks. No submit
+        // still references the image: a recorded frame retains this
+        // inner through the target's retention table, released only
+        // after the frame's work provably ended — or by the targets'
+        // best-effort teardown quiesce, the same corner every retained
+        // class shares and the retention fields document.
+        unsafe {
+            self.shared
+                .device
+                .destroy_image_view(self.view, Some(&self.shared.alloc_cbs()));
+            self.shared
+                .device
+                .free_memory(self.memory, Some(&self.shared.alloc_cbs()));
+            self.shared
+                .device
+                .destroy_image(self.image, Some(&self.shared.alloc_cbs()));
+        }
+    }
+}
+
+/// An image a pass renders into and a later pass samples. Holds its
+/// device alive; destroyed on drop.
+///
+/// # Contract
+///
+/// The image's **contents are frame-scoped**: every frame's first use
+/// of it starts from undefined pixels, and nothing rendered into it is
+/// promised to a later frame — the frame contract refuses a
+/// contents-preserving first-use load exactly as it does for the
+/// surface. The image itself outlives every frame that names it, held
+/// by the target's retention table until that frame's work provably
+/// ended, so a caller may drop the handle mid-frame and take nothing
+/// away from the GPU.
+///
+/// There is no host path — no upload, no readback — and no resize: an
+/// image is its size for its whole life, and a differently-sized frame
+/// wants a different image.
+pub struct RenderImage {
+    pub(crate) inner: Rc<RenderImageInner>,
+}
+
+impl RenderImage {
+    /// The image's size in pixels.
+    #[must_use]
+    pub fn extent(&self) -> Extent {
+        self.inner.extent
+    }
+
+    /// Which attachment slot this image can fill.
+    #[must_use]
+    pub fn kind(&self) -> RenderImageKind {
+        self.inner.kind
+    }
+}
+
+impl std::fmt::Debug for RenderImage {
+    /// Kind and dimensions, not handles — the crate's posture.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RenderImage")
+            .field("kind", &self.inner.kind)
+            .field("extent", &self.inner.extent)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Device {
+    /// Create a render image: one device-local image with attachment
+    /// and sampled usage, its format decided by the kind.
+    ///
+    /// The format is **pre-checked against the adapter's own feature
+    /// report** — `SAMPLED_IMAGE` plus the kind's attachment feature
+    /// under optimal tiling — so an adapter whose depth format cannot
+    /// be sampled refuses here, at creation, rather than as undefined
+    /// sampling behaviour in some later frame.
+    ///
+    /// # Errors
+    ///
+    /// [`TargetError::Creation`] for a malformed extent, a format the
+    /// adapter cannot sample or attach, or a driver refusal;
+    /// [`TargetError::DepthUnsupported`] for a Depth image on an
+    /// adapter with no depth format at all;
+    /// [`TargetError::OutOfDeviceMemory`] when the allocation fails for
+    /// want of device memory; [`TargetError::DeviceLost`] when the
+    /// device was already lost.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one creation ladder with its unwind at every rung; splitting scatters the reverse order"
+    )]
+    pub fn create_render_image(&self, desc: &RenderImageDesc) -> Result<RenderImage, TargetError> {
+        let shared = &self.shared;
+        check_extent(desc.extent, shared.max_image_dimension_2d)?;
+        if shared.lost.poisoned() {
+            return Err(TargetError::DeviceLost);
+        }
+        let (format, usage, aspect) = match desc.kind {
+            RenderImageKind::Color => (
+                vk::Format::R8G8B8A8_UNORM,
+                vk::ImageUsageFlags::COLOR_ATTACHMENT | vk::ImageUsageFlags::SAMPLED,
+                vk::ImageAspectFlags::COLOR,
+            ),
+            RenderImageKind::Depth => {
+                let format = shared.depth_format.ok_or(TargetError::DepthUnsupported {
+                    chain: crate::vk::depth::CHAIN_NAMES,
+                })?;
+                (
+                    format,
+                    vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT | vk::ImageUsageFlags::SAMPLED,
+                    vk::ImageAspectFlags::DEPTH,
+                )
+            }
+        };
+        // The pre-check. Color's features are spec-guaranteed for
+        // R8G8B8A8_UNORM, but one rule beats one rule and an exemption:
+        // both kinds hold their format to what the frame model will ask
+        // of it, and the query is a static property read once per call.
+        let attachment_feature = match desc.kind {
+            RenderImageKind::Color => vk::FormatFeatureFlags::COLOR_ATTACHMENT,
+            RenderImageKind::Depth => vk::FormatFeatureFlags::DEPTH_STENCIL_ATTACHMENT,
+        };
+        // SAFETY: category 2 (ash dispatch): instance and physical
+        // device live via the spine. (The same argument covers every
+        // dispatch call below.)
+        let features = unsafe {
+            shared
+                .instance
+                .get_physical_device_format_properties(shared.physical, format)
+        }
+        .optimal_tiling_features;
+        let needed = vk::FormatFeatureFlags::SAMPLED_IMAGE | attachment_feature;
+        if !features.contains(needed) {
+            return Err(TargetError::Creation {
+                call: "create_render_image(the adapter cannot sample this format)",
+                code: 0,
+            });
+        }
+
+        let image_info = vk::ImageCreateInfo::default()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(format)
+            .extent(vk::Extent3D {
+                width: desc.extent.width,
+                height: desc.extent.height,
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .tiling(vk::ImageTiling::OPTIMAL)
+            .usage(usage)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED);
+        // SAFETY: device live via the spine; the create info is a
+        // local; the callbacks' ledger outlives the image.
+        let image = unsafe {
+            shared
+                .device
+                .create_image(&image_info, Some(&shared.alloc_cbs()))
+        }
+        .map_err(|code| creation("vkCreateImage(render)", code))?;
+        let destroy_image = |shared: &Rc<DeviceShared>| {
+            // SAFETY: image live; nothing bound or recorded against it
+            // on this unwind path.
+            unsafe {
+                shared
+                    .device
+                    .destroy_image(image, Some(&shared.alloc_cbs()));
+            }
+        };
+
+        // SAFETY: image live.
+        let requirements = unsafe { shared.device.get_image_memory_requirements(image) };
+        // SAFETY: instance and physical device live via the spine.
+        let memory_properties = unsafe {
+            shared
+                .instance
+                .get_physical_device_memory_properties(shared.physical)
+        };
+        let type_index = image_memory_type(&memory_properties, requirements.memory_type_bits)
+            .ok_or(TargetError::Creation {
+                call: "render image memory type",
+                code: 0,
+            })
+            .inspect_err(|_| destroy_image(shared))?;
+        let alloc = vk::MemoryAllocateInfo::default()
+            .allocation_size(requirements.size)
+            .memory_type_index(type_index);
+        // SAFETY: device live; info local.
+        let memory = match unsafe {
+            shared
+                .device
+                .allocate_memory(&alloc, Some(&shared.alloc_cbs()))
+        } {
+            Ok(memory) => memory,
+            Err(code) if code == vk::Result::ERROR_OUT_OF_DEVICE_MEMORY => {
+                destroy_image(shared);
+                return Err(TargetError::OutOfDeviceMemory {
+                    call: "vkAllocateMemory(render)",
+                });
+            }
+            Err(code) => {
+                destroy_image(shared);
+                return Err(creation("vkAllocateMemory(render)", code));
+            }
+        };
+        // Driver truth, not host arithmetic, matching the depth image's
+        // record.
+        renew_diag::info!(
+            target: "renew-rhi",
+            "render image: {}x{} {:?}, {} bytes device memory",
+            desc.extent.width,
+            desc.extent.height,
+            format,
+            requirements.size
+        );
+        // SAFETY: image and memory live; offset 0 within an allocation
+        // sized from this image's own requirements.
+        if let Err(code) = unsafe { shared.device.bind_image_memory(image, memory, 0) } {
+            // SAFETY: both live, nothing else references them.
+            unsafe {
+                shared.device.free_memory(memory, Some(&shared.alloc_cbs()));
+            }
+            destroy_image(shared);
+            return Err(creation("vkBindImageMemory(render)", code));
+        }
+
+        // One view serves both faces of the image: the attachment names
+        // it, and a binding samples through it. Depth views name the
+        // depth aspect alone, the depth attachment's own convention.
+        let view_info = vk::ImageViewCreateInfo::default()
+            .image(image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(format)
+            .subresource_range(
+                vk::ImageSubresourceRange::default()
+                    .aspect_mask(aspect)
+                    .base_mip_level(0)
+                    .level_count(1)
+                    .base_array_layer(0)
+                    .layer_count(1),
+            );
+        // SAFETY: image live and bound.
+        let view = match unsafe {
+            shared
+                .device
+                .create_image_view(&view_info, Some(&shared.alloc_cbs()))
+        } {
+            Ok(view) => view,
+            Err(code) => {
+                // SAFETY: both live, nothing else references them.
+                unsafe {
+                    shared.device.free_memory(memory, Some(&shared.alloc_cbs()));
+                }
+                destroy_image(shared);
+                return Err(creation("vkCreateImageView(render)", code));
+            }
+        };
+
+        Ok(RenderImage {
+            inner: Rc::new(RenderImageInner {
+                shared: Rc::clone(shared),
+                image,
+                memory,
+                view,
+                format,
+                kind: desc.kind,
+                extent: desc.extent,
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The extent refusals, both rules, with no device involved.
+    #[test]
+    fn malformed_extents_are_refused_by_name() {
+        let refusal = check_extent(
+            Extent {
+                width: 0,
+                height: 4,
+            },
+            4096,
+        );
+        assert!(matches!(
+            refusal,
+            Err(TargetError::Creation {
+                call: "create_render_image(zero extent)",
+                ..
+            })
+        ));
+        let refusal = check_extent(
+            Extent {
+                width: 4,
+                height: 8192,
+            },
+            4096,
+        );
+        assert!(matches!(
+            refusal,
+            Err(TargetError::Creation {
+                call: "create_render_image(extent exceeds the device limit)",
+                ..
+            })
+        ));
+        assert!(
+            check_extent(
+                Extent {
+                    width: 4,
+                    height: 4,
+                },
+                4096,
+            )
+            .is_ok()
+        );
+    }
+}

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -461,22 +461,33 @@ impl WindowTarget {
     ///
     /// The frame-shape contract is asserted before any fence is waited
     /// or written — among its refusals: a frame needs at least one
-    /// pass; a pass carries exactly one color attachment;
-    /// `LoadOp::Load` is refused on an attachment's first use in the
-    /// frame; clear values must match their attachment's kind and a
-    /// depth clear its documented range; an item's pipeline depth state
-    /// must match its pass; one buffer feeds at most one item per
-    /// frame; an item names geometry exactly when its pipeline declares
-    /// per-vertex input, and a mesh's vertex stride equals the stride
-    /// that pipeline's layout packs to; an item names bindings exactly
-    /// when its pipeline declares sampled slots, and exactly as many as
-    /// it declares; and a frame carries at most the retention table's
-    /// width of distinct resources — per-frame buffers, meshes and
-    /// bindings together, the repeatable classes counting once however
-    /// many items name them. Frame data longer than its buffer's
-    /// per-frame capacity also panics through a retained assertion: the
-    /// length bounds a copy into mapped device memory, which makes it a
-    /// memory-safety boundary rather than a contract nicety.
+    /// pass, and at least one surface pass; a surface pass carries
+    /// exactly one color attachment, an image pass none (its one
+    /// attachment rides its target); `LoadOp::Load` is refused on each
+    /// identity's first use in the frame, and on a render image whose
+    /// last targeting pass discarded; clear values must match their
+    /// attachment's kind and a depth clear its documented range; an
+    /// item's pipeline depth state must match its pass, its format an
+    /// image pass's kind, and a depth-only pipeline draws only into
+    /// depth images; one buffer carries one `FrameData` per frame
+    /// (pointer-identical data may repeat across items; differing data
+    /// is refused); an item names geometry exactly when its pipeline
+    /// declares per-vertex input, and a mesh's vertex stride equals the
+    /// stride that pipeline's layout packs to; an item names bindings
+    /// exactly when its pipeline declares sampled slots, and exactly as
+    /// many as it declares; the per-image walk is one-way — a frame
+    /// writes an image before reading it, never in the same pass, never
+    /// re-targeting after a read, storing whatever a later pass loads
+    /// or samples — over at most
+    /// [`MAX_FRAME_RENDER_IMAGES`](crate::MAX_FRAME_RENDER_IMAGES)
+    /// distinct images; and a frame carries at most the retention
+    /// table's width of distinct resources — per-frame buffers, meshes,
+    /// bindings and pass-target images together, the repeatable classes
+    /// counting once however many mentions. Frame data longer than its
+    /// buffer's per-frame capacity also panics through a retained
+    /// assertion: the length bounds a copy into mapped device memory,
+    /// which makes it a memory-safety boundary rather than a contract
+    /// nicety.
     ///
     /// # Errors
     ///
@@ -599,6 +610,10 @@ impl WindowTarget {
                 // path — where a skipped hold is memory freed under a
                 // live submit.
                 if let pass::PassTarget::Image(image, _) = &pass.target {
+                    debug_assert!(
+                        Rc::ptr_eq(&image.inner.shared, &self.shared),
+                        "render image and target come from different devices"
+                    );
                     let resource = Retained::Image(Rc::clone(&image.inner));
                     if !pass::already_retained(&resource, &self.retained[frame][..retained_count]) {
                         self.retained[frame][retained_count] = Some(resource);

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -23,7 +23,7 @@ use crate::vk::depth::{self, DepthResources};
 use crate::vk::device::{Device, DeviceShared, FENCE_TIMEOUT_NS};
 use crate::vk::pass::{self, MAX_RETAINED_RESOURCES, RenderDesc, Retained};
 use crate::vk::pipeline::{INSTANCE_BINDING, TargetFormat, VERTEX_BINDING};
-use crate::vk::transition::{self, ImageUse};
+use crate::vk::transition;
 
 fn creation(call: &'static str, code: vk::Result) -> TargetError {
     match code {
@@ -510,13 +510,17 @@ impl WindowTarget {
             });
         }
         for pass in desc.passes {
+            let surface_pass = matches!(pass.target, pass::PassTarget::Surface);
             for item in pass.items {
                 debug_assert!(
                     Rc::ptr_eq(&self.shared, &item.pipeline.shared),
                     "pipeline and target come from different devices"
                 );
+                // Image passes matched their format against their image
+                // in the contract; the surface's own format is this
+                // target's to assert.
                 debug_assert!(
-                    item.pipeline.format == self.format,
+                    !surface_pass || item.pipeline.format == self.format,
                     "pipeline targets {:?}, swapchain is {:?}",
                     item.pipeline.format,
                     self.format
@@ -590,6 +594,17 @@ impl WindowTarget {
             }
             let mut retained_count = 0usize;
             for pass in desc.passes {
+                // A pass-target image is retained by the pass itself,
+                // the offscreen loop's reasoning on the asynchronous
+                // path — where a skipped hold is memory freed under a
+                // live submit.
+                if let pass::PassTarget::Image(image, _) = &pass.target {
+                    let resource = Retained::Image(Rc::clone(&image.inner));
+                    if !pass::already_retained(&resource, &self.retained[frame][..retained_count]) {
+                        self.retained[frame][retained_count] = Some(resource);
+                        retained_count += 1;
+                    }
+                }
                 for item in pass.items {
                     if let Some(mesh) = item.mesh {
                         debug_assert!(
@@ -761,61 +776,79 @@ impl WindowTarget {
                 &vk::DependencyInfo::default().image_memory_barriers(&barriers),
             );
 
-            let area = vk::Rect2D {
-                offset: vk::Offset2D { x: 0, y: 0 },
-                extent: vk::Extent2D {
-                    width: chain_extent.width,
-                    height: chain_extent.height,
-                },
-            };
             // The walk: for each pass, its boundary barriers from the
-            // pure core (the acquire-chained first-use above already
-            // covered pass 0's color), then its attachments, then its
-            // items in slice order. Depth transitions from UNDEFINED
-            // once per frame on this slot's own image.
-            let mut depth_in_use = false;
+            // shared frame walk (the same state machine the contract
+            // proved), then its attachments, then its items — every one
+            // following the pass's target. One deliberate exception:
+            // the surface's FIRST use was already transitioned by the
+            // acquire-chained barrier above, whose source stage exists
+            // for semaphore chaining — so the walk's surface first-use
+            // pair is recognised and skipped, never re-emitted.
+            let mut walk = pass::FrameWalk::new();
             for (index, pass) in desc.passes.iter().enumerate() {
-                let mut barriers = [vk::ImageMemoryBarrier2::default(); 2];
-                let mut barrier_count = 0;
-                if index > 0 {
-                    let color_masks = transition::pass_boundary(
-                        ImageUse::ColorAttachment,
-                        ImageUse::ColorAttachment,
-                    );
-                    barriers[0] = vk::ImageMemoryBarrier2::default()
-                        .src_stage_mask(color_masks.src_stage)
-                        .src_access_mask(color_masks.src_access)
-                        .dst_stage_mask(color_masks.dst_stage)
-                        .dst_access_mask(color_masks.dst_access)
-                        .old_layout(color_masks.old_layout)
-                        .new_layout(color_masks.new_layout)
-                        .image(image)
-                        .subresource_range(color_range());
-                    barrier_count = 1;
+                let uses = walk.advance_target(index, pass);
+                let mut barriers = [vk::ImageMemoryBarrier2::default(); pass::MAX_PASS_BARRIERS];
+                let mut barrier_count = 0usize;
+                if let Some((from, to)) = uses.color {
+                    // The acquire-chained exception: exactly the
+                    // surface's first use, nothing else.
+                    let acquire_chained =
+                        matches!(from, transition::ImageUse::ColorAttachmentFirstUse);
+                    if !acquire_chained {
+                        let masks = transition::pass_boundary(from, to);
+                        let barrier_image = match &pass.target {
+                            pass::PassTarget::Surface => image,
+                            pass::PassTarget::Image(target_image, _) => target_image.inner.image,
+                        };
+                        barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
+                            .src_stage_mask(masks.src_stage)
+                            .src_access_mask(masks.src_access)
+                            .dst_stage_mask(masks.dst_stage)
+                            .dst_access_mask(masks.dst_access)
+                            .old_layout(masks.old_layout)
+                            .new_layout(masks.new_layout)
+                            .image(barrier_image)
+                            .subresource_range(color_range());
+                        barrier_count += 1;
+                    }
                 }
-                if pass.depth.is_some() {
-                    let depth_slot = &chain.depth[frame];
-                    let depth_masks = if depth_in_use {
-                        transition::pass_boundary(
-                            ImageUse::DepthAttachment,
-                            ImageUse::DepthAttachment,
-                        )
-                    } else {
-                        transition::pass_boundary(
-                            ImageUse::DepthAttachmentFirstUse,
-                            ImageUse::DepthAttachment,
-                        )
+                if let Some((from, to)) = uses.depth {
+                    let masks = transition::pass_boundary(from, to);
+                    // Total for surface passes by the depth-availability
+                    // check before recording began; an image pass
+                    // carries its own depth image in its target.
+                    let (barrier_image, format) = match &pass.target {
+                        pass::PassTarget::Surface => {
+                            let depth_slot = &chain.depth[frame];
+                            (depth_slot.image, depth_slot.format)
+                        }
+                        pass::PassTarget::Image(target_image, _) => {
+                            (target_image.inner.image, target_image.inner.format)
+                        }
                     };
-                    depth_in_use = true;
                     barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
-                        .src_stage_mask(depth_masks.src_stage)
-                        .src_access_mask(depth_masks.src_access)
-                        .dst_stage_mask(depth_masks.dst_stage)
-                        .dst_access_mask(depth_masks.dst_access)
-                        .old_layout(depth_masks.old_layout)
-                        .new_layout(depth_masks.new_layout)
-                        .image(depth_slot.image)
-                        .subresource_range(depth::barrier_range(depth_slot.format));
+                        .src_stage_mask(masks.src_stage)
+                        .src_access_mask(masks.src_access)
+                        .dst_stage_mask(masks.dst_stage)
+                        .dst_access_mask(masks.dst_access)
+                        .old_layout(masks.old_layout)
+                        .new_layout(masks.new_layout)
+                        .image(barrier_image)
+                        .subresource_range(depth::barrier_range(format));
+                    barrier_count += 1;
+                }
+                let (samples, sample_count) = walk.advance_sampling(index, pass);
+                for sample in samples.iter().take(sample_count).flatten() {
+                    let masks = transition::pass_boundary(sample.uses.0, sample.uses.1);
+                    barriers[barrier_count] = vk::ImageMemoryBarrier2::default()
+                        .src_stage_mask(masks.src_stage)
+                        .src_access_mask(masks.src_access)
+                        .dst_stage_mask(masks.dst_stage)
+                        .dst_access_mask(masks.dst_access)
+                        .old_layout(masks.old_layout)
+                        .new_layout(masks.new_layout)
+                        .image(sample.image)
+                        .subresource_range(sample.range);
                     barrier_count += 1;
                 }
                 if barrier_count > 0 {
@@ -826,27 +859,66 @@ impl WindowTarget {
                     );
                 }
 
-                let color = &pass.color[0];
-                let color_attachment = vk::RenderingAttachmentInfo::default()
-                    .image_view(view)
-                    .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
-                    .load_op(color.load.to_vk())
-                    .store_op(color.store.to_vk())
-                    .clear_value(pass::vk_clear_color(color));
-                let color_attachments = [color_attachment];
-                let depth_attachment = pass.depth.as_ref().map(|attachment| {
-                    let depth_slot = &chain.depth[frame];
-                    vk::RenderingAttachmentInfo::default()
-                        .image_view(depth_slot.view)
-                        .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                        .load_op(attachment.load.to_vk())
-                        .store_op(attachment.store.to_vk())
-                        .clear_value(pass::vk_clear_depth(attachment))
-                });
+                // Attachments and geometry follow the target, the
+                // offscreen loop's shape with this chain's own images.
+                let mut color_attachments: [vk::RenderingAttachmentInfo<'_>; 1] =
+                    [vk::RenderingAttachmentInfo::default()];
+                let mut color_attachment_count = 0usize;
+                let mut depth_attachment = None;
+                let extent = match &pass.target {
+                    pass::PassTarget::Surface => {
+                        let color = &pass.color[0];
+                        color_attachments[0] = vk::RenderingAttachmentInfo::default()
+                            .image_view(view)
+                            .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                            .load_op(color.load.to_vk())
+                            .store_op(color.store.to_vk())
+                            .clear_value(pass::vk_clear_color(color));
+                        color_attachment_count = 1;
+                        depth_attachment = pass.depth.as_ref().map(|attachment| {
+                            let depth_slot = &chain.depth[frame];
+                            vk::RenderingAttachmentInfo::default()
+                                .image_view(depth_slot.view)
+                                .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+                                .load_op(attachment.load.to_vk())
+                                .store_op(attachment.store.to_vk())
+                                .clear_value(pass::vk_clear_depth(attachment))
+                        });
+                        chain_extent
+                    }
+                    pass::PassTarget::Image(target_image, attachment) => {
+                        if target_image.kind() == crate::RenderImageKind::Depth {
+                            depth_attachment = Some(
+                                vk::RenderingAttachmentInfo::default()
+                                    .image_view(target_image.inner.view)
+                                    .image_layout(vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
+                                    .load_op(attachment.load.to_vk())
+                                    .store_op(attachment.store.to_vk())
+                                    .clear_value(pass::vk_clear_depth(attachment)),
+                            );
+                        } else {
+                            color_attachments[0] = vk::RenderingAttachmentInfo::default()
+                                .image_view(target_image.inner.view)
+                                .image_layout(vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL)
+                                .load_op(attachment.load.to_vk())
+                                .store_op(attachment.store.to_vk())
+                                .clear_value(pass::vk_clear_color(attachment));
+                            color_attachment_count = 1;
+                        }
+                        target_image.extent()
+                    }
+                };
+                let area = vk::Rect2D {
+                    offset: vk::Offset2D { x: 0, y: 0 },
+                    extent: vk::Extent2D {
+                        width: extent.width,
+                        height: extent.height,
+                    },
+                };
                 let mut rendering_info = vk::RenderingInfo::default()
                     .render_area(area)
                     .layer_count(1)
-                    .color_attachments(&color_attachments);
+                    .color_attachments(&color_attachments[..color_attachment_count]);
                 if let Some(depth_attachment) = &depth_attachment {
                     rendering_info = rendering_info.depth_attachment(depth_attachment);
                 }
@@ -858,8 +930,8 @@ impl WindowTarget {
                     let viewport = vk::Viewport {
                         x: 0.0,
                         y: 0.0,
-                        width: chain_extent.width as f32,
-                        height: chain_extent.height as f32,
+                        width: extent.width as f32,
+                        height: extent.height as f32,
                         min_depth: 0.0,
                         max_depth: 1.0,
                     };

--- a/crates/rhi/src/vk/texture.rs
+++ b/crates/rhi/src/vk/texture.rs
@@ -27,7 +27,6 @@ use crate::config::Extent;
 use crate::error::TargetError;
 use crate::vk::device::{Device, DeviceShared, FENCE_TIMEOUT_NS};
 use crate::vk::offscreen::{BPP, color_range, creation, image_memory_type, pick_memory_type};
-use crate::vk::pipeline::TargetFormat;
 
 /// The pixels and dimensions of a sampled image.
 ///
@@ -354,7 +353,7 @@ fn upload(
 ) -> Result<Texture, TargetError> {
     let image_info = vk::ImageCreateInfo::default()
         .image_type(vk::ImageType::TYPE_2D)
-        .format(TargetFormat::Rgba8Unorm.to_vk())
+        .format(vk::Format::R8G8B8A8_UNORM)
         .extent(vk::Extent3D {
             width: desc.extent.width,
             height: desc.extent.height,
@@ -407,7 +406,7 @@ fn upload(
     let view_info = vk::ImageViewCreateInfo::default()
         .image(image)
         .view_type(vk::ImageViewType::TYPE_2D)
-        .format(TargetFormat::Rgba8Unorm.to_vk())
+        .format(vk::Format::R8G8B8A8_UNORM)
         .subresource_range(color_range());
     // SAFETY: image live and bound.
     let view = unsafe {

--- a/crates/rhi/src/vk/transition.rs
+++ b/crates/rhi/src/vk/transition.rs
@@ -42,6 +42,25 @@ pub(crate) enum ImageUse {
     DepthAttachmentFirstUse,
     /// A depth attachment a previous pass wrote this frame.
     DepthAttachment,
+    /// This frame's first use of a **render image** as a color target.
+    ///
+    /// Not [`Self::ColorAttachmentFirstUse`], and the difference is a
+    /// real hazard: a target-owned image sits behind a per-slot fence
+    /// wait, so nothing can still touch it and its source scope is
+    /// empty. A render image is ONE physical image across frames in
+    /// flight — the previous frame's attachment writes and sampling
+    /// reads are not fence-proven when this frame first writes it, so
+    /// the first-use barrier must wait on the stages that could still
+    /// be using it.
+    RenderColorFirstUse,
+    /// This frame's first use of a render image as a depth target —
+    /// [`Self::RenderColorFirstUse`]'s reasoning at the depth stages.
+    RenderDepthFirstUse,
+    /// A render image a pass in this frame rendered into, now read by
+    /// a sampling pass. Emitted once, at the first sampling pass's
+    /// boundary; the contract refuses re-targeting after sampling, so
+    /// no arm leads back out.
+    SampledInPass,
 }
 
 /// The pass-boundary barrier for an attachment moving `from` → `to`.
@@ -98,6 +117,59 @@ pub(crate) fn pass_boundary(from: ImageUse, to: ImageUse) -> BarrierMasks {
                 | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
             old_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
             new_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        },
+        // A render image's first frame use: the source scope covers the
+        // stages a previous frame could still be running against this
+        // ONE physical image, and its WRITE access besides. `UNDEFINED`
+        // discards contents, but a layout transition is itself a write,
+        // and ordering it against the previous frame's attachment
+        // writes takes availability — execution alone is a
+        // write-after-write hazard, which sync validation reported on
+        // this barrier's first windowed run and this access mask fixed.
+        // The previous frame's sampling reads need only the execution
+        // half, which the fragment-shader stage supplies.
+        (ImageUse::RenderColorFirstUse, ImageUse::ColorAttachment) => BarrierMasks {
+            src_stage: vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            src_access: vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            dst_stage: vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+            dst_access: vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            old_layout: vk::ImageLayout::UNDEFINED,
+            new_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        },
+        (ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment) => BarrierMasks {
+            src_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
+                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            dst_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
+                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            dst_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            old_layout: vk::ImageLayout::UNDEFINED,
+            new_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        },
+        // Rendered this frame, sampled from here on: the writing
+        // stage's results made available to fragment sampling, with the
+        // layout following. Emitted at the first sampling pass's
+        // boundary and never reversed — the contract refuses
+        // re-targeting after sampling.
+        (ImageUse::ColorAttachment, ImageUse::SampledInPass) => BarrierMasks {
+            src_stage: vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+            src_access: vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            dst_stage: vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            dst_access: vk::AccessFlags2::SHADER_SAMPLED_READ,
+            old_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+            new_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+        },
+        (ImageUse::DepthAttachment, ImageUse::SampledInPass) => BarrierMasks {
+            src_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
+                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            dst_stage: vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            dst_access: vk::AccessFlags2::SHADER_SAMPLED_READ,
+            old_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            new_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         },
         (from, to) => unreachable!("no pass boundary produces {from:?} -> {to:?}"),
     }
@@ -256,6 +328,109 @@ mod tests {
         );
     }
 
+    /// The render-image arms, pinned like the rest of the table. The
+    /// source STAGES on the first uses are the point: an execution-only
+    /// wait on whatever a previous frame could still be running against
+    /// the one physical image. A CPU rasterizer draws identical pixels
+    /// with these masks wrong, so this table is the oracle.
+    #[test]
+    fn the_render_image_arms_are_pinned_field_by_field() {
+        let tests_stages = vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
+            | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS;
+        let depth_rw = vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+            | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE;
+
+        let render_color = pass_boundary(ImageUse::RenderColorFirstUse, ImageUse::ColorAttachment);
+        assert_eq!(
+            render_color.src_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            render_color.src_access,
+            vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+        );
+        assert_eq!(
+            render_color.dst_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+        );
+        assert_eq!(
+            render_color.dst_access,
+            vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+        );
+        assert_eq!(render_color.old_layout, vk::ImageLayout::UNDEFINED);
+        assert_eq!(
+            render_color.new_layout,
+            vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+        );
+
+        let render_depth = pass_boundary(ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment);
+        assert_eq!(
+            render_depth.src_stage,
+            tests_stages | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            render_depth.src_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(render_depth.dst_stage, tests_stages);
+        assert_eq!(render_depth.dst_access, depth_rw);
+        assert_eq!(render_depth.old_layout, vk::ImageLayout::UNDEFINED);
+        assert_eq!(
+            render_depth.new_layout,
+            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        );
+
+        let color_sampled = pass_boundary(ImageUse::ColorAttachment, ImageUse::SampledInPass);
+        assert_eq!(
+            color_sampled.src_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+        );
+        assert_eq!(
+            color_sampled.src_access,
+            vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+        );
+        assert_eq!(
+            color_sampled.dst_stage,
+            vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            color_sampled.dst_access,
+            vk::AccessFlags2::SHADER_SAMPLED_READ
+        );
+        assert_eq!(
+            color_sampled.old_layout,
+            vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+        );
+        assert_eq!(
+            color_sampled.new_layout,
+            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+        );
+
+        let depth_sampled = pass_boundary(ImageUse::DepthAttachment, ImageUse::SampledInPass);
+        assert_eq!(depth_sampled.src_stage, tests_stages);
+        assert_eq!(
+            depth_sampled.src_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(
+            depth_sampled.dst_stage,
+            vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            depth_sampled.dst_access,
+            vk::AccessFlags2::SHADER_SAMPLED_READ
+        );
+        assert_eq!(
+            depth_sampled.old_layout,
+            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        );
+        assert_eq!(
+            depth_sampled.new_layout,
+            vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+        );
+    }
+
     /// The excluded sites' literals, pinned exactly as they ship today.
     /// These are the barriers the pure core deliberately does not own;
     /// a change to any mask here is a change to a synchronization
@@ -335,6 +510,16 @@ mod tests {
         assert!(
             result.is_err(),
             "moving to a first use is a contract violation"
+        );
+        // No arm leads back out of sampling: the contract refuses
+        // re-targeting after a sampling pass, so the table has nothing
+        // to answer with.
+        let result = std::panic::catch_unwind(|| {
+            pass_boundary(ImageUse::SampledInPass, ImageUse::ColorAttachment)
+        });
+        assert!(
+            result.is_err(),
+            "re-targeting after sampling is a contract violation"
         );
     }
 }

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -533,14 +533,19 @@ fn malformed_frames_are_refused_by_name() {
         .create_buffer(64, BufferUsage::PerFrame)
         .expect("per-frame buffer");
     let bytes = [0u8; 24];
+    // The relaxed buffer rule, both sides: pointer-identical FrameData
+    // may repeat (the same draw from two items is one copy written
+    // twice), while DIFFERING data for one buffer is still the
+    // second-copy-wins race, refused by name.
     refused(
-        "two items naming one buffer",
-        "one buffer, one item",
+        "two items with different data for one buffer",
+        "one buffer, one FrameData",
         &|target| {
             let color = clear(black);
+            let other_bytes = [7u8; 24];
             let items = [
                 Item::new(&instanced).frame_data(FrameData::new(&buffer, &bytes, 1)),
-                Item::new(&instanced).frame_data(FrameData::new(&buffer, &bytes, 1)),
+                Item::new(&instanced).frame_data(FrameData::new(&buffer, &other_bytes, 1)),
             ];
             let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
         },
@@ -715,6 +720,151 @@ fn malformed_frames_are_refused_by_name() {
             let _ = Item::new(&two_slot).bindings(&[&binding; 5]);
         },
     );
+    // The render-image identity rules, each refused by name. One
+    // color image and its binding serve every case; the sampled cases
+    // ride the one-slot pipeline.
+    let image = device
+        .create_render_image(&renew_rhi::RenderImageDesc::new(
+            renew_rhi::RenderImageKind::Color,
+            Extent {
+                width: 8,
+                height: 8,
+            },
+        ))
+        .expect("refusal fixture image");
+    let image_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&image), &sampler))
+        .expect("refusal fixture image binding");
+    let store = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+        StoreOp::Store,
+    );
+    refused(
+        "an image pass carrying surface slices",
+        "carries its one attachment in its target",
+        &|target| {
+            let color = clear(black);
+            let mut pass = Pass::render_to(&image, store, &[]);
+            pass.color = &color;
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[pass, Pass::new(&color, &surface)]));
+        },
+    );
+    refused(
+        "a frame with no surface pass",
+        "at least one surface pass",
+        &|target| {
+            let _ = target.render(&RenderDesc::new(&[Pass::render_to(&image, store, &[])]));
+        },
+    );
+    refused(
+        "a contents-preserving load on an image's first use",
+        "render-image contents are frame-scoped",
+        &|target| {
+            let color = clear(black);
+            let load = Attachment::new(LoadOp::Load, StoreOp::Store);
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, load, &[]),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+    refused(
+        "sampling an image the frame never rendered",
+        "must write it first",
+        &|target| {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&image_binding])];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+    refused(
+        "a pass sampling its own target",
+        "feedback within one pass",
+        &|target| {
+            let color = clear(black);
+            let sampled_desc =
+                PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1);
+            let feedback = device
+                .create_pipeline(&sampled_desc)
+                .expect("feedback pipeline");
+            let items = [Item::new(&feedback).bindings(&[&image_binding])];
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, store, &items),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+    refused(
+        "re-targeting an image after sampling it",
+        "one-way",
+        &|target| {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&image_binding])];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, store, &[]),
+                Pass::new(&color, &items),
+                Pass::render_to(&image, store, &[]),
+            ]));
+        },
+    );
+    refused(
+        "discarding contents a later pass samples",
+        "must Store",
+        &|target| {
+            let color = clear(black);
+            let discard = Attachment::new(
+                LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+                StoreOp::Discard,
+            );
+            let items = [Item::new(&one_slot).bindings(&[&image_binding])];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, discard, &[]),
+                Pass::new(&color, &items),
+            ]));
+        },
+    );
+    refused(
+        "a depth clear on a color image",
+        "clears to its kind's value",
+        &|target| {
+            let color = clear(black);
+            let wrong = Attachment::new(LoadOp::Clear(ClearValue::Depth(0.0)), StoreOp::Store);
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, wrong, &[]),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+    refused(
+        "a surface-format pipeline drawn into a color image",
+        "must match the image it",
+        &|target| {
+            let color = clear(black);
+            // The mismatch under test is depth-only-vs-color, the one
+            // shape a color pipeline cannot be.
+            let depth_only = device
+                .create_pipeline(
+                    &PipelineDesc::depth_mesh(builtin::MESH_VS_SPV, builtin::MESH_LAYOUT)
+                        .depth_state(DepthState::read_write()),
+                )
+                .expect("depth-only pipeline");
+            let mesh = device
+                .create_mesh(&MeshDesc::new(&[0u8; 36 * 3], 36, &[0, 1, 2]))
+                .expect("mesh");
+            let items = [Item::new(&depth_only).mesh(&mesh)];
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, store, &items),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+    drop(image_binding);
+    drop(image);
     drop(two_slot);
     drop(one_slot);
     drop(binding);

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -839,23 +839,25 @@ fn malformed_frames_are_refused_by_name() {
             ]));
         },
     );
+    // The depth-only placement rule, both wrong homes: a color image
+    // pass and a surface pass. Retained rather than the surface format
+    // match's dev-only assert, because the zero-attachment shape in a
+    // color pass is an undefined draw, not a channel swap.
+    let depth_only = device
+        .create_pipeline(
+            &PipelineDesc::depth_mesh(builtin::MESH_VS_SPV, builtin::MESH_LAYOUT)
+                .depth_state(DepthState::read_write()),
+        )
+        .expect("depth-only pipeline");
+    let quad_mesh = device
+        .create_mesh(&MeshDesc::new(&[0u8; 36 * 3], 36, &[0, 1, 2]))
+        .expect("mesh");
     refused(
-        "a surface-format pipeline drawn into a color image",
-        "must match the image it",
+        "a depth-only pipeline drawn into a color image",
+        "draws only into depth-kinded",
         &|target| {
             let color = clear(black);
-            // The mismatch under test is depth-only-vs-color, the one
-            // shape a color pipeline cannot be.
-            let depth_only = device
-                .create_pipeline(
-                    &PipelineDesc::depth_mesh(builtin::MESH_VS_SPV, builtin::MESH_LAYOUT)
-                        .depth_state(DepthState::read_write()),
-                )
-                .expect("depth-only pipeline");
-            let mesh = device
-                .create_mesh(&MeshDesc::new(&[0u8; 36 * 3], 36, &[0, 1, 2]))
-                .expect("mesh");
-            let items = [Item::new(&depth_only).mesh(&mesh)];
+            let items = [Item::new(&depth_only).mesh(&quad_mesh)];
             let surface = [Item::new(&pipeline)];
             let _ = target.render(&RenderDesc::new(&[
                 Pass::render_to(&image, store, &items),
@@ -863,6 +865,66 @@ fn malformed_frames_are_refused_by_name() {
             ]));
         },
     );
+    refused(
+        "a depth-only pipeline drawn in a surface pass",
+        "draws only into depth-kinded",
+        &|target| {
+            let color = clear(black);
+            let fresh = Attachment::new(LoadOp::Clear(ClearValue::Depth(0.0)), StoreOp::Discard);
+            let items = [Item::new(&depth_only).mesh(&quad_mesh)];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items).depth(fresh)]));
+        },
+    );
+    // The store-tracking rules the walk owns: loading what the last
+    // targeting pass threw away, and the image ceiling.
+    refused(
+        "a load of discarded render-image contents",
+        "store what a later pass loads",
+        &|target| {
+            let color = clear(black);
+            let discard = Attachment::new(
+                LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+                StoreOp::Discard,
+            );
+            let load = Attachment::new(LoadOp::Load, StoreOp::Store);
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&image, discard, &[]),
+                Pass::render_to(&image, load, &[]),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+    let many_images: Vec<renew_rhi::RenderImage> = (0..5)
+        .map(|_| {
+            device
+                .create_render_image(&renew_rhi::RenderImageDesc::new(
+                    renew_rhi::RenderImageKind::Color,
+                    Extent {
+                        width: 8,
+                        height: 8,
+                    },
+                ))
+                .expect("boundary image")
+        })
+        .collect();
+    refused(
+        "a fifth distinct render image",
+        "at most 4 distinct render images",
+        &|target| {
+            let color = clear(black);
+            let surface = [Item::new(&pipeline)];
+            let image_passes: Vec<Pass<'_>> = many_images
+                .iter()
+                .map(|image| Pass::render_to(image, store, &[]))
+                .chain(std::iter::once(Pass::new(&color, &surface)))
+                .collect();
+            let _ = target.render(&RenderDesc::new(&image_passes));
+        },
+    );
+    drop(many_images);
+    drop(quad_mesh);
+    drop(depth_only);
     drop(image_binding);
     drop(image);
     drop(two_slot);
@@ -879,6 +941,77 @@ fn malformed_frames_are_refused_by_name() {
     target
         .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
         .expect("the target survives every refusal");
+    assert_no_validation_errors(&device);
+}
+
+/// Four distinct render images in one frame — the documented ceiling —
+/// two of them sampled by the same surface pass: the multi-image walk,
+/// the pass-level retention of every image, and a batched sampling
+/// boundary, all under validation. The refusal battery proves the
+/// fifth is refused; this proves the fourth is not.
+#[test]
+fn four_render_images_fill_the_frame_ceiling() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 8,
+            height: 8,
+        })
+        .expect("offscreen target");
+    let images: Vec<renew_rhi::RenderImage> = (0..4)
+        .map(|_| {
+            device
+                .create_render_image(&renew_rhi::RenderImageDesc::new(
+                    renew_rhi::RenderImageKind::Color,
+                    Extent {
+                        width: 8,
+                        height: 8,
+                    },
+                ))
+                .expect("frame image")
+        })
+        .collect();
+    let sampler = device
+        .create_sampler(&SamplerDesc::atlas())
+        .expect("sampler");
+    let bindings: Vec<renew_rhi::Binding> = images
+        .iter()
+        .take(2)
+        .map(|image| {
+            device
+                .create_binding(&BindingDesc::new(BindingSource::Image(image), &sampler))
+                .expect("image binding")
+        })
+        .collect();
+    let reader = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1),
+        )
+        .expect("reader pipeline");
+    let ops = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(0.5, 0.5, 0.5, 1.0))),
+        StoreOp::Store,
+    );
+    let color = clear(Color::new(0.0, 0.0, 0.0, 1.0));
+    let surface_items = [
+        Item::new(&reader).bindings(&[&bindings[0]]),
+        Item::new(&reader).bindings(&[&bindings[1]]),
+    ];
+    let passes: Vec<Pass<'_>> = images
+        .iter()
+        .map(|image| Pass::render_to(image, ops, &[]))
+        .chain(std::iter::once(Pass::new(&color, &surface_items)))
+        .collect();
+    target
+        .render(&RenderDesc::new(&passes))
+        .expect("four-image frame");
+    drop(target);
+    drop(reader);
+    drop(bindings);
+    drop(images);
+    drop(sampler);
     assert_no_validation_errors(&device);
 }
 

--- a/crates/rhi/tests/fault.rs
+++ b/crates/rhi/tests/fault.rs
@@ -857,11 +857,26 @@ fn every_driver_failure_ladder_behaves() {
                 Ok(_) => return Err("T17: the upload survived a lost device".to_owned()),
             }
             match device.create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS)) {
-                Err(TargetError::DeviceLost) => Ok(()),
-                Err(other) => Err(wrong("T17", "DeviceLost on the next call", &other)),
+                Err(TargetError::DeviceLost) => {}
+                Err(other) => return Err(wrong("T17", "DeviceLost on the next call", &other)),
                 Ok(_) => {
-                    Err("T17: the device was not poisoned, so the next upload proceeded".to_owned())
+                    return Err(
+                        "T17: the device was not poisoned, so the next upload proceeded".to_owned(),
+                    );
                 }
+            }
+            // Every creation path guards on the same poison flag; the
+            // render image's guard is probed on the same lost device.
+            match device.create_render_image(&renew_rhi::RenderImageDesc::new(
+                renew_rhi::RenderImageKind::Color,
+                Extent {
+                    width: 4,
+                    height: 4,
+                },
+            )) {
+                Err(TargetError::DeviceLost) => Ok(()),
+                Err(other) => Err(wrong("T17", "DeviceLost from create_render_image", &other)),
+                Ok(_) => Err("T17: a render image was created on a poisoned device".to_owned()),
             }
         },
     ));
@@ -908,6 +923,78 @@ fn every_driver_failure_ladder_behaves() {
                 .create_texture(&TextureDesc::new(TEXEL_SIZE, &TEXELS))
                 .map(|_| ())
                 .map_err(|error| format!("{name}: recovery upload failed: {error}"))
+        }));
+    }
+
+    // ---- R · render-image creation ladder ---------------------------
+    // Every fallible Vulkan call `create_render_image` makes, in the
+    // order it makes them, appended after the ladders that existed when
+    // it landed. No upload and no staging state: each failure must
+    // surface the right call and unwind whatever preceded it, which the
+    // validation check after each case proves.
+    let render_image_ladder: &[(&str, &str, &str, bool)] = &[
+        (
+            "R1",
+            "vkCreateImage=ERROR_OUT_OF_HOST_MEMORY",
+            "vkCreateImage(render)",
+            false,
+        ),
+        (
+            "R2",
+            "vkAllocateMemory=ERROR_OUT_OF_DEVICE_MEMORY",
+            "vkAllocateMemory(render)",
+            true,
+        ),
+        (
+            "R3",
+            "vkBindImageMemory=ERROR_OUT_OF_HOST_MEMORY",
+            "vkBindImageMemory(render)",
+            false,
+        ),
+        (
+            "R4",
+            "vkCreateImageView=ERROR_OUT_OF_HOST_MEMORY",
+            "vkCreateImageView(render)",
+            false,
+        ),
+        // The allocation's second failure shape: anything that is not
+        // out-of-device-memory reports as Creation through the other
+        // arm of the same match.
+        (
+            "R5",
+            "vkAllocateMemory=ERROR_OUT_OF_HOST_MEMORY",
+            "vkAllocateMemory(render)",
+            false,
+        ),
+    ];
+    for &(name, fault, call, device_memory) in render_image_ladder {
+        verdicts.push(device_case(name, fault, |device| {
+            let desc = renew_rhi::RenderImageDesc::new(
+                renew_rhi::RenderImageKind::Color,
+                Extent {
+                    width: 8,
+                    height: 8,
+                },
+            );
+            match device.create_render_image(&desc) {
+                Err(error) => {
+                    let matched = if device_memory {
+                        matches!(&error, TargetError::OutOfDeviceMemory { call: got } if *got == call)
+                    } else {
+                        matches!(&error, TargetError::Creation { call: got, .. } if *got == call)
+                    };
+                    if !matched {
+                        return Err(wrong(name, call, &error));
+                    }
+                }
+                Ok(_) => {
+                    return Err(format!("{name}: the image was created despite the fault"));
+                }
+            }
+            device
+                .create_render_image(&desc)
+                .map(|_| ())
+                .map_err(|error| format!("{name}: recovery image failed: {error}"))
         }));
     }
 

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -659,15 +659,14 @@ fn a_rendered_image_samples_back_byte_exact() {
         Item::new(&pipeline).bindings(&[&image_binding]),
         Item::new(&pipeline).bindings(&[&image_binding]),
     ];
-    // The second targeting pass re-draws the same quad over a Load —
-    // the between-pass arm of a render image's walk, and a second
-    // mention the pass-level retention must recognise rather than
-    // double-count. The pixels are the proof it changed nothing.
+    // The second targeting pass draws NOTHING over a Load — so the
+    // sampled pixels below are the proof that Load actually preserved
+    // the first pass's contents, while the pass itself drives the
+    // between-pass walk arm and a second retention mention.
     let load_value = Attachment::new(LoadOp::Load, StoreOp::Store);
-    let again = [Item::new(&pipeline).bindings(&[&atlas_binding])];
     let passes = [
         Pass::render_to(&image, clear_value, &into_image),
-        Pass::render_to(&image, load_value, &again),
+        Pass::render_to(&image, load_value, &[]),
         Pass::new(&color, &onto_surface),
     ];
     let mut pixels = vec![0u8; target.byte_len()];
@@ -804,14 +803,13 @@ fn a_depth_only_pass_writes_depth_a_sampler_reads_back() {
     let color = clear(Color::new(1.0, 0.0, 1.0, 1.0));
     let casting = [Item::new(&caster).mesh(&mesh)];
     let reading = [Item::new(&reader).bindings(&[&depth_binding])];
-    // The second casting pass re-draws the same quad over a Load — the
-    // depth image's between-pass walk arm; GREATER_OR_EQUAL over equal
-    // depths changes nothing, which the pixels prove.
+    // The second casting pass draws NOTHING over a Load — the sampled
+    // halves below prove the depth Load preserved the quad's writes,
+    // while the pass drives the depth image's between-pass walk arm.
     let depth_again = Attachment::new(LoadOp::Load, StoreOp::Store);
-    let casting_again = [Item::new(&caster).mesh(&mesh)];
     let passes = [
         Pass::render_to(&image, depth_ops, &casting),
-        Pass::render_to(&image, depth_again, &casting_again),
+        Pass::render_to(&image, depth_again, &[]),
         Pass::new(&color, &reading),
     ];
     target

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -24,7 +24,8 @@ use std::path::{Path, PathBuf};
 use renew_rhi::{
     AdapterKind, Attachment, BindingDesc, BindingSource, Blend, ClearValue, Color, DepthState,
     Device, DeviceDesc, DeviceError, Extent, Item, LoadOp, MeshDesc, Pass, PipelineDesc,
-    RenderDesc, SamplerDesc, StoreOp, TargetFormat, TextureDesc, Validation, builtin,
+    RenderDesc, RenderImageDesc, RenderImageKind, SamplerDesc, StoreOp, TargetFormat, TextureDesc,
+    Validation, builtin,
 };
 
 /// The one color attachment these frames render into: cleared, stored.
@@ -559,6 +560,293 @@ fn two_textures_share_one_pipeline() {
     drop(right);
     drop(left_texture);
     drop(right_texture);
+    drop(sampler);
+    assert_no_validation_errors(&device);
+}
+
+/// The atlas trio the sampled tests start from: texture, sampler, and
+/// the binding over both.
+fn atlas_fixture(
+    device: &Device,
+    texels: u32,
+    atlas: &[u8],
+) -> Result<(renew_rhi::Texture, renew_rhi::Sampler, renew_rhi::Binding), String> {
+    let texture = device
+        .create_texture(&TextureDesc::new(
+            Extent {
+                width: texels,
+                height: texels,
+            },
+            atlas,
+        ))
+        .map_err(|error| format!("texture upload: {error}"))?;
+    let sampler = device
+        .create_sampler(&SamplerDesc::atlas())
+        .map_err(|error| format!("sampler: {error}"))?;
+    let binding = device
+        .create_binding(&BindingDesc::new(
+            BindingSource::Texture(&texture),
+            &sampler,
+        ))
+        .map_err(|error| format!("atlas binding: {error}"))?;
+    Ok((texture, sampler, binding))
+}
+
+/// The color round-trip: pass one renders the atlas quad into a
+/// render image, pass two samples that image onto the surface — through
+/// ONE pipeline, whose two items name two different bindings. The
+/// surface must answer with exactly the bytes the direct sampled test
+/// proves, because at equal sizes the nearest-sampled copy is the
+/// identity: what this adds is the whole rendered-then-sampled path —
+/// attachment write, layout transition to shader-read, sampled read —
+/// under active validation, with a CPU oracle.
+#[test]
+fn a_rendered_image_samples_back_byte_exact() {
+    const SIZE: u32 = 8;
+    const TEXELS: u32 = 2;
+    #[rustfmt::skip]
+    const ATLAS: [u8; 16] = [
+        10, 20, 30, 255,    40, 50, 60, 255,
+        70, 80, 90, 255,    100, 110, 120, 255,
+    ];
+
+    let Some(device) = device_or_skip().expect("device bring-up") else {
+        return;
+    };
+    let (texture, sampler, atlas_binding) =
+        atlas_fixture(&device, TEXELS, &ATLAS).expect("atlas fixture");
+    let image = device
+        .create_render_image(&RenderImageDesc::new(
+            RenderImageKind::Color,
+            Extent {
+                width: SIZE,
+                height: SIZE,
+            },
+        ))
+        .expect("render image");
+    // The image's own Debug and accessors, asserted here for the same
+    // reason the binding's are: the device suite skips where the
+    // validation layer is absent.
+    assert_eq!(image.extent().width, SIZE);
+    assert_eq!(image.kind(), RenderImageKind::Color);
+    let shown = format!("{image:?}");
+    assert!(shown.starts_with("RenderImage"), "{shown}");
+    let image_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&image), &sampler))
+        .expect("image binding");
+    let pipeline = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1),
+        )
+        .expect("sampled pipeline");
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: SIZE,
+            height: SIZE,
+        })
+        .expect("offscreen target");
+
+    let clear_value = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(1.0, 0.0, 1.0, 1.0))),
+        StoreOp::Store,
+    );
+    let color = clear(Color::new(1.0, 0.0, 1.0, 1.0));
+    let into_image = [Item::new(&pipeline).bindings(&[&atlas_binding])];
+    // Two sampling items: the second mention of an already-sampled
+    // image must recognise the transition already happened, not emit
+    // it twice — identical draws, so the pixels also prove it.
+    let onto_surface = [
+        Item::new(&pipeline).bindings(&[&image_binding]),
+        Item::new(&pipeline).bindings(&[&image_binding]),
+    ];
+    // The second targeting pass re-draws the same quad over a Load —
+    // the between-pass arm of a render image's walk, and a second
+    // mention the pass-level retention must recognise rather than
+    // double-count. The pixels are the proof it changed nothing.
+    let load_value = Attachment::new(LoadOp::Load, StoreOp::Store);
+    let again = [Item::new(&pipeline).bindings(&[&atlas_binding])];
+    let passes = [
+        Pass::render_to(&image, clear_value, &into_image),
+        Pass::render_to(&image, load_value, &again),
+        Pass::new(&color, &onto_surface),
+    ];
+    let mut pixels = vec![0u8; target.byte_len()];
+    // Twice, identically: the second frame re-walks the image from
+    // UNDEFINED — frame-scoped contents re-proven, not assumed.
+    for round in 0..2 {
+        target
+            .render(&RenderDesc::new(&passes))
+            .expect("round-trip render");
+        target.read_back_into(&mut pixels);
+        for y in 0..SIZE {
+            for x in 0..SIZE {
+                let texel = ((y * TEXELS) / SIZE) * TEXELS + (x * TEXELS) / SIZE;
+                let expected = &ATLAS[(texel as usize) * 4..(texel as usize) * 4 + 4];
+                let offset = ((y * SIZE + x) as usize) * 4;
+                assert_eq!(
+                    &pixels[offset..offset + 4],
+                    expected,
+                    "round {round}, pixel ({x},{y}) should carry texel {texel} through the \
+                     image on adapter {:?}",
+                    device.adapter()
+                );
+            }
+        }
+    }
+
+    // Teardown first, oracle second, the whole cast.
+    drop(target);
+    drop(pipeline);
+    drop(image_binding);
+    drop(atlas_binding);
+    drop(image);
+    drop(texture);
+    drop(sampler);
+    assert_no_validation_errors(&device);
+}
+
+/// A quad over the left half of clip space at `depth`, packed to the
+/// mesh layout's 36-byte records: positions pass straight through the
+/// mesh vertex stage; colour and uv ride along unread — the layout
+/// describes the record, not the use.
+fn left_half_quad(depth: f32) -> Vec<u8> {
+    let mut vertices = Vec::new();
+    for [x, y] in [
+        [-1.0f32, -1.0],
+        [0.0, -1.0],
+        [0.0, 1.0],
+        [-1.0, -1.0],
+        [0.0, 1.0],
+        [-1.0, 1.0],
+    ] {
+        for value in [x, y, depth] {
+            vertices.extend_from_slice(&value.to_ne_bytes());
+        }
+        for _ in 0..6 {
+            vertices.extend_from_slice(&0.0f32.to_ne_bytes());
+        }
+    }
+    vertices
+}
+
+/// The shadow shape: a depth-only pass — no fragment stage, no color
+/// attachment — writes a half-screen quad's depth into a depth-kinded
+/// render image, and a sampling pass reads it back onto the surface.
+/// Depth formats sample as (D, 0, 0, 1), so the surface's red channel
+/// is the depth buffer itself: the quad's clip-space z where it
+/// covered, the reversed-Z far clear where it did not — a CPU oracle
+/// over the whole rendered-depth path.
+#[test]
+fn a_depth_only_pass_writes_depth_a_sampler_reads_back() {
+    const SIZE: u32 = 8;
+    // Chosen so both depth formats round-trip to one byte without a
+    // tie: 0.25 is exact in f32 and in UNORM24 lands at 63.75 * (1/255)
+    // steps — 64 after conversion, unambiguously.
+    const QUAD_DEPTH: f32 = 0.25;
+
+    let Some(device) = device_or_skip().expect("device bring-up") else {
+        return;
+    };
+    let image = match device.create_render_image(&RenderImageDesc::new(
+        RenderImageKind::Depth,
+        Extent {
+            width: SIZE,
+            height: SIZE,
+        },
+    )) {
+        Ok(image) => image,
+        // An adapter whose depth format cannot be sampled refuses at
+        // creation by design; off the strict lane that is a skip, on it
+        // the refusal must fail loudly.
+        Err(error) => {
+            assert!(
+                !strict(),
+                "RENEW_GOLDEN=1 but the depth render image was refused: {error}"
+            );
+            eprintln!("SKIP: depth render image refused: {error}");
+            return;
+        }
+    };
+    let sampler = device
+        .create_sampler(&SamplerDesc::atlas())
+        .expect("sampler");
+    let depth_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&image), &sampler))
+        .expect("depth binding");
+    // The caster: a mesh pipeline with no fragment stage, reusing the
+    // full mesh pair's vertex stage — its colour output simply has no
+    // consumer.
+    let caster = device
+        .create_pipeline(
+            &PipelineDesc::depth_mesh(builtin::MESH_VS_SPV, builtin::MESH_LAYOUT)
+                .depth_state(DepthState::read_write()),
+        )
+        .expect("depth-only pipeline");
+    let reader = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1),
+        )
+        .expect("reader pipeline");
+    let vertices = left_half_quad(QUAD_DEPTH);
+    let mesh = device
+        .create_mesh(&MeshDesc::new(&vertices, 36, &[0, 1, 2, 3, 4, 5]))
+        .expect("caster quad");
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: SIZE,
+            height: SIZE,
+        })
+        .expect("offscreen target");
+
+    // Reversed-Z: the clear is the far plane at 0.0, and the quad's
+    // GREATER_OR_EQUAL 0.25 wins where it covers.
+    let depth_ops = Attachment::new(LoadOp::Clear(ClearValue::Depth(0.0)), StoreOp::Store);
+    let color = clear(Color::new(1.0, 0.0, 1.0, 1.0));
+    let casting = [Item::new(&caster).mesh(&mesh)];
+    let reading = [Item::new(&reader).bindings(&[&depth_binding])];
+    // The second casting pass re-draws the same quad over a Load — the
+    // depth image's between-pass walk arm; GREATER_OR_EQUAL over equal
+    // depths changes nothing, which the pixels prove.
+    let depth_again = Attachment::new(LoadOp::Load, StoreOp::Store);
+    let casting_again = [Item::new(&caster).mesh(&mesh)];
+    let passes = [
+        Pass::render_to(&image, depth_ops, &casting),
+        Pass::render_to(&image, depth_again, &casting_again),
+        Pass::new(&color, &reading),
+    ];
+    target
+        .render(&RenderDesc::new(&passes))
+        .expect("shadow render");
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+
+    for y in 0..SIZE {
+        for x in 0..SIZE {
+            // Depth samples as (D, 0, 0, 1); UNORM8 conversion of 0.25
+            // is 64, of the far clear 0.
+            let expected: [u8; 4] = if x < SIZE / 2 {
+                [64, 0, 0, 255]
+            } else {
+                [0, 0, 0, 255]
+            };
+            let offset = ((y * SIZE + x) as usize) * 4;
+            assert_eq!(
+                &pixels[offset..offset + 4],
+                &expected,
+                "pixel ({x},{y}) on adapter {:?} (format {:?})",
+                device.adapter(),
+                device.depth_format_name()
+            );
+        }
+    }
+
+    // Teardown first, oracle second, the whole cast.
+    drop(target);
+    drop(caster);
+    drop(reader);
+    drop(mesh);
+    drop(depth_binding);
+    drop(image);
     drop(sampler);
     assert_no_validation_errors(&device);
 }

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -549,7 +549,7 @@ fn render_image_fixture(
 /// The render image's sampling consumer: an atlas sampler over the
 /// image, bound once, drawn by a full-target quad in the target's own
 /// format. Extracted for the reason every fixture here is: it is
-/// fixture work, and  is at the length the lint refuses.
+/// fixture work, and `ready` is at the length the lint refuses.
 fn image_consumer_fixture(
     device: &Device,
     render_image: &renew_rhi::RenderImage,

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -40,6 +40,22 @@ struct SmokeApp {
     /// The one binding the textured pipeline's item names — built with
     /// its pipeline, held for the run.
     binding: Option<renew_rhi::Binding>,
+    /// A render image written by every frame's leading pass, sampled
+    /// by a surface item — the render-then-read shape, its first-use
+    /// barrier waiting on the previous frame's work against the ONE
+    /// physical image, across frames in flight where only the
+    /// validation layer can judge it.
+    render_image: Option<renew_rhi::RenderImage>,
+    /// The binding the sampling item reads the render image through.
+    image_binding: Option<renew_rhi::Binding>,
+    /// The pipeline the sampling item draws with, in the target's own
+    /// format.
+    sampled_pipeline: Option<renew_rhi::RenderPipeline>,
+    /// A depth-kinded render image cleared by its own empty pass each
+    /// frame — the depth-image target arms on the window path; `None`
+    /// where the adapter has no depth format, mirroring the depth
+    /// pipeline's own optionality.
+    render_depth_image: Option<renew_rhi::RenderImage>,
     /// A depth-testing triangle for the frame's depth passes, `None`
     /// when the adapter offers no depth format — a reported skip of the
     /// depth passes off the strict lane, a failure on it (the exercise
@@ -72,6 +88,10 @@ impl SmokeApp {
             target: None,
             pipeline: None,
             binding: None,
+            render_image: None,
+            image_binding: None,
+            sampled_pipeline: None,
+            render_depth_image: None,
             depth_pipeline: None,
             push_pipeline: None,
             mesh_pipeline: None,
@@ -213,10 +233,29 @@ impl WindowApp for SmokeApp {
                 return;
             }
         };
+        let (render_image, render_depth_image) = match render_image_fixture(&device) {
+            Ok(pair) => pair,
+            Err(error) => {
+                self.failure = Some(error);
+                return;
+            }
+        };
+        let (image_binding, sampled_pipeline) =
+            match image_consumer_fixture(&device, &render_image, target.format()) {
+                Ok(pair) => pair,
+                Err(error) => {
+                    self.failure = Some(error);
+                    return;
+                }
+            };
         self.device = Some(device);
         self.target = Some(target);
         self.pipeline = Some(pipeline);
         self.binding = Some(binding);
+        self.render_image = Some(render_image);
+        self.image_binding = Some(image_binding);
+        self.sampled_pipeline = Some(sampled_pipeline);
+        self.render_depth_image = render_depth_image;
         self.depth_pipeline = depth_pipeline;
         self.push_pipeline = Some(push_pipeline);
         self.mesh_pipeline = Some(mesh_pipeline);
@@ -309,20 +348,36 @@ impl WindowApp for SmokeApp {
                     .pipeline
                     .as_ref()
                     .zip(self.push_pipeline.as_ref())
-                    .zip(self.binding.as_ref());
+                    .zip(self.binding.as_ref())
+                    .zip(
+                        self.sampled_pipeline
+                            .as_ref()
+                            .zip(self.image_binding.as_ref()),
+                    );
                 let items: &[Item<'_>] = match (drawn, geometry) {
-                    (Some(((pipeline, push_pipeline), binding)), Some((mesh_pipeline, mesh))) => {
+                    (
+                        Some((((pipeline, push_pipeline), binding), (sampled, image_binding))),
+                        Some((mesh_pipeline, mesh)),
+                    ) => {
                         items_with_mesh = [
                             Item::new(push_pipeline).push_data(&pushed),
                             Item::new(pipeline).bindings(&[binding]),
+                            // The read half of the render image's frame:
+                            // the sampling transition crosses at this
+                            // pass's boundary, under the same oracle.
+                            Item::new(sampled).bindings(&[image_binding]),
                             Item::new(mesh_pipeline).mesh(mesh),
                         ];
                         &items_with_mesh
                     }
-                    (Some(((pipeline, push_pipeline), binding)), None) => {
+                    (
+                        Some((((pipeline, push_pipeline), binding), (sampled, image_binding))),
+                        None,
+                    ) => {
                         items_storage = [
                             Item::new(push_pipeline).push_data(&pushed),
                             Item::new(pipeline).bindings(&[binding]),
+                            Item::new(sampled).bindings(&[image_binding]),
                         ];
                         &items_storage
                     }
@@ -336,6 +391,39 @@ impl WindowApp for SmokeApp {
                 // barrier, all on the window path under Required
                 // validation.
                 let load = [Attachment::new(LoadOp::Load, StoreOp::Store)];
+                // The leading image pass: cleared, stored, drawn by
+                // nothing, sampled by nothing. What it exercises is
+                // the asynchronous path's pass-target retention and
+                // the render image's first-use barrier — the
+                // write-after-write hazard against the previous
+                // frame's pass over the same physical image, which
+                // only this suite's validation can judge.
+                let image_pass_storage;
+                let image_pass: &[Pass<'_>] = match self.render_image.as_ref() {
+                    Some(image) => {
+                        let ops = Attachment::new(
+                            LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+                            StoreOp::Store,
+                        );
+                        image_pass_storage = [Pass::render_to(image, ops, &[])];
+                        &image_pass_storage
+                    }
+                    None => &[],
+                };
+                // The depth image's pass: cleared, stored, drawn by
+                // nothing, sampled by nothing — the depth-kinded target
+                // arms of the window path's walk, under the same
+                // oracle. Its ops clear to the reversed-Z far plane.
+                let depth_image_storage;
+                let depth_image_pass: &[Pass<'_>] = match self.render_depth_image.as_ref() {
+                    Some(image) => {
+                        let ops =
+                            Attachment::new(LoadOp::Clear(ClearValue::Depth(0.0)), StoreOp::Store);
+                        depth_image_storage = [Pass::render_to(image, ops, &[])];
+                        &depth_image_storage
+                    }
+                    None => &[],
+                };
                 let depth_items_storage;
                 let passes_three;
                 let passes_one;
@@ -353,13 +441,27 @@ impl WindowApp for SmokeApp {
                     let fresh =
                         Attachment::new(LoadOp::Clear(ClearValue::Depth(0.0)), StoreOp::Discard);
                     passes_three = [
+                        image_pass
+                            .first()
+                            .copied()
+                            .unwrap_or(Pass::new(&color, items)),
+                        depth_image_pass
+                            .first()
+                            .copied()
+                            .unwrap_or(Pass::new(&color, items)),
                         Pass::new(&color, items),
                         Pass::new(&load, &depth_items_storage).depth(fresh),
                         Pass::new(&load, &depth_items_storage).depth(fresh),
                     ];
                     &passes_three
                 } else {
-                    passes_one = [Pass::new(&color, items)];
+                    passes_one = [
+                        image_pass
+                            .first()
+                            .copied()
+                            .unwrap_or(Pass::new(&color, items)),
+                        Pass::new(&color, items),
+                    ];
                     &passes_one
                 };
                 // The ring must actually cycle. A ring stuck on slot
@@ -410,6 +512,62 @@ impl WindowApp for SmokeApp {
             control.request_redraw();
         }
     }
+}
+
+/// The frame's render images: the color one every run writes and
+/// samples, and the depth one whose empty pass exists wherever the
+/// adapter has a depth format — mirroring the depth pipeline's own
+/// optionality.
+fn render_image_fixture(
+    device: &Device,
+) -> Result<(renew_rhi::RenderImage, Option<renew_rhi::RenderImage>), String> {
+    let size = Extent {
+        width: 16,
+        height: 16,
+    };
+    let color = device
+        .create_render_image(&renew_rhi::RenderImageDesc::new(
+            renew_rhi::RenderImageKind::Color,
+            size,
+        ))
+        .map_err(|error| format!("render image failed: {error}"))?;
+    let depth = if device.depth_format_name().is_some() {
+        Some(
+            device
+                .create_render_image(&renew_rhi::RenderImageDesc::new(
+                    renew_rhi::RenderImageKind::Depth,
+                    size,
+                ))
+                .map_err(|error| format!("depth render image failed: {error}"))?,
+        )
+    } else {
+        None
+    };
+    Ok((color, depth))
+}
+
+/// The render image's sampling consumer: an atlas sampler over the
+/// image, bound once, drawn by a full-target quad in the target's own
+/// format. Extracted for the reason every fixture here is: it is
+/// fixture work, and  is at the length the lint refuses.
+fn image_consumer_fixture(
+    device: &Device,
+    render_image: &renew_rhi::RenderImage,
+    format: renew_rhi::TargetFormat,
+) -> Result<(renew_rhi::Binding, renew_rhi::RenderPipeline), String> {
+    let sampler = device
+        .create_sampler(&SamplerDesc::atlas())
+        .map_err(|error| format!("image sampler failed: {error}"))?;
+    let binding = device
+        .create_binding(&BindingDesc::new(
+            BindingSource::Image(render_image),
+            &sampler,
+        ))
+        .map_err(|error| format!("image binding failed: {error}"))?;
+    let pipeline = device
+        .create_pipeline(&PipelineDesc::new(builtin::TEXTURED, format).sampled_bindings(1))
+        .map_err(|error| format!("sampled pipeline failed: {error}"))?;
+    Ok((binding, pipeline))
 }
 
 /// The textured pipeline, so that the window record path actually

--- a/crates/rhi/tests/zero_alloc.rs
+++ b/crates/rhi/tests/zero_alloc.rs
@@ -98,6 +98,25 @@ fn steady_state_frames_allocate_nothing() {
             &sampler,
         ))
         .expect("binding");
+    // The render-image pair, for the image-pass frame below: the pass
+    // walk, the identity state machine, the extra barriers, and the
+    // sampling transition all run inside the measured window, and none
+    // of them may allocate.
+    let render_image = device
+        .create_render_image(&renew_rhi::RenderImageDesc::new(
+            renew_rhi::RenderImageKind::Color,
+            Extent {
+                width: 16,
+                height: 16,
+            },
+        ))
+        .expect("render image");
+    let image_binding = device
+        .create_binding(&BindingDesc::new(
+            BindingSource::Image(&render_image),
+            &sampler,
+        ))
+        .expect("image binding");
     let pipeline = device
         .create_pipeline(
             &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1),
@@ -198,6 +217,23 @@ fn steady_state_frames_allocate_nothing() {
             // measured on the same zero-delta terms as the single-item
             // frames (which stay above, so a regression names its
             // shape).
+            // The render-to-then-sample frame: an image pass through
+            // the walk's first-use arm, then a surface pass whose item
+            // samples it through the transition arm — the full
+            // render-image path on the same zero-delta terms.
+            let image_ops = Attachment::new(
+                LoadOp::Clear(ClearValue::Color(clear_color)),
+                StoreOp::Store,
+            );
+            let into_image = [Item::new(&pipeline).bindings(&[&binding])];
+            let from_image = [Item::new(&pipeline).bindings(&[&image_binding])];
+            let image_passes = [
+                Pass::render_to(&render_image, image_ops, &into_image),
+                Pass::new(&color, &from_image),
+            ];
+            target
+                .render(&RenderDesc::new(&image_passes))
+                .expect("steady image frame");
             let load = [Attachment::new(LoadOp::Load, StoreOp::Store)];
             let first_items = [
                 Item::new(&pipeline).bindings(&[&binding]),

--- a/crates/rhi/tests/zero_alloc.rs
+++ b/crates/rhi/tests/zero_alloc.rs
@@ -174,6 +174,19 @@ fn steady_state_frames_allocate_nothing() {
         target
             .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
             .expect("warmup push frame");
+        let image_ops = Attachment::new(
+            LoadOp::Clear(ClearValue::Color(clear_color)),
+            StoreOp::Store,
+        );
+        let into_image = [Item::new(&pipeline).bindings(&[&binding])];
+        let from_image = [Item::new(&pipeline).bindings(&[&image_binding])];
+        let image_passes = [
+            Pass::render_to(&render_image, image_ops, &into_image),
+            Pass::new(&color, &from_image),
+        ];
+        target
+            .render(&RenderDesc::new(&image_passes))
+            .expect("warmup image frame");
         target.read_back_into(&mut pixels);
     }
 


### PR DESCRIPTION
Passes gain image identity. A `RenderImage` is one physical image with attachment and sampled usage, kinded Color or Depth at creation, its format pre-checked against the adapter's own feature report. Its **contents are frame-scoped** — every frame's first use starts from undefined pixels — while the image itself is retained by any frame that names it. A pass renders into one via `Pass::render_to`, whose image kind decides the pass shape so a mismatch is unrepresentable, and items sample it through an ordinary binding.

**One walk plans every barrier.** The per-identity rules and the `ImageUse` transition pairs live in a single state machine, driven by the frame contract before any GPU call and re-driven by each record path — two targets selecting masks independently is how barrier drift happens, and two consumers of one walk cannot drift. The refusals are named: write before read, no feedback within a pass, no re-targeting after sampling, no loading or sampling what the last targeting pass discarded, first-use loads, at most four distinct images, at least one surface pass.

**The transition table earned its masks the hard way.** The render-image first-use arms wait on the stages a previous frame could still be running against the one physical image — and carry its write access besides, because a layout transition is itself a write and ordering it against a prior frame's attachment write takes availability. The windowed suite's validation layer reported the write-after-write hazard on the execution-only mask's very first run across frames in flight; the access bit is the fix, and the suite now leads every frame with image passes and a sampling consumer so the oracle stays on duty.

**Depth images draw through depth-only pipelines**: one vertex stage, no fragment stage, no color attachment, `TargetFormat::DepthOnly` — and a retained placement rule keeps that shape out of every other pass, where a zero-attachment draw is undefined rather than merely wrong. The per-frame buffer rule relaxes to one-buffer-one-`FrameData`: pointer-identical data may repeat across items, differing data is still the second-copy-wins race.

**Proof.** A color round-trip golden renders the atlas into an image, holds it through an empty Load pass, and samples it back byte-exact — twice, so frame-scoped contents are re-proven. A shadow-shaped golden writes a quad's depth through a fragment-stage-free pipeline and reads the depth buffer back as exact bytes. Thirty malformed-frame refusals fire by name, a four-image frame proves the ceiling's legal side under validation, the fault ladder gains the render image's creation arms plus a poisoned-device probe, and the zero-allocation gates measure the whole path.
