### PR TITLE
docs(rhi): the mesh layout is three attributes and thirty-six bytes

### DIFF
--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -329,8 +329,15 @@ pub mod builtin {
     };
 
     /// The per-vertex layout [`MESH`] consumes: clip-space position,
-    /// then colour. Packs to 28 bytes, which is the stride every mesh
-    /// drawn by that pipeline must carry.
+    /// then colour, then a texture coordinate. Packs to **36 bytes**,
+    /// which is the stride every mesh drawn by that pipeline must carry.
+    ///
+    /// The coordinate is carried even though this pipeline never samples
+    /// anything, and `mesh.vert` says why at the declaration: the record
+    /// is shared with the paths that do sample, and a pipeline describes
+    /// the whole record rather than the part one shader happens to read.
+    /// An attribute a shader ignores is legal; a record the pipeline
+    /// mis-describes is not.
     pub const MESH_LAYOUT: &[crate::VertexAttribute] = &[
         crate::VertexAttribute::Vec3,
         crate::VertexAttribute::Vec4,


### PR DESCRIPTION
The doc beside this layout described **two attributes and twenty-eight bytes** — the shape it had before a texture coordinate joined the vertex record. The slice underneath has said three ever since (`Vec3 + Vec4 + Vec2`), and the mesh crate's own stride constant agrees at thirty-six.

The coordinate's presence is not an oversight, and the corrected text says so — borrowing the reason the vertex shader already gives at its own declaration: the record is shared with the paths that sample, and a pipeline describes the whole record rather than the part one shader happens to read. An attribute a shader ignores is legal; a record the pipeline mis-describes is not.

Worth noting where this was found rather than how: it turned up while establishing what a reflection check over the shader bytes would have to recover. **A byte count in prose beside a slice that computes one is exactly the coupling nothing currently verifies** — the numbers agree by construction and cannot notice a shader that has moved on.

Documentation only; no behavioural surface, so no test accompanies it. The slice, the shader and the stride were already consistent — only the sentence was not.