### PR TITLE
feat(rhi): a pass's draws, listed on the stack

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -76,7 +76,7 @@ reason = "The unreachable arm of the walk's surface-depth barrier: a depth-carry
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [730]
+lines = [862]
 reason = "The unreachable arm behind the sample-before-write refusal: the assert immediately above proved the entry exists, and the let-else restates it without a banned expect. No frame can drive it."
 
 [[exempt]]
@@ -131,7 +131,7 @@ reason = "The comparison refusing to start because no workspace root is above it
 
 [[exempt]]
 file = "samples/cube/src/windowed.rs"
-lines = [639, 640, 641, 642, 643, 644, 729]
+lines = [639, 640, 641, 642, 643, 644, 718]
 reason = "The two places a window resize is acted on: rebuilding the crosshair for the new shape, and telling the swapchain its new size. Both need a real window-system resize, and the lane that measures coverage has none - its windowed runs happen under a virtual display with no window manager, so the window it opens is the only size it will ever be. Note for anyone running coverage on a desktop: these lines ARE covered there, because a real window manager sends a resize on the way up, and the gate will call this exemption stale. The gate that decides is the headless one. Everything these lines follow from is covered everywhere: record_present drives the recovery from a dormant swapchain with a constructed outcome, the resize event handler is driven with a constructed event, and the crosshair geometry is checked at four aspects without a device."
 
 [[exempt]]

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -27,7 +27,8 @@ else, which the build matrix proves by building and testing without it.
   alive and drawing — including the caller-side frame composition,
   which is stack arrays and allocates nothing either.
 - **This crate never renders.** `item` returns the rendering crate's
-  own draw item and `attachment` the matching color attachment; the
+  own draw item and the rendering crate's `color_attachment` the
+  matching color attachment; the
   caller composes the pass and the frame itself (the borrows end at
   the render call), and targets belong to the caller. It never touches
   a window, a clock, or the filesystem — the lint file makes the ways
@@ -48,10 +49,10 @@ else, which the build matrix proves by building and testing without it.
 - `SpriteRenderer` — `new` uploads the atlas and builds the pipeline
   (premultiplied blending, nearest/clamped sampling) and the per-frame
   buffer; `begin`/`push` fill; `item` is the frame's draw, for a pass
-  the caller composes with `attachment(clear)`:
+  the caller composes with `renew_rhi::color_attachment(clear)`:
 
   ```rust
-  let color = [renew_render2d::attachment(SKY)];
+  let color = [renew_rhi::color_attachment(SKY)];
   let items = [renderer.item()];
   let passes = [Pass::new(&color, &items)];
   target.render(&RenderDesc::new(&passes))?;

--- a/crates/render2d/src/gpu.rs
+++ b/crates/render2d/src/gpu.rs
@@ -4,9 +4,9 @@
 //! rendering-crate seam stays one file wide and `fill.rs` never moves.
 
 use renew_rhi::{
-    Attachment, Binding, BindingDesc, BindingSource, Blend, Buffer, BufferUsage, Color, Device,
-    Extent, FrameData, Item, PipelineDesc, PipelineError, RenderPipeline, SamplerDesc, Shaders,
-    TargetError, TargetFormat, TextureDesc, VertexAttribute,
+    Binding, BindingDesc, BindingSource, Blend, Buffer, BufferUsage, Device, Extent, FrameData,
+    Item, PipelineDesc, PipelineError, RenderPipeline, SamplerDesc, Shaders, TargetError,
+    TargetFormat, TextureDesc, VertexAttribute,
 };
 
 use crate::fill::{self, Canvas, Sprite};
@@ -224,19 +224,20 @@ impl SpriteRenderer {
     /// This frame's draw: every pushed sprite, in push order, as one
     /// item for a pass the caller composes.
     ///
-    /// The caller builds the frame on its own stack — see
-    /// [`attachment`] for the matching color attachment — and the
-    /// borrows end at the `render` call:
+    /// The caller builds the frame on its own stack — the matching
+    /// colour attachment is the rendering crate's `color_attachment`,
+    /// which every consumer shares — and the borrows end at the
+    /// `render` call:
     ///
     /// ```no_run
     /// use renew_render2d::SpriteRenderer;
-    /// use renew_rhi::{Color, OffscreenTarget, Pass, RenderDesc, TargetError};
+    /// use renew_rhi::{Color, OffscreenTarget, Pass, RenderDesc, TargetError, color_attachment};
     /// fn frame(
     ///     renderer: &SpriteRenderer,
     ///     target: &mut OffscreenTarget,
     ///     sky: Color,
     /// ) -> Result<(), TargetError> {
-    ///     let color = [renew_render2d::attachment(sky)];
+    ///     let color = [color_attachment(sky)];
     ///     let items = [renderer.item()];
     ///     let passes = [Pass::new(&color, &items)];
     ///     target.render(&RenderDesc::new(&passes))
@@ -256,17 +257,6 @@ impl SpriteRenderer {
             ))
             .bindings(&[&self.binding])
     }
-}
-
-/// The color attachment a sprite frame renders into: cleared to
-/// `clear`, stored. The free half of the frame [`SpriteRenderer::item`]
-/// is the draw half of.
-///
-/// The definition lives in the rendering crate, which owns the frame
-/// vocabulary; this is the name a 2D consumer already imports.
-#[must_use]
-pub fn attachment(clear: Color) -> Attachment {
-    renew_rhi::color_attachment(clear)
 }
 
 impl core::fmt::Debug for SpriteRenderer {

--- a/crates/render2d/src/gpu.rs
+++ b/crates/render2d/src/gpu.rs
@@ -4,9 +4,9 @@
 //! rendering-crate seam stays one file wide and `fill.rs` never moves.
 
 use renew_rhi::{
-    Attachment, Binding, BindingDesc, BindingSource, Blend, Buffer, BufferUsage, ClearValue, Color,
-    Device, Extent, FrameData, Item, LoadOp, PipelineDesc, PipelineError, RenderPipeline,
-    SamplerDesc, Shaders, StoreOp, TargetError, TargetFormat, TextureDesc, VertexAttribute,
+    Attachment, Binding, BindingDesc, BindingSource, Blend, Buffer, BufferUsage, Color, Device,
+    Extent, FrameData, Item, PipelineDesc, PipelineError, RenderPipeline, SamplerDesc, Shaders,
+    TargetError, TargetFormat, TextureDesc, VertexAttribute,
 };
 
 use crate::fill::{self, Canvas, Sprite};
@@ -261,9 +261,12 @@ impl SpriteRenderer {
 /// The color attachment a sprite frame renders into: cleared to
 /// `clear`, stored. The free half of the frame [`SpriteRenderer::item`]
 /// is the draw half of.
+///
+/// The definition lives in the rendering crate, which owns the frame
+/// vocabulary; this is the name a 2D consumer already imports.
 #[must_use]
 pub fn attachment(clear: Color) -> Attachment {
-    Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)
+    renew_rhi::color_attachment(clear)
 }
 
 impl core::fmt::Debug for SpriteRenderer {

--- a/crates/render2d/src/lib.rs
+++ b/crates/render2d/src/lib.rs
@@ -13,7 +13,7 @@
 //! - **All allocations happen at creation.** `begin`/`push`/`item`
 //!   allocate nothing; the crate's gate measures it.
 //! - **Target-agnostic.** [`SpriteRenderer::item`] returns the
-//!   rendering crate's own draw item and [`attachment`] the matching
+//!   rendering crate's own draw item and its `color_attachment` the matching
 //!   color attachment; the caller composes the frame on its own stack
 //!   and hands it to whichever target it holds. This crate never
 //!   renders, never presents, and never touches a window.
@@ -31,4 +31,4 @@ mod fill;
 mod gpu;
 
 pub use fill::{Canvas, Region, Sprite};
-pub use gpu::{AtlasDesc, Render2dError, SpriteRenderer, attachment};
+pub use gpu::{AtlasDesc, Render2dError, SpriteRenderer};

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -24,7 +24,7 @@
 
 use std::path::{Path, PathBuf};
 
-use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer, attachment};
+use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer};
 use renew_rhi::{
     AdapterKind, Color, Device, DeviceDesc, DeviceError, Extent, Pass, RenderDesc, TargetFormat,
     Validation,
@@ -205,7 +205,7 @@ fn opaque_sprites_match_the_computed_image_exactly() {
     renderer.push(&Sprite::new(RED, 8.0, 8.0).size(16.0, 16.0));
     renderer.push(&Sprite::new(GREEN, 32.0, 8.0).size(16.0, 16.0));
     renderer.push(&Sprite::new(BLUE, 16.0, 16.0).size(16.0, 16.0));
-    let color = [attachment(CLEAR)];
+    let color = [renew_rhi::color_attachment(CLEAR)];
     let items = [renderer.item()];
     let passes = [Pass::new(&color, &items)];
     target
@@ -289,7 +289,7 @@ fn blended_sprites_match_structure_and_the_committed_golden() {
             .size(16.0, 16.0)
             .tint([0.5, 0.5, 0.5, 0.5]),
     );
-    let color = [attachment(CLEAR)];
+    let color = [renew_rhi::color_attachment(CLEAR)];
     let items = [renderer.item()];
     let passes = [Pass::new(&color, &items)];
     target

--- a/crates/render2d/tests/zero_alloc.rs
+++ b/crates/render2d/tests/zero_alloc.rs
@@ -13,7 +13,7 @@
 //! would pass vacuously the moment the fill path allocated.
 
 use renew_memory::{CountingAllocator, counters};
-use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer, attachment};
+use renew_render2d::{AtlasDesc, Canvas, Region, Sprite, SpriteRenderer};
 use renew_rhi::{
     Color, Device, DeviceDesc, DeviceError, Extent, Pass, RenderDesc, TargetFormat, Validation,
 };
@@ -153,7 +153,7 @@ fn steady_state_fill_and_render_allocates_nothing() {
             renderer.sprites() > 0,
             "the measured frame must be non-empty"
         );
-        let color = [attachment(clear)];
+        let color = [renew_rhi::color_attachment(clear)];
         let items = [renderer.item()];
         let passes = [Pass::new(&color, &items)];
         target

--- a/crates/render3d/README.md
+++ b/crates/render3d/README.md
@@ -30,7 +30,9 @@ mesh comes out, and a draw item goes into a frame the caller composes.
   nearest the light, and a fragment is lit exactly when its own light
   depth reaches it within a constant bias — constant because the
   light is orthographic, which makes light depth linear.
-- `attachment` / `depth_attachment` / `pass` — the frame pieces. `pass`
+- `depth_attachment` / `pass` — the frame pieces this crate owns (the
+  colour attachment is the rendering crate's shared `color_attachment`).
+  `pass`
   always attaches depth; the parts stay public for frames it does not
   fit.
 
@@ -40,7 +42,7 @@ let mut scene = Scene::new();
 scene.quad(corners, [0.0, 1.0, 0.0, 1.0]);
 let mesh = renderer.upload(&device, &scene)?;
 
-let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+let color = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
 let items = [renderer.item(&mesh)];
 target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
 ```

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -702,9 +702,14 @@ impl core::fmt::Debug for ShadowedCameraRenderer {
 
 /// The colour attachment a 3D frame renders into: cleared to `clear`,
 /// stored.
+///
+/// The definition lives in the rendering crate, which owns the frame
+/// vocabulary; this is the name a 3D consumer already imports. Its
+/// depth sibling below is deliberately NOT forwarded: that one encodes
+/// this crate's reversed-Z convention.
 #[must_use]
 pub fn attachment(clear: Color) -> Attachment {
-    Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)
+    renew_rhi::color_attachment(clear)
 }
 
 /// The depth attachment a 3D frame needs: cleared to the far plane,

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -14,7 +14,7 @@
 //! window.
 
 use renew_rhi::{
-    Attachment, ClearValue, Color, Device, Item, LoadOp, Mesh, MeshDesc, Pass, PipelineDesc,
+    Attachment, ClearValue, Device, Item, LoadOp, Mesh, MeshDesc, Pass, PipelineDesc,
     PipelineError, RenderPipeline, StoreOp, TargetError, TargetFormat, VertexAttribute, builtin,
 };
 
@@ -700,18 +700,6 @@ impl core::fmt::Debug for ShadowedCameraRenderer {
     }
 }
 
-/// The colour attachment a 3D frame renders into: cleared to `clear`,
-/// stored.
-///
-/// The definition lives in the rendering crate, which owns the frame
-/// vocabulary; this is the name a 3D consumer already imports. Its
-/// depth sibling below is deliberately NOT forwarded: that one encodes
-/// this crate's reversed-Z convention.
-#[must_use]
-pub fn attachment(clear: Color) -> Attachment {
-    renew_rhi::color_attachment(clear)
-}
-
 /// The depth attachment a 3D frame needs: cleared to the far plane,
 /// discarded at the end.
 ///
@@ -735,7 +723,8 @@ pub fn depth_attachment() -> Attachment {
 /// optional for 3D geometry, and this is the shape that cannot omit it.
 /// The parts stay public for the frames this does not fit — a caller
 /// composing 3D geometry beside a 2D overlay builds its own pass from
-/// [`attachment`], [`depth_attachment`] and [`MeshRenderer::item`].
+/// the rendering crate's `color_attachment`, [`depth_attachment`] and
+/// [`MeshRenderer::item`].
 ///
 /// # One pass per frame
 ///

--- a/crates/render3d/src/lib.rs
+++ b/crates/render3d/src/lib.rs
@@ -18,7 +18,7 @@
 //!   pair takes geometry already projected, the camera pair takes a
 //!   matrix per draw and projects on the GPU.
 //! - **Target-agnostic.** [`MeshRenderer::item`] returns the rendering
-//!   crate's own draw item and [`attachment`] the matching colour
+//!   crate's own draw item and its `color_attachment` the matching colour
 //!   attachment; the caller composes the frame on its own stack and
 //!   hands it to whichever target it holds. This crate never renders,
 //!   never presents, and never touches a window.
@@ -44,6 +44,6 @@ mod scene;
 
 pub use gpu::{
     Camera, CameraRenderer, MeshRenderer, Render3dError, ShadowMatrices, ShadowedCameraRenderer,
-    TexturedCameraRenderer, TexturedMeshRenderer, attachment, depth_attachment, pass,
+    TexturedCameraRenderer, TexturedMeshRenderer, depth_attachment, pass,
 };
 pub use scene::Scene;

--- a/crates/render3d/tests/golden.rs
+++ b/crates/render3d/tests/golden.rs
@@ -16,7 +16,7 @@
 
 use renew_render3d::{
     Camera, CameraRenderer, MeshRenderer, Render3dError, Scene, ShadowMatrices,
-    ShadowedCameraRenderer, TexturedCameraRenderer, TexturedMeshRenderer, attachment, pass,
+    ShadowedCameraRenderer, TexturedCameraRenderer, TexturedMeshRenderer, pass,
 };
 use renew_rhi::{
     Color, Device, DeviceDesc, DeviceError, Extent, RenderDesc, TargetFormat, Validation,
@@ -168,7 +168,7 @@ fn a_quad_covers_the_target_in_its_own_colour() -> Result<(), Box<dyn std::error
 
     // Magenta appears nowhere in the geometry, so a quad that failed to
     // cover shows as unwritten rather than as a plausible colour.
-    let color = [attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let color = [renew_rhi::color_attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
     let items = [renderer.item(&mesh)];
     let passes = [pass(&color, &items)];
     target.render(&RenderDesc::new(&passes))?;
@@ -225,7 +225,7 @@ fn the_nearer_quad_wins_in_either_push_order() -> Result<(), Box<dyn std::error:
         full_quad(&mut scene, first.0, first.1);
         full_quad(&mut scene, second.0, second.1);
         let mesh = renderer.upload(&device, &scene)?;
-        let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+        let color = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
         let items = [renderer.item(&mesh)];
         target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
         let mut pixels = vec![0u8; target.byte_len()];
@@ -278,7 +278,7 @@ fn at_equal_depth_the_later_push_wins() -> Result<(), Box<dyn std::error::Error>
         full_quad(&mut scene, 0.5, first);
         full_quad(&mut scene, 0.5, second);
         let mesh = renderer.upload(&device, &scene)?;
-        let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+        let color = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
         let items = [renderer.item(&mesh)];
         target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
         let mut pixels = vec![0u8; target.byte_len()];
@@ -314,7 +314,7 @@ fn one_mesh_may_be_drawn_by_several_items() -> Result<(), Box<dyn std::error::Er
     full_quad(&mut scene, 0.5, [0.0, 1.0, 0.0, 1.0]);
     let mesh = renderer.upload(&device, &scene)?;
 
-    let color = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let color = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
     let items = [renderer.item(&mesh), renderer.item(&mesh)];
     target.render(&RenderDesc::new(&[pass(&color, &items)]))?;
     let mut pixels = vec![0u8; target.byte_len()];
@@ -388,7 +388,7 @@ fn an_identity_camera_covers_what_the_mesh_path_covers() -> Result<(), Box<dyn s
         height: SIZE,
     };
     let clear_colour = [255, 0, 255, 255];
-    let clear = [attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
     let mut scene = Scene::new();
     half_quad(&mut scene, 0.5, [0.0, 1.0, 0.0, 1.0]);
 
@@ -466,7 +466,7 @@ fn a_translation_moves_the_picture_rather_than_bending_it() -> Result<(), Box<dy
     columns[3][0] = 0.5;
     let camera = Camera::from_columns(columns);
 
-    let clear = [attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
     let items = [through.item(&mesh, &camera)];
     target.render(&RenderDesc::new(&[pass(&clear, &items)]))?;
     let mut pixels = vec![0u8; target.byte_len()];
@@ -508,7 +508,7 @@ fn the_camera_path_fades_with_distance() -> Result<(), Box<dyn std::error::Error
         height: SIZE,
     };
     let through = CameraRenderer::new(&device, TargetFormat::Rgba8Unorm)?;
-    let clear = [attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
 
     // Columns of a matrix whose last row is (0, 0, 1, 0): w becomes z.
     let mut columns = IDENTITY;
@@ -610,7 +610,7 @@ fn a_textured_draw_shows_the_texture_it_was_given() -> Result<(), Box<dyn std::e
         width: 2,
         height: 2,
     };
-    let clear = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
     let mut scene = Scene::new();
     full_quad(&mut scene, 0.5, [1.0, 1.0, 1.0, 1.0]);
     let camera = Camera::from_columns(IDENTITY);
@@ -668,7 +668,7 @@ fn the_vertex_colour_tints_the_texture() -> Result<(), Box<dyn std::error::Error
         width: 2,
         height: 2,
     };
-    let clear = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
     let camera = Camera::from_columns(IDENTITY);
     let white: Vec<u8> = [255u8, 255, 255, 255].repeat(4);
 
@@ -787,7 +787,7 @@ fn the_plain_textured_path_draws_its_texture() -> Result<(), Box<dyn std::error:
     full_quad(&mut scene, 0.5, [1.0, 1.0, 1.0, 1.0]);
     let mesh = renderer.upload(&device, &scene)?;
 
-    let clear = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
     let items = [renderer.item(&mesh)];
     target.render(&RenderDesc::new(&[pass(&clear, &items)]))?;
     let mut pixels = vec![0u8; target.byte_len()];
@@ -828,7 +828,7 @@ fn a_caster_between_light_and_floor_dims_the_floor() -> Result<(), Box<dyn std::
         height: 2,
     };
     let white: Vec<u8> = [255u8, 255, 255, 255].repeat(4);
-    let clear = [attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
+    let clear = [renew_rhi::color_attachment(Color::new(0.0, 0.0, 0.0, 1.0))];
 
     // The floor spans the whole target at depth 0.3; the blocker is a
     // nearer patch over clip x in [-0.25, 0.25] AND clip y in [-1, 0].

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -23,7 +23,8 @@ display server, and the golden-image tests attest the bytes.
   `Presented` or `NeedsResize` (resizes and minimized windows are
   protocol outcomes, never errors). Two frames in flight, FIFO
   presentation.
-- `RenderDesc` / `Pass` / `Attachment` / `Item` — the frame vocabulary.
+- `RenderDesc` / `Pass` / `Attachment` / `Item` / `ItemList` /
+  `color_attachment` — the frame vocabulary.
   Attachments carry their load and store ops (`LoadOp::Clear` holds its
   `ClearValue`, so a clear value without a clearing load is
   unrepresentable); depth is a per-target internal image a pass opts

--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -78,8 +78,8 @@ pub use vk::device::{Device, HostAllocationStats, ValidationReport};
 pub use vk::mesh::{Mesh, MeshDesc};
 pub use vk::offscreen::OffscreenTarget;
 pub use vk::pass::{
-    Attachment, Bindings, ClearValue, Item, LoadOp, MAX_FRAME_RENDER_IMAGES, Pass, PassTarget,
-    RenderDesc, StoreOp,
+    Attachment, Bindings, ClearValue, Item, ItemList, LoadOp, MAX_FRAME_RENDER_IMAGES, Pass,
+    PassTarget, RenderDesc, StoreOp, color_attachment,
 };
 pub use vk::pipeline::{
     AddressMode, Blend, DepthState, Filter, FrameData, MAX_PUSH_CONSTANT_BYTES, MeshShaders,

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -297,6 +297,145 @@ impl<'a> Item<'a> {
     }
 }
 
+/// A pass's draw list, built on the stack.
+///
+/// **The shape every consumer with an optional draw arrives at.** A
+/// frame whose middle item is conditional cannot be one array literal,
+/// so callers reach for one of three things: two whole branches that
+/// each build an array and each call `render` (the duplication is in
+/// the render call, which is the part worth writing once), a `Vec`
+/// (a heap allocation per frame, in a path whose whole discipline is
+/// not to), or an array of `Option`s that nothing downstream accepts.
+/// This is the fourth: fixed capacity, pushed conditionally, handed
+/// over as a slice.
+///
+/// Capacity is a const parameter rather than a ceiling this crate
+/// picks, because a draw list is the caller's shape — [`Pass`] itself
+/// takes any slice, and nothing here bounds how many items a frame may
+/// carry.
+///
+/// ```ignore
+/// let mut items = ItemList::<3>::new(world.item(&mesh, &camera));
+/// if live > 0 {
+///     items.push(dust.item(&packed, live, &push));
+/// }
+/// items.push(overlay.item(&crosshair));
+/// let passes = [Pass::new(&color, items.as_slice())];
+/// ```
+#[derive(Clone, Copy)]
+pub struct ItemList<'a, const N: usize> {
+    /// Seeded with the first item and overwritten by pushes: `Item` is
+    /// `Copy` and has no meaningful empty value, so a filled array with
+    /// a live count is the shape that needs no `unsafe` and no
+    /// `Option` the caller would have to strip.
+    items: [Item<'a>; N],
+    count: usize,
+}
+
+impl<'a, const N: usize> ItemList<'a, N> {
+    /// A list holding `first`.
+    ///
+    /// Seeded rather than empty because a pass drawing nothing is
+    /// written `&[]` — clearer than a list that happens to have had
+    /// nothing pushed into it, and it keeps this type's slice
+    /// non-empty by construction.
+    ///
+    /// # Panics
+    ///
+    /// A zero capacity cannot hold the seed, which is a caller mistake
+    /// no value can express — asserted rather than returned.
+    #[must_use]
+    pub fn new(first: Item<'a>) -> Self {
+        assert!(
+            N > 0,
+            "an item list holds at least the item it is seeded with"
+        );
+        Self {
+            items: [first; N],
+            count: 1,
+        }
+    }
+
+    /// Append `item`.
+    ///
+    /// # Panics
+    ///
+    /// Past the declared capacity. The capacity is the caller's own
+    /// number and the count is known where the list is built, so an
+    /// overflow is a mistake in one place rather than a condition to
+    /// handle — and silently dropping a draw would be a frame that
+    /// renders differently than written.
+    pub fn push(&mut self, item: Item<'a>) {
+        assert!(
+            self.count < N,
+            "an ItemList<{N}> holds {N} items; the {}th was pushed",
+            self.count + 1
+        );
+        self.items[self.count] = item;
+        self.count += 1;
+    }
+
+    /// Append `item` when there is one — the optional-draw shape, so a
+    /// caller writes no `if let` around a push.
+    ///
+    /// # Panics
+    ///
+    /// As [`Self::push`], when the item is present.
+    pub fn push_some(&mut self, item: Option<Item<'a>>) {
+        if let Some(item) = item {
+            self.push(item);
+        }
+    }
+
+    /// The items pushed so far, in order — what [`Pass`] takes.
+    #[must_use]
+    pub fn as_slice(&self) -> &[Item<'a>] {
+        &self.items[..self.count]
+    }
+
+    /// How many items are in the list.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    /// Never true: the list is seeded with an item and nothing removes
+    /// one. Present because the lint that pairs it with [`Self::len`]
+    /// is right in general, and answering it honestly is cheaper than
+    /// an exemption.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<const N: usize> fmt::Debug for ItemList<'_, N> {
+    /// The count and the capacity, not the draws — [`RenderDesc`]'s own
+    /// posture.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ItemList")
+            .field("items", &self.count)
+            .field("capacity", &N)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The colour attachment a frame renders into: cleared to `clear`,
+/// stored.
+///
+/// **One definition, because three crates had written it identically.**
+/// The 2D renderer, the 3D renderer and the triangle sample each
+/// carried the same two-line function; a caller composing a frame from
+/// more than one of them imported whichever it happened to name first.
+/// The depth attachment deliberately does NOT join it: that one
+/// encodes the reversed-Z convention and refuses to take the clear
+/// value as a parameter, which is a renderer's policy rather than the
+/// frame vocabulary's.
+#[must_use]
+pub fn color_attachment(clear: Color) -> Attachment {
+    Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)
+}
+
 /// An item's binding list: up to [`MAX_SAMPLED_BINDINGS`] references,
 /// stored inline so [`Item`] stays `Copy` and borrows no caller-owned
 /// slice storage.
@@ -1151,6 +1290,29 @@ pub(crate) fn vk_clear_depth(attachment: &Attachment) -> ash::vk::ClearValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **The colour attachment three crates had written identically.**
+    /// Pinned on content rather than smoke-called: the load op carries
+    /// the clear value, the store op keeps it, and a caller that got
+    /// either backwards would draw a frame that discarded what it just
+    /// rendered.
+    #[test]
+    fn the_colour_attachment_clears_to_its_value_and_stores() {
+        let attachment = color_attachment(Color::new(0.25, 0.5, 0.75, 1.0));
+        assert!(matches!(attachment.store, StoreOp::Store));
+        let LoadOp::Clear(ClearValue::Color(colour)) = attachment.load else {
+            panic!(
+                "a colour attachment clears to a colour, got {:?}",
+                attachment.load
+            );
+        };
+        // Bit equality: the helper moves the value, it never does
+        // arithmetic on it.
+        assert_eq!(
+            [colour.r, colour.g, colour.b, colour.a].map(f32::to_bits),
+            [0.25f32, 0.5, 0.75, 1.0].map(f32::to_bits)
+        );
+    }
 
     /// The binding list's device-free boundary: an empty list is a
     /// legal value of the type (the frame contract, not the

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -1290,19 +1290,21 @@ mod tests {
     /// either backwards would draw a frame that discarded what it just
     /// rendered.
     #[test]
+    #[allow(unsafe_code)]
     fn the_colour_attachment_clears_to_its_value_and_stores() {
         let attachment = color_attachment(Color::new(0.25, 0.5, 0.75, 1.0));
         assert!(matches!(attachment.store, StoreOp::Store));
-        let LoadOp::Clear(ClearValue::Color(colour)) = attachment.load else {
-            panic!(
-                "a colour attachment clears to a colour, got {:?}",
-                attachment.load
-            );
-        };
+        // Read through the crate's own converter rather than matching
+        // the load op: the converter is total, so this proves the same
+        // thing with no arm that only a broken helper could reach —
+        // and it proves the two agree, which a match would not.
+        // SAFETY: reading the union arm the converter just wrote, as
+        // the clear-value test beside this one does.
+        let raw = unsafe { vk_clear_color(&attachment).color.float32 };
         // Bit equality: the helper moves the value, it never does
         // arithmetic on it.
         assert_eq!(
-            [colour.r, colour.g, colour.b, colour.a].map(f32::to_bits),
+            raw.map(f32::to_bits),
             [0.25f32, 0.5, 0.75, 1.0].map(f32::to_bits)
         );
     }

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -314,15 +314,21 @@ impl<'a> Item<'a> {
 /// takes any slice, and nothing here bounds how many items a frame may
 /// carry.
 ///
+/// Sketched rather than compiled — every item needs a live pipeline,
+/// which needs a device; the device suite drives the real thing.
+///
 /// ```ignore
-/// let mut items = ItemList::<3>::new(world.item(&mesh, &camera));
+/// let mut items = ItemList::<3>::new(world.item(&mesh, &matrices));
 /// if live > 0 {
-///     items.push(dust.item(&packed, live, &push));
+///     items.push(dust.item(&instances, live, &push));
 /// }
 /// items.push(overlay.item(&crosshair));
 /// let passes = [Pass::new(&color, items.as_slice())];
 /// ```
-#[derive(Clone, Copy)]
+/// **Deliberately not `Copy`.** This is an accumulator driven by
+/// `&mut self`: a copy taken mid-build would swallow every later push
+/// with no diagnostic, which is the failure mode `Range` refuses `Copy`
+/// to avoid. Nothing in the tree wants one.
 pub struct ItemList<'a, const N: usize> {
     /// Seeded with the first item and overwritten by pushes: `Item` is
     /// `Copy` and has no meaningful empty value, so a filled array with
@@ -368,7 +374,7 @@ impl<'a, const N: usize> ItemList<'a, N> {
     pub fn push(&mut self, item: Item<'a>) {
         assert!(
             self.count < N,
-            "an ItemList<{N}> holds {N} items; the {}th was pushed",
+            "an item list of capacity {N} is full; item {} was pushed",
             self.count + 1
         );
         self.items[self.count] = item;
@@ -392,21 +398,6 @@ impl<'a, const N: usize> ItemList<'a, N> {
     pub fn as_slice(&self) -> &[Item<'a>] {
         &self.items[..self.count]
     }
-
-    /// How many items are in the list.
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.count
-    }
-
-    /// Never true: the list is seeded with an item and nothing removes
-    /// one. Present because the lint that pairs it with [`Self::len`]
-    /// is right in general, and answering it honestly is cheaper than
-    /// an exemption.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        false
-    }
 }
 
 impl<const N: usize> fmt::Debug for ItemList<'_, N> {
@@ -423,14 +414,16 @@ impl<const N: usize> fmt::Debug for ItemList<'_, N> {
 /// The colour attachment a frame renders into: cleared to `clear`,
 /// stored.
 ///
-/// **One definition, because three crates had written it identically.**
-/// The 2D renderer, the 3D renderer and the triangle sample each
-/// carried the same two-line function; a caller composing a frame from
-/// more than one of them imported whichever it happened to name first.
-/// The depth attachment deliberately does NOT join it: that one
-/// encodes the reversed-Z convention and refuses to take the clear
-/// value as a parameter, which is a renderer's policy rather than the
-/// frame vocabulary's.
+/// **One definition and one name, because three crates had written it
+/// identically.** The 2D renderer, the 3D renderer and the triangle
+/// sample each carried the same two-line function, so a caller
+/// composing a frame from more than one of them imported whichever it
+/// happened to name first. Forwarding wrappers would have left that
+/// ambiguity in place, so the wrappers are gone: this is the name
+/// every consumer uses. The depth attachment deliberately does NOT
+/// join it — that one encodes the reversed-Z convention and refuses to
+/// take the clear value as a parameter, which is a renderer's policy
+/// rather than the frame vocabulary's.
 #[must_use]
 pub fn color_attachment(clear: Color) -> Attachment {
     Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -361,13 +361,12 @@ fn the_item_list_composes_a_frames_draws_in_order() {
     // no identity of its own, so the push block is the label.
     let labels: [[u8; 16]; 4] = [[1; 16], [2; 16], [3; 16], [4; 16]];
     let mut list = ItemList::<4>::new(Item::new(&pipeline).push_data(&labels[0]));
-    assert_eq!(list.len(), 1, "a seeded list holds its seed");
-    assert!(!list.is_empty());
+    assert_eq!(list.as_slice().len(), 1, "a seeded list holds its seed");
     list.push(Item::new(&pipeline).push_data(&labels[1]));
     // The optional shape, both ways: absent adds nothing, present
     // appends exactly where a push would have.
     list.push_some(None);
-    assert_eq!(list.len(), 2, "an absent item is not a draw");
+    assert_eq!(list.as_slice().len(), 2, "an absent item is not a draw");
     list.push_some(Some(Item::new(&pipeline).push_data(&labels[2])));
     list.push(Item::new(&pipeline).push_data(&labels[3]));
     let slice = list.as_slice();
@@ -399,7 +398,18 @@ fn the_item_list_composes_a_frames_draws_in_order() {
         let _ = ItemList::<0>::new(Item::new(&pipeline).push_data(&labels[0]));
     }));
     std::panic::set_hook(hook);
-    assert!(over.is_err(), "a third item in a list of two must refuse");
+    // By name, not merely "something panicked": without the assert the
+    // very next line indexes out of bounds and this test would pass on
+    // the wrong panic entirely.
+    let message = over
+        .expect_err("a third item in a list of two must refuse")
+        .downcast_ref::<String>()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        message.contains("item list of capacity 2 is full"),
+        "refused, but not by name: {message:?}"
+    );
     assert!(empty.is_err(), "a list of zero cannot hold its seed");
 
     // And the list composes a frame that actually renders, which is

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -8,9 +8,9 @@
 
 use renew_rhi::{
     AddressMode, Attachment, Binding, BindingDesc, BindingSource, BufferUsage, ClearValue, Color,
-    DepthState, Device, DeviceDesc, DeviceError, Extent, Filter, FrameData, Item, LoadOp, MeshDesc,
-    Pass, PipelineDesc, PipelineError, RenderDesc, Sampler, SamplerDesc, Shaders, StoreOp,
-    TargetFormat, Texture, Validation, builtin,
+    DepthState, Device, DeviceDesc, DeviceError, Extent, Filter, FrameData, Item, ItemList, LoadOp,
+    MeshDesc, Pass, PipelineDesc, PipelineError, RenderDesc, Sampler, SamplerDesc, Shaders,
+    StoreOp, TargetFormat, Texture, Validation, builtin,
 };
 
 /// The one color attachment these frames render into: cleared, stored.
@@ -338,6 +338,87 @@ fn cross_device_pipeline_is_a_dev_build_contract_violation() {
         outcome.is_err(),
         "mixing objects across devices must trip the dev-build contract check"
     );
+}
+
+/// **The draw list hands over what was pushed, in order.** The order
+/// is the whole claim: a list that reordered draws would compose a
+/// frame that renders differently than written, and every consumer
+/// with an optional middle draw depends on it. It lives here rather
+/// than beside the type because an `Item` names a real pipeline, and a
+/// pipeline needs a device.
+#[test]
+fn the_item_list_composes_a_frames_draws_in_order() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let pipeline = device
+        .create_pipeline(
+            &PipelineDesc::new(push_color_shaders(), TargetFormat::Rgba8Unorm)
+                .push_constant_size(16),
+        )
+        .expect("push-constant pipeline");
+    // Four distinguishable items over one pipeline: an `Item` carries
+    // no identity of its own, so the push block is the label.
+    let labels: [[u8; 16]; 4] = [[1; 16], [2; 16], [3; 16], [4; 16]];
+    let mut list = ItemList::<4>::new(Item::new(&pipeline).push_data(&labels[0]));
+    assert_eq!(list.len(), 1, "a seeded list holds its seed");
+    assert!(!list.is_empty());
+    list.push(Item::new(&pipeline).push_data(&labels[1]));
+    // The optional shape, both ways: absent adds nothing, present
+    // appends exactly where a push would have.
+    list.push_some(None);
+    assert_eq!(list.len(), 2, "an absent item is not a draw");
+    list.push_some(Some(Item::new(&pipeline).push_data(&labels[2])));
+    list.push(Item::new(&pipeline).push_data(&labels[3]));
+    let slice = list.as_slice();
+    assert_eq!(slice.len(), 4);
+    for (index, item) in slice.iter().enumerate() {
+        assert_eq!(
+            item.push_data,
+            Some(&labels[index][..]),
+            "item {index} is not the one pushed there"
+        );
+    }
+
+    // The Debug form reports the shape, not the draws.
+    let shown = format!("{list:?}");
+    assert!(shown.contains("ItemList"), "{shown}");
+    assert!(shown.contains("items: 4"), "{shown}");
+    assert!(shown.contains("capacity: 4"), "{shown}");
+
+    // Past its capacity it refuses by name rather than dropping a draw,
+    // and a list of zero cannot hold the seed it is given.
+    let hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let over = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut two = ItemList::<2>::new(Item::new(&pipeline).push_data(&labels[0]));
+        two.push(Item::new(&pipeline).push_data(&labels[1]));
+        two.push(Item::new(&pipeline).push_data(&labels[2]));
+    }));
+    let empty = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = ItemList::<0>::new(Item::new(&pipeline).push_data(&labels[0]));
+    }));
+    std::panic::set_hook(hook);
+    assert!(over.is_err(), "a third item in a list of two must refuse");
+    assert!(empty.is_err(), "a list of zero cannot hold its seed");
+
+    // And the list composes a frame that actually renders, which is
+    // the point of the type: three draws, in order, through one target.
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 8,
+            height: 8,
+        })
+        .expect("offscreen target");
+    let color = clear(Color::new(0.0, 0.0, 0.0, 1.0));
+    let mut frame = ItemList::<3>::new(Item::new(&pipeline).push_data(&labels[0]));
+    frame.push_some(Some(Item::new(&pipeline).push_data(&labels[1])));
+    frame.push(Item::new(&pipeline).push_data(&labels[2]));
+    target
+        .render(&RenderDesc::new(&[Pass::new(&color, frame.as_slice())]))
+        .expect("a frame composed by the list renders");
+    drop(target);
+    assert_no_validation_errors(&device);
 }
 
 /// Every frame-shape refusal, driven. The contract asserts fire before

--- a/crates/ui-render/tests/golden.rs
+++ b/crates/ui-render/tests/golden.rs
@@ -13,7 +13,7 @@
 //! the 2D renderer's own Testing notes record.
 
 use renew_math::Alpha;
-use renew_render2d::{AtlasDesc, Canvas, SpriteRenderer, attachment};
+use renew_render2d::{AtlasDesc, Canvas, SpriteRenderer};
 use renew_rhi::{
     Color, Device, DeviceDesc, DeviceError, Extent, Pass, RenderDesc, TargetFormat, Validation,
 };
@@ -134,7 +134,7 @@ fn a_presented_tree_lands_in_computed_pixels() {
     sprites.begin();
     presenter.emit(Alpha::ZERO, &mut sprites);
     assert_eq!(sprites.sprites(), 2, "two panels, no transparent root");
-    let color = [attachment(CLEAR)];
+    let color = [renew_rhi::color_attachment(CLEAR)];
     let items = [sprites.item()];
     let passes = [Pass::new(&color, &items)];
     target.render(&RenderDesc::new(&passes)).expect("render");
@@ -232,7 +232,7 @@ fn text_lands_inside_its_measured_box() {
     let width = u32::try_from(width).expect("a two-glyph label fits any canvas");
     sprites.begin();
     renew_ui_render::emit_text(&mut sprites, 4.0, 4.0, text, [1.0, 1.0, 1.0, 1.0]);
-    let color = [attachment(CLEAR)];
+    let color = [renew_rhi::color_attachment(CLEAR)];
     let items = [sprites.item()];
     let passes = [Pass::new(&color, &items)];
     target.render(&RenderDesc::new(&passes)).expect("render");

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -14,7 +14,9 @@ use renew_render3d::{
     Camera as RenderCamera, MeshRenderer, Scene, ShadowMatrices, ShadowedCameraRenderer,
     TexturedMeshRenderer, attachment, pass,
 };
-use renew_rhi::{Color, Device, DeviceDesc, Extent, RenderDesc, TargetFormat, Validation};
+use renew_rhi::{
+    Color, Device, DeviceDesc, Extent, ItemList, RenderDesc, TargetFormat, Validation,
+};
 use renew_sample_cube_world::grid::{Cell, Grid};
 
 use crate::mesh::{aimed_colour, colour, corner_shades, faces};
@@ -415,19 +417,20 @@ pub(crate) fn draw_scene(
     // Dust after the world and before the overlay: it tests the world's
     // depth without writing its own, and the crosshair stays on top of
     // everything because a sight that hides behind smoke is not a sight.
-    let world_item = renderer.item(&mesh, &packed);
-    let mut items = Vec::with_capacity(3);
-    items.push(world_item);
-    if let Some((sprinkler, instances, live, push)) = dust_parts.as_ref() {
-        items.push(sprinkler.item(instances, *live, push));
-    }
-    if let Some((plain, mesh)) = over.as_ref() {
-        items.push(plain.item(mesh));
-    }
+    let mut items = ItemList::<3>::new(renderer.item(&mesh, &packed));
+    items.push_some(
+        dust_parts
+            .as_ref()
+            .map(|(sprinkler, instances, live, push)| sprinkler.item(instances, *live, push)),
+    );
+    items.push_some(over.as_ref().map(|(plain, mesh)| plain.item(mesh)));
     // The caster pass leads: the world's depth as the sun sees it,
     // into the map the world item samples.
     let casting = [renderer.caster_item(&caster_mesh, &light_packed)];
-    let passes = [renderer.shadow_pass(&casting), pass(&color, &items)];
+    let passes = [
+        renderer.shadow_pass(&casting),
+        pass(&color, items.as_slice()),
+    ];
     target
         .render(&RenderDesc::new(&passes))
         .map_err(|error| RenderError::Refused(error.to_string()))?;

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -12,10 +12,11 @@
 
 use renew_render3d::{
     Camera as RenderCamera, MeshRenderer, Scene, ShadowMatrices, ShadowedCameraRenderer,
-    TexturedMeshRenderer, attachment, pass,
+    TexturedMeshRenderer, pass,
 };
 use renew_rhi::{
     Color, Device, DeviceDesc, Extent, ItemList, RenderDesc, TargetFormat, Validation,
+    color_attachment,
 };
 use renew_sample_cube_world::grid::{Cell, Grid};
 
@@ -181,7 +182,7 @@ pub fn draw_clip_space(scene: &Scene, surface: ClipSurface) -> Result<Vec<u8>, R
         }
     };
 
-    let color = [attachment(BACKDROP)];
+    let color = [color_attachment(BACKDROP)];
     let passes = [pass(&color, &items)];
     target
         .render(&RenderDesc::new(&passes))
@@ -410,7 +411,7 @@ pub(crate) fn draw_scene(
         _ => None,
     };
 
-    let color = [attachment(BACKDROP)];
+    let color = [color_attachment(BACKDROP)];
     // The world first, whatever is over it second. Both are in one pass:
     // the overlay sits at the near plane, so the depth test cannot put
     // the world in front of it, and the order settles it regardless.

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -56,8 +56,8 @@ use renew_render3d::{
     Camera as RenderCamera, MeshRenderer, ShadowMatrices, ShadowedCameraRenderer, attachment, pass,
 };
 use renew_rhi::{
-    Device, DeviceDesc, DeviceError, Extent, Mesh, PresentOutcome, RenderDesc, Validation,
-    WindowTarget,
+    Device, DeviceDesc, DeviceError, Extent, ItemList, Mesh, PresentOutcome, RenderDesc,
+    Validation, WindowTarget,
 };
 use renew_sample_cube_world::{Cell, Cube, Intent, Tuning};
 
@@ -670,35 +670,24 @@ impl CubeApp {
         // back from the first resize showing the last frame it managed,
         // for ever.
         //
-        // Two arrays rather than one `Vec`, because this runs once a
-        // frame and the steady-state loop is meant to reach the heap
-        // never: a two-element `Vec` would be an allocation and a free
-        // every frame, to hold a count known at compile time.
-        //
         // The world first, dust over it, the crosshair over everything:
         // the dust tests the world's depth without writing its own, and
         // a sight that hides behind smoke is not a sight. The overlay
         // sits at the near plane, so the depth test cannot put a block
         // in front of it; the order settles it anyway.
         //
-        // Two branches so each holds a fixed-size array: a frame with no
-        // dust — most of them — should not pay for an empty draw, and
-        // neither branch reaches the heap. A crosshair that failed to
-        // upload is simply absent — a frame of the world is worth more
-        // than no frame at all.
-        let outcome = if live > 0 {
-            let items = [
-                world,
-                gpu.sprinkler.item(&gpu.instances, live, &push),
-                gpu.overlay.item(&gpu.crosshair),
-            ];
-            let passes = [shadow, pass(&color, &items)];
-            gpu.target.render(&RenderDesc::new(&passes))
-        } else {
-            let items = [world, gpu.overlay.item(&gpu.crosshair)];
-            let passes = [shadow, pass(&color, &items)];
-            gpu.target.render(&RenderDesc::new(&passes))
-        };
+        // A stack list rather than a `Vec`, because this runs once a
+        // frame and the steady-state loop is meant to reach the heap
+        // never — and rather than the two branches this used to carry,
+        // which duplicated the render call to hold two array sizes. A
+        // frame with no dust — most of them — pays for no empty draw.
+        let mut items = ItemList::<3>::new(world);
+        if live > 0 {
+            items.push(gpu.sprinkler.item(&gpu.instances, live, &push));
+        }
+        items.push(gpu.overlay.item(&gpu.crosshair));
+        let passes = [shadow, pass(&color, items.as_slice())];
+        let outcome = gpu.target.render(&RenderDesc::new(&passes));
         self.record_present(&outcome);
     }
 

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -53,11 +53,11 @@ use renew_platform::window::{
     LoopControl, WindowApp, WindowConfig, WindowError, WindowRef, run_window_app,
 };
 use renew_render3d::{
-    Camera as RenderCamera, MeshRenderer, ShadowMatrices, ShadowedCameraRenderer, attachment, pass,
+    Camera as RenderCamera, MeshRenderer, ShadowMatrices, ShadowedCameraRenderer, pass,
 };
 use renew_rhi::{
     Device, DeviceDesc, DeviceError, Extent, ItemList, Mesh, PresentOutcome, RenderDesc,
-    Validation, WindowTarget,
+    Validation, WindowTarget, color_attachment,
 };
 use renew_sample_cube_world::{Cell, Cube, Intent, Tuning};
 
@@ -645,7 +645,7 @@ impl CubeApp {
         }
 
         let packed = ShadowMatrices::from_columns(camera.columns(), gpu.light_columns);
-        let color = [attachment(SKY)];
+        let color = [color_attachment(SKY)];
         // The frame's particles, packed into the scratch sized at
         // bring-up — a burst costs the steady-state loop no allocation.
         // The billboard basis comes from the same blended view the world

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -400,7 +400,7 @@ impl GlideApp {
         }
         // The frame, composed on this stack; the borrows end at the
         // render call. Two items: the world's atlas, then the UI's.
-        let color = [renew_render2d::attachment(SKY)];
+        let color = [renew_rhi::color_attachment(SKY)];
         let items = [renderer.item(), ui_sprites.item()];
         let passes = [Pass::new(&color, &items)];
         let outcome = target.render(&RenderDesc::new(&passes));

--- a/samples/glide/tests/golden.rs
+++ b/samples/glide/tests/golden.rs
@@ -161,7 +161,7 @@ fn capture(device: &Device, world: &World) -> Result<Vec<u8>, String> {
         };
         renderer.push(&Sprite::new(region, sprite.x, sprite.y).size(sprite.width, sprite.height));
     }
-    let color = [renew_render2d::attachment(SKY)];
+    let color = [renew_rhi::color_attachment(SKY)];
     let items = [renderer.item()];
     let passes = [Pass::new(&color, &items)];
     let frame = RenderDesc::new(&passes);

--- a/samples/hello_triangle/src/offscreen.rs
+++ b/samples/hello_triangle/src/offscreen.rs
@@ -17,8 +17,9 @@ use renew_rhi::{
 
 use crate::cli::{Options, Report};
 use crate::error::{SampleError, device_error, pipeline_error, render_error, target_error};
-use crate::render::{Surface, clear_attachment, clear_color};
+use crate::render::{Surface, clear_color};
 use crate::world::World;
+use renew_rhi::color_attachment;
 
 /// The headless image size. Small on purpose: the oracle compares every
 /// pixel of it, and 64×64 is enough to prove the loop reached the
@@ -150,7 +151,7 @@ impl HeadlessRun {
         // The frame, composed on this stack: one pass, cleared to the
         // world's colour, drawing the triangle when a pipeline exists.
         // The borrows end at the render call.
-        let color = [clear_attachment(clear)];
+        let color = [color_attachment(clear)];
         let items_storage;
         let items: &[Item<'_>] = match self.pipeline.as_ref() {
             Some(pipeline) => {
@@ -184,7 +185,7 @@ impl HeadlessRun {
     /// [`SampleError::Failed`] if the renderer could not draw.
     pub fn redraw(&mut self) -> Result<(), SampleError> {
         let clear = clear_color(&self.world, Alpha::ZERO);
-        let color = [clear_attachment(clear)];
+        let color = [color_attachment(clear)];
         let items_storage;
         let items: &[Item<'_>] = match self.pipeline.as_ref() {
             Some(pipeline) => {

--- a/samples/hello_triangle/src/render.rs
+++ b/samples/hello_triangle/src/render.rs
@@ -1,10 +1,7 @@
 //! Where a frame goes, and the colour it goes there with.
 
 use renew_math::Alpha;
-use renew_rhi::{
-    Attachment, ClearValue, Color, LoadOp, OffscreenTarget, RenderDesc, StoreOp, TargetError,
-    TargetFormat,
-};
+use renew_rhi::{Attachment, Color, OffscreenTarget, RenderDesc, TargetError, TargetFormat};
 #[cfg(feature = "window")]
 use renew_rhi::{PresentOutcome, WindowTarget};
 
@@ -78,7 +75,7 @@ impl Surface {
 /// stores it.
 #[must_use]
 pub fn clear_attachment(clear: Color) -> Attachment {
-    Attachment::new(LoadOp::Clear(ClearValue::Color(clear)), StoreOp::Store)
+    renew_rhi::color_attachment(clear)
 }
 
 /// The clear colour for a frame standing `alpha` of the way past the

--- a/samples/hello_triangle/src/render.rs
+++ b/samples/hello_triangle/src/render.rs
@@ -1,7 +1,7 @@
 //! Where a frame goes, and the colour it goes there with.
 
 use renew_math::Alpha;
-use renew_rhi::{Attachment, Color, OffscreenTarget, RenderDesc, TargetError, TargetFormat};
+use renew_rhi::{Color, OffscreenTarget, RenderDesc, TargetError, TargetFormat};
 #[cfg(feature = "window")]
 use renew_rhi::{PresentOutcome, WindowTarget};
 
@@ -67,15 +67,6 @@ impl Surface {
                 .map(|outcome| outcome == PresentOutcome::Presented),
         }
     }
-}
-
-/// The one color attachment every frame here renders into: cleared to
-/// `clear`, stored. The frame itself is composed at each call site —
-/// the borrows in a composed frame end at the render call, so nothing
-/// stores it.
-#[must_use]
-pub fn clear_attachment(clear: Color) -> Attachment {
-    renew_rhi::color_attachment(clear)
 }
 
 /// The clear colour for a frame standing `alpha` of the way past the

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -29,8 +29,9 @@ use renew_rhi::{
 use crate::cli::{Options, Report};
 use crate::error::{SampleError, device_error, pipeline_error, render_error, target_error};
 use crate::readout::{self, Readout};
-use crate::render::{Surface, clear_attachment, clear_color};
+use crate::render::{Surface, clear_color};
 use crate::world::World;
+use renew_rhi::color_attachment;
 
 /// What the window is called before any measurement exists, and the text
 /// every frame-time reading is appended to.
@@ -192,7 +193,7 @@ impl TriangleApp {
         let clear = clear_color(&self.world, self.alpha);
         // The frame, composed on this stack; the borrows end at the
         // render call.
-        let color = [clear_attachment(clear)];
+        let color = [color_attachment(clear)];
         let items = [Item::new(pipeline)];
         let passes = [Pass::new(&color, &items)];
         let outcome = surface.render(&RenderDesc::new(&passes));


### PR DESCRIPTION
Two small additions to the frame vocabulary, and one deduplication that had been waiting for somewhere to live.

**`ItemList<'a, N>`** — a pass's draw list, built on the stack. A frame whose middle draw is conditional cannot be one array literal, so callers reached for one of three things: two whole branches that each built an array and each called `render` (the duplication being in the render call, which is the part worth writing once), a `Vec` allocated per frame, or an array of `Option`s that nothing downstream accepts. This is the fourth: capacity from the caller, seeded, pushed conditionally, handed over as a slice. It is deliberately not `Copy` — on an accumulator driven by `&mut` pushes, a copy taken mid-build would swallow every later push with no diagnostic.

It replaces two hand-rolled solutions, both in the cube sample. It does **not** replace the zero-or-one shape in the triangle sample and cannot: a list that might hold nothing needs no seed, and this one demands one, so a pass drawing nothing keeps being written `&[]`.

**`color_attachment`** — one definition *and one name* for a two-line helper three crates had each written identically. The wrappers are deleted rather than forwarded: forwarding would have left exactly the ambiguity the duplication caused, with a caller composing from two renderers still importing whichever name it reached first. No crate needed a new dependency to follow the change — every one of them already had it. `depth_attachment` deliberately stays where it is, encoding the reversed-Z convention and refusing to take its clear value as a parameter, which is a renderer's policy rather than the frame vocabulary's.

**Evidence.** The list is pinned in the device suite: ordering (four labelled draws, so a reversal fails), the optional push proving a no-op, the capacity refusal proved *by name* — without the check the next line indexes out of bounds, and a test that only asserted "something panicked" would pass on the wrong panic — the Debug form, and a frame the list composes actually rendering under validation. The migration is pixel-neutral: the cube's committed still re-renders byte-identical.
