### PR TITLE
feat(snapshot): the picture moves between ticks, keyed so it moves with itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,18 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-camera $sel
           cargo build $sel
           cargo test $sel
+      # The snapshot pair: two captures of one slot space and the
+      # (slot, generation) rule deciding which pairs may blend. The
+      # maths crate below it, the side-scroller its one consumer — the
+      # exclude list is upward-closed by excluding that game with it.
+      # Two edges must never appear or this cell hollows out: no entity
+      # storage below it, and no renderer above it.
+      - name: Build and test without the snapshot pair
+        run: |
+          sel="--workspace --exclude renew-snapshot --exclude renew-sample-glide"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-snapshot $sel
+          cargo build $sel
+          cargo test $sel
       # The widget tree: structure, layout, and interaction over the
       # fixed-point and digest crates. Its consumers are the UI
       # presenter, the windowed game whose pause menu embeds it, the
@@ -429,7 +441,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-snapshot"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-math",
+ "renew-memory",
+]
+
+[[package]]
 name = "renew-trace"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "renew-replay",
  "renew-rhi",
  "renew-sample-glide-world",
+ "renew-snapshot",
  "renew-trace",
  "renew-ui",
  "renew-ui-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
-    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ time pending: 11666657 ns
 ## Modules
 
 Every module is independently buildable, testable, and — outside the minimal core —
-removable. CI proves the last part on every commit, and proves it *one crate at a time*: sixteen
+removable. CI proves the last part on every commit, and proves it *one crate at a time*: twenty-one
 configurations, each with one optional crate and everything that depends on it excluded, every one
-built **and** tested. A seventeenth builds the minimal core alone and asserts that no optional crate
+built **and** tested. A twenty-second builds the minimal core alone and asserts that no optional crate
 reached its graph. The platform crate is built again with its windowing feature compiled away, and
 the game is built with no graphics crate in its dependency graph at all — which is the removability
 claim from the other side, and the reason the window is a feature rather than a default.
@@ -105,6 +105,8 @@ claim from the other side, and the reason the window is a feature rather than a 
 | **`renew-camera`** | Presentation-side viewpoints: a look-at view, a reversed-depth perspective, and a blend between ticks for display-rate smoothness | `bootstrap` · optional |
 | **`renew-snapshot`** | Two captures of one slot space blended by the interpolation factor, keyed so a recycled slot never inherits the previous tenant's motion | `bootstrap` · optional |
 | **`renew-particles`** | A fixed-capacity particle pool stepped at the simulation's cadence, seeded so replays reproduce the picture | `bootstrap` · optional |
+| **`renew-ui`** | A widget tree solved in fixed point inside the simulation, so a layout is part of what a replay reproduces | `bootstrap` · optional |
+| **`renew-ui-render`** | Presentation for the widget tree: retained snapshots blended at display rate, clipped on the CPU, emitted as sprites | `bootstrap` · optional |
 | **`renew-audio`** | Mixing and playback, behind the platform's device seam | `bootstrap` · optional |
 | **`renew-asset`** | Content-addressed asset packs, with every entry verifiable against its digest | `bootstrap` · optional |
 | **`renew-png`** | PNG encoding with no dependencies — pixels in, the bytes of a file out, so a sample can commit a picture of itself | `bootstrap` · optional |
@@ -175,7 +177,7 @@ Every commit on `main` clears all of these, on Windows, Linux, and macOS:
 | No panicking shortcuts | `unwrap`, `expect`, `panic`, `todo`, `dbg!` denied outside tests |
 | `unsafe` denied by default | workspace-wide `unsafe_code = "deny"`; the crates that need it opt in per crate, and `undocumented_unsafe_blocks = "deny"` makes every block state the invariant that keeps it sound |
 | Module graph is a DAG | crate manifest and dependency-graph check (`renew check`) |
-| Optional modules stay removable | sixteen configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
+| Optional modules stay removable | twenty-one configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
 | Licenses and advisories | `cargo-deny`, over the full dependency tree including dev-dependencies |
 | Sanitizers and Miri | scheduled nightly runs (ASan, TSan, Miri) |
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ claim from the other side, and the reason the window is a feature rather than a 
 | **`renew-render2d`** | Sprites from an atlas, one instanced draw | `bootstrap` · optional |
 | **`renew-render3d`** | Indexed geometry, depth-tested, in submission order | `bootstrap` · optional |
 | **`renew-camera`** | Presentation-side viewpoints: a look-at view, a reversed-depth perspective, and a blend between ticks for display-rate smoothness | `bootstrap` · optional |
+| **`renew-snapshot`** | Two captures of one slot space blended by the interpolation factor, keyed so a recycled slot never inherits the previous tenant's motion | `bootstrap` · optional |
 | **`renew-particles`** | A fixed-capacity particle pool stepped at the simulation's cadence, seeded so replays reproduce the picture | `bootstrap` · optional |
 | **`renew-audio`** | Mixing and playback, behind the platform's device seam | `bootstrap` · optional |
 | **`renew-asset`** | Content-addressed asset packs, with every entry verifiable against its digest | `bootstrap` · optional |
 | **`renew-png`** | PNG encoding with no dependencies — pixels in, the bytes of a file out, so a sample can commit a picture of itself | `bootstrap` · optional |
 
-Twenty-three engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
+Twenty-six engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
 prints the live list with each crate's declared maturity, read from its manifest rather than from
 this table.
 

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -156,5 +156,5 @@ reason = "The scenario binary's two refusal arms: the argument guard (a drifted 
 
 [[exempt]]
 file = "samples/glide/src/windowed.rs"
-lines = [392, 393, 394, 395, 396, 397, 398]
+lines = [407, 408, 409, 410, 411, 412, 413]
 reason = "The menu-open half of the draw: the presenter's snapshots advanced and emitted, and a label placed per button. The lane's windowed run is keyboardless under a virtual display, so nothing there ever opens the menu, and no test reaches draw at all - drawing needs the bring-up's live target. Everything the block decides is covered without it: the advance/emit pair by the presentation crate's own tests, the placement arithmetic by a unit test on label_origin (the block's only computation), and the routing, pausing, restarting and rescaling behind it by constructed-event tests on the seam. Deliberately narrow: the is_open check the frame evaluates every draw is measured and not exempt."

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "renew-snapshot"
+description = "Two captures of one slot space, and the rule that decides which pairs may be blended"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Two captures of one slot space blended by the interpolation factor, keyed by (slot, generation) so a recycled slot's new tenant never inherits the old tenant's motion."
+maturity = "bootstrap"
+core = false
+extension_points = ["Blend"]
+simulation = false
+
+# The maths crate and nothing else. Two things follow from that and both
+# are deliberate: the crate names no storage type, so it cannot drag an
+# ECS into a renderer's build; and it does not deny float arithmetic,
+# which is what mechanically refuses every simulation crate an edge to
+# it.
+[dependencies]
+renew-math = { path = "../core/math" }
+
+# The classification is a property over arbitrary (slot, generation,
+# value) sequences, which is the testing table's containers row. The
+# counting allocator holds the steady-state claim. Same versions every
+# sibling pins.
+[dev-dependencies]
+proptest = "1.11"
+renew-memory = { path = "../core/memory" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under instrumented allocators.
+[features]
+sanitized = []
+
+[lints]
+workspace = true

--- a/crates/snapshot/README.md
+++ b/crates/snapshot/README.md
@@ -17,20 +17,24 @@ streaks the newcomer out of its predecessor's last position. So every value is k
 `(slot, generation)`, and a pair blends only when both halves agree:
 
 ```rust
+use renew_math::Alpha;
 use renew_snapshot::{Key, Snapshots};
 
 let mut pipes = Snapshots::<f32>::new(16);
 
 // Once per executed producer step:
-let mut capture = pipes.capture();
-capture.put(Key::new(3, 0), 320.0);
-drop(capture);
+{
+    let mut capture = pipes.capture();
+    capture.put(Key::new(3, 0), 320.0);
+}
 
 // Once per frame, with the loop's interpolation factor:
+let alpha = Alpha::ZERO; // in a real loop, from the frame plan's remainder
 for drawn in pipes.frame(alpha) {
-    // drawn.value is already resolved — blended, or standing at its
-    // one known tick. There is no call site here that could blend
-    // across a recycled slot.
+    // drawn.value is already resolved — blended, or standing at its one
+    // known tick. There is no call site here that could blend across a
+    // recycled slot.
+    let _ = drawn.value;
 }
 ```
 
@@ -59,10 +63,12 @@ them all and each reset clears exactly the set the previous reset let through. I
 rather than an optimisation: both passes cross-read the other buffer, so a slot live two steps ago
 and absent since would otherwise still read as present and wrongly suppress a dying row.
 
-**Capacity is fixed, with `resize` as the named escape.** The steady-state frame loop performs no
-heap allocation, so growth-on-demand inside the loop is not available. The budget is the
-consumer's obligation; a producer whose live set is bounded by its own rules asserts that bound in
-a test, and `put` refuses by name rather than as a bare slice index if the rules ever outgrow it.
+**Capacity is fixed at construction.** The steady-state frame loop performs no heap allocation,
+so growth-on-demand inside the loop is not available. The budget is the consumer's obligation; a
+producer whose live set is bounded by its own rules asserts that bound in a test, and `put`
+refuses by name rather than as a bare slice index if the rules ever outgrow it. There is
+deliberately no `resize` — every producer in this tree has a bounded live set, so it would be a
+method nobody had ever run, and it is free to add when one arrives that does not.
 
 ## Limits, stated rather than implied
 

--- a/crates/snapshot/README.md
+++ b/crates/snapshot/README.md
@@ -1,0 +1,92 @@
+# renew-snapshot
+
+Two captures of one slot space, and the rule that decides which pairs may be blended.
+
+**Status:** `bootstrap` · optional. Interface churn expected; breaking its API costs nothing yet.
+The manifest in `Cargo.toml` is authoritative for maturity, dependencies and core status.
+
+## What it is for
+
+A producer steps at a fixed timestep; frames arrive faster. Drawing the current state on every
+frame means the picture only moves when the producer does — positions repeat for a few frames and
+then jump. The fix is to keep the last two states and draw between them.
+
+The part that is easy to get wrong is identity. A dense slot that a producer frees and hands to
+something else is the same *index* holding a different *thing*, and blending across that pairing
+streaks the newcomer out of its predecessor's last position. So every value is keyed by
+`(slot, generation)`, and a pair blends only when both halves agree:
+
+```rust
+use renew_snapshot::{Key, Snapshots};
+
+let mut pipes = Snapshots::<f32>::new(16);
+
+// Once per executed producer step:
+let mut capture = pipes.capture();
+capture.put(Key::new(3, 0), 320.0);
+drop(capture);
+
+// Once per frame, with the loop's interpolation factor:
+for drawn in pipes.frame(alpha) {
+    // drawn.value is already resolved — blended, or standing at its
+    // one known tick. There is no call site here that could blend
+    // across a recycled slot.
+}
+```
+
+## Key decisions, and why
+
+**The container blends; the consumer never does.** `frame` hands back resolved values rather than
+a "here are the two endpoints, you decide" pair. A consumer holding both endpoints is a consumer
+that can blend the wrong two, which is the one mistake this crate exists to prevent. Making it
+unspellable is stronger than documenting it.
+
+**The tick boundary is the container's guarantee, not the payload's.** At `Alpha::ZERO`, `frame`
+returns the earlier capture bit for bit and never calls `Blend::blend`. Committed images and
+computed-pixel oracles are rendered at tick boundaries, so this is the case that must not move,
+and resting it on every payload implementing lerp exactly would be resting it on nothing.
+
+**Keys are plain integers, not an entity handle.** The crate names no storage type, so a renderer
+can depend on it without an entity-storage crate appearing in the renderer's build graph.
+Widening a narrower generation counter at the fill site is lossless and costs the producer one
+`u64::from`.
+
+**The reset is by outgoing order, not a full clear.** Clearing every entry each step is
+O(capacity) against a slot space that typically never shrinks. Instead each capture clears exactly
+the slots the previous one wrote. The invariant is *every slot outside `order` has
+`present == false`, and its stale value is unreachable* — inductive, because construction defaults
+them all and each reset clears exactly the set the previous reset let through. It is load-bearing
+rather than an optimisation: both passes cross-read the other buffer, so a slot live two steps ago
+and absent since would otherwise still read as present and wrongly suppress a dying row.
+
+**Capacity is fixed, with `resize` as the named escape.** The steady-state frame loop performs no
+heap allocation, so growth-on-demand inside the loop is not available. The budget is the
+consumer's obligation; a producer whose live set is bounded by its own rules asserts that bound in
+a test, and `put` refuses by name rather than as a bare slice index if the rules ever outgrow it.
+
+## Limits, stated rather than implied
+
+- **Only what is captured through it interpolates.** A renderer packing instances straight from
+  current state is unaffected by this crate existing.
+- **A singleton does not want this.** A camera, or anything whose identity is the session, wants
+  one `Option<T>` and one blend — `None` is the newborn rule already expressed in the type system.
+  A key is needed exactly when a slot can be recycled.
+- **Generations are assumed not to wrap.** A slot reused 2^64 times would alias its own past. No
+  producer in this tree can reach that; it is stated because it is untestable.
+- **`Fate::Dying` is reported, never acted on.** A painter's-order pass draws it once more
+  underneath the living so nothing vanishes mid-blend; a depth-tested pass drops it with a
+  one-line filter. This crate does not know which it is talking to.
+
+## Testing
+
+Unit tests pin the named cases; `tests/properties.rs` pins the rules those cases are instances of;
+`tests/zero_alloc.rs` holds the allocation contract with a counting allocator, exercising the
+recycle path *inside* the measured window.
+
+The pair that matters most is `a_recycled_slot_never_inherits_the_dead_tenants_motion` and
+`a_survivor_at_the_same_slot_and_generation_does_blend`. They ship adjacent and are named as a
+pair on purpose: alone, the first passes against an implementation that never blends anything at
+all.
+
+No fuzz target: the testing table's fuzz row is for parsers of external data, and this crate
+parses nothing.

--- a/crates/snapshot/clippy.toml
+++ b/crates/snapshot/clippy.toml
@@ -1,0 +1,39 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated). Contract
+# tripwires: a snapshot pair is a pure function of the captures it took
+# and the blend factor it was handed — it never reads a clock, never
+# touches the filesystem, never spawns a thread. Floats are its medium
+# on purpose: this crate is presentation-side, and the structure
+# checker's float fence is what keeps it out of every simulation
+# crate's closure.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a snapshot pair is advanced by the caller at the cadence the caller owns" },
+    { path = "std::time::SystemTime::now", reason = "a snapshot pair is advanced by the caller at the cadence the caller owns" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_to_string", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::copy", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::metadata", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::read_dir", reason = "this crate never touches the filesystem" },
+    { path = "std::thread::spawn", reason = "this crate never spawns; parallelism belongs to the job system" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::io::Read::read_to_string", reason = "the whole-file road the fs bans would otherwise leave open" },
+    { path = "std::io::Read::read_to_end", reason = "the whole-file road the fs bans would otherwise leave open" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "a snapshot pair holds no randomness at all, and nothing self-seeding may suggest otherwise" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "self-seeding entropy has no place behind a reproducibility contract" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -25,8 +25,9 @@
 //!   case is this container's guarantee rather than each payload's, so a
 //!   sloppy `blend` cannot move a picture that an oracle or a committed
 //!   image stands on.
-//! - **Nothing here allocates** after construction, except
-//!   [`Snapshots::resize`], which says so in its own name.
+//! - **Nothing here allocates** after construction. The budget is fixed
+//!   at construction and [`Capture::put`] refuses a slot past it by
+//!   name.
 //!
 //! # Capture locals, never composed transforms
 //!
@@ -108,9 +109,14 @@ pub trait Blend: Copy {
 impl Blend for f32 {
     fn blend(from: Self, to: Self, alpha: Alpha) -> Self {
         // `from + (to - from) * t` rather than `from * (1 - t) + to * t`:
-        // the first is exact at t = 0 for every input, which is the case
-        // the container short-circuits anyway, and it is the spelling the
-        // rest of the tree already uses.
+        // fewer roundings, and the spelling the rest of the tree uses.
+        //
+        // It is NOT exact at t = 0 — `-0.0 + (x - -0.0) * 0.0` is `+0.0`,
+        // so the sign of a zero would be lost. That is precisely why the
+        // container short-circuits the boundary rather than trusting this
+        // to reproduce it, and why the trait says so in its contract.
+        // `alpha_zero_is_bit_exactly_the_earlier_capture` is the test that
+        // would fail if the short-circuit were removed.
         from + (to - from) * alpha.get()
     }
 }
@@ -188,55 +194,27 @@ pub struct Snapshots<T> {
     current: Buffer<T>,
 }
 
-impl<T> Snapshots<T> {
-    /// How many slots this pair was sized for. A [`Capture::put`] past
-    /// this refuses by name.
-    #[must_use]
-    pub fn slots(&self) -> u32 {
-        // Built from a u32 and only ever grown from one.
-        u32::try_from(self.current.entries.len()).unwrap_or(u32::MAX)
-    }
-}
-
 impl<T: Default + Copy> Snapshots<T> {
     /// A pair sized for `slots` slots, both captures empty.
     ///
-    /// **The budget is the consumer's obligation.** A producer whose live
-    /// set is bounded by its own rules asserts that bound in a test; one
-    /// whose bound can rise calls [`Snapshots::resize`] between frames.
-    /// Sizing by a storage crate's high-water slot count works and never
-    /// shrinks, which is the safe direction.
+    /// **The budget is the consumer's obligation, and it is fixed.** A
+    /// producer whose live set is bounded by its own rules asserts that
+    /// bound in a test; sizing by a storage crate's high-water slot count
+    /// also works, and never shrinks, which is the safe direction.
+    /// [`Capture::put`] refuses by name rather than silently dropping a
+    /// value if the budget turns out to be wrong.
+    ///
+    /// There is deliberately no `resize`. Growing while keeping both
+    /// captures is easy to write and nothing in the tree needs it — every
+    /// producer here has a bounded live set — and an unused method is a
+    /// method nobody has ever run. It is free to add when a producer
+    /// arrives whose slot space really does grow.
     #[must_use]
     pub fn new(slots: u32) -> Self {
         Self {
             previous: Buffer::with_slots(slots),
             current: Buffer::with_slots(slots),
         }
-    }
-
-    /// Grow to `slots`, keeping both captures.
-    ///
-    /// **The one method here that allocates.** Call it between frames,
-    /// never inside the loop. Reconstructing the pair instead would
-    /// discard the earlier capture and make every slot a newborn for one
-    /// tick, which is a visible pop.
-    ///
-    /// Growing only: a request at or below the current size is a no-op.
-    /// Shrinking is not offered because it would have to decide what
-    /// becomes of live slots past the new bound, and nothing needs it.
-    pub fn resize(&mut self, slots: u32) {
-        let wanted = slots as usize;
-        if wanted <= self.current.entries.len() {
-            return;
-        }
-        self.previous.entries.resize(wanted, Entry::default());
-        self.current.entries.resize(wanted, Entry::default());
-        self.previous
-            .order
-            .reserve(wanted - self.previous.order.len());
-        self.current
-            .order
-            .reserve(wanted - self.current.order.len());
     }
 }
 
@@ -278,6 +256,14 @@ impl<T: Blend> Snapshots<T> {
     ///
     /// At `Alpha::ZERO` every [`Fate::Living`] value is bit-exactly its
     /// earlier capture, and [`Blend::blend`] is not called.
+    ///
+    /// **The same rule is implemented a second time in the tree**, over a
+    /// different payload: `UiPresenter::frame` in `renew-ui-render` blends
+    /// widget rectangles and their inherited clips under exactly this
+    /// generation guard. The two were not merged — the payloads have
+    /// little in common and one is already green — so a correction to the
+    /// rule has to be made in both, and each names the other so neither
+    /// is corrected alone.
     pub fn frame(&self, alpha: Alpha) -> impl Iterator<Item = Drawn<T>> + '_ {
         // Alpha is a ratio of unsigned integers clamped below one, so it
         // is never negative and never a negative zero; comparing bits is
@@ -531,6 +517,15 @@ mod tests {
         }
     }
 
+    /// The premise of the test below: this payload really does refuse.
+    /// Without this, a `NeverBlends` that had quietly stopped panicking
+    /// would make the short-circuit test pass for no reason.
+    #[test]
+    #[should_panic(expected = "must not consult blend")]
+    fn the_refusing_payload_really_refuses() {
+        let _ = NeverBlends::blend(NeverBlends(1.0), NeverBlends(2.0), half());
+    }
+
     #[test]
     fn blend_is_never_consulted_at_zero() {
         let mut pair = Snapshots::<NeverBlends>::new(4);
@@ -593,37 +588,6 @@ mod tests {
                 .collect::<Vec<_>>()
         };
         assert_eq!(run(), run(), "same captures, same frame, bit for bit");
-    }
-
-    #[test]
-    fn resize_preserves_both_captures() {
-        let mut pair = Snapshots::<f32>::new(2);
-        tick(&mut pair, [(0, 0, 0.0)]);
-        tick(&mut pair, [(0, 0, 100.0)]);
-        pair.resize(64);
-        assert_eq!(pair.slots(), 64);
-        let frame = drawn(&pair, quarter());
-        assert_eq!(frame.len(), 1);
-        assert_eq!(
-            frame[0].fate,
-            Fate::Living,
-            "growing must not make a survivor look newborn — that is a visible pop"
-        );
-        assert_eq!(frame[0].value.to_bits(), 25.0f32.to_bits());
-        // And the new room is usable.
-        tick(&mut pair, [(0, 0, 200.0), (63, 0, 7.0)]);
-        assert_eq!(drawn(&pair, half()).len(), 2);
-    }
-
-    #[test]
-    fn resize_never_shrinks() {
-        let mut pair = Snapshots::<f32>::new(16);
-        pair.resize(4);
-        assert_eq!(
-            pair.slots(),
-            16,
-            "a smaller request is a no-op, not a truncation"
-        );
     }
 
     #[test]

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -1,0 +1,638 @@
+//! Two captures of one slot space, and the rule that decides which pairs
+//! may be blended.
+//!
+//! A producer steps at a fixed timestep; frames arrive faster. A consumer
+//! captures the producer's presentation state once per executed step and
+//! reads back the last two blended by the ratified interpolation factor —
+//! keyed by `(slot, generation)`, so a slot's value is only ever blended
+//! with *itself*. A recycled slot's new tenant never inherits the old
+//! tenant's motion; that pairing, and nothing else, is what this crate is
+//! for.
+//!
+//! # Contract
+//!
+//! - **A slot blends only with the same slot at the same generation.**
+//!   Any other pairing is reported as [`Fate::Newborn`] or [`Fate::Dying`]
+//!   and drawn unblended, at the one tick that is known about it.
+//! - **The consumer never blends.** [`Snapshots::frame`] hands back values
+//!   already resolved, so there is no call site at which a consumer could
+//!   blend across a recycled slot even by mistake.
+//! - **`frame` yields in the order [`Capture::put`] was called**, dying
+//!   slots first. This crate never sorts and has no opinion about draw
+//!   order beyond that.
+//! - **At `Alpha::ZERO` every living value is bit-exactly its earlier
+//!   capture**, and [`Blend::blend`] is not called at all. The tick-exact
+//!   case is this container's guarantee rather than each payload's, so a
+//!   sloppy `blend` cannot move a picture that an oracle or a committed
+//!   image stands on.
+//! - **Nothing here allocates** after construction, except
+//!   [`Snapshots::resize`], which says so in its own name.
+//!
+//! # Capture locals, never composed transforms
+//!
+//! Two composed world matrices blended component-wise interpolate along a
+//! chord; blending the locals and composing afterwards does not. Capture
+//! what a thing *is* — a position, a gap centre — and derive what it looks
+//! like on the far side of the blend. A pipe's `(x, gap_y)` blends and the
+//! two bars derived from it are right; the two bars blended directly are
+//! not.
+//!
+//! # When not to use this
+//!
+//! **A key is needed exactly when a slot can be recycled.** A singleton
+//! with permanent identity — a camera, a player whose lifetime is the
+//! session — wants one `Option<T>` and one blend, where `None` *is* the
+//! newborn rule expressed in the type system. Forcing it through a keyed
+//! container adds a slot dimension of size one and buys nothing.
+//!
+//! # What this does not reach
+//!
+//! Only things captured through it interpolate. A renderer that packs its
+//! own instances straight from current state is unaffected by this crate
+//! existing, and saying otherwise would be a claim about code this crate
+//! never sees.
+
+// A snapshot pair is arithmetic over values the caller handed it; it does
+// not print. Floats are its medium on purpose — this crate is
+// presentation-side, and deliberately does NOT deny float arithmetic,
+// which is what mechanically refuses every simulation crate an edge to
+// it.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+
+use renew_math::Alpha;
+
+/// Which slot, and how many times it had been reused when the value was
+/// captured.
+///
+/// Deliberately not `Default`: a zeroed key names slot 0 at generation 0,
+/// which is a real key, and a defaulted one that accidentally works is
+/// worse than one that will not compile.
+///
+/// The fields are plain integers rather than any storage crate's handle.
+/// That is what keeps this crate nameable from a renderer without
+/// dragging entity storage into the renderer's build.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Key {
+    /// The dense index the producer stores this thing at.
+    pub slot: u32,
+    /// How many tenants that slot has had. Widened at the fill site — a
+    /// producer with a narrower counter passes `u64::from(..)`, which is
+    /// lossless.
+    pub generation: u64,
+}
+
+impl Key {
+    /// The key for `slot` at `generation`.
+    #[must_use]
+    pub const fn new(slot: u32, generation: u64) -> Self {
+        Self { slot, generation }
+    }
+}
+
+/// A value that can stand between two of its own captures.
+///
+/// # Contract
+///
+/// - `blend` is a pure function of its three arguments: no clock, no
+///   stored state, same inputs same answer.
+/// - It is **never called at `Alpha::ZERO`** — [`Snapshots::frame`]
+///   short-circuits there and returns the earlier capture bit for bit.
+///   Implementors need not reproduce that case exactly, and should not
+///   try: the container owns it.
+pub trait Blend: Copy {
+    /// This value `alpha` of the way from `from` to `to`.
+    #[must_use]
+    fn blend(from: Self, to: Self, alpha: Alpha) -> Self;
+}
+
+impl Blend for f32 {
+    fn blend(from: Self, to: Self, alpha: Alpha) -> Self {
+        // `from + (to - from) * t` rather than `from * (1 - t) + to * t`:
+        // the first is exact at t = 0 for every input, which is the case
+        // the container short-circuits anyway, and it is the spelling the
+        // rest of the tree already uses.
+        from + (to - from) * alpha.get()
+    }
+}
+
+/// What two captures say about one slot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Fate {
+    /// The same key in both captures: the value is blended.
+    Living,
+    /// Present only in the newer capture — a newborn, or a recycled
+    /// slot's new tenant. One known tick, so it stands at it.
+    Newborn,
+    /// Present only in the older capture. Its last known value.
+    ///
+    /// Reported, never acted on: a painter's-order 2D pass draws it once
+    /// more underneath the living so nothing vanishes mid-blend, and a
+    /// depth-tested pass drops it with a one-line filter. This crate does
+    /// not know which it is talking to.
+    Dying,
+}
+
+/// One slot's contribution to one frame.
+///
+/// Produced only by [`Snapshots::frame`], never built by callers — the
+/// resolution is the container's job, and a hand-built one would be a
+/// value nothing resolved.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct Drawn<T> {
+    /// The slot and the generation the value belongs to. For
+    /// [`Fate::Dying`] this is the departed tenant's generation, not
+    /// whatever occupies the slot now.
+    pub key: Key,
+    /// The resolved value: blended for [`Fate::Living`], as captured
+    /// otherwise.
+    pub value: T,
+    /// Which of the three cases produced it.
+    pub fate: Fate,
+}
+
+/// One slot in one capture.
+#[derive(Clone, Copy, Debug, Default)]
+struct Entry<T> {
+    /// A field rather than a sentinel generation, because generation 0 of
+    /// slot 0 is a real key. It is also the only thing a reset writes,
+    /// which is what makes the by-order reset below sound.
+    present: bool,
+    generation: u64,
+    value: T,
+}
+
+/// One capture: slot-indexed entries plus the order they were written.
+#[derive(Debug)]
+struct Buffer<T> {
+    entries: Vec<Entry<T>>,
+    /// The slots written this capture, in the order they were written.
+    order: Vec<u32>,
+}
+
+impl<T: Default + Copy> Buffer<T> {
+    fn with_slots(slots: u32) -> Self {
+        Self {
+            entries: vec![Entry::default(); slots as usize],
+            order: Vec::with_capacity(slots as usize),
+        }
+    }
+}
+
+/// Two captures of one slot space, and the blend between them.
+///
+/// See the crate documentation for the rule this exists to hold.
+#[derive(Debug)]
+pub struct Snapshots<T> {
+    previous: Buffer<T>,
+    current: Buffer<T>,
+}
+
+impl<T> Snapshots<T> {
+    /// How many slots this pair was sized for. A [`Capture::put`] past
+    /// this refuses by name.
+    #[must_use]
+    pub fn slots(&self) -> u32 {
+        // Built from a u32 and only ever grown from one.
+        u32::try_from(self.current.entries.len()).unwrap_or(u32::MAX)
+    }
+}
+
+impl<T: Default + Copy> Snapshots<T> {
+    /// A pair sized for `slots` slots, both captures empty.
+    ///
+    /// **The budget is the consumer's obligation.** A producer whose live
+    /// set is bounded by its own rules asserts that bound in a test; one
+    /// whose bound can rise calls [`Snapshots::resize`] between frames.
+    /// Sizing by a storage crate's high-water slot count works and never
+    /// shrinks, which is the safe direction.
+    #[must_use]
+    pub fn new(slots: u32) -> Self {
+        Self {
+            previous: Buffer::with_slots(slots),
+            current: Buffer::with_slots(slots),
+        }
+    }
+
+    /// Grow to `slots`, keeping both captures.
+    ///
+    /// **The one method here that allocates.** Call it between frames,
+    /// never inside the loop. Reconstructing the pair instead would
+    /// discard the earlier capture and make every slot a newborn for one
+    /// tick, which is a visible pop.
+    ///
+    /// Growing only: a request at or below the current size is a no-op.
+    /// Shrinking is not offered because it would have to decide what
+    /// becomes of live slots past the new bound, and nothing needs it.
+    pub fn resize(&mut self, slots: u32) {
+        let wanted = slots as usize;
+        if wanted <= self.current.entries.len() {
+            return;
+        }
+        self.previous.entries.resize(wanted, Entry::default());
+        self.current.entries.resize(wanted, Entry::default());
+        self.previous
+            .order
+            .reserve(wanted - self.previous.order.len());
+        self.current
+            .order
+            .reserve(wanted - self.current.order.len());
+    }
+}
+
+impl<T: Copy> Snapshots<T> {
+    /// Retire the current capture to previous and open a new one. Call
+    /// once per **executed** producer step, after the step — a frame that
+    /// runs three catch-up steps captures three times, or the earlier
+    /// capture is three ticks stale and the blend spans the wrong
+    /// interval.
+    ///
+    /// The blend never asks how old a capture is: a host that stops
+    /// stepping and resumes blends one interval from wherever it left
+    /// off. A host that wants a pause to hold perfectly still freezes its
+    /// own factor and stops capturing — freezing only one of the two
+    /// sweeps a frozen pair, which looks worse than not blending at all.
+    pub fn capture(&mut self) -> Capture<'_, T> {
+        core::mem::swap(&mut self.previous, &mut self.current);
+        // Reset by outgoing order rather than clearing every entry. The
+        // invariant is "every slot outside `order` has `present == false`,
+        // and its stale value is unreachable", which is inductive:
+        // construction defaults them all, and each reset clears exactly
+        // the set the previous reset let through. Clearing the whole array
+        // instead would be O(capacity) per step against a slot space that
+        // never shrinks.
+        for &slot in &self.current.order {
+            self.current.entries[slot as usize].present = false;
+        }
+        self.current.order.clear();
+        Capture {
+            buffer: &mut self.current,
+        }
+    }
+}
+
+impl<T: Blend> Snapshots<T> {
+    /// One frame: the [`Fate::Dying`] slots first, in the earlier
+    /// capture's put order, then the newer capture's slots in its put
+    /// order. Borrowing and allocation-free.
+    ///
+    /// At `Alpha::ZERO` every [`Fate::Living`] value is bit-exactly its
+    /// earlier capture, and [`Blend::blend`] is not called.
+    pub fn frame(&self, alpha: Alpha) -> impl Iterator<Item = Drawn<T>> + '_ {
+        // Alpha is a ratio of unsigned integers clamped below one, so it
+        // is never negative and never a negative zero; comparing bits is
+        // an exact "is this the tick boundary" with no float equality.
+        let tick_exact = alpha.get().to_bits() == 0;
+        let dying = self.previous.order.iter().filter_map(move |&slot| {
+            let old = self.previous.entries[slot as usize];
+            let now = self.current.entries[slot as usize];
+            if now.present && now.generation == old.generation {
+                return None;
+            }
+            Some(Drawn {
+                key: Key::new(slot, old.generation),
+                value: old.value,
+                fate: Fate::Dying,
+            })
+        });
+        let living = self.current.order.iter().map(move |&slot| {
+            let now = self.current.entries[slot as usize];
+            let old = self.previous.entries[slot as usize];
+            let (value, fate) = if old.present && old.generation == now.generation {
+                let value = if tick_exact {
+                    old.value
+                } else {
+                    T::blend(old.value, now.value, alpha)
+                };
+                (value, Fate::Living)
+            } else {
+                (now.value, Fate::Newborn)
+            };
+            Drawn {
+                key: Key::new(slot, now.generation),
+                value,
+                fate,
+            }
+        });
+        dying.chain(living)
+    }
+}
+
+/// The write half of one capture.
+///
+/// Dropping it without writing anything is not an error — it is the
+/// truthful answer for an emptied world, where everything dies once and
+/// then stops.
+#[derive(Debug)]
+pub struct Capture<'a, T> {
+    buffer: &'a mut Buffer<T>,
+}
+
+impl<T: Copy> Capture<'_, T> {
+    /// Record one slot's presentation state.
+    ///
+    /// **The order of these calls is the order [`Snapshots::frame`]
+    /// yields.** This crate never sorts.
+    ///
+    /// # Panics
+    ///
+    /// When `key.slot` is past the budget, and when a slot is put twice
+    /// in one capture — both by name. The first would otherwise be a bare
+    /// slice index whose message names neither the budget nor the
+    /// producer; the second would silently draw one thing twice and blend
+    /// the survivor against whichever write happened to land last.
+    pub fn put(&mut self, key: Key, value: T) {
+        let slots = self.buffer.entries.len();
+        assert!(
+            (key.slot as usize) < slots,
+            "slot {} is past this snapshot pair's budget of {slots} slots: size the pair \
+             for the producer's slot space, or grow it with resize before the frame",
+            key.slot
+        );
+        let entry = &mut self.buffer.entries[key.slot as usize];
+        assert!(
+            !entry.present,
+            "slot {} was put twice in one capture: a slot holds one value per capture, \
+             and two would draw it twice and blend the survivor against whichever landed last",
+            key.slot
+        );
+        entry.present = true;
+        entry.generation = key.generation;
+        entry.value = value;
+        self.buffer.order.push(key.slot);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Blend, Capture, Drawn, Fate, Key, Snapshots};
+    use core::num::NonZeroU64;
+    use renew_math::Alpha;
+
+    /// Half a step past the boundary — the factor every blend claim below
+    /// is made at, chosen because it is exact in binary and so an
+    /// expectation can be written as a literal rather than a tolerance.
+    fn half() -> Alpha {
+        Alpha::new(1, NonZeroU64::new(2).expect("2 is not zero"))
+    }
+
+    fn quarter() -> Alpha {
+        Alpha::new(1, NonZeroU64::new(4).expect("4 is not zero"))
+    }
+
+    /// One tick's worth of puts, so the tests read as ticks rather than
+    /// as borrow bookkeeping.
+    fn tick<T: Copy, const N: usize>(pair: &mut Snapshots<T>, values: [(u32, u64, T); N]) {
+        let mut capture: Capture<'_, T> = pair.capture();
+        for (slot, generation, value) in values {
+            capture.put(Key::new(slot, generation), value);
+        }
+    }
+
+    fn drawn<T: Blend>(pair: &Snapshots<T>, alpha: Alpha) -> Vec<Drawn<T>> {
+        pair.frame(alpha).collect()
+    }
+
+    #[test]
+    fn a_capture_yields_what_was_put() {
+        let mut pair = Snapshots::<f32>::new(8);
+        tick(&mut pair, [(0, 0, 1.0), (3, 0, 2.0), (5, 0, 3.0)]);
+        let frame = drawn(&pair, half());
+        assert_eq!(frame.len(), 3, "three slots in, three out");
+        assert!(
+            frame.iter().all(|d| d.fate == Fate::Newborn),
+            "with one capture behind them every slot is a newborn"
+        );
+        assert_eq!(
+            frame.iter().map(|d| d.value).collect::<Vec<_>>(),
+            [1.0, 2.0, 3.0],
+            "a newborn stands at its one known tick, unblended"
+        );
+    }
+
+    #[test]
+    fn the_order_out_is_the_order_put_in() {
+        let mut pair = Snapshots::<f32>::new(8);
+        // Deliberately not ascending: the crate must not sort, and a
+        // sorted expectation would pass against an implementation that
+        // did.
+        tick(
+            &mut pair,
+            [(5, 0, 5.0), (1, 0, 1.0), (7, 0, 7.0), (0, 0, 0.0)],
+        );
+        assert_eq!(
+            drawn(&pair, half())
+                .iter()
+                .map(|d| d.key.slot)
+                .collect::<Vec<_>>(),
+            [5, 1, 7, 0]
+        );
+    }
+
+    /// **The deliverable.** A slot whose tenant was replaced must not
+    /// blend the newcomer out of the corpse's last position.
+    ///
+    /// Read this beside `a_survivor_at_the_same_slot_and_generation_does_blend`:
+    /// alone, this test passes against an implementation that never
+    /// blends anything at all.
+    #[test]
+    fn a_recycled_slot_never_inherits_the_dead_tenants_motion() {
+        let mut pair = Snapshots::<f32>::new(8);
+        tick(&mut pair, [(3, 0, -16.0)]);
+        tick(&mut pair, [(3, 1, 320.0)]);
+        let frame = drawn(&pair, half());
+        assert_eq!(
+            frame.len(),
+            2,
+            "the corpse draws once more beside the newborn"
+        );
+        let dying = frame
+            .iter()
+            .find(|d| d.fate == Fate::Dying)
+            .expect("the previous tenant is dying");
+        let newborn = frame
+            .iter()
+            .find(|d| d.fate == Fate::Newborn)
+            .expect("the new tenant is a newborn");
+        assert_eq!(
+            dying.key.generation, 0,
+            "the dying entry names the tenant that left"
+        );
+        assert_eq!(dying.value.to_bits(), (-16.0f32).to_bits());
+        assert_eq!(newborn.key.generation, 1);
+        assert_eq!(
+            newborn.value.to_bits(),
+            320.0f32.to_bits(),
+            "the newborn stands exactly where it was captured — 152.0 here would be it \
+             blended out of the corpse, which is the whole defect"
+        );
+    }
+
+    /// The negative control for the test above: at the *same* generation
+    /// the value genuinely does move.
+    #[test]
+    fn a_survivor_at_the_same_slot_and_generation_does_blend() {
+        let mut pair = Snapshots::<f32>::new(8);
+        tick(&mut pair, [(3, 0, 0.0)]);
+        tick(&mut pair, [(3, 0, 100.0)]);
+        let frame = drawn(&pair, quarter());
+        assert_eq!(frame.len(), 1, "nothing died");
+        assert_eq!(frame[0].fate, Fate::Living);
+        assert_eq!(
+            frame[0].value.to_bits(),
+            25.0f32.to_bits(),
+            "a quarter of the way from 0 to 100"
+        );
+    }
+
+    /// The by-order reset's invariant: a slot cleared two captures ago
+    /// must not still read as present and suppress a dying entry.
+    #[test]
+    fn a_slot_live_two_ticks_ago_and_absent_since_is_not_read_as_present() {
+        let mut pair = Snapshots::<f32>::new(8);
+        tick(&mut pair, [(2, 0, 10.0)]);
+        tick(&mut pair, []);
+        tick(&mut pair, [(2, 1, 99.0)]);
+        let frame = drawn(&pair, half());
+        assert_eq!(
+            frame.len(),
+            1,
+            "the tenant that left two captures ago has already had its last draw"
+        );
+        assert_eq!(frame[0].fate, Fate::Newborn);
+        assert_eq!(frame[0].value.to_bits(), 99.0f32.to_bits());
+    }
+
+    #[test]
+    fn a_departed_entity_draws_once_more_and_then_stops() {
+        let mut pair = Snapshots::<f32>::new(8);
+        tick(&mut pair, [(1, 0, 42.0)]);
+        tick(&mut pair, []);
+        let first = drawn(&pair, half());
+        assert_eq!(first.len(), 1, "it draws once more at its last known place");
+        assert_eq!(first[0].fate, Fate::Dying);
+        assert_eq!(first[0].value.to_bits(), 42.0f32.to_bits());
+        tick(&mut pair, []);
+        assert!(
+            drawn(&pair, half()).is_empty(),
+            "and then it is gone, rather than lingering forever"
+        );
+    }
+
+    /// A payload that refuses to be blended, so the short-circuit is
+    /// proved by construction rather than by comparing numbers that
+    /// happen to agree at zero.
+    #[derive(Clone, Copy, Debug, Default, PartialEq)]
+    struct NeverBlends(f32);
+
+    impl Blend for NeverBlends {
+        fn blend(_from: Self, _to: Self, _alpha: Alpha) -> Self {
+            panic!("the container must not consult blend at the tick boundary");
+        }
+    }
+
+    #[test]
+    fn blend_is_never_consulted_at_zero() {
+        let mut pair = Snapshots::<NeverBlends>::new(4);
+        tick(&mut pair, [(0, 0, NeverBlends(1.0))]);
+        tick(&mut pair, [(0, 0, NeverBlends(2.0))]);
+        let frame = drawn(&pair, Alpha::ZERO);
+        assert_eq!(
+            frame[0].value,
+            NeverBlends(1.0),
+            "the earlier capture, untouched"
+        );
+    }
+
+    #[test]
+    fn alpha_zero_is_bit_exactly_the_earlier_capture() {
+        let mut pair = Snapshots::<f32>::new(4);
+        // Negative zero is the trap: `from + (to - from) * 0.0` turns
+        // -0.0 into +0.0, so an implementation that blended anyway would
+        // pass a `==` comparison and fail this one.
+        tick(&mut pair, [(0, 0, -0.0), (1, 0, 5.0)]);
+        tick(&mut pair, [(0, 0, 7.0), (1, 0, 9.0)]);
+        let frame = drawn(&pair, Alpha::ZERO);
+        assert_eq!(
+            frame[0].value.to_bits(),
+            (-0.0f32).to_bits(),
+            "sign of zero survives"
+        );
+        assert_eq!(frame[1].value.to_bits(), 5.0f32.to_bits());
+    }
+
+    #[test]
+    #[should_panic(expected = "past this snapshot pair's budget")]
+    fn a_slot_past_the_budget_refuses_by_name() {
+        let mut pair = Snapshots::<f32>::new(4);
+        tick(&mut pair, [(4, 0, 1.0)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "was put twice in one capture")]
+    fn putting_a_slot_twice_refuses_by_name() {
+        let mut pair = Snapshots::<f32>::new(4);
+        tick(&mut pair, [(1, 0, 1.0), (1, 0, 2.0)]);
+    }
+
+    #[test]
+    fn presentation_is_a_pure_function() {
+        let script = [
+            [(0u32, 0u64, 1.0f32), (1, 0, 2.0)],
+            [(0, 0, 3.0), (1, 1, 4.0)],
+            [(0, 0, 5.0), (1, 1, 6.0)],
+        ];
+        let run = || {
+            let mut pair = Snapshots::<f32>::new(8);
+            for step in script {
+                tick(&mut pair, step);
+            }
+            drawn(&pair, half())
+                .iter()
+                .map(|d| (d.key, d.value.to_bits(), d.fate))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(run(), run(), "same captures, same frame, bit for bit");
+    }
+
+    #[test]
+    fn resize_preserves_both_captures() {
+        let mut pair = Snapshots::<f32>::new(2);
+        tick(&mut pair, [(0, 0, 0.0)]);
+        tick(&mut pair, [(0, 0, 100.0)]);
+        pair.resize(64);
+        assert_eq!(pair.slots(), 64);
+        let frame = drawn(&pair, quarter());
+        assert_eq!(frame.len(), 1);
+        assert_eq!(
+            frame[0].fate,
+            Fate::Living,
+            "growing must not make a survivor look newborn — that is a visible pop"
+        );
+        assert_eq!(frame[0].value.to_bits(), 25.0f32.to_bits());
+        // And the new room is usable.
+        tick(&mut pair, [(0, 0, 200.0), (63, 0, 7.0)]);
+        assert_eq!(drawn(&pair, half()).len(), 2);
+    }
+
+    #[test]
+    fn resize_never_shrinks() {
+        let mut pair = Snapshots::<f32>::new(16);
+        pair.resize(4);
+        assert_eq!(
+            pair.slots(),
+            16,
+            "a smaller request is a no-op, not a truncation"
+        );
+    }
+
+    #[test]
+    fn an_emptied_producer_is_a_capture_with_no_puts() {
+        let mut pair = Snapshots::<f32>::new(4);
+        tick(&mut pair, [(0, 0, 1.0), (2, 0, 2.0)]);
+        tick(&mut pair, []);
+        let frame = drawn(&pair, half());
+        assert_eq!(frame.len(), 2, "everything dies once");
+        assert!(frame.iter().all(|d| d.fate == Fate::Dying));
+    }
+}

--- a/crates/snapshot/tests/properties.proptest-regressions
+++ b/crates/snapshot/tests/properties.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ba8f7bf1561f5e2fc2ed29f5354e954ef587a5b36e38cc0c028eff9e9a3243de # shrinks to first = [(7, 3, -0.0)], second = [(7, 3, -0.0)]

--- a/crates/snapshot/tests/properties.rs
+++ b/crates/snapshot/tests/properties.rs
@@ -15,10 +15,27 @@ const SLOTS: u32 = 12;
 /// unique because putting a slot twice is a refusal by contract rather
 /// than a case to explore.
 fn capture_strategy() -> impl Strategy<Value = Vec<(u32, u64, f32)>> {
-    prop::collection::vec((0..SLOTS, 0..4u64, -1000.0f32..1000.0), 0..8).prop_map(|mut rows| {
-        rows.sort_by_key(|&(slot, _, _)| slot);
-        rows.dedup_by_key(|&mut (slot, _, _)| slot);
-        rows
+    // The value space includes a negative zero on purpose. For every
+    // ordinary float `from + (to - from) * 0.0` is bit-identical to
+    // `from`, so without this the boundary property could not tell a
+    // short-circuit from a blend, and would pass against its own
+    // deletion.
+    let value = prop_oneof![Just(-0.0f32), Just(0.0f32), -1000.0f32..1000.0];
+    prop::collection::vec((0..SLOTS, 0..4u64, value), 0..8).prop_map(|rows| {
+        // Unique by slot, because putting one twice is a refusal by
+        // contract rather than a case to explore — but the FIRST
+        // occurrence's position is kept rather than sorting, or the put
+        // order would always be ascending and the property claiming that
+        // order survives would be testing nothing.
+        let mut seen = Vec::new();
+        let mut unique = Vec::new();
+        for row in rows {
+            if !seen.contains(&row.0) {
+                seen.push(row.0);
+                unique.push(row);
+            }
+        }
+        unique
     })
 }
 
@@ -134,11 +151,20 @@ proptest! {
 
     /// At the tick boundary every living value is bit-exactly its earlier
     /// capture — the guarantee committed images stand on.
+    ///
+    /// The second capture's values are forced to differ from the first's,
+    /// so a container that blended at zero instead of short-circuiting
+    /// would produce a different number and fail here. Without that, both
+    /// captures could agree and the test would pass either way.
     #[test]
     fn the_tick_boundary_is_the_earlier_capture_exactly(
         first in capture_strategy(),
         second in capture_strategy(),
     ) {
+        let second: Vec<_> = second
+            .into_iter()
+            .map(|(slot, generation, value)| (slot, generation, value + 1234.5))
+            .collect();
         let mut pair = Snapshots::<f32>::new(SLOTS);
         {
             let mut capture = pair.capture();

--- a/crates/snapshot/tests/properties.rs
+++ b/crates/snapshot/tests/properties.rs
@@ -1,0 +1,165 @@
+//! Properties of the classification, over arbitrary capture sequences.
+//!
+//! The unit tests pin named cases; these pin the rules those cases are
+//! instances of. The one that matters most is exclusivity: every row is
+//! exactly one of living, newborn or dying, and which one is decided by
+//! the generations alone.
+
+use proptest::prelude::*;
+use renew_math::Alpha;
+use renew_snapshot::{Fate, Key, Snapshots};
+
+const SLOTS: u32 = 12;
+
+/// One capture: a set of (slot, generation, value), with slots made
+/// unique because putting a slot twice is a refusal by contract rather
+/// than a case to explore.
+fn capture_strategy() -> impl Strategy<Value = Vec<(u32, u64, f32)>> {
+    prop::collection::vec((0..SLOTS, 0..4u64, -1000.0f32..1000.0), 0..8).prop_map(|mut rows| {
+        rows.sort_by_key(|&(slot, _, _)| slot);
+        rows.dedup_by_key(|&mut (slot, _, _)| slot);
+        rows
+    })
+}
+
+/// The step length every alpha below is a fraction of. Written as a
+/// total `match` rather than an `expect`: this is a helper rather than a
+/// test function, so the crate's in-test allowances do not reach it, and
+/// a fallible construction of a literal is worth avoiding anyway.
+const STEP_NANOS: core::num::NonZeroU64 = match core::num::NonZeroU64::new(1000) {
+    Some(value) => value,
+    None => core::num::NonZeroU64::MIN,
+};
+
+fn alpha_strategy() -> impl Strategy<Value = Alpha> {
+    (0..1000u64).prop_map(|n| Alpha::new(n, STEP_NANOS))
+}
+
+proptest! {
+    /// Every row is exactly one fate, and the fate is a function of the
+    /// two captures' generations at that slot — nothing else.
+    #[test]
+    fn classification_is_total_and_exclusive(
+        first in capture_strategy(),
+        second in capture_strategy(),
+        alpha in alpha_strategy(),
+    ) {
+        let mut pair = Snapshots::<f32>::new(SLOTS);
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &first {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &second {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        let rows: Vec<_> = pair.frame(alpha).collect();
+
+        for row in &rows {
+            let was = first.iter().find(|&&(slot, _, _)| slot == row.key.slot);
+            let is = second.iter().find(|&&(slot, _, _)| slot == row.key.slot);
+            match row.fate {
+                Fate::Living => {
+                    let (_, old_generation, _) = *was.expect("living implies it was there before");
+                    let (_, new_generation, _) = *is.expect("living implies it is there now");
+                    prop_assert_eq!(old_generation, new_generation, "living means the tenant stayed");
+                    prop_assert_eq!(row.key.generation, new_generation);
+                }
+                Fate::Newborn => {
+                    let (_, new_generation, new_value) =
+                        *is.expect("a newborn is in the newer capture");
+                    prop_assert_eq!(row.key.generation, new_generation);
+                    prop_assert_eq!(row.value.to_bits(), new_value.to_bits(),
+                        "a newborn stands at its one known tick, never blended");
+                    if let Some(&(_, old_generation, _)) = was {
+                        prop_assert_ne!(old_generation, new_generation,
+                            "a newborn at an occupied slot means the tenant changed");
+                    }
+                }
+                Fate::Dying => {
+                    let (_, old_generation, old_value) =
+                        *was.expect("a dying row is in the older capture");
+                    prop_assert_eq!(row.key.generation, old_generation);
+                    prop_assert_eq!(row.value.to_bits(), old_value.to_bits(),
+                        "a dying row is its last capture, never blended");
+                    if let Some(&(_, new_generation, _)) = is {
+                        prop_assert_ne!(old_generation, new_generation);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Every slot in the newer capture appears exactly once, in put
+    /// order, and every dying row precedes every one of them.
+    #[test]
+    fn each_current_slot_appears_once_in_put_order_after_the_dying(
+        first in capture_strategy(),
+        second in capture_strategy(),
+        alpha in alpha_strategy(),
+    ) {
+        let mut pair = Snapshots::<f32>::new(SLOTS);
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &first {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &second {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        let rows: Vec<_> = pair.frame(alpha).collect();
+
+        let living_order: Vec<u32> = rows
+            .iter()
+            .filter(|row| row.fate != Fate::Dying)
+            .map(|row| row.key.slot)
+            .collect();
+        let put_order: Vec<u32> = second.iter().map(|&(slot, _, _)| slot).collect();
+        prop_assert_eq!(living_order, put_order, "put order survives, and nothing is dropped");
+
+        let last_dying = rows.iter().rposition(|row| row.fate == Fate::Dying);
+        let first_other = rows.iter().position(|row| row.fate != Fate::Dying);
+        if let (Some(last), Some(first)) = (last_dying, first_other) {
+            prop_assert!(last < first, "the departing draw underneath the living");
+        }
+    }
+
+    /// At the tick boundary every living value is bit-exactly its earlier
+    /// capture — the guarantee committed images stand on.
+    #[test]
+    fn the_tick_boundary_is_the_earlier_capture_exactly(
+        first in capture_strategy(),
+        second in capture_strategy(),
+    ) {
+        let mut pair = Snapshots::<f32>::new(SLOTS);
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &first {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        {
+            let mut capture = pair.capture();
+            for &(slot, generation, value) in &second {
+                capture.put(Key::new(slot, generation), value);
+            }
+        }
+        for row in pair.frame(Alpha::ZERO) {
+            if row.fate == Fate::Living {
+                let (_, _, was) = *first
+                    .iter()
+                    .find(|&&(slot, _, _)| slot == row.key.slot)
+                    .expect("living implies it was there");
+                prop_assert_eq!(row.value.to_bits(), was.to_bits());
+            }
+        }
+    }
+}

--- a/crates/snapshot/tests/zero_alloc.rs
+++ b/crates/snapshot/tests/zero_alloc.rs
@@ -1,0 +1,81 @@
+//! Mechanical enforcement of the pair's allocation contract: after
+//! construction, capturing and framing allocate exactly nothing.
+//!
+//! Shipped with the crate's first commit rather than after it. The
+//! measured window recycles a slot every other step, so the branch that
+//! produces a dying entry beside a newborn — the one path that yields
+//! more rows than were put — is inside the window rather than beside it.
+
+use renew_math::Alpha;
+use renew_memory::{CountingAllocator, counters};
+use renew_snapshot::{Fate, Key, Snapshots};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_steady_state_allocates_nothing() {
+    // Everything that may allocate happens out here: the pair itself and
+    // one warmup capture-and-frame.
+    let mut pair = Snapshots::<f32>::new(16);
+    let half = Alpha::new(1, core::num::NonZeroU64::new(2).expect("two"));
+    {
+        let mut capture = pair.capture();
+        for slot in 0u16..8 {
+            capture.put(Key::new(u32::from(slot), 0), f32::from(slot));
+        }
+    }
+    assert_eq!(pair.frame(half).count(), 8, "the warmup really drew");
+
+    // The measured window: a capture and a full frame walk, repeatedly,
+    // with slot 3's tenant replaced on every other step so the recycle
+    // path is measured too — that is the branch that emits a dying row
+    // beside a newborn, and it is the one a naive implementation would
+    // service with a temporary.
+    let mut generation = 0u64;
+    let verdict = counters::quiet_window(5, || {
+        for step in 0u16..8 {
+            if step % 2 == 0 {
+                generation += 1;
+            }
+            {
+                let mut capture = pair.capture();
+                for slot in 0u16..8 {
+                    let generation = if slot == 3 { generation } else { 0 };
+                    capture.put(
+                        Key::new(u32::from(slot), generation),
+                        f32::from(slot) + f32::from(step),
+                    );
+                }
+            }
+            let mut drawn = 0;
+            let mut dying = 0;
+            for row in pair.frame(half) {
+                drawn += 1;
+                if row.fate == Fate::Dying {
+                    dying += 1;
+                }
+            }
+            // Eight live slots always; on a step that replaced slot 3's
+            // tenant, its predecessor draws once more underneath. Step 0
+            // counts: the warmup left slot 3 at generation 0 and the
+            // first step bumps it, so the very first window frame already
+            // walks the recycle path.
+            let expected_dying = usize::from(step % 2 == 0);
+            assert_eq!(
+                dying, expected_dying,
+                "the recycle path must really be exercised"
+            );
+            assert_eq!(
+                drawn,
+                8 + expected_dying,
+                "every windowed frame must really draw"
+            );
+        }
+    });
+    verdict.expect("the pair's steady state stays heap-silent");
+}

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -174,6 +174,13 @@ impl UiPresenter {
     /// This is the whole of what a frame draws, as data: every
     /// decision the presenter makes is observable here without a
     /// device, which is where the tests hold it.
+    ///
+    /// **The same rule is implemented a second time in the tree**, over a
+    /// different payload: `Snapshots::frame` in `renew-snapshot` blends an
+    /// arbitrary payload under exactly this generation guard. The two were
+    /// not merged — the payloads have little in common and this one was
+    /// already green — so a correction to the rule has to be made in both,
+    /// and each names the other so neither is corrected alone.
     pub fn frame(&self, alpha: Alpha) -> impl Iterator<Item = Quad> + '_ {
         let dying = self.previous.order.iter().filter_map(move |&index| {
             let old = self.previous.entries[index as usize];

--- a/samples/glide/Cargo.toml
+++ b/samples/glide/Cargo.toml
@@ -39,6 +39,10 @@ renew-sample-glide-world = { path = "world" }
 # The pointer seam: the one documented quantization the drivers and
 # the replay harness apply before events reach the tree.
 renew-math = { path = "../../crates/core/math" }
+# The snapshot pair, unconditional rather than behind the window
+# feature: the blended fill is part of the game's picture, and a plain
+# headless test has to be able to reach it.
+renew-snapshot = { path = "../../crates/snapshot" }
 # The pause menu: a real retained widget tree, folded into the
 # session digest — a menu that can restart the run is gameplay.
 renew-ui = { path = "../../crates/ui" }

--- a/samples/glide/src/scene.rs
+++ b/samples/glide/src/scene.rs
@@ -7,9 +7,12 @@
 //! sprite type themselves; the mapping is a handful of lines each, and
 //! that duplication is cheaper than a GPU edge on the game.
 
+use renew_math::Alpha;
 use renew_sample_glide_world::{
-    BIRD_HALF_UNITS, BIRD_X_UNITS, PIPE_GAP_HALF_UNITS, PIPE_WIDTH_UNITS, VIEW_HEIGHT, World,
+    BIRD_HALF_UNITS, BIRD_X_UNITS, PIPE_GAP_HALF_UNITS, PIPE_WIDTH_UNITS, UNITS_PER_PIXEL,
+    VIEW_HEIGHT, World,
 };
+use renew_snapshot::{Blend, Key, Snapshots};
 
 /// Which picture a sprite shows. Deliberately CLOSED, against the
 /// grain of the input enums elsewhere: a new tile must break every
@@ -59,32 +62,169 @@ pub struct SceneSprite {
 )]
 pub fn scene(world: &World, out: &mut Vec<SceneSprite>) {
     out.clear();
-    let height = VIEW_HEIGHT as f32;
-    world.for_each_pipe_units(|x, gap_y| {
-        let gap_top = (gap_y - PIPE_GAP_HALF_UNITS) as f32;
-        let gap_bottom = (gap_y + PIPE_GAP_HALF_UNITS) as f32;
-        out.push(SceneSprite {
-            tile: Tile::Pipe,
-            x: x as f32,
-            y: 0.0,
-            width: PIPE_WIDTH_UNITS as f32,
-            height: gap_top,
-        });
-        out.push(SceneSprite {
-            tile: Tile::Pipe,
-            x: x as f32,
-            y: gap_bottom,
-            width: PIPE_WIDTH_UNITS as f32,
-            height: height - gap_bottom,
-        });
+    world.for_each_pipe_units(|x, gap_y| push_pipe(out, x as f32, gap_y as f32));
+    push_bird(out, world.bird_y_units() as f32);
+}
+
+/// One pipe's two bars, from the pipe's left edge and gap centre: the
+/// top bar from the ceiling down to the gap, the bottom bar from the gap
+/// down to the floor.
+///
+/// The one derivation, shared by the tick-exact fill above and the
+/// blended one below. Two copies of this arithmetic would be two places
+/// for the gap's half-height to drift.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "canvas units are bounded by the view constants, far below f32's exact range"
+)]
+fn push_pipe(out: &mut Vec<SceneSprite>, x: f32, gap_y: f32) {
+    let half = PIPE_GAP_HALF_UNITS as f32;
+    let gap_top = gap_y - half;
+    let gap_bottom = gap_y + half;
+    out.push(SceneSprite {
+        tile: Tile::Pipe,
+        x,
+        y: 0.0,
+        width: PIPE_WIDTH_UNITS as f32,
+        height: gap_top,
     });
+    out.push(SceneSprite {
+        tile: Tile::Pipe,
+        x,
+        y: gap_bottom,
+        width: PIPE_WIDTH_UNITS as f32,
+        height: VIEW_HEIGHT as f32 - gap_bottom,
+    });
+}
+
+/// The bird's square body, from its centre's y.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "canvas units are bounded by the view constants, far below f32's exact range"
+)]
+fn push_bird(out: &mut Vec<SceneSprite>, centre_y: f32) {
+    let half = BIRD_HALF_UNITS as f32;
     out.push(SceneSprite {
         tile: Tile::Bird,
         x: (BIRD_X_UNITS - BIRD_HALF_UNITS) as f32,
-        y: (world.bird_y_units() - BIRD_HALF_UNITS) as f32,
-        width: (2 * BIRD_HALF_UNITS) as f32,
-        height: (2 * BIRD_HALF_UNITS) as f32,
+        y: centre_y - half,
+        width: 2.0 * half,
+        height: 2.0 * half,
     });
+}
+
+/// The most pipe slots presentation is sized for.
+///
+/// The rules bound live pipes well under this: they spawn every ninety
+/// ticks and are culled once fully past the left edge, and the world's
+/// own test pins the peak. Sixteen is that with room to spare, and
+/// `Capture::put` refuses by name rather than silently dropping a pipe if
+/// the rules ever outgrow it — a refusal being the outcome that gets
+/// noticed.
+const PIPE_SLOTS: u32 = 16;
+
+/// One world unit as a screen unit.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "world coordinates are bounded by the view constants, far below f32's exact range"
+)]
+fn units(world_units: i64) -> f32 {
+    world_units as f32 / UNITS_PER_PIXEL as f32
+}
+
+/// One pipe's blendable locals.
+///
+/// The locals, deliberately, and not the two bars derived from them: two
+/// derived rectangles blended directly interpolate along a chord the
+/// derivation would never have drawn, and the gap would breathe as the
+/// pipe moved. Blend what the pipe *is*, then derive what it looks like.
+///
+/// A named struct rather than `[f32; 2]`, because a transposed column in
+/// an anonymous array is invisible at the call site.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct PipeAt {
+    /// Left edge, screen units.
+    pub x: f32,
+    /// Gap centre, screen units.
+    pub gap_y: f32,
+}
+
+impl Blend for PipeAt {
+    fn blend(from: Self, to: Self, alpha: Alpha) -> Self {
+        Self {
+            x: f32::blend(from.x, to.x, alpha),
+            gap_y: f32::blend(from.gap_y, to.gap_y, alpha),
+        }
+    }
+}
+
+/// The game's picture between two ticks.
+///
+/// The world steps sixty times a second and frames arrive faster, so
+/// drawing current state means every pipe holds position for a frame and
+/// then jumps. This keeps the last two ticks and draws between them.
+#[derive(Debug)]
+pub struct Presentation {
+    pipes: Snapshots<PipeAt>,
+    /// The bird is not an entity — three scalars on the world — so it is
+    /// one previous value and one blend, which is the whole of what a
+    /// singleton needs. A key is wanted exactly when a slot can be
+    /// recycled, and this one cannot be.
+    bird_y: f32,
+    previous_bird_y: Option<f32>,
+}
+
+impl Presentation {
+    /// A presentation seeded from the world as it stands, so the first
+    /// frame blends out of a real tick rather than out of a zero.
+    #[must_use]
+    pub fn new(world: &World) -> Self {
+        Self {
+            pipes: Snapshots::new(PIPE_SLOTS),
+            bird_y: units(world.bird_y()),
+            previous_bird_y: None,
+        }
+    }
+
+    /// Capture this tick's locals. Call once per **executed** step, after
+    /// the step — a frame that runs three catch-up steps captures three
+    /// times, or the earlier capture is stale and the blend spans the
+    /// wrong interval.
+    pub fn capture(&mut self, world: &World) {
+        let mut capture = self.pipes.capture();
+        world.for_each_pipe(|slot, generation, x, gap_y| {
+            capture.put(
+                Key::new(slot, u64::from(generation)),
+                PipeAt {
+                    x: units(x),
+                    gap_y: units(gap_y),
+                },
+            );
+        });
+        self.previous_bird_y = Some(self.bird_y);
+        self.bird_y = units(world.bird_y());
+    }
+
+    /// Fill `out` with the picture standing `alpha` past the last
+    /// capture, in [`scene`]'s draw order: pipes as two bars each, then
+    /// the bird over them.
+    ///
+    /// A pipe that left between the two captures draws once more at its
+    /// last known place, underneath the living. It is still on screen
+    /// there — the cull fires once a pipe is fully past the left edge,
+    /// which happens *after* the move that took it there — so dropping it
+    /// would pop a visible sliver out at a tick boundary.
+    pub fn fill(&self, alpha: Alpha, out: &mut Vec<SceneSprite>) {
+        out.clear();
+        for drawn in self.pipes.frame(alpha) {
+            push_pipe(out, drawn.value.x, drawn.value.gap_y);
+        }
+        let y = match self.previous_bird_y {
+            Some(previous) => f32::blend(previous, self.bird_y, alpha),
+            None => self.bird_y,
+        };
+        push_bird(out, y);
+    }
 }
 
 #[cfg(test)]
@@ -190,5 +330,248 @@ mod tests {
             b(228.0),
             "observed: frozen at death"
         );
+    }
+
+    /// Half a step past the boundary — exact in binary, so expectations
+    /// are literals rather than tolerances.
+    fn half() -> Alpha {
+        Alpha::new(1, core::num::NonZeroU64::new(2).expect("two"))
+    }
+
+    /// Step the world once and capture it, the pairing the driver makes.
+    fn advance(presentation: &mut Presentation, world: &mut World) {
+        let flap = world.autopilot();
+        world.step(flap);
+        presentation.capture(world);
+    }
+
+    /// **The defect this fill exists to remove.** The whole-unit reading
+    /// truncates a pipe's 0.9-units-per-tick motion, so its reported
+    /// position holds still for one tick in every ten. Captured locals
+    /// keep the sub-unit part, so the same run moves every tick.
+    #[test]
+    fn captured_motion_has_no_stalls_the_truncated_reading_has() {
+        let mut world = piloted(200);
+        let mut presentation = Presentation::new(&world);
+        // Warm the pair. Reading at the boundary hands back the EARLIER
+        // capture, so an unwarmed pair reports its first tick twice and
+        // the duplicate would be this harness rather than the code.
+        presentation.capture(&world);
+
+        let mut truncated: Vec<i32> = Vec::new();
+        let mut captured: Vec<f32> = Vec::new();
+        let mut scratch = Vec::new();
+        for _ in 0..24 {
+            let mut first_truncated = None;
+            world.for_each_pipe_units(|x, _| {
+                if first_truncated.is_none() {
+                    first_truncated = Some(x);
+                }
+            });
+            if let Some(x) = first_truncated {
+                truncated.push(x);
+            }
+            // Step first, then capture: the boundary reading hands back
+            // the earlier capture, so this records the very state the
+            // truncated reading above was taken from.
+            let flap = world.autopilot();
+            world.step(flap);
+            presentation.capture(&world);
+            presentation.fill(Alpha::ZERO, &mut scratch);
+            captured.push(scratch[0].x);
+        }
+
+        // Bit equality, the module's own pattern: a stall IS two identical
+        // readings, so an epsilon would be answering a different question.
+        let stalls = |series: &[f32]| series.windows(2).filter(|w| b(w[0]) == b(w[1])).count();
+        let truncated_stalls = truncated.windows(2).filter(|w| w[0] == w[1]).count();
+        assert!(
+            truncated_stalls > 0,
+            "premise: the whole-unit reading must really stall, or this test proves nothing \
+             (series {truncated:?})"
+        );
+        assert_eq!(
+            stalls(&captured),
+            0,
+            "captured locals must move every tick (series {captured:?})"
+        );
+        for pair in captured.windows(2) {
+            assert!(
+                pair[1] < pair[0],
+                "and always leftward, never jittering back: {pair:?}"
+            );
+        }
+    }
+
+    /// A pipe that left the screen draws once more where it last stood,
+    /// then stops.
+    ///
+    /// **Why the recycling case is not tested here.** The rule that a
+    /// newcomer must not be blended out of its slot's previous tenant is
+    /// held — and constructed directly — in the crate that owns the pair.
+    /// This game cannot reach it: measured over three thousand ticks, a
+    /// vacated slot is never reused on the tick it is freed, and instead
+    /// sits empty for seventy-seven ticks before a new pipe takes it. The
+    /// previous capture therefore never holds the corpse when the
+    /// newcomer appears, so every new pipe here is a newborn and no
+    /// streak is expressible. A test asserting otherwise would pass
+    /// against a missing guard, which is worse than no test.
+    #[test]
+    fn a_departed_pipe_draws_once_more_and_then_stops() {
+        let mut world = piloted(120);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+
+        let mut scratch = Vec::new();
+        let mut departure = None;
+        for _ in 0..900 {
+            let before = {
+                presentation.fill(Alpha::ZERO, &mut scratch);
+                scratch.iter().filter(|s| s.tile == Tile::Pipe).count()
+            };
+            let live_before = pipe_slots(&world);
+            advance(&mut presentation, &mut world);
+            let live_after = pipe_slots(&world);
+            if live_after.len() < live_before.len() {
+                presentation.fill(Alpha::ZERO, &mut scratch);
+                let drawn = scratch.iter().filter(|s| s.tile == Tile::Pipe).count();
+                departure = Some((before, drawn, live_after.len()));
+                break;
+            }
+        }
+        let (_, drawn_on_the_tick_it_left, live) =
+            departure.expect("a pipe must leave the screen within nine hundred ticks");
+        assert_eq!(
+            drawn_on_the_tick_it_left,
+            (live + 1) * 2,
+            "the departing pipe is still drawn, as two bars, beside the {live} that remain"
+        );
+
+        // One more capture with nothing else changing, and it is gone.
+        let live = pipe_slots(&world).len();
+        advance(&mut presentation, &mut world);
+        presentation.fill(Alpha::ZERO, &mut scratch);
+        let drawn = scratch.iter().filter(|s| s.tile == Tile::Pipe).count();
+        assert!(
+            drawn <= live * 2,
+            "and then it stops being drawn rather than lingering"
+        );
+    }
+
+    /// The slots the world currently holds pipes in.
+    fn pipe_slots(world: &World) -> Vec<u32> {
+        let mut slots = Vec::new();
+        world.for_each_pipe(|slot, _, _, _| slots.push(slot));
+        slots
+    }
+
+    #[test]
+    fn the_blend_stands_at_its_captured_ticks() {
+        let mut world = piloted(200);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+        let mut earlier = Vec::new();
+        presentation.fill(Alpha::ZERO, &mut earlier);
+        let earlier_bird = earlier
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .copied()
+            .expect("a bird is always drawn");
+
+        advance(&mut presentation, &mut world);
+        let mut at_zero = Vec::new();
+        presentation.fill(Alpha::ZERO, &mut at_zero);
+        let bird_at_zero = at_zero
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .copied()
+            .expect("a bird is always drawn");
+        assert_eq!(
+            b(bird_at_zero.y),
+            b(earlier_bird.y),
+            "at the boundary the picture is the earlier capture, bit for bit"
+        );
+
+        let mut at_half = Vec::new();
+        presentation.fill(half(), &mut at_half);
+        let bird_at_half = at_half
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .copied()
+            .expect("a bird is always drawn");
+        assert_ne!(
+            b(bird_at_half.y),
+            b(earlier_bird.y),
+            "and past it the picture has actually moved"
+        );
+    }
+
+    /// Two identical captures leave nothing to interpolate, so the
+    /// blended fill must agree with the tick-exact oracle at every
+    /// factor — within the whole unit the oracle truncates away.
+    #[test]
+    fn the_blended_fill_agrees_with_the_oracle_at_a_standstill() {
+        let world = piloted(240);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+        presentation.capture(&world);
+
+        let mut oracle = Vec::new();
+        scene(&world, &mut oracle);
+        let mut blended = Vec::new();
+        for step in 0..8u64 {
+            let alpha = Alpha::new(
+                step * 125,
+                core::num::NonZeroU64::new(1000).expect("nonzero"),
+            );
+            presentation.fill(alpha, &mut blended);
+            assert_eq!(
+                blended.len(),
+                oracle.len(),
+                "the same picture, sprite for sprite"
+            );
+            for (drawn, expected) in blended.iter().zip(&oracle) {
+                assert_eq!(drawn.tile, expected.tile, "and in the same order");
+                assert!(
+                    (drawn.x - expected.x).abs() < 1.0 && (drawn.y - expected.y).abs() < 1.0,
+                    "within the unit the oracle truncates: {drawn:?} against {expected:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pipe_slots_stay_inside_the_budget() {
+        let mut world = World::new(7);
+        let mut highest = 0;
+        for _ in 0..3_000 {
+            let flap = world.autopilot();
+            world.step(flap);
+            world.for_each_pipe(|slot, _, _, _| highest = highest.max(slot));
+            if !world.alive() {
+                world = World::new(7);
+            }
+        }
+        assert!(
+            highest < PIPE_SLOTS,
+            "the rules allocated slot {highest}, past the presentation budget of {PIPE_SLOTS}"
+        );
+    }
+
+    /// A frozen pair with a frozen factor is the same picture every
+    /// frame. This is what a paused game rests on — the driver holds the
+    /// factor still, and this is the half of that contract living here.
+    #[test]
+    fn a_frozen_pair_at_a_frozen_factor_repeats_exactly() {
+        let world = piloted(300);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+        let mut first = Vec::new();
+        presentation.fill(half(), &mut first);
+        for _ in 0..4 {
+            let mut again = Vec::new();
+            presentation.fill(half(), &mut again);
+            assert_eq!(first, again, "nothing moves while nothing is captured");
+        }
     }
 }

--- a/samples/glide/src/scene.rs
+++ b/samples/glide/src/scene.rs
@@ -30,9 +30,10 @@ pub enum Tile {
 /// screen units; y down from the top-left).
 ///
 /// `#[non_exhaustive]` without a constructor — a deliberate deviation
-/// from the descriptor pattern: this is a read-side record produced
-/// only by [`scene`], never built by callers, so the constructor would
-/// have exactly one caller and it lives in this file.
+/// from the descriptor pattern: this is a read-side record produced only
+/// by this module, by [`scene`] and by [`Presentation::fill`], never
+/// built by callers, so a constructor would have no caller outside this
+/// file.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct SceneSprite {
@@ -177,6 +178,10 @@ pub struct Presentation {
 impl Presentation {
     /// A presentation seeded from the world as it stands, so the first
     /// frame blends out of a real tick rather than out of a zero.
+    ///
+    /// Only the bird is seeded, and only the bird needs to be: a new
+    /// world holds no pipes at all — the first appears inside a step —
+    /// so there is nothing for the pipe captures to start from.
     #[must_use]
     pub fn new(world: &World) -> Self {
         Self {
@@ -205,9 +210,17 @@ impl Presentation {
         self.bird_y = units(world.bird_y());
     }
 
-    /// Fill `out` with the picture standing `alpha` past the last
-    /// capture, in [`scene`]'s draw order: pipes as two bars each, then
-    /// the bird over them.
+    /// Fill `out` with the picture standing `alpha` of the way from the
+    /// second-newest capture to the newest, in [`scene`]'s draw order:
+    /// pipes as two bars each, then the bird over them.
+    ///
+    /// **So the picture lags the world by up to one tick.** At a zero
+    /// factor this draws the tick before last, and it reaches the last
+    /// tick only as the factor approaches one. That is inherent to
+    /// interpolating between two known states rather than extrapolating
+    /// past the newest one, and it is the usual trade: extrapolation has
+    /// no lag and overshoots instead, which shows as a rubber-band
+    /// correction on every direction change.
     ///
     /// A pipe that left between the two captures draws once more at its
     /// last known place, underneath the living. It is still on screen
@@ -425,21 +438,17 @@ mod tests {
         let mut scratch = Vec::new();
         let mut departure = None;
         for _ in 0..900 {
-            let before = {
-                presentation.fill(Alpha::ZERO, &mut scratch);
-                scratch.iter().filter(|s| s.tile == Tile::Pipe).count()
-            };
             let live_before = pipe_slots(&world);
             advance(&mut presentation, &mut world);
             let live_after = pipe_slots(&world);
             if live_after.len() < live_before.len() {
                 presentation.fill(Alpha::ZERO, &mut scratch);
                 let drawn = scratch.iter().filter(|s| s.tile == Tile::Pipe).count();
-                departure = Some((before, drawn, live_after.len()));
+                departure = Some((drawn, live_after.len()));
                 break;
             }
         }
-        let (_, drawn_on_the_tick_it_left, live) =
+        let (drawn_on_the_tick_it_left, live) =
             departure.expect("a pipe must leave the screen within nine hundred ticks");
         assert_eq!(
             drawn_on_the_tick_it_left,
@@ -452,9 +461,11 @@ mod tests {
         advance(&mut presentation, &mut world);
         presentation.fill(Alpha::ZERO, &mut scratch);
         let drawn = scratch.iter().filter(|s| s.tile == Tile::Pipe).count();
-        assert!(
-            drawn <= live * 2,
-            "and then it stops being drawn rather than lingering"
+        assert_eq!(
+            drawn,
+            live * 2,
+            "and then it stops being drawn rather than lingering — exactly the {live} live \
+             pipes, as two bars each, and no more"
         );
     }
 
@@ -548,30 +559,159 @@ mod tests {
             let flap = world.autopilot();
             world.step(flap);
             world.for_each_pipe(|slot, _, _, _| highest = highest.max(slot));
-            if !world.alive() {
-                world = World::new(7);
-            }
         }
+        // Asserted rather than handled: the pilot survives the whole run,
+        // so a restart arm here would be a branch nothing reaches, and a
+        // dead world would silently stop spawning and make the budget
+        // claim vacuous.
+        assert!(
+            world.alive(),
+            "the pilot must survive, or nothing was spawning"
+        );
         assert!(
             highest < PIPE_SLOTS,
             "the rules allocated slot {highest}, past the presentation budget of {PIPE_SLOTS}"
         );
     }
 
-    /// A frozen pair with a frozen factor is the same picture every
-    /// frame. This is what a paused game rests on — the driver holds the
-    /// factor still, and this is the half of that contract living here.
+    /// **The claim the blended fill exists to make.** Between two ticks a
+    /// pipe stands strictly between where it was and where it is, and it
+    /// gets there monotonically as the factor rises.
+    ///
+    /// Without this the whole fill could ignore its factor for pipes and
+    /// every other test here would still pass: the rest read at the
+    /// boundary, or through the bird, or across two identical captures.
     #[test]
-    fn a_frozen_pair_at_a_frozen_factor_repeats_exactly() {
-        let world = piloted(300);
+    fn a_pipe_between_ticks_stands_between_its_captured_positions() {
+        let mut world = piloted(200);
         let mut presentation = Presentation::new(&world);
         presentation.capture(&world);
-        let mut first = Vec::new();
-        presentation.fill(half(), &mut first);
+        let earlier = pipe_lefts(&presentation, Alpha::ZERO);
+        advance(&mut presentation, &mut world);
+        let later = pipe_lefts_at_one(&presentation);
+        assert!(!earlier.is_empty(), "premise: there must be pipes to move");
+        assert_eq!(
+            earlier.len(),
+            later.len(),
+            "premise: the same pipes both ticks"
+        );
+        assert!(
+            earlier.iter().zip(&later).all(|(was, is)| is < was),
+            "premise: the pipes must actually have moved left ({earlier:?} then {later:?})"
+        );
+
+        let mut previous = earlier.clone();
+        for step in 1..=4u64 {
+            let alpha = Alpha::new(
+                step * 200,
+                core::num::NonZeroU64::new(1000).expect("nonzero"),
+            );
+            let between = pipe_lefts(&presentation, alpha);
+            for (index, drawn) in between.iter().enumerate() {
+                let (was, is) = (earlier[index], later[index]);
+                let held = previous[index];
+                assert!(
+                    *drawn < was && *drawn > is,
+                    "at factor {step}/5 pipe {index} stands at {drawn}, outside ({is} .. {was})"
+                );
+                assert!(
+                    *drawn < held,
+                    "and each step of the factor must move pipe {index} further than {held}, \
+                     never hold it"
+                );
+            }
+            previous = between;
+        }
+    }
+
+    /// The bird interpolates too, and by the same rule.
+    #[test]
+    fn the_bird_between_ticks_stands_between_its_captured_heights() {
+        let mut world = piloted(205);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+        let earlier = bird_top(&presentation, Alpha::ZERO);
+        advance(&mut presentation, &mut world);
+        let later = bird_top_at_one(&presentation);
+        assert!(
+            b(earlier) != b(later),
+            "premise: the bird must actually have moved between these ticks"
+        );
+        let middle = bird_top(&presentation, half());
+        let low = earlier.min(later);
+        let high = earlier.max(later);
+        assert!(
+            middle > low && middle < high,
+            "the half-way bird stands at {middle}, outside ({low} .. {high})"
+        );
+    }
+
+    /// A frozen pair with a frozen factor repeats the picture it was
+    /// frozen at — which is what a paused game rests on, the driver
+    /// holding the factor still being the other half of that contract.
+    ///
+    /// Asserting only that two calls agree would be a tautology: `fill`
+    /// is a pure function, so it would pass with the body deleted. The
+    /// picture is therefore compared against the one taken before the
+    /// freeze, and asserted non-empty.
+    #[test]
+    fn a_frozen_pair_at_a_frozen_factor_repeats_the_picture_it_froze_at() {
+        let mut world = piloted(300);
+        let mut presentation = Presentation::new(&world);
+        presentation.capture(&world);
+        advance(&mut presentation, &mut world);
+        let mut before_the_pause = Vec::new();
+        presentation.fill(half(), &mut before_the_pause);
+        assert!(
+            before_the_pause.iter().any(|s| s.tile == Tile::Pipe),
+            "premise: the frozen picture must contain something to freeze"
+        );
+        // The world keeps stepping; nothing is captured, exactly as a
+        // paused driver behaves.
         for _ in 0..4 {
+            let flap = world.autopilot();
+            world.step(flap);
             let mut again = Vec::new();
             presentation.fill(half(), &mut again);
-            assert_eq!(first, again, "nothing moves while nothing is captured");
+            assert_eq!(
+                before_the_pause, again,
+                "an uncaptured world must not reach the picture"
+            );
         }
+    }
+
+    /// Every pipe's left edge at `alpha`, in draw order.
+    fn pipe_lefts(presentation: &Presentation, alpha: Alpha) -> Vec<f32> {
+        let mut out = Vec::new();
+        presentation.fill(alpha, &mut out);
+        out.iter()
+            .filter(|s| s.tile == Tile::Pipe)
+            .map(|s| s.x)
+            .step_by(2)
+            .collect()
+    }
+
+    /// The same, as close to the newer capture as the factor can get.
+    fn pipe_lefts_at_one(presentation: &Presentation) -> Vec<f32> {
+        pipe_lefts(
+            presentation,
+            Alpha::new(u64::MAX, core::num::NonZeroU64::new(1).expect("one")),
+        )
+    }
+
+    fn bird_top(presentation: &Presentation, alpha: Alpha) -> f32 {
+        let mut out = Vec::new();
+        presentation.fill(alpha, &mut out);
+        out.iter()
+            .find(|s| s.tile == Tile::Bird)
+            .map(|s| s.y)
+            .expect("a bird is always drawn")
+    }
+
+    fn bird_top_at_one(presentation: &Presentation) -> f32 {
+        bird_top(
+            presentation,
+            Alpha::new(u64::MAX, core::num::NonZeroU64::new(1).expect("one")),
+        )
     }
 }

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -13,6 +13,7 @@
 use renew_event::WindowEvent;
 use renew_frame::{FrameLoop, FrameStats, Nanos, StepBudget, Timestamp, Timestep};
 use renew_input::InputMap;
+use renew_math::Alpha;
 use renew_platform::Clock;
 use renew_platform::window::{
     LoopControl, NativeWindow, WindowApp, WindowConfig, WindowError, WindowRef, run_window_app,
@@ -26,7 +27,7 @@ use renew_sample_glide_world::{Action, VIEW_HEIGHT, VIEW_WIDTH, World};
 #[cfg(feature = "audio")]
 use crate::audio::Audio;
 use crate::cli::{Options, Report};
-use crate::scene::{SceneSprite, Tile, scene};
+use crate::scene::{Presentation, SceneSprite, Tile};
 use crate::{SampleError, scripted};
 
 /// The window's base title; the score readout appends to it.
@@ -215,6 +216,14 @@ pub struct GlideApp {
     /// texture in the frame, drawn as its own item in the same pass.
     ui_sprites: Option<renew_render2d::SpriteRenderer>,
     scene_scratch: Vec<SceneSprite>,
+    /// The last two ticks of the world's picture, so a frame between
+    /// them draws between them rather than repeating whichever tick
+    /// happened last.
+    presentation: Presentation,
+    /// How far past the last executed step this frame stands. Stored
+    /// rather than passed, because drawing is an event the platform
+    /// raises and not a tail of the update that computed it.
+    alpha: Alpha,
     /// The HUD's score line, formatted in place each frame.
     hud_score: String,
     title: Title,
@@ -247,11 +256,17 @@ pub struct GlideApp {
 impl GlideApp {
     #[must_use]
     pub fn new(options: &Options) -> Self {
+        // Hoisted so the presentation starts from a real tick: seeded
+        // from a default world, the first frame would blend the bird up
+        // from y = 0.
+        let world = World::new(options.seed);
         Self {
             clock: Clock::start(),
             seed: options.seed,
             ticks_wanted: options.window_ticks,
-            world: World::new(options.seed),
+            presentation: Presentation::new(&world),
+            alpha: Alpha::ZERO,
+            world,
             input: scripted::input_map(),
             pending_flaps: 0,
             #[cfg(feature = "audio")]
@@ -367,7 +382,7 @@ impl GlideApp {
         else {
             return;
         };
-        scene(&self.world, &mut self.scene_scratch);
+        self.presentation.fill(self.alpha, &mut self.scene_scratch);
         renderer.begin();
         for sprite in &self.scene_scratch {
             let region = match sprite.tile {
@@ -507,6 +522,12 @@ impl GlideApp {
             for action in self.menu.drain() {
                 if action == crate::menu::MenuAction::Restart {
                     self.world = World::new(self.seed);
+                    // The pair belongs to the world it captured. Keeping
+                    // it across a restart would blend the new bird out of
+                    // the old one's last position and drag every pipe
+                    // across the screen for one interval.
+                    self.presentation = Presentation::new(&self.world);
+                    self.alpha = Alpha::ZERO;
                     self.pending_flaps = 0;
                 }
             }
@@ -544,8 +565,22 @@ impl GlideApp {
                     // drift away from the sounding one.
                     let _ = (before_alive, before_score, flap_passed);
                 }
+                // Once per EXECUTED step, never once per frame: a frame
+                // that runs three catch-up steps must leave the earlier
+                // capture one tick back, not three.
+                self.presentation.capture(&self.world);
             }
             self.input.advance();
+            // The factor moves only while the world does. The plan's
+            // remainder keeps cycling whether or not the caller executes
+            // the steps, so updating this while paused would sweep it
+            // from zero to one against a frozen pair of captures and make
+            // a paused game oscillate by a whole tick of motion — worse
+            // than the stutter this removes. Frozen factor over a frozen
+            // pair is the last frame drawn before the pause, exactly.
+            if !paused {
+                self.alpha = Alpha::new(plan.remainder().get(), Timestep::HZ_60.nanos());
+            }
             self.stats.absorb(&plan);
             let _ = self.relabel();
             if self.drawn_since_update {

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -579,7 +579,7 @@ impl GlideApp {
             // than the stutter this removes. Frozen factor over a frozen
             // pair is the last frame drawn before the pause, exactly.
             if !paused {
-                self.alpha = Alpha::new(plan.remainder().get(), Timestep::HZ_60.nanos());
+                self.alpha = Alpha::new(plan.remainder().get(), plan.timestep().nanos());
             }
             self.stats.absorb(&plan);
             let _ = self.relabel();
@@ -1237,5 +1237,157 @@ mod tests {
     fn the_unavailable_error_displays_its_reason() {
         let error = SampleError::Unavailable("no display server".to_string());
         assert_eq!(error.to_string(), "no display server");
+    }
+
+    /// **The pause freezes the interpolation factor, not only the steps.**
+    ///
+    /// The frame plan's remainder keeps cycling from wall time whether or
+    /// not the caller executes any steps. Advancing the factor from it
+    /// while the world is frozen would sweep the picture from one capture
+    /// to the other and back, at display rate, for as long as the menu
+    /// stayed open — a paused game oscillating by a whole tick of motion,
+    /// which is worse than the stutter the blend removes.
+    #[test]
+    fn an_open_menu_freezes_the_interpolation_factor_with_the_world() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        // Run far enough that a pair of captures exists and the factor is
+        // somewhere in the middle of a step.
+        app.update_at(Timestamp::from_nanos(4 * STEP + STEP / 2), &mut control);
+        let running = app.alpha;
+        let tick = app.world.tick();
+        assert!(
+            running.get() > 0.0,
+            "premise: the factor must be mid-step, or freezing it proves nothing"
+        );
+
+        escape(&mut app);
+        assert!(app.menu.is_open());
+        // Frames keep arriving at times that would give quite different
+        // factors if the pause were not honoured.
+        for eighth in 1..=6u64 {
+            app.update_at(
+                Timestamp::from_nanos(5 * STEP + eighth * STEP / 8),
+                &mut control,
+            );
+            assert_eq!(
+                app.alpha.get().to_bits(),
+                running.get().to_bits(),
+                "the factor moved while the world was paused"
+            );
+            assert_eq!(
+                app.world.tick(),
+                tick,
+                "and the world must not have stepped"
+            );
+        }
+    }
+
+    /// A restart replaces the world, so it must replace the captures with
+    /// it — otherwise the first frame after a restart blends the new bird
+    /// out of the dead one's last position and drags every pipe across
+    /// the screen for one interval.
+    #[test]
+    fn a_restart_replaces_the_captures_with_the_world() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        // Fly a while, so the world's picture is far from a new world's.
+        // Several updates rather than one long jump: the step budget caps
+        // how much catch-up a single update will run.
+        for tick in 1..=200u64 {
+            app.update_at(Timestamp::from_nanos(tick * STEP), &mut control);
+        }
+        let mut before = Vec::new();
+        app.presentation.fill(renew_math::Alpha::ZERO, &mut before);
+        let flown = app.world.tick();
+        assert!(
+            flown > 100,
+            "premise: the world must really have flown, reached {flown}"
+        );
+
+        escape(&mut app);
+        app.size = Extent {
+            width: VIEW_WIDTH,
+            height: VIEW_HEIGHT,
+        };
+        let (x, y) = centre_of(&app, 1);
+        click_physical(&mut app, x, y);
+        app.update_at(Timestamp::from_nanos(201 * STEP), &mut control);
+        assert!(
+            !app.menu.is_open(),
+            "premise: the restart button was activated"
+        );
+        assert!(
+            app.world.tick() < flown,
+            "premise: the world really restarted"
+        );
+
+        let mut after = Vec::new();
+        app.presentation.fill(renew_math::Alpha::ZERO, &mut after);
+        assert_ne!(
+            before, after,
+            "the captures must have been replaced along with the world"
+        );
+        // And what it holds is the NEW world, not a blend reaching back
+        // into the old one: the bird stands where a freshly started world
+        // puts it, not where two hundred ticks of flying had taken it.
+        let fresh = World::new(7);
+        let mut expected = Vec::new();
+        crate::scene::Presentation::new(&fresh).fill(renew_math::Alpha::ZERO, &mut expected);
+        let restarted_bird = after
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .expect("a bird is drawn");
+        let fresh_bird = expected
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .expect("a bird is drawn");
+        assert!(
+            (restarted_bird.y - fresh_bird.y).abs() < 4.0,
+            "the restarted bird stands at {}, not near a new world's {} — the captures              still reach into the world that was replaced",
+            restarted_bird.y,
+            fresh_bird.y
+        );
+    }
+
+    /// A frame that runs several catch-up steps captures once per step,
+    /// so the pair it leaves behind spans one tick rather than several.
+    #[test]
+    fn a_catch_up_frame_captures_once_per_executed_step() {
+        let mut app = app();
+        let mut control = LoopControl::default();
+        // One update covering many steps at once.
+        app.update_at(Timestamp::from_nanos(5 * STEP), &mut control);
+        let caught_up = app.world.tick();
+        assert!(
+            caught_up >= 5,
+            "premise: several steps must have run at once"
+        );
+
+        // The pair now spans exactly the last interval: the picture at the
+        // boundary is one tick behind the world, not five.
+        let mut at_zero = Vec::new();
+        app.presentation.fill(renew_math::Alpha::ZERO, &mut at_zero);
+        let mut reference = crate::scene::Presentation::new(&app.world);
+        reference.capture(&app.world);
+        reference.capture(&app.world);
+        let mut current = Vec::new();
+        reference.fill(renew_math::Alpha::ZERO, &mut current);
+        let bird_at_zero = at_zero
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .expect("a bird is drawn");
+        let bird_now = current
+            .iter()
+            .find(|s| s.tile == Tile::Bird)
+            .expect("a bird is drawn");
+        // One tick of bird travel is small; five would not be.
+        assert!(
+            (bird_at_zero.y - bird_now.y).abs() < 4.0,
+            "the earlier capture is {} against a current {}, which is more than one tick \
+             of travel — the captures did not keep up with the steps",
+            bird_at_zero.y,
+            bird_now.y
+        );
     }
 }

--- a/samples/glide/world/src/lib.rs
+++ b/samples/glide/world/src/lib.rs
@@ -280,18 +280,16 @@ impl World {
     /// inherit a dependency on how the world stores things.
     pub fn for_each_pipe(&self, mut visit: impl FnMut(u32, u32, i64, i64)) {
         for (slot, pipe) in self.body.iter() {
-            // Unreachable: `spawn_pipes` writes both stores together and
-            // `sweep` removes from both, so a body without its handle does
-            // not occur. Written as a skip rather than a default because
-            // the two wrong answers differ in kind — a default of zero is
-            // a REAL generation, and would silently let a consumer pair
-            // two different tenants of one slot, where a skip only ever
-            // omits a pipe. When neither branch can be reached, take the
-            // one whose failure is visible.
-            let Some(entity) = self.pipe.get(slot).copied() else {
-                continue;
-            };
-            visit(slot, entity.generation(), pipe.x, pipe.gap_y);
+            // The same lookup and the same spelling the digest uses for
+            // it below. A body without its handle cannot occur —
+            // `spawn_pipes` writes both stores together and `sweep`
+            // removes from both — and this is written as an expression
+            // rather than a skipping branch for the reason the `Pipe`
+            // struct already gives: an arm no test can reach is a hole in
+            // the coverage gate, not a safety net. The impossibility is
+            // stated here rather than defended with a branch.
+            let generation = self.pipe.get(slot).map_or(0, |entity| entity.generation());
+            visit(slot, generation, pipe.x, pipe.gap_y);
         }
     }
 

--- a/samples/glide/world/src/lib.rs
+++ b/samples/glide/world/src/lib.rs
@@ -36,7 +36,13 @@ use renew_frame::StateHash;
 use renew_rng::{Rng, Seed, StreamId};
 
 /// Fixed-point scale: world units per screen unit.
-const ONE: i64 = 1_000;
+/// World units per screen unit. Public because presentation has to
+/// divide by it in floats this crate is forbidden to compute in: the
+/// conversion happens at the consumer's boundary, and a consumer that
+/// cannot see the scale would have to hard-code it.
+pub const UNITS_PER_PIXEL: i64 = 1_000;
+
+const ONE: i64 = UNITS_PER_PIXEL;
 
 const GRAVITY: i64 = 45;
 /// Tuned for a steering input rather than a blind schedule: strong
@@ -223,6 +229,16 @@ impl World {
         (self.bird_y / ONE) as i32
     }
 
+    /// The bird's centre in world units, unrounded.
+    ///
+    /// The whole-unit reading above loses everything below a screen
+    /// pixel, which is most of a tick's motion near the apex of a flap;
+    /// presentation blends between ticks and needs what was lost.
+    #[must_use]
+    pub fn bird_y(&self) -> i64 {
+        self.bird_y
+    }
+
     /// Visit every pipe as (left edge x, gap centre y) in whole screen
     /// units, ascending slot order — the store's own guarantee, so draw
     /// order is a property of the rules, not the storage. Allocation-free
@@ -235,8 +251,35 @@ impl World {
         reason = "pipe coordinates are bounded by spawn position and exit cull to well under i32"
     )]
     pub fn for_each_pipe_units(&self, mut visit: impl FnMut(i32, i32)) {
-        for (_, pipe) in self.body.iter() {
-            visit((pipe.x / ONE) as i32, (pipe.gap_y / ONE) as i32);
+        // One line over the keyed walk below, so the truncation lives in
+        // exactly one place and this reading cannot drift from that one.
+        self.for_each_pipe(|_, _, x, gap_y| visit((x / ONE) as i32, (gap_y / ONE) as i32));
+    }
+
+    /// Visit every pipe as (slot, generation, left edge x, gap centre y)
+    /// in world units, ascending slot order — the store's own guarantee.
+    ///
+    /// The un-truncated, keyed companion to [`World::for_each_pipe_units`],
+    /// and both halves of that are load-bearing. Presentation blends
+    /// between ticks, so it needs finer than whole screen units; and it
+    /// needs the generation, because a slot freed by a pipe leaving the
+    /// screen is handed to a new pipe within ninety ticks, and a
+    /// slot-keyed blend without the generation would drag the newcomer
+    /// across the whole screen out of its predecessor's corpse.
+    ///
+    /// Plain integers rather than the handle itself: the key a consumer
+    /// builds from these names no storage type, so presentation does not
+    /// inherit a dependency on how the world stores things.
+    pub fn for_each_pipe(&self, mut visit: impl FnMut(u32, u32, i64, i64)) {
+        for (slot, pipe) in self.body.iter() {
+            // Skip rather than default. The digest may read a missing
+            // handle as generation 0 because it is hashing, but here 0 is
+            // a real generation, and defaulting to it would let the guard
+            // pass across two different tenants of one slot.
+            let Some(entity) = self.pipe.get(slot).copied() else {
+                continue;
+            };
+            visit(slot, entity.generation(), pipe.x, pipe.gap_y);
         }
     }
 

--- a/samples/glide/world/src/lib.rs
+++ b/samples/glide/world/src/lib.rs
@@ -259,23 +259,35 @@ impl World {
     /// Visit every pipe as (slot, generation, left edge x, gap centre y)
     /// in world units, ascending slot order — the store's own guarantee.
     ///
-    /// The un-truncated, keyed companion to [`World::for_each_pipe_units`],
-    /// and both halves of that are load-bearing. Presentation blends
-    /// between ticks, so it needs finer than whole screen units; and it
-    /// needs the generation, because a slot freed by a pipe leaving the
-    /// screen is handed to a new pipe within ninety ticks, and a
-    /// slot-keyed blend without the generation would drag the newcomer
-    /// across the whole screen out of its predecessor's corpse.
+    /// The un-truncated, keyed companion to [`World::for_each_pipe_units`].
+    ///
+    /// Un-truncated because presentation blends between ticks and needs
+    /// finer than whole screen units — the rounded reading loses nine
+    /// tenths of a unit of pipe travel per tick, which is most of it.
+    ///
+    /// Keyed because a consumer pairing captures across ticks must be
+    /// able to tell one tenant of a slot from the next. **In this game it
+    /// never has to:** a slot vacated by a pipe leaving the screen sits
+    /// empty for seventy-seven ticks before a new pipe takes it, measured
+    /// over three thousand, so no two consecutive captures ever hold
+    /// different tenants of one slot. The generation is offered because a
+    /// reading that omits it cannot be used safely by any consumer whose
+    /// producer is less forgiving, not because this world would misbehave
+    /// without it.
     ///
     /// Plain integers rather than the handle itself: the key a consumer
     /// builds from these names no storage type, so presentation does not
     /// inherit a dependency on how the world stores things.
     pub fn for_each_pipe(&self, mut visit: impl FnMut(u32, u32, i64, i64)) {
         for (slot, pipe) in self.body.iter() {
-            // Skip rather than default. The digest may read a missing
-            // handle as generation 0 because it is hashing, but here 0 is
-            // a real generation, and defaulting to it would let the guard
-            // pass across two different tenants of one slot.
+            // Unreachable: `spawn_pipes` writes both stores together and
+            // `sweep` removes from both, so a body without its handle does
+            // not occur. Written as a skip rather than a default because
+            // the two wrong answers differ in kind — a default of zero is
+            // a REAL generation, and would silently let a consumer pair
+            // two different tenants of one slot, where a skip only ever
+            // omits a pipe. When neither branch can be reached, take the
+            // one whose failure is visible.
             let Some(entity) = self.pipe.get(slot).copied() else {
                 continue;
             };


### PR DESCRIPTION
A producer steps at a fixed timestep; frames arrive faster. Drawing the world as it stood at the last tick means the picture only moves when the producer does. This adds the container that fixes that, and its first consumer.

**`renew-snapshot`** keeps two captures of one slot space and blends between them, keyed by `(slot, generation)` so a value is only ever blended with itself — a dense slot that a producer frees and hands to something else is the same index holding a different thing, and blending across that pairing streaks the newcomer out of its predecessor's last position.

Three decisions worth stating, because each rules out an easier design that works until it doesn't. **The container blends and the consumer never does**: handing back two endpoints leaves a call site that can blend the wrong two, and making that unspellable beats documenting it. **The tick boundary is the container's guarantee, not each payload's** — at a zero factor the earlier capture comes back bit for bit and the payload's blend is not called at all, because committed images and computed-pixel oracles are rendered at tick boundaries, and resting that case on every payload implementing lerp exactly would rest it on nothing. **The reset walks the outgoing write order** rather than clearing every entry, which is load-bearing rather than an optimisation: both passes cross-read the other buffer, so a slot live two steps ago and absent since would otherwise still read as present and wrongly suppress a departure. Keys are plain integers, so a renderer can name this without entity storage appearing in its build graph.

**The consumer had two defects, and the second is the one worth measuring.** The side-scroller judders between ticks — that is the obvious one. But its picture was also quantised before it was ever drawn: pipes travel nine tenths of a screen unit per tick and the only reading presentation had truncated to whole units, so the reported position went 140, 139, 138 … 132, 131, **131**, and a pipe visibly held still for a whole tick roughly six times a second on every display regardless of refresh rate. Interpolation alone would not have fixed that — the sub-unit part was already gone at the boundary. So the world grows a keyed, un-truncated reading beside the rounded one, which now delegates to it so the truncation lives in one place.

What is captured is each pipe's own left edge and gap centre rather than the two bars derived from them: blending derived rectangles interpolates along a chord the derivation would never have drawn, and the gap would breathe as the pipe moved.

The interpolation factor freezes with the world when the pause menu opens. The frame plan's remainder keeps cycling whether or not the caller executes any steps, so moving the factor against a frozen pair would sweep a paused game back and forth by a whole tick of motion — worse than the stutter this removes. A restart replaces the captures too, or the new bird blends out of the dead one's last position.

**A consequence, stated rather than left to be discovered:** at a tick boundary the fill returns the earlier capture, so the picture now lags the world by up to one tick. That is inherent to interpolating between two known states rather than extrapolating past the newest one, and it is the usual trade — extrapolation has no lag and overshoots instead. It is named in the container's contract and in the consumer's.

**One test names what it cannot cover, deliberately.** The rule that a slot's new tenant must never be blended out of its predecessor is held in the crate that owns the pair, which constructs the case directly. The game cannot reach it: measured over three thousand ticks, a vacated slot is never reused on the tick it is freed and instead sits empty for seventy-seven, so every new pipe there is a newborn and no such blend is expressible. A regression test asserting otherwise would have passed against a missing guard, which is worse than no test.

**Evidence.** Named cases, properties over arbitrary capture sequences, and an allocation gate that exercises the recycle path inside the measured window. Every claim the tests make was checked by breaking the code and watching the named test fail — including the two headline ones, the tick-boundary short-circuit, the pause freeze and the restart reset. The quantisation figure above is measured, not derived. The tick-exact fill still produces byte-identical output, and it is the path the committed images render through, so their bytes do not move.

Two things are deliberately left undone and recorded as debt rather than left silent: the widget presenter is not rebuilt on this container, and the game's widget snapshots still advance once per frame against that presenter's own contract. The second carries the sharper note — that path has therefore never actually blended anything in a running host.
