### PR TITLE
docs(fixed): the float bridge lives where it is written

### DIFF
--- a/crates/fixed/src/lib.rs
+++ b/crates/fixed/src/lib.rs
@@ -16,10 +16,14 @@
 //! - **Q47.16 in an `i64`.** 16 fractional bits: a resolution of 2⁻¹⁶, and a
 //!   range of ±2⁴⁷. See [`Fixed`] for why those numbers and not others.
 //! - **No `f32` or `f64` in any signature this crate exposes.** Converting to
-//!   a float is a presentation concern and lives in the maths crate, which
-//!   depends on this one. A simulation cannot reach that crate, so it cannot
-//!   perform the conversion — enforced by the structure checker rather than by
-//!   anyone remembering.
+//!   a float is a presentation concern, and the conversion is written at the
+//!   boundary that needs it rather than offered here. It cannot be centralised
+//!   in the maths crate: that crate is core and this one is optional, so the
+//!   core-closure rule refuses the edge outright. Nor is centralising it worth
+//!   much — each boundary carries its own precision-loss exemption with its own
+//!   reason, and one shared helper would flatten those into a single reason
+//!   that fits none of them. What stops a simulation from converting is not
+//!   this contract but the float-arithmetic denial it already builds under.
 //! - **Every operation is deterministic and target-independent.** No operation
 //!   here consults a clock, an allocator, an environment variable, or anything
 //!   whose value could differ between two machines running the same build.


### PR DESCRIPTION
The fixed-point crate's contract said that converting to a float "lives in the maths crate, which depends on this one". It does not, and it cannot: the maths crate has no dependencies at all, and the named edge is refused twice over independently — the maths crate is core and this one is optional, so core closure rejects it, and the maturity ladder rejects it again.

A false sentence under a **Contract** heading is the worst place in the tree for one, because that heading is where a reader goes for a guarantee rather than a description.

The replacement states what is actually true and why it is not a defect: the conversion is written at each boundary that needs one — three today, in two spellings — and centralising it would not be an improvement. Each site carries its own precision-loss exemption with its own reason (sub-pixel rounding where the picture is the only casualty; world-scale coordinates where the precision is far outside any world built), and one shared helper would flatten three differently-justified exemptions into a single reason fitting none of them.

It also names the real enforcement. What stops a simulation from converting is not this contract but the float-arithmetic denial such a crate already builds under — worth saying in the place a reader is looking for the guarantee.

Documentation only; no behavioural surface, so no test accompanies it.