### PR TITLE
build: compiled shaders are declared binary rather than detected

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,12 @@
 # Corpus entries are byte-exact fuzzer inputs: any eol conversion would
 # change the bytes coverage was measured on. Never text.
 fuzz/corpus/** -text
+
+# Compiled shaders are byte-exact build outputs, committed beside their
+# GLSL so a clean clone needs no shader toolchain. Every pipeline compares
+# them by content, and the review rule is that a blob change without its
+# source change is a reject - so a checkout that rewrote a byte would
+# break the comparison, not merely annoy it. Git detects these as binary
+# today; this says so, because the two rules above are here for the same
+# reason and were each added after the auto-detection was trusted once.
+*.spv -text


### PR DESCRIPTION
Every pipeline compares its shader bytes by content, and the standing review rule is that a blob change without its source change is a reject. So a checkout that rewrote a byte inside one would not annoy the build — it would break the comparison that rule rests on.

**Git detects these as binary today and stores them correctly — checked, not assumed:** every committed blob already reads `-text` in both index and working tree, and this attribute changes none of them. What it removes is the reliance on detection continuing to be right.

The two rules already in this file are here for exactly that reason, each added after auto-detection was trusted once: trace fixtures pinned to LF because a CRLF checkout failed byte comparisons on one platform only, and fuzz corpus entries marked binary because conversion would change the bytes coverage was measured on. Shader blobs belong in the same list and were simply never added.

Found while establishing what a reflection check over those bytes would need — the blobs' byte-exactness is load-bearing for more of the tree than it looked.