### PR TITLE
test(ecs): what storage costs the heap, measured

### DIFF
--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-ecs/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ name = "renew-ecs"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "renew-memory",
 ]
 
 [[package]]

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -23,6 +23,15 @@ simulation = true
 
 [dev-dependencies]
 proptest = "1.11"
+# The counting allocator behind the steady-state gate. A DEV edge only:
+# the shipping dependency list above stays empty, so the crate is still
+# byte-identical in every removability configuration.
+renew-memory = { path = "../core/memory" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under instrumented allocators.
+[features]
+sanitized = []
 
 [lints]
 workspace = true

--- a/crates/ecs/tests/zero_alloc.rs
+++ b/crates/ecs/tests/zero_alloc.rs
@@ -1,0 +1,128 @@
+//! What storage costs the heap in a steady state, measured rather than
+//! assumed — and the one call that costs it something, pinned so the
+//! cost cannot go quiet.
+//!
+//! **Why this crate needed a gate before it needed a fix.** The steady
+//! frame loop is meant to reach the heap never, and this is the crate a
+//! game touches most: every system that walks components in a defined
+//! order goes through here, once per system per step. Until now nothing
+//! here counted allocations at all, so the budget was stated in the
+//! standards and unenforced exactly where it was most likely to be spent.
+//! The measurement gap was the worse half of the problem: without it, the
+//! day the budget binds, an overrun surfaces as a diffuse regression
+//! across every system at once instead of as one identifiable call.
+//!
+//! **The ordered mutable walk allocates, and that is recorded rather than
+//! hidden.** It collects the visit order before handing out any `&mut`,
+//! because deciding the order borrows the same structure the values live
+//! in and the honest alternative was `unsafe`. That trade was written
+//! down when it was made; this file makes it *visible*, so the fix — a
+//! cached visit order, invalidated on structural change — can be judged
+//! against a number rather than an argument. The test that pins it fails
+//! the day the allocation goes away, which is the point: it is a
+//! tripwire on a known cost, not an endorsement of it.
+//!
+//! One `#[global_allocator]` is process-wide, so the whole file is one
+//! sequence of measured windows rather than several racing tests.
+
+use renew_ecs::{Entities, Store};
+use renew_memory::{CountingAllocator, counters};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Enough slots that the sparse array is grown well before any window
+/// opens, and small enough that the test stays instant.
+const SLOTS: u32 = 64;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_steady_state_costs_the_heap_nothing_except_the_ordered_mutable_walk() {
+    // Everything allowed to allocate happens out here: the allocator
+    // grows both containers to their high-water mark, and nothing below
+    // exceeds it.
+    let mut entities = Entities::new();
+    let mut store: Store<u32> = Store::new();
+    let mut live: Vec<_> = Vec::with_capacity(SLOTS as usize);
+    for value in 0..SLOTS {
+        let entity = entities.spawn();
+        store.insert(entity.index(), value);
+        live.push(entity);
+    }
+    assert_eq!(store.len(), SLOTS as usize, "the fixture really filled");
+
+    // --- Reading, in order and out of it, and by slot.
+    let mut seen = 0u64;
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            for (slot, value) in store.iter() {
+                seen = seen
+                    .wrapping_add(u64::from(slot))
+                    .wrapping_add(u64::from(*value));
+            }
+            for value in store.iter_unordered() {
+                seen = seen.wrapping_add(u64::from(*value));
+            }
+            for entity in &live {
+                if let Some(value) = store.get(entity.index()) {
+                    seen = seen.wrapping_add(u64::from(*value));
+                }
+            }
+        }
+    });
+    verdict.expect("reading storage stays heap-silent");
+    assert!(seen > 0, "the windowed reads really visited components");
+
+    // --- Mutating in place, which is the other half of a system's work.
+    let verdict = counters::quiet_window(5, || {
+        for round in 0..8u32 {
+            for entity in &live {
+                if let Some(value) = store.get_mut(entity.index()) {
+                    *value = value.wrapping_add(round);
+                }
+            }
+        }
+    });
+    verdict.expect("mutating components in place stays heap-silent");
+
+    // --- Churn within the high-water mark: a slot freed and refilled is
+    // the shape a spawner and a despawner make between them, and it must
+    // not reach for the allocator to do it.
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..8 {
+            let doomed = live.pop().expect("the fixture is not empty");
+            store.remove(doomed.index());
+            assert!(entities.despawn(doomed));
+            let reborn = entities.spawn();
+            store.insert(reborn.index(), 7);
+            live.push(reborn);
+        }
+    });
+    verdict.expect("churn inside the high-water mark stays heap-silent");
+    assert_eq!(
+        store.len(),
+        SLOTS as usize,
+        "churn left the population where it was"
+    );
+
+    // --- And the one that does allocate. This is a tripwire on a
+    // recorded cost: it fails if the walk becomes free, which is the
+    // signal that the cached-order fix landed and this file should stop
+    // claiming otherwise.
+    let mut touched = 0u32;
+    let verdict = counters::quiet_window(1, || {
+        store.for_each_mut(|_, value| {
+            touched += 1;
+            *value = value.wrapping_add(1);
+        });
+    });
+    assert_eq!(touched, SLOTS, "the walk really visited every component");
+    assert!(
+        verdict.is_err(),
+        "the ordered mutable walk no longer allocates — if that is deliberate, this \
+         expectation and the debt entry behind it are both out of date"
+    );
+}


### PR DESCRIPTION
Storage is the crate a game touches most — every system that walks components in a defined order comes through here, once per system per step — and nothing in it counted allocations. The steady-state budget was stated in the standards and unenforced exactly where it was most likely to be spent.

**That gap was the worse half of the problem.** Without a number, the day the budget binds, an overrun surfaces as a diffuse regression across every system at once rather than as one identifiable call.

So the steady state is now measured: reading in order and out of it, reading by slot, mutating in place, and churn inside the high-water mark are each asserted heap-silent — with every window proved live by a value it accumulates, rather than trusted to have run. Verified by mutation: an allocation introduced into the ordered read is caught.

**The ordered mutable walk is the exception, and it is pinned as a tripwire rather than exempted.** It collects the visit order before handing out any `&mut`, because deciding that order borrows the same structure the values live in and the honest alternative was `unsafe` — a trade that was written down when it was made. The test asserts that it *does* allocate, so the day a cached visit order makes it free, the test fails and says so. A recorded cost that nothing observes is how a diffuse regression gets built.

The allocation itself is untouched on purpose: nothing in the engine calls that walk yet, and the guidance attached to it is that the cached approach should be measured before an `unsafe` one is considered. There is now something to measure against.

The counting allocator arrives as a **dev-dependency only**, so the shipping dependency list stays empty and the crate remains byte-identical in every removability configuration — which is why that list was empty to begin with.