### PR TITLE
feat(scene): local placements composed into world placements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
       # turns forgetting that into a red cell rather than a green one.
       - name: Build and test without the entity storage
         run: |
-          sel="--workspace --exclude renew-ecs --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
+          sel="--workspace --exclude renew-ecs --exclude renew-scene --exclude renew-physics2d --exclude renew-physics3d --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-glide-world --exclude renew-sample-glide --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-ecs $sel
           cargo build $sel
           cargo test $sel
@@ -295,6 +295,18 @@ jobs:
         run: |
           sel="--workspace --exclude renew-snapshot --exclude renew-sample-glide"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-snapshot $sel
+          cargo build $sel
+          cargo test $sel
+      # Parenting: local placements, and the pass composing them into world
+      # placements. Storage and the number type below it, the platformer its
+      # one consumer — the exclude list is upward-closed by excluding that
+      # game and its binary with it. Two edges must never appear or this cell
+      # hollows out: nothing rendering below it, and nothing above it that a
+      # headless build cannot run.
+      - name: Build and test without the parenting pass
+        run: |
+          sel="--workspace --exclude renew-scene --exclude renew-sample-leap-world --exclude renew-sample-leap"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-scene $sel
           cargo build $sel
           cargo test $sel
       # The widget tree: structure, layout, and interaction over the
@@ -374,7 +386,7 @@ jobs:
       # each went red here until the cell named the dependent.
       - name: Build and test without fixed-point arithmetic
         run: |
-          sel="--workspace --exclude renew-fixed --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-bench --exclude renew-cli"
+          sel="--workspace --exclude renew-fixed --exclude renew-scene --exclude renew-physics2d --exclude renew-physics3d --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-glide --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-bench --exclude renew-cli"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-fixed $sel
           cargo build $sel
           cargo test $sel
@@ -441,7 +453,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot renew-scene; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-ecs/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-ecs/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized,renew-scene/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,17 @@ dependencies = [
  "renew-fixed",
  "renew-frame",
  "renew-physics2d",
+ "renew-scene",
+]
+
+[[package]]
+name = "renew-scene"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "renew-ecs",
+ "renew-fixed",
+ "renew-memory",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
-    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/scene", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/scene/Cargo.toml
+++ b/crates/scene/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "renew-scene"
+description = "Local placements, parenting, and a propagation pass composing them over entity storage"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.renew]
+purpose = "Local placements and parent links held as components, and the pass that composes them into world placements, resolving a parent before its children wherever the links form a forest and cutting each loop in exactly one place where they do not."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+# Storage and the number type, and nothing else. Two edges, both
+# deliberate: the pass reads and writes components, and it composes
+# placements in the arithmetic a simulation is allowed to reproduce.
+# Notably absent, and it must stay absent: any edge to the rendering
+# crate. One would make the GPU cell strip the hierarchy, so the
+# engine's own evidence would read "no parenting without a GPU".
+[dependencies]
+renew-ecs = { path = "../ecs" }
+renew-fixed = { path = "../fixed" }
+
+# The propagation is a relation over arbitrary trees, which is the
+# testing table's row for properties rather than examples. The counting
+# allocator holds the steady-state claim.
+[dev-dependencies]
+proptest = "1.11"
+renew-memory = { path = "../core/memory" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under instrumented allocators.
+[features]
+sanitized = []
+
+[lints]
+workspace = true

--- a/crates/scene/README.md
+++ b/crates/scene/README.md
@@ -1,0 +1,137 @@
+# renew-scene
+
+Local placements, parenting, and a deterministic pass that composes them into world placements.
+
+**Status:** `bootstrap` · optional. Interface churn expected; breaking its API costs nothing yet.
+The manifest in `Cargo.toml` is authoritative for maturity, dependencies and core status.
+
+## What it is for
+
+Things in a world are usually placed relative to other things: a turret on a tank, a lamp on a
+post, a platform on the arm that swings it. Writing down where each one *is* means rewriting all
+of them whenever the thing underneath moves, and getting one of them wrong looks exactly like a
+physics bug.
+
+So a node stores where it sits relative to its parent, and the world placement is derived:
+
+```rust
+use renew_ecs::{Entities, Store};
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_scene::{Global, Local, Parent, Scratch, propagate};
+
+let mut entities = Entities::new();
+let (mut parents, mut locals, mut globals) = (Store::default(), Store::default(), Store::default());
+
+// A hub, turned a quarter turn, with a child one unit along its x axis.
+let hub = entities.spawn();
+locals.insert(hub.index(), Local::new(Vec2::ZERO, Angle::QUARTER));
+
+let arm = entities.spawn();
+locals.insert(arm.index(), Local::new(Vec2::new(Fixed::ONE, Fixed::ZERO), Angle::ZERO));
+parents.insert(arm.index(), Parent(hub));
+
+let mut scratch = Scratch::new();
+let counts = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+assert_eq!(counts.nodes, 2);
+
+// The child swung round with its parent rather than staying on the x axis.
+let placed: Global = *globals.get(arm.index()).expect("placed");
+assert_eq!(placed.translation(), Vec2::new(Fixed::ZERO, Fixed::ONE));
+assert_eq!(placed.rotation(), Angle::QUARTER);
+```
+
+That last assertion is the whole reason the crate exists. A child that only ever *translated* with
+its parent could be computed by adding two vectors at the call site; rotating the offset into the
+parent's frame is the part that has to live somewhere and be tested.
+
+## What it promises
+
+**Total.** Every *live* entity with a `Local` gets a `Global` — including nodes whose parent was
+despawned, nodes whose parent is not a scene node, and nodes inside a loop. There is no live input
+for which a node is silently skipped. A despawned entity is not walked at all, and keeps whatever
+`Global` it last had; see *Not here* below. `Propagated` counts each category so a caller can assert
+`orphaned + cyclic == 0` and hear about the mistake at the point it was made.
+
+**Exact rotation.** Angles are binary-angle integers and compose by wrapping addition, so a chain
+of a hundred rotations lands on exactly the angle one multiplication would give. Translation
+composes in fixed point and saturates rather than wrapping, and `renew_fixed::saturations()`
+counts it when it does.
+
+**Derived, never authored.** `Global` has no public fields, and no public way to build one *from a
+placement* — no constructor taking a translation and a rotation, and deliberately no `Default`,
+since a derived one is a public constructor reachable through every `unwrap_or_default` in every
+consumer. `Global::IDENTITY` names one value, the world origin. Everything else exists because
+`propagate` wrote it, which makes "a world placement is a function of the hierarchy" a property of
+the type rather than a convention anyone can forget.
+
+**No steady-state allocation.** `Scratch` is caller-owned capacity. Once it and the output store
+have grown to fit the world, propagating allocates nothing, and a counting-allocator gate holds
+that against a window that moves and re-parents the hierarchy every tick.
+
+## Two mechanics that look like details and are not
+
+**A parent is a whole handle, not a slot.** `Parent` stores an `Entity` including its generation,
+and the pass checks it. Slots are recycled; a bare index would silently re-attach an orphaned
+child to whatever entity moved in next. The check is against the `Entities` passed to `propagate`,
+and generations are unique only within one allocator — a handle minted by a *different* `Entities`
+whose slot and generation both happen to match will be obeyed. Nothing in the engine hands entities
+from two allocators into one world, and this crate does not defend against it.
+
+**Resolution order is not slot order.** The entity allocator hands out recycled slots
+newest-first, so a child can hold a *lower* slot than its parent. A single ascending pass would
+then compose that child against its parent's *previous-tick* placement — one frame of lag, on some
+entities, depending on spawn history, and perfectly reproducible, so no determinism test would
+ever see it. The pass climbs each node's ancestry first and composes on the way back down.
+
+## Determinism, and the one place it stops
+
+For a hierarchy without loops, the output depends on the shape of that hierarchy and on nothing
+else. The same shape laid into a different set of slots produces the same placements bit for bit,
+which is held by a property test that permutes the slot assignment and compares.
+
+**A loop is the exception, and it is stated rather than hedged.** Every node still gets a
+placement and `Propagated::cyclic` still reports the loop. The cut falls on the member the climb
+reaches **last** — the one whose own parent is the member the climb entered the loop by — and which
+member that is follows from which node the pass seeded from, which is entity order. Relabel the
+world and a different member may be cut. No traversal order fixes this — a loop has no member that
+a hierarchy can call first — so a caller who needs reproducible placements must not build one, and
+the count is how they find out they did.
+
+## Where it is used
+
+`renew-sample-leap-world` drives its moving platforms this way: a hub turns, a deck hangs off it
+at a fixed arm, and the deck's collision transform is whatever composing those two gives. Nothing
+in that sample writes a deck position down, which is what makes it evidence — and its tests hold
+the collider against the composed placement every tick, so the two cannot drift apart unnoticed.
+
+That evidence is in the world crate's tests rather than on screen. The playable level contains no
+moving platform, because the sample draws with a grid of characters and has no rule for what a
+rotated box looks like in one.
+
+## Testing
+
+Property tests rather than examples, because the pass is a relation over arbitrary trees: an
+independent top-down reference the traversal shares no code with, a relabelling test that permutes
+the slot assignment and compares bit for bit, and the tree-count relation. A counting-allocator gate
+holds the steady-state claim, over a window that moves and re-parents the hierarchy every tick and
+whose chain is laid out so the climb runs its full depth.
+
+No fuzz target: that obligation is for parsers of external data, and this crate parses nothing —
+its inputs are components another crate's storage already validated.
+
+No state-hash test: the determinism obligation is discharged by the relabelling property above,
+since this crate holds no state of its own between calls. `Scratch` is capacity, not state, and a
+test asserts that a buffer which has just served a different world answers identically.
+
+## Not here
+
+**No transform matrices, no 3D, no scale.** Two dimensions, a translation and a rotation, because
+that is what the one consumer needs and every unused axis is a thing to keep correct for nothing.
+
+**No change tracking.** The pass composes the whole hierarchy each call. A dirty-flag scheme would
+be measured against this one before it replaced it, not instead of it.
+
+**No despawn cleanup.** Despawning an entity does not remove its components — true of every store
+in this engine, and scene is not special. A despawned node is not walked, so its `Global` simply
+stops being updated; it is never read as anybody's parent, because the handle check rejects it
+first. The same is true of a live node whose `Local` was removed.

--- a/crates/scene/clippy.toml
+++ b/crates/scene/clippy.toml
@@ -1,0 +1,39 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate is simulation-designated: its output feeds state digests, so
+# every input to a placement must come from the world and from nothing else.
+# The disallowed lists below are that rule made mechanical — a clock, a
+# self-seeded hasher, or a file read would each make a placement a function
+# of something the digest does not cover, and the digests of two runs would
+# disagree for a reason no test could name.
+#
+# The float deny is at the crate root rather than here, beside the sentence
+# that explains it.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
+    { path = "std::time::SystemTime::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists: fixed partitioning and a fixed reduction order" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, and nothing behind a reproducibility contract may" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "same reason as RandomState: self-seeding entropy has no place here" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs of the same binary" },
+]
+
+# The SAFETY-comment lint accepts the comment above an attribute or
+# on the statement that owns the block.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/scene/src/lib.rs
+++ b/crates/scene/src/lib.rs
@@ -1,0 +1,421 @@
+//! Parenting: local placements composed into world placements.
+//!
+//! A scene node is an entity carrying a [`Local`] — where it sits relative to
+//! whatever it is attached to. Attachment is a second component, [`Parent`],
+//! holding a whole [`Entity`] handle. [`propagate`] reads those two stores and
+//! fills a third with [`Global`], the world placement, resolving every parent
+//! before its children.
+//!
+//! # Contract
+//!
+//! * **Deterministic.** For a hierarchy without loops, the output depends on
+//!   the *shape* of that hierarchy and on nothing else — not on slot numbers,
+//!   not on insertion history, not on how many times [`propagate`] has run.
+//!   Two worlds built with different slot assignments but the same shape
+//!   produce the same placements, bit for bit; the relabelling property test
+//!   holds this.
+//!
+//!   **A loop is the one exception, and it is exact rather than hedged.** Every
+//!   node still gets a placement and the count still reports the loop. The cut
+//!   falls on the loop member the climb reaches **last** — the one whose own
+//!   parent is the member the climb entered the loop by — and *which* member
+//!   that is follows from which node the pass seeded from, which is entity
+//!   order. Relabel the world and a different member may be cut, so the
+//!   placements inside a loop can differ between two worlds of the same shape.
+//!   No ordering fixes this — a loop has no member a hierarchy can call first —
+//!   so a caller who needs reproducible placements must not build one, and
+//!   [`Propagated::cyclic`] is how they find out they did.
+//! * **Total.** Every *live* entity with a [`Local`] gets a [`Global`],
+//!   including nodes whose parent died, nodes whose parent is not a scene node,
+//!   and nodes inside a cycle. There is no live input for which a node is
+//!   silently skipped; [`Propagated`] counts each category so a caller can
+//!   notice. A **despawned** entity is not walked at all — see *Stale globals*.
+//! * **Exact rotation.** Angles compose by wrapping addition on a binary-angle
+//!   integer, so a chain of rotations neither drifts nor accumulates error, at
+//!   any depth. Translation composes in fixed point and saturates rather than
+//!   wrapping; `renew_fixed::saturations()` counts it when it happens.
+//! * **Globals are derived, never authored.** [`Global`] has no public fields,
+//!   and no public way to build one *from a placement* — no constructor taking
+//!   a translation and a rotation, and no [`Default`]. The only values that
+//!   exist are the ones [`propagate`] derived and [`Global::IDENTITY`], the
+//!   world origin. That is what makes "a world placement is a function of the
+//!   hierarchy" a property of the type rather than a habit a caller can forget.
+//!
+//! # Two mechanics that look like details and are not
+//!
+//! **A parent is a whole handle, not a slot.** [`Parent`] stores [`Entity`],
+//! generation included, and [`propagate`] checks it against [`Entities`]. Slots
+//! are recycled; a bare index would silently re-attach an orphan to whatever
+//! moved in next, which is a bug that reproduces perfectly and looks like a
+//! physics glitch.
+//!
+//! The check is against the [`Entities`] handed to [`propagate`], and generations
+//! are only unique within one allocator. A handle minted by a *different*
+//! `Entities` whose slot and generation both happen to match will be obeyed.
+//! Nothing in the engine hands out entities from two allocators into one world,
+//! and this crate does not defend against it.
+//!
+//! **Resolution order is not slot order.** `Entities::spawn` pops its free list
+//! newest-first, so a child can hold a *lower* slot than its parent. A single
+//! ascending pass would then compose that child against its parent's
+//! *previous-tick* placement — one frame of lag, on some entities, depending on
+//! spawn history. It is invisible to a determinism test, because it is
+//! perfectly reproducible. [`propagate`] therefore walks each node's ancestry
+//! upward first and composes on the way back down. `slot_order_does_not_decide`
+//! is the regression test.
+//!
+//! # Stale globals
+//!
+//! Despawning an entity does not remove its components — that is true of every
+//! store in this engine and scene is not special. A [`Global`] left behind by a
+//! despawned node is never *read* as anybody's parent, because the handle check
+//! rejects it first; it is only occupying a slot until the caller removes it.
+
+// The determinism rule a simulation crate lives under: no floating-point
+// arithmetic whose result can reach digested state. A placement composed with
+// a float would be reproducible on one machine and not across a fleet, which
+// is the failure the whole fixed-point stack exists to refuse. Denied here
+// rather than left to review — the lint covers operators only, so it is
+// necessary and not sufficient, but what it covers it covers with teeth.
+#![deny(
+    clippy::float_arithmetic,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    missing_docs
+)]
+
+use renew_ecs::{Entities, Entity, Store};
+use renew_fixed::{Angle, Vec2};
+
+/// Where a node sits relative to its parent, or relative to the world when it
+/// has none.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Local {
+    /// Offset from the parent's origin, in the parent's rotated frame.
+    pub translation: Vec2,
+    /// Rotation relative to the parent's.
+    pub rotation: Angle,
+}
+
+impl Local {
+    /// A placement built from its parts.
+    #[must_use]
+    pub const fn new(translation: Vec2, rotation: Angle) -> Self {
+        Self {
+            translation,
+            rotation,
+        }
+    }
+}
+
+/// What a node is attached to.
+///
+/// The whole handle, generation included — see the crate docs for why a slot
+/// would be a defect rather than an optimisation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Parent(pub Entity);
+
+/// Where a node sits in the world.
+///
+/// Derived, never authored: no public fields, and no way to build one from a
+/// translation and a rotation. [`Global::IDENTITY`] is the single exception and
+/// names one value, the world origin — you can say "nowhere in particular", but
+/// you cannot say where something is. Everything else exists because
+/// [`propagate`] wrote it.
+///
+/// Deliberately not [`Default`]: a derived `Default` is a public constructor,
+/// and one silently reachable through every `unwrap_or_default` in every
+/// consumer, which is exactly how "derived, never authored" would stop being
+/// true without anybody deciding it should.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Global {
+    translation: Vec2,
+    rotation: Angle,
+}
+
+impl Global {
+    /// The world origin, facing along the x axis.
+    ///
+    /// What a node with no usable parent composes against.
+    pub const IDENTITY: Self = Self {
+        translation: Vec2::ZERO,
+        rotation: Angle::ZERO,
+    };
+
+    /// Position in world space.
+    #[must_use]
+    pub const fn translation(self) -> Vec2 {
+        self.translation
+    }
+
+    /// Orientation in world space.
+    #[must_use]
+    pub const fn rotation(self) -> Angle {
+        self.rotation
+    }
+
+    /// A child's world placement, given its parent's.
+    ///
+    /// Rotation adds, wrapping and exact. Translation rotates into the
+    /// parent's frame before it adds, which is what makes a child orbit when
+    /// its parent turns instead of sliding.
+    fn compose(self, local: Local) -> Self {
+        Self {
+            translation: self.translation + local.translation.rotate(self.rotation),
+            rotation: self.rotation + local.rotation,
+        }
+    }
+}
+
+/// What a single [`propagate`] call did.
+///
+/// The three failure counts are diagnostics, not errors: every node in them
+/// still received a [`Global`]. They exist so a caller can assert `orphaned +
+/// cyclic == 0` in a test and find out at the point of the mistake rather than
+/// three frames later when something is drawn in the wrong place.
+///
+/// They count nodes composed **against the world origin** rather than against a
+/// parent — which is not the same as landing there, since such a node still
+/// sits wherever its own [`Local`] puts it. So they are not a partition of
+/// `nodes` and their sum is not it: an ordinary child composes against a parent
+/// that resolved, and belongs to none of the three. `roots + orphaned + cyclic`
+/// is the number of independent trees the pass found.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Propagated {
+    /// Nodes given a world placement — every entity with a [`Local`].
+    pub nodes: u32,
+    /// Nodes with no [`Parent`] component, composed against the world.
+    pub roots: u32,
+    /// Nodes whose [`Parent`] names a despawned entity, or one that is not a
+    /// scene node. Composed as if they had no parent.
+    pub orphaned: u32,
+    /// Nodes whose parent chain closes a loop. One member of each loop is
+    /// composed as if it had no parent, so the rest can compose against it and
+    /// the pass terminates. See the crate docs: *which* member that is
+    /// depends on entity order, and it is the single case where two worlds of
+    /// the same shape can disagree.
+    pub cyclic: u32,
+}
+
+/// Reusable buffers for [`propagate`].
+///
+/// Capacity, not state: two calls with the same world produce the same result
+/// whatever this held beforehand. Owned by the caller so the pass can promise
+/// no steady-state allocation — hand it the same one every tick and it stops
+/// growing once the world stops.
+#[derive(Clone, Debug, Default)]
+pub struct Scratch {
+    marks: Vec<Mark>,
+    ancestry: Vec<u32>,
+}
+
+impl Scratch {
+    /// Empty. The first [`propagate`] sizes it.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sized up front, for a caller that would rather not allocate on the
+    /// first tick.
+    #[must_use]
+    pub fn with_capacity(entities: usize) -> Self {
+        Self {
+            marks: Vec::with_capacity(entities),
+            ancestry: Vec::with_capacity(entities),
+        }
+    }
+}
+
+/// How far a slot has got in the current call.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum Mark {
+    /// Not reached yet.
+    #[default]
+    Untouched,
+    /// On the path currently being climbed. Reaching one of these again is
+    /// what a cycle looks like from the inside.
+    Climbing,
+    /// Has its [`Global`].
+    Placed,
+}
+
+/// Compose every [`Local`] into a [`Global`], parents first.
+///
+/// Runs in time proportional to the number of scene nodes plus the highest
+/// occupied slot: each node's ancestry is climbed once across the whole call,
+/// not once per node. Allocates only while `scratch` or `globals` is still
+/// growing to fit the world.
+///
+/// The return value is the only report of a malformed hierarchy — a discarded
+/// [`Propagated`] turns a parent typo into a thing quietly drawn in the wrong
+/// place — so it is `#[must_use]`.
+///
+/// # Example
+///
+/// A hub turned a quarter turn, with a child one unit along its x axis. The
+/// child swings round to the y axis rather than staying put, which is the one
+/// thing a caller could not have got by adding two vectors — and the reason
+/// this crate exists rather than the composition living at each call site.
+///
+/// ```
+/// use renew_ecs::{Entities, Store};
+/// use renew_fixed::{Angle, Fixed, Vec2};
+/// use renew_scene::{Global, Local, Parent, Scratch, propagate};
+///
+/// let mut entities = Entities::new();
+/// let (mut parents, mut locals, mut globals) =
+///     (Store::default(), Store::default(), Store::default());
+///
+/// let hub = entities.spawn();
+/// locals.insert(hub.index(), Local::new(Vec2::ZERO, Angle::QUARTER));
+///
+/// let arm = entities.spawn();
+/// locals.insert(
+///     arm.index(),
+///     Local::new(Vec2::new(Fixed::ONE, Fixed::ZERO), Angle::ZERO),
+/// );
+/// parents.insert(arm.index(), Parent(hub));
+///
+/// let mut scratch = Scratch::new();
+/// let counts = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+/// assert_eq!(counts.nodes, 2);
+///
+/// let placed: Global = *globals.get(arm.index()).expect("placed");
+/// assert_eq!(placed.translation(), Vec2::new(Fixed::ZERO, Fixed::ONE));
+/// assert_eq!(placed.rotation(), Angle::QUARTER);
+/// ```
+#[must_use]
+pub fn propagate(
+    scratch: &mut Scratch,
+    entities: &Entities,
+    parents: &Store<Parent>,
+    locals: &Store<Local>,
+    globals: &mut Store<Global>,
+) -> Propagated {
+    let Scratch { marks, ancestry } = scratch;
+    marks.clear();
+    marks.resize(entities.capacity(), Mark::Untouched);
+    ancestry.clear();
+
+    let mut counts = Propagated::default();
+
+    for entity in entities.iter() {
+        let slot = entity.index();
+        if !locals.contains(slot) || mark_of(marks, slot) != Mark::Untouched {
+            continue;
+        }
+
+        // Climb to the top of this node's ancestry, marking the path, and stop
+        // at the first ancestor that is already placed, already on the path
+        // (a cycle), or has no usable parent.
+        let mut cursor = slot;
+        loop {
+            set_mark(marks, cursor, Mark::Climbing);
+            ancestry.push(cursor);
+            match parent_slot(entities, parents, locals, cursor) {
+                Some(next) if mark_of(marks, next) == Mark::Untouched => cursor = next,
+                _ => break,
+            }
+        }
+
+        // Back down. The climb pushed deepest-first, so this walks the buffer
+        // in reverse — shallowest ancestor first, every parent placed before
+        // the child that composes against it. Reading it *forwards* is the
+        // previous-tick lag the crate docs describe, so the direction here is
+        // the whole correctness argument and not a style choice.
+        for &node in ancestry.iter().rev() {
+            // Both fallbacks below are unreachable and asserted rather than
+            // quietly taken: every slot in `ancestry` was admitted by a
+            // `locals.contains` check, and every slot marked `Placed` had a
+            // global written in this same loop. Substituting the identity for
+            // either would put a node at the world origin and call it an
+            // answer.
+            debug_assert!(locals.contains(node), "a climbed node always has a local");
+            let local = locals.get(node).copied().unwrap_or_default();
+            let base = match parent_slot(entities, parents, locals, node) {
+                Some(above) if mark_of(marks, above) == Mark::Placed => {
+                    debug_assert!(globals.contains(above), "a placed node always has a global");
+                    globals.get(above).copied().unwrap_or(Global::IDENTITY)
+                }
+                Some(_) => {
+                    counts.cyclic = counts.cyclic.saturating_add(1);
+                    Global::IDENTITY
+                }
+                None => {
+                    if parents.contains(node) {
+                        counts.orphaned = counts.orphaned.saturating_add(1);
+                    } else {
+                        counts.roots = counts.roots.saturating_add(1);
+                    }
+                    Global::IDENTITY
+                }
+            };
+            globals.insert(node, base.compose(local));
+            set_mark(marks, node, Mark::Placed);
+            counts.nodes = counts.nodes.saturating_add(1);
+        }
+        ancestry.clear();
+    }
+
+    counts
+}
+
+/// The slot this node composes against, or `None` when it composes against the
+/// world.
+///
+/// `None` covers three different situations that the caller distinguishes by
+/// asking whether a [`Parent`] component exists at all: no parent, a parent
+/// handle whose entity is gone, and a parent that carries no [`Local`] and so
+/// has no placement to compose against.
+///
+/// A node parented to *itself* is not one of them. It is a loop of length one
+/// and is reported as such, because the climb marks a node before asking what
+/// is above it. Answering `None` here instead would file the same node under
+/// `orphaned`, which points at a different mistake with a different fix.
+fn parent_slot(
+    entities: &Entities,
+    parents: &Store<Parent>,
+    locals: &Store<Local>,
+    slot: u32,
+) -> Option<u32> {
+    let Parent(handle) = *parents.get(slot)?;
+    if !entities.is_alive(handle) {
+        return None;
+    }
+    let above = handle.index();
+    if !locals.contains(above) {
+        return None;
+    }
+    Some(above)
+}
+
+fn mark_of(marks: &[Mark], slot: u32) -> Mark {
+    usize::try_from(slot)
+        .ok()
+        .and_then(|slot| marks.get(slot))
+        .copied()
+        .unwrap_or_default()
+}
+
+/// Every slot reaching here indexes within `marks`: it is sized to the entity
+/// allocator's capacity before the walk begins, and slots arrive either from a
+/// live entity or from a parent handle already checked against `Entities` —
+/// both below that capacity.
+///
+/// Asserted rather than clamped, because a slot that fell outside would make
+/// this a silent no-op, and a mark that never gets set makes the climb's cycle
+/// detection blind: the loop below would stop terminating rather than answer
+/// wrongly, which is the worse of the two failures.
+fn set_mark(marks: &mut [Mark], slot: u32, mark: Mark) {
+    debug_assert!(
+        usize::try_from(slot).is_ok_and(|slot| slot < marks.len()),
+        "slot {slot} is outside the range the walk marked"
+    );
+    if let Some(entry) = usize::try_from(slot)
+        .ok()
+        .and_then(|slot| marks.get_mut(slot))
+    {
+        *entry = mark;
+    }
+}

--- a/crates/scene/tests/propagate.rs
+++ b/crates/scene/tests/propagate.rs
@@ -1,0 +1,423 @@
+//! What the pass promises, one case per promise.
+//!
+//! Every test here builds its world through the real entity allocator rather
+//! than handing `propagate` a table, because two of the promises — the handle
+//! check and the resolution order — are *about* what that allocator does with
+//! slots. A table would test the arithmetic and quietly skip the mechanics.
+
+use renew_ecs::{Entities, Store};
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_scene::{Global, Local, Parent, Propagated, Scratch, propagate};
+
+/// A world under construction, so each test spends its lines on its own case
+/// rather than on four parallel stores.
+#[derive(Default)]
+struct World {
+    entities: Entities,
+    parents: Store<Parent>,
+    locals: Store<Local>,
+    globals: Store<Global>,
+    scratch: Scratch,
+}
+
+impl World {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn node(&mut self, local: Local) -> renew_ecs::Entity {
+        let entity = self.entities.spawn();
+        self.locals.insert(entity.index(), local);
+        entity
+    }
+
+    fn attach(&mut self, child: renew_ecs::Entity, parent: renew_ecs::Entity) {
+        self.parents.insert(child.index(), Parent(parent));
+    }
+
+    fn run(&mut self) -> Propagated {
+        propagate(
+            &mut self.scratch,
+            &self.entities,
+            &self.parents,
+            &self.locals,
+            &mut self.globals,
+        )
+    }
+
+    /// Every scene node is placed — that is the totality promise, and a
+    /// helper that softened it into a default would let the suite pass on the
+    /// one failure it exists to catch.
+    #[allow(clippy::expect_used, reason = "a missing placement is the defect")]
+    fn placement(&self, entity: renew_ecs::Entity) -> Global {
+        *self
+            .globals
+            .get(entity.index())
+            .expect("every scene node is placed")
+    }
+}
+
+fn at(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+#[test]
+fn a_node_with_no_parent_lands_exactly_where_its_local_says() {
+    let mut world = World::new();
+    let lone = world.node(Local::new(at(3, -4), Angle::QUARTER));
+
+    let counts = world.run();
+
+    assert_eq!(world.placement(lone).translation(), at(3, -4));
+    assert_eq!(world.placement(lone).rotation(), Angle::QUARTER);
+    assert_eq!(
+        counts,
+        Propagated {
+            nodes: 1,
+            roots: 1,
+            orphaned: 0,
+            cyclic: 0
+        }
+    );
+}
+
+/// The case that separates "compose" from "add": a child one unit along its
+/// parent's x axis, with the parent turned a quarter turn, must swing round to
+/// the parent's y axis rather than staying put.
+#[test]
+fn a_child_orbits_when_its_parent_turns() {
+    let mut world = World::new();
+    let parent = world.node(Local::new(at(10, 0), Angle::QUARTER));
+    let child = world.node(Local::new(at(1, 0), Angle::ZERO));
+    world.attach(child, parent);
+
+    world.run();
+
+    let placed = world.placement(child);
+    assert_eq!(
+        placed.translation(),
+        at(10, 1),
+        "the child swung with x -> y"
+    );
+    assert_eq!(
+        placed.rotation(),
+        Angle::QUARTER,
+        "and inherited the turn itself"
+    );
+}
+
+/// The formula, pinned by hand at a depth and with angles where the plausible
+/// alternatives disagree.
+///
+/// Every other test here gives the child a zero rotation, and with that the
+/// correct `local.translation.rotate(parent.rotation)` and the wrong
+/// `local.translation.rotate(parent.rotation + local.rotation)` produce the
+/// same answer. The numbers below are chosen so they do not, and each is
+/// worked out on paper rather than read off a run:
+///
+/// * hub: no parent, so it sits at its own local — (10, 0), turned a quarter.
+/// * arm: (2, 0) rotated by the hub's quarter turn is (0, 2), so (10, 2);
+///   turned a quarter more, so a half turn in total. The wrong convention
+///   would rotate by a half turn and give (8, 0).
+/// * tip: (1, 0) rotated by the arm's half turn is (-1, 0), so (9, 2).
+#[test]
+fn the_composition_formula_is_pinned_by_hand() {
+    let mut world = World::new();
+    let hub = world.node(Local::new(at(10, 0), Angle::from_degrees(90)));
+    let arm = world.node(Local::new(at(2, 0), Angle::from_degrees(90)));
+    world.attach(arm, hub);
+    let tip = world.node(Local::new(at(1, 0), Angle::ZERO));
+    world.attach(tip, arm);
+
+    world.run();
+
+    assert_eq!(world.placement(hub).translation(), at(10, 0));
+    assert_eq!(world.placement(hub).rotation(), Angle::from_degrees(90));
+    assert_eq!(world.placement(arm).translation(), at(10, 2));
+    assert_eq!(world.placement(arm).rotation(), Angle::from_degrees(180));
+    assert_eq!(world.placement(tip).translation(), at(9, 2));
+    assert_eq!(world.placement(tip).rotation(), Angle::from_degrees(180));
+}
+
+/// Rotation composes by wrapping integer addition, so a chain of any depth
+/// lands on exactly the angle one multiplication would give — no drift, no
+/// epsilon, nothing that grows with depth.
+///
+/// The step is deliberately one that a turn does *not* divide evenly. Its own
+/// representation error is real and is the input's; the point is that the
+/// chain adds nothing to it.
+#[test]
+fn a_chain_of_rotations_adds_exactly_and_drifts_not_at_all() {
+    let mut world = World::new();
+    let step = Angle::from_degrees(3);
+    let mut previous = world.node(Local::new(Vec2::ZERO, step));
+    for _ in 0..119 {
+        let next = world.node(Local::new(Vec2::ZERO, step));
+        world.attach(next, previous);
+        previous = next;
+    }
+
+    world.run();
+
+    let summed = Angle::from_bits(step.to_bits().wrapping_mul(120));
+    assert_eq!(world.placement(previous).rotation(), summed);
+
+    // And a step a turn *does* divide evenly comes back to exactly zero, so
+    // the assertion above is not passing on two matching wrong answers.
+    let mut world = World::new();
+    let quarter = Angle::from_degrees(90);
+    let mut previous = world.node(Local::new(Vec2::ZERO, quarter));
+    for _ in 0..3 {
+        let next = world.node(Local::new(Vec2::ZERO, quarter));
+        world.attach(next, previous);
+        previous = next;
+    }
+    world.run();
+    assert_eq!(world.placement(previous).rotation(), Angle::ZERO);
+}
+
+/// The mechanic the crate docs single out. The entity allocator hands out
+/// recycled slots newest-first, so a child can hold a lower slot than its
+/// parent; a pass that walked slots in order would compose this child against
+/// the placement its parent held on the *previous* tick.
+///
+/// The premise is asserted, not assumed: if a future allocator change stops
+/// producing the inversion, this test fails loudly instead of passing on a
+/// world that no longer contains the case it was written for.
+#[test]
+fn slot_order_does_not_decide() {
+    let mut world = World::new();
+
+    // Burn three slots and free them. The free list now hands them back in
+    // an order that lets the child land below the parent.
+    let scratch: Vec<_> = (0..3).map(|_| world.entities.spawn()).collect();
+    for entity in scratch {
+        world.entities.despawn(entity);
+    }
+
+    let parent = world.node(Local::new(at(100, 0), Angle::ZERO));
+    let child = world.node(Local::new(at(5, 0), Angle::ZERO));
+    world.attach(child, parent);
+
+    assert!(
+        child.index() < parent.index(),
+        "premise: the child must hold the lower slot, or this test proves nothing \
+         (child {}, parent {})",
+        child.index(),
+        parent.index()
+    );
+
+    world.run();
+
+    assert_eq!(
+        world.placement(child).translation(),
+        at(105, 0),
+        "the child composed against its parent's placement from this tick"
+    );
+
+    // And again on a second tick, because the failure mode this guards is
+    // *stale* data — a slot-order pass gets the first tick wrong in the same
+    // direction every time, so one tick alone could not tell the two apart.
+    world.run();
+    assert_eq!(world.placement(child).translation(), at(105, 0));
+}
+
+/// A despawned parent must not keep placing its children, and — the sharper
+/// half — a *new* entity moving into the dead parent's slot must not inherit
+/// them.
+#[test]
+fn a_dead_parent_leaves_an_orphan_and_never_a_stand_in() {
+    let mut world = World::new();
+    let parent = world.node(Local::new(at(100, 0), Angle::ZERO));
+    let child = world.node(Local::new(at(5, 0), Angle::ZERO));
+    world.attach(child, parent);
+    world.run();
+    assert_eq!(world.placement(child).translation(), at(105, 0));
+
+    world.entities.despawn(parent);
+    let counts = world.run();
+    assert_eq!(
+        world.placement(child).translation(),
+        at(5, 0),
+        "the child fell back to the world"
+    );
+    assert_eq!(counts.orphaned, 1);
+    assert_eq!(
+        counts.roots, 0,
+        "an orphan is not a root, and is counted apart"
+    );
+
+    // Somebody else takes the freed slot. The stale handle names that slot;
+    // only the generation stops it being obeyed.
+    let stand_in = world.node(Local::new(at(-70, 0), Angle::ZERO));
+    assert_eq!(
+        stand_in.index(),
+        parent.index(),
+        "premise: the slot must really be reused, or this proves nothing"
+    );
+    let counts = world.run();
+    assert_eq!(
+        world.placement(child).translation(),
+        at(5, 0),
+        "the child did not adopt the slot's new tenant"
+    );
+    assert_eq!(counts.orphaned, 1);
+}
+
+/// A parent that is alive but is not a scene node has no placement to compose
+/// against, which is the same outcome by a different route.
+#[test]
+fn a_parent_that_is_not_a_scene_node_orphans_its_child() {
+    let mut world = World::new();
+    let bare = world.entities.spawn();
+    let child = world.node(Local::new(at(5, 0), Angle::ZERO));
+    world.attach(child, bare);
+
+    let counts = world.run();
+
+    assert_eq!(world.placement(child).translation(), at(5, 0));
+    assert_eq!(counts.orphaned, 1);
+    assert_eq!(
+        counts.nodes, 1,
+        "the bare entity is not a node and is not placed"
+    );
+}
+
+#[test]
+fn a_cycle_terminates_and_is_counted_rather_than_hanging() {
+    let mut world = World::new();
+    let first = world.node(Local::new(at(1, 0), Angle::ZERO));
+    let second = world.node(Local::new(at(2, 0), Angle::ZERO));
+    let third = world.node(Local::new(at(4, 0), Angle::ZERO));
+    world.attach(first, third);
+    world.attach(second, first);
+    world.attach(third, second);
+
+    let counts = world.run();
+
+    assert_eq!(counts.nodes, 3, "totality holds even inside a loop");
+    assert_eq!(counts.cyclic, 1, "the loop is cut in exactly one place");
+    assert_eq!(counts.roots, 0);
+
+    // The cut lands on the member the climb reaches last — the one whose own
+    // parent is the node the climb started from. Seeding at `first` walks
+    // first -> third -> second, so `second` is cut and the rest compose down
+    // from it: 2, then 2+4, then 2+4+1.
+    assert_eq!(world.placement(second).translation(), at(2, 0));
+    assert_eq!(world.placement(third).translation(), at(6, 0));
+    assert_eq!(world.placement(first).translation(), at(7, 0));
+}
+
+#[test]
+fn a_node_parented_to_itself_is_a_loop_of_one_not_an_orphan() {
+    let mut world = World::new();
+    let ouroboros = world.node(Local::new(at(9, 0), Angle::ZERO));
+    world.attach(ouroboros, ouroboros);
+
+    let counts = world.run();
+
+    assert_eq!(counts.cyclic, 1);
+    assert_eq!(counts.orphaned, 0);
+    assert_eq!(world.placement(ouroboros).translation(), at(9, 0));
+}
+
+/// Totality, stated as one assertion over a world holding every category at
+/// once — the arrangement a caller actually hands over.
+#[test]
+fn every_local_gets_a_global_whatever_else_is_wrong() {
+    let mut world = World::new();
+    let root = world.node(Local::new(at(1, 1), Angle::ZERO));
+    let child = world.node(Local::new(at(1, 0), Angle::ZERO));
+    world.attach(child, root);
+    let doomed = world.node(Local::new(at(2, 2), Angle::ZERO));
+    let orphan = world.node(Local::new(at(3, 3), Angle::ZERO));
+    world.attach(orphan, doomed);
+    world.entities.despawn(doomed);
+    let looped = world.node(Local::new(at(4, 4), Angle::ZERO));
+    world.attach(looped, looped);
+
+    let counts = world.run();
+
+    for entity in [root, child, orphan, looped] {
+        assert!(
+            world.globals.get(entity.index()).is_some(),
+            "slot {} went unplaced",
+            entity.index()
+        );
+    }
+    assert_eq!(counts.nodes, 4);
+    // Three of the four composed against the world origin, one for each way of
+    // having no usable parent — which is not the same as landing there, since
+    // each still sits where its own local puts it. `child` composed against a
+    // real parent and so appears in none of the three.
+    assert_eq!(counts.roots, 1);
+    assert_eq!(counts.orphaned, 1);
+    assert_eq!(counts.cyclic, 1);
+}
+
+/// The scratch buffer is capacity, not state: a second call on an unchanged
+/// world must produce an identical result, and so must a call on a scratch
+/// that has just serviced a completely different world.
+#[test]
+fn the_scratch_carries_capacity_and_never_answers() {
+    let mut used = World::new();
+    let deep = used.node(Local::new(at(1, 0), Angle::from_degrees(30)));
+    let deeper = used.node(Local::new(at(1, 0), Angle::from_degrees(30)));
+    used.attach(deeper, deep);
+    used.run();
+
+    let mut fresh = World::new();
+    let lone = fresh.node(Local::new(at(7, 8), Angle::from_degrees(45)));
+    let first = propagate(
+        &mut fresh.scratch,
+        &fresh.entities,
+        &fresh.parents,
+        &fresh.locals,
+        &mut fresh.globals,
+    );
+    let expected = fresh.placement(lone);
+
+    // Same world, but through the scratch that just walked a two-deep chain.
+    let second = propagate(
+        &mut used.scratch,
+        &fresh.entities,
+        &fresh.parents,
+        &fresh.locals,
+        &mut fresh.globals,
+    );
+
+    assert_eq!(first, second);
+    assert_eq!(fresh.placement(lone), expected);
+}
+
+/// Composition saturates rather than wrapping, and says so through the
+/// counter — silence would be a placement that reads plausible and is not.
+#[test]
+fn overflow_saturates_and_is_counted() {
+    let mut world = World::new();
+    let huge = Vec2::new(Fixed::MAX, Fixed::ZERO);
+    let base = world.node(Local::new(huge, Angle::ZERO));
+    let further = world.node(Local::new(huge, Angle::ZERO));
+    world.attach(further, base);
+
+    let before = renew_fixed::saturations();
+    world.run();
+    let after = renew_fixed::saturations();
+
+    assert!(
+        after.0 > before.0,
+        "the overflow must be reported, not absorbed"
+    );
+    assert_eq!(
+        world.placement(further).translation().x,
+        Fixed::MAX,
+        "and clamped rather than wrapped to a negative"
+    );
+}
+
+/// An empty world is a legal world.
+#[test]
+fn nothing_in_produces_nothing_out() {
+    let mut world = World::new();
+    assert_eq!(world.run(), Propagated::default());
+}

--- a/crates/scene/tests/properties.proptest-regressions
+++ b/crates/scene/tests/properties.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e4bd9a117a83b10ec3e716983bdcc8a66b154a00855475838a52cdb49c7f0ca9 # shrinks to shape = Shape { parents: [None, None], locals: [Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }, Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }] }, seed = 9770274087005721344
+cc 5bb54760c91375947fdcd9e94673bcac3776ed94a9fd09efe7a3dc5a435bfacf # shrinks to shape = Shape { parents: [None, None, None, Some(1)], locals: [Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }, Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }, Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }, Local { translation: Vec2 { x: Fixed(0), y: Fixed(0) }, rotation: Angle(0) }] }, seed = 2598196046998495156

--- a/crates/scene/tests/properties.rs
+++ b/crates/scene/tests/properties.rs
@@ -1,0 +1,285 @@
+//! The two claims that examples cannot hold: the pass agrees with an
+//! independent composition of the same hierarchy, and it does not care what
+//! slots that hierarchy happens to occupy.
+
+use proptest::prelude::*;
+use renew_ecs::{Entities, Entity, Store};
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_scene::{Global, Local, Parent, Propagated, Scratch, propagate};
+
+/// A hierarchy as a plain table: node `n`'s parent is `parents[n]`, always an
+/// earlier index or none.
+///
+/// The ordering constraint is what makes the shape a forest by construction —
+/// the strategy cannot emit a loop — and it is also what lets the reference
+/// below compose in one forward pass. `propagate` gets no such help: the table
+/// is laid into entity slots in an order chosen to break the correspondence.
+#[derive(Clone, Debug)]
+struct Shape {
+    parents: Vec<Option<usize>>,
+    locals: Vec<Local>,
+}
+
+fn shapes(max_nodes: usize) -> impl Strategy<Value = Shape> {
+    prop::collection::vec(
+        (
+            // 0 means "no parent"; otherwise an offset back up the table, so
+            // deep chains and wide fans both occur.
+            0usize..8,
+            -1000i32..1000,
+            -1000i32..1000,
+            any::<u32>(),
+        ),
+        1..max_nodes,
+    )
+    .prop_map(|rows| {
+        let mut parents = Vec::with_capacity(rows.len());
+        let mut locals = Vec::with_capacity(rows.len());
+        for (index, (back, x, y, turn)) in rows.into_iter().enumerate() {
+            parents.push(if back == 0 || back > index {
+                None
+            } else {
+                Some(index - back)
+            });
+            locals.push(Local::new(
+                Vec2::new(Fixed::from_int(x), Fixed::from_int(y)),
+                Angle::from_bits(turn),
+            ));
+        }
+        Shape { parents, locals }
+    })
+}
+
+/// Composition done the one way `propagate` is forbidden to do it: straight
+/// down the table, relying on every parent preceding its child.
+///
+/// This shares no code with the implementation — not the traversal, not the
+/// marking, not the buffers. Only the arithmetic is common, and it has to be:
+/// two different formulas would test that they disagree.
+fn reference(shape: &Shape) -> Vec<(Vec2, Angle)> {
+    let mut placed: Vec<(Vec2, Angle)> = Vec::with_capacity(shape.parents.len());
+    for (index, parent) in shape.parents.iter().enumerate() {
+        let (base_translation, base_rotation) = parent
+            .and_then(|parent| placed.get(parent).copied())
+            .unwrap_or((Vec2::ZERO, Angle::ZERO));
+        let local = shape.locals[index];
+        placed.push((
+            base_translation + local.translation.rotate(base_rotation),
+            base_rotation + local.rotation,
+        ));
+    }
+    placed
+}
+
+/// A world holding `shape`, with table index `n` living in whatever slot the
+/// entity allocator gave it.
+struct Laid {
+    entities: Vec<Entity>,
+    globals: Store<Global>,
+    counts: Propagated,
+}
+
+/// Build the world, spawning in `order` so the caller decides which slots the
+/// nodes land in.
+///
+/// `order` is a permutation of the table indices: it is the order the entities
+/// are *created* in, which is what fixes the slot each node gets.
+fn lay_out(shape: &Shape, order: &[usize]) -> Laid {
+    let mut entities = Entities::new();
+    // Spawn in creation order, then transpose: `created[position]` is the
+    // entity handed to table index `order[position]`. Built this way there is
+    // no absent case, so there is none to unwrap.
+    let created: Vec<Entity> = order.iter().map(|_| entities.spawn()).collect();
+    let mut handles = created.clone();
+    for (position, &index) in order.iter().enumerate() {
+        handles[index] = created[position];
+    }
+
+    let mut parents: Store<Parent> = Store::default();
+    let mut locals: Store<Local> = Store::default();
+    let mut globals: Store<Global> = Store::default();
+    for (index, handle) in handles.iter().enumerate() {
+        locals.insert(handle.index(), shape.locals[index]);
+        if let Some(parent) = shape.parents[index] {
+            parents.insert(handle.index(), Parent(handles[parent]));
+        }
+    }
+
+    let mut scratch = Scratch::new();
+    let counts = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+    assert_eq!(
+        counts.nodes as usize,
+        shape.parents.len(),
+        "totality: every node in the table must be placed"
+    );
+    assert_eq!(counts.cyclic, 0, "the strategy cannot emit a loop");
+    assert_eq!(counts.orphaned, 0, "nothing was despawned");
+
+    Laid {
+        entities: handles,
+        globals,
+        counts,
+    }
+}
+
+/// Totality again: an unplaced node is the defect, not a case to smooth over.
+#[allow(clippy::expect_used, reason = "a missing placement is the defect")]
+fn placement(laid: &Laid, index: usize) -> Global {
+    *laid
+        .globals
+        .get(laid.entities[index].index())
+        .expect("placed")
+}
+
+proptest! {
+    /// The pass composes the same hierarchy the same way an independent
+    /// top-down pass does, whatever shape it is.
+    #[test]
+    fn the_pass_agrees_with_an_independent_composition(shape in shapes(40)) {
+        let expected = reference(&shape);
+        let order: Vec<usize> = (0..shape.parents.len()).collect();
+        let laid = lay_out(&shape, &order);
+
+        for (index, &(translation, rotation)) in expected.iter().enumerate() {
+            let placed = placement(&laid, index);
+            prop_assert_eq!(placed.translation(), translation, "node {}", index);
+            prop_assert_eq!(placed.rotation(), rotation, "node {}", index);
+        }
+    }
+
+    /// Relabelling. The same shape laid into a different set of slots must
+    /// produce identical placements, bit for bit — the property that says the
+    /// answer comes from the hierarchy and not from the allocator.
+    ///
+    /// The permuted layout is also held against the independent reference.
+    /// Comparing the two runs only to *each other* would pass an implementation
+    /// that was wrong the same way in every layout, and the identity layout —
+    /// the one the other property test uses — is the one where the climb is
+    /// shallowest.
+    ///
+    /// Creating the nodes in a permuted order is what makes the slots differ,
+    /// and it routinely puts children below their parents, which is exactly
+    /// the arrangement a slot-order pass gets wrong.
+    #[test]
+    fn placements_survive_relabelling(shape in shapes(40), seed in any::<u64>()) {
+        let count = shape.parents.len();
+        let straight: Vec<usize> = (0..count).collect();
+
+        // A permutation from the seed, so the shrinker can reproduce it.
+        let mut shuffled = straight.clone();
+        let mut state = seed | 1;
+        for index in (1..count).rev() {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let span = u64::try_from(index).unwrap_or(u64::MAX).saturating_add(1);
+            let pick = usize::try_from(state % span).unwrap_or(0);
+            shuffled.swap(index, pick);
+        }
+        // A shuffle is allowed to come out as the identity, and when it does
+        // the two layouts are the same world and the comparison below is
+        // vacuous. Nudge it rather than skipping the case: a skip would leave
+        // the run reporting successes it never made.
+        if shuffled == straight && count > 1 {
+            shuffled.swap(0, 1);
+        }
+
+        // The arrangement this test exists for is a child in a *lower* slot
+        // than its parent. The identity layout can never contain one — the
+        // strategy only ever names an earlier table index as a parent — so it
+        // has to come from the permutation, and a random permutation need not
+        // provide it. Reversing the creation order inverts every edge at once,
+        // which is the strongest form of the case rather than a weakening.
+        let edges = shape.parents.iter().filter(|p| p.is_some()).count();
+        let inverts = |order: &[usize]| {
+            let mut slots = vec![0usize; count];
+            for (position, &index) in order.iter().enumerate() {
+                slots[index] = position;
+            }
+            (0..count).any(|n| shape.parents[n].is_some_and(|p| slots[n] < slots[p]))
+        };
+        if edges > 0 && !inverts(&shuffled) {
+            shuffled = straight.iter().rev().copied().collect();
+        }
+
+        let first = lay_out(&shape, &straight);
+        let second = lay_out(&shape, &shuffled);
+
+        // The premise: unless the two layouts really differ, this proves
+        // nothing. A one-node shape cannot differ, so it is excused by name.
+        let differs = (0..count).any(|n| first.entities[n].index() != second.entities[n].index());
+        prop_assert!(
+            differs || count == 1,
+            "premise: the permutation must actually move something"
+        );
+
+        // Checked against the world that was built, not the order it was built
+        // from: a child really did end up below its parent.
+        if edges > 0 {
+            prop_assert!(
+                (0..count).any(|n| {
+                    shape.parents[n]
+                        .is_some_and(|p| second.entities[n].index() < second.entities[p].index())
+                }),
+                "premise: no child ended up below its parent, so resolution order went untested"
+            );
+        }
+
+        let expected = reference(&shape);
+        for (index, &(translation, rotation)) in expected.iter().enumerate() {
+            let a = placement(&first, index);
+            let b = placement(&second, index);
+            prop_assert_eq!(a.translation(), b.translation(), "node {}", index);
+            prop_assert_eq!(a.rotation(), b.rotation(), "node {}", index);
+            prop_assert_eq!(b.translation(), translation, "node {} vs reference", index);
+            prop_assert_eq!(b.rotation(), rotation, "node {} vs reference", index);
+        }
+    }
+
+    /// The three counts are documented as the number of independent trees the
+    /// pass found. For a forest with no loops and nothing despawned that is
+    /// exactly the number of nodes with no parent — asserted here because the
+    /// claim lives in the public docs and was held by nothing.
+    #[test]
+    fn the_counts_report_how_many_independent_trees_there_were(shape in shapes(40)) {
+        let order: Vec<usize> = (0..shape.parents.len()).collect();
+        let laid = lay_out(&shape, &order);
+        let rootless = shape.parents.iter().filter(|p| p.is_none()).count();
+        prop_assert_eq!(laid.counts.roots as usize, rootless);
+        prop_assert_eq!(laid.counts.orphaned, 0);
+        prop_assert_eq!(laid.counts.cyclic, 0);
+        prop_assert_eq!(laid.counts.nodes as usize, shape.parents.len());
+    }
+
+    /// Running twice changes nothing: the pass is a function of the world, and
+    /// the globals it wrote last time are not an input to it.
+    #[test]
+    fn a_second_pass_over_an_unchanged_world_changes_nothing(shape in shapes(24)) {
+        let mut entities = Entities::new();
+        let handles: Vec<Entity> = (0..shape.parents.len()).map(|_| entities.spawn()).collect();
+        let mut parents: Store<Parent> = Store::default();
+        let mut locals: Store<Local> = Store::default();
+        let mut globals: Store<Global> = Store::default();
+        for (index, handle) in handles.iter().enumerate() {
+            locals.insert(handle.index(), shape.locals[index]);
+            if let Some(parent) = shape.parents[index] {
+                parents.insert(handle.index(), Parent(handles[parent]));
+            }
+        }
+
+        let mut scratch = Scratch::new();
+        let first = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+        let after_first: Vec<Global> = handles
+            .iter()
+            .map(|h| *globals.get(h.index()).expect("placed"))
+            .collect();
+        let second = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+        let after_second: Vec<Global> = handles
+            .iter()
+            .map(|h| *globals.get(h.index()).expect("placed"))
+            .collect();
+
+        prop_assert_eq!(first, second);
+        prop_assert_eq!(after_first, after_second);
+    }
+}

--- a/crates/scene/tests/zero_alloc.rs
+++ b/crates/scene/tests/zero_alloc.rs
@@ -1,0 +1,110 @@
+//! Mechanical enforcement of the pass's allocation contract: once the world
+//! has stopped growing, propagating it allocates exactly nothing.
+//!
+//! The measured window moves the hierarchy rather than just re-running it —
+//! locals are rewritten every step and a subtree is re-parented — because a
+//! pass that allocated only when the answer *changed* would sail through a
+//! window that asked it the same question five times.
+//!
+//! One counting test per file, always: the allocator is process-global and
+//! cargo runs a file's tests concurrently, so a second one here would measure
+//! this one's allocations and fail on a defect that does not exist.
+
+use renew_ecs::{Entities, Entity, Store};
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_memory::{CountingAllocator, counters};
+use renew_scene::{Global, Local, Parent, Scratch, propagate};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const NODES: u32 = 64;
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+fn the_steady_state_allocates_nothing() {
+    // Everything that may allocate happens out here: the stores, the scratch,
+    // and one warmup pass that sizes both of them to the world.
+    let mut entities = Entities::new();
+    let mut parents: Store<Parent> = Store::default();
+    let mut locals: Store<Local> = Store::default();
+    let mut globals: Store<Global> = Store::default();
+    let mut scratch = Scratch::with_capacity(NODES as usize);
+
+    // A chain laid out so that the climb actually climbs. The entity allocator
+    // hands recycled slots back newest-first, so burning `NODES` slots and
+    // freeing them in order makes the next `NODES` spawns descend — the root
+    // takes the highest slot and each child one lower. `Entities::iter()` then
+    // seeds at the *leaf*, and one walk runs the whole depth.
+    //
+    // Spawned in ascending order instead, as this test first was, every node
+    // finds its parent already placed and the ancestry buffer never holds more
+    // than one entry — so the gate would pass with the buffer removed
+    // altogether, which is the opposite of what it is here to prove.
+    let burnt: Vec<Entity> = (0..NODES).map(|_| entities.spawn()).collect();
+    for handle in burnt {
+        entities.despawn(handle);
+    }
+    let handles: Vec<Entity> = (0..NODES).map(|_| entities.spawn()).collect();
+    for (depth, handle) in handles.iter().enumerate() {
+        locals.insert(handle.index(), Local::new(unit(1), Angle::from_degrees(5)));
+        if depth > 0 {
+            parents.insert(handle.index(), Parent(handles[depth - 1]));
+        }
+    }
+    assert!(
+        handles
+            .windows(2)
+            .all(|pair| pair[1].index() < pair[0].index()),
+        "premise: every child must hold a lower slot than its parent, or the \
+         climb is one deep and this measures nothing"
+    );
+
+    let warmup = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+    assert_eq!(warmup.nodes, NODES, "the warmup really walked the world");
+
+    let mut step = 0i32;
+    let verdict = counters::quiet_window(5, || {
+        for _ in 0..4 {
+            step = step.wrapping_add(1);
+
+            // Move everything: a pass that allocated only on change would
+            // otherwise never be asked to.
+            for handle in &handles {
+                locals.insert(
+                    handle.index(),
+                    Local::new(unit(step % 7), Angle::from_degrees(step % 360)),
+                );
+            }
+
+            // And re-shape it, alternating the tail between hanging off the
+            // head and hanging off the world — re-parenting is the operation
+            // a caller does at runtime, and it changes the climb's depth.
+            let tail = handles[NODES as usize / 2];
+            if step % 2 == 0 {
+                parents.insert(tail.index(), Parent(handles[0]));
+            } else {
+                parents.remove(tail.index());
+            }
+
+            let counts = propagate(&mut scratch, &entities, &parents, &locals, &mut globals);
+            assert_eq!(counts.nodes, NODES, "every windowed pass really ran");
+            assert_eq!(counts.cyclic, 0);
+            assert_eq!(
+                counts.roots,
+                if step % 2 == 0 { 1 } else { 2 },
+                "the re-parenting must really take effect, or the window is \
+                 measuring the same shape four times"
+            );
+        }
+    });
+
+    verdict.expect("propagating a settled world stays heap-silent");
+}
+
+fn unit(x: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::ZERO)
+}

--- a/samples/leap/README.md
+++ b/samples/leap/README.md
@@ -41,7 +41,8 @@ The digest covers the character's position, its velocity, its footing
 and the jump latch — the latch because two characters standing in the
 same place at the same speed still diverge on the next tick if one is
 holding the button and the other is not. It does not cover the level,
-which no script can change.
+which no script can change. A world with moving platforms digests those
+too, but this one has none, so the line above is the whole of it.
 
 `--json` prints the same report as one document instead, carrying a
 `schema_version` from its first release so a consumer can tell a shape
@@ -141,6 +142,38 @@ floor. The floor is finite and there is nothing beneath it, so a
 character that walked off its end would fall with nothing to land on
 — none of the three scripts gets near it, because each is stopped by
 the wall or the ledge long before x = ±40.
+
+## Moving platforms
+
+The world understands one more kind of terrain than this level uses: a
+platform placed by a hierarchy rather than written down. A hub sits
+somewhere and turns; a deck hangs off it at a fixed arm; where the deck
+*is* each tick is whatever composing those two gives. Nothing records a
+deck position anywhere, which is the point — a deck cannot disagree with
+the thing that moves it.
+
+`Leap::add_orbit` builds one. Its placement reaches both the collision
+world and the digest — so two runs of the same input trace place every
+platform identically, and a digest that matched while a platform did not
+would be a contradiction the absorption rules out.
+
+Two limits are worth stating plainly, because both are real and both are
+easy to assume away:
+
+- **A deck's travel does not reach what stands on it.** It is solid, it
+  moves, and a character resting on it keeps touching it while the
+  surface is still underneath — but the motion is not transferred, so
+  the character slides off rather than riding along. It works as terrain
+  that moves; it does not yet work as a lift.
+- **A deck moves without sweeping.** That is the same fact from the
+  other side, and it is not benign: a deck placed *into* a character is
+  depenetrated by that character's next move, which can shift a rider
+  instantly and by any distance. Measured at 1.5 units in a single tick.
+- **The picture cannot draw one.** The view above tests each character
+  cell against an upright box, and a deck carries a rotation. Rather
+  than invent a rule for what a tilted box looks like in a grid of
+  characters, this level simply has no moving platform in it. The
+  capability is exercised by the world's own tests.
 
 ## The scripts
 

--- a/samples/leap/world/Cargo.toml
+++ b/samples/leap/world/Cargo.toml
@@ -23,6 +23,7 @@ renew-ecs = { path = "../../../crates/ecs" }
 renew-fixed = { path = "../../../crates/fixed" }
 renew-frame = { path = "../../../crates/frame" }
 renew-physics2d = { path = "../../../crates/physics2d" }
+renew-scene = { path = "../../../crates/scene" }
 
 [lints]
 workspace = true

--- a/samples/leap/world/README.md
+++ b/samples/leap/world/README.md
@@ -3,13 +3,14 @@
 The platformer's simulation: one character, some solid boxes, and the rules that connect them.
 
 **Status: bootstrap.** A sample, not an engine module — nothing in the engine depends on it, and it
-exists to exercise `renew-physics2d` against a shape of problem a real game has.
+exists to exercise `renew-physics2d` and `renew-scene` against a shape of problem a real game
+has.
 
 ## What it is
 
-A pure function of its inputs. `Leap::new` takes tuning, a start position and a list of platforms;
-`step` takes one `Intent` — run left or right, jump or not — and advances the world by exactly one
-tick. Nothing reads a clock, a file, or a random number. The same intents in the same order produce
+A pure function of its inputs. `Leap::new` takes tuning, a start position and a list of platforms,
+and `add_orbit` adds a moving one; `step` takes one `Intent` — run left or right, jump or not — and
+advances the world by exactly one tick. Nothing reads a clock, a file, or a random number. The same intents in the same order produce
 the same digest on every machine, which is the property that lets three platforms compare one line
 of output.
 
@@ -24,6 +25,22 @@ way each faced, which is the physics crate's intended use rather than a workarou
 walking off a ledge. Counted in ticks because a fixed-timestep simulation has no other honest unit,
 and a wall-clock version would not reproduce.
 
+**A moving platform's position is derived, never written down.** `add_orbit` builds two nodes: a
+hub that turns, and a deck hanging off it at a fixed arm. Where the deck is each tick is whatever
+`renew-scene` makes of those two, and that result is what reaches both the collision world and the
+digest — there is no second place a deck position is recorded that could drift out of agreement.
+The composition is the point: a deck that merely slid back and forth could be driven by adding two
+vectors, and would be evidence for nothing.
+
+Two things a moving platform does *not* do, both measured rather than assumed:
+
+- **Its travel does not reach a rider.** A character standing on a deck keeps touching it while the
+  surface is under it, but the deck's motion is not transferred; it slides off the way the geometry
+  tilts. Terrain that moves, not a lift.
+- **It moves without sweeping.** A deck placed *into* a character is depenetrated by that
+  character's next move, which can displace a rider instantly and by any distance. The two facts
+  together are the honest description, and each has a test asserting it.
+
 **The character's size is public.** `CHARACTER_HALF_EXTENTS` is exported because anything drawing
 the world needs it — a drawing that guesses puts the character somewhere it is not, and a
 one-cell-tall picture of a two-unit-tall body makes a character standing on the floor look like one
@@ -32,7 +49,8 @@ hovering above it.
 ## What it is not
 
 Not a game: no scoring, no enemies, no level loading. The level is whatever list of platforms the
-caller passes, and `samples/leap` supplies one with a floor, a wall and a ledge.
+caller passes plus whatever orbits it adds, and `samples/leap` supplies one with a floor, a wall and
+a ledge — and no moving platform, because its character-grid view cannot draw a rotated one.
 
 Not tuned for feel. The numbers in `Tuning` are chosen to make the interesting cases happen
 quickly, not to be pleasant to play.

--- a/samples/leap/world/src/lib.rs
+++ b/samples/leap/world/src/lib.rs
@@ -19,12 +19,13 @@
 // necessary and not sufficient, but what it covers it covers with teeth.
 #![deny(clippy::float_arithmetic)]
 
-use renew_ecs::{Entities, Entity};
-use renew_fixed::{Fixed, Vec2};
+use renew_ecs::{Entities, Entity, Store};
+use renew_fixed::{Angle, Fixed, Vec2};
 use renew_frame::StateHash;
 use renew_physics2d::{
     BodyKind, Collider, Filter, Shape, ShapeIndex, SlideEnd, SlideHit, Transform, World,
 };
+use renew_scene::{Global, Local, Parent, Scratch, propagate};
 
 /// What the player is asking for this tick.
 ///
@@ -148,6 +149,35 @@ impl Platform {
     }
 }
 
+/// A platform carried around a turning pivot.
+///
+/// **Where the deck is, is never written down.** A hub sits at `pivot` and
+/// turns by `turn_per_tick`; the deck hangs off it at a fixed `arm` and its
+/// world placement is whatever composing those two gives. That is the whole
+/// reason this exists in a platformer sample rather than a unit test: a deck
+/// that only slid back and forth could be driven by adding two vectors, and
+/// would be evidence for nothing. Rotating the arm is the case addition
+/// cannot express.
+#[derive(Clone, Copy, Debug)]
+pub struct Orbit {
+    /// Centre of the turn, in world space.
+    pub pivot: Vec2,
+    /// Offset from the hub to the deck, measured in the hub's frame.
+    pub arm: Vec2,
+    /// Half-extents of the deck.
+    pub half_extents: Vec2,
+    /// How far the hub turns each tick.
+    pub turn_per_tick: Angle,
+}
+
+/// One built orbit: the two nodes it became, and the rate it turns at.
+#[derive(Clone, Copy, Debug)]
+struct Orbiting {
+    hub: Entity,
+    deck: Entity,
+    turn_per_tick: Angle,
+}
+
 /// Everything the terrain collides with.
 /// How large the character is, measured from its centre.
 ///
@@ -195,6 +225,15 @@ pub struct Leap {
     jump_was_held: bool,
     tick: u64,
     hits: [SlideHit; MAX_SLIDE_HITS],
+    /// The hierarchy behind every moving platform. Three stores and a buffer
+    /// rather than one list of positions, because the positions are the
+    /// *output*: nothing here may be written by hand, or the sample would be
+    /// asserting against numbers it had itself supplied.
+    locals: Store<Local>,
+    parents: Store<Parent>,
+    globals: Store<Global>,
+    scratch: Scratch,
+    orbits: Vec<Orbiting>,
 }
 
 impl Leap {
@@ -250,12 +289,118 @@ impl Leap {
                 normal: Vec2::ZERO,
                 origin: Vec2::ZERO,
             }; MAX_SLIDE_HITS],
+            locals: Store::default(),
+            parents: Store::default(),
+            globals: Store::default(),
+            scratch: Scratch::new(),
+            orbits: Vec::new(),
+        }
+    }
+
+    /// Add a moving platform, and return the entity its deck is.
+    ///
+    /// Additive rather than a fourth argument to [`Leap::new`]: a level with no
+    /// moving parts says so by not calling this, and its digest is byte-for-byte
+    /// what it was before moving platforms existed.
+    ///
+    /// **Construction-only, for the same reason [`Tuning`] is fixed at
+    /// construction.** Calling it mid-run adds a body and changes the digest
+    /// from that tick onward, so two runs of the same input trace would diverge
+    /// on nothing the trace records. Nothing enforces it — a world does not know
+    /// when its caller thinks setup ended — which is why it is written down.
+    pub fn add_orbit(&mut self, orbit: Orbit) -> Entity {
+        let hub = self.entities.spawn();
+        self.locals
+            .insert(hub.index(), Local::new(orbit.pivot, Angle::ZERO));
+
+        let deck = self.entities.spawn();
+        self.locals
+            .insert(deck.index(), Local::new(orbit.arm, Angle::ZERO));
+        self.parents.insert(deck.index(), Parent(hub));
+
+        // The body is created at the origin on purpose. Seeding it with
+        // `pivot + arm` would be the sample writing down an answer it is
+        // supposed to derive, and it would agree with the derivation for
+        // exactly as long as nobody gave the hub a starting angle.
+        self.physics
+            .create_body(deck, BodyKind::Kinematic, Transform::IDENTITY);
+        self.physics.add_shape(
+            deck,
+            Shape::Box {
+                half_extents: orbit.half_extents,
+            },
+            Transform::IDENTITY,
+            Filter::new(TERRAIN_LAYER, CHARACTER_LAYER),
+        );
+
+        self.orbits.push(Orbiting {
+            hub,
+            deck,
+            turn_per_tick: orbit.turn_per_tick,
+        });
+        self.place_decks();
+        deck
+    }
+
+    /// Turn every hub by one tick's worth, then move the decks to wherever
+    /// that puts them.
+    fn advance_orbits(&mut self) {
+        for orbiting in &self.orbits {
+            if let Some(local) = self.locals.get_mut(orbiting.hub.index()) {
+                local.rotation = local.rotation + orbiting.turn_per_tick;
+            }
+        }
+        self.place_decks();
+    }
+
+    /// Compose the hierarchy and hand the result to the physics world.
+    ///
+    /// Every deck transform after construction comes from here — `add_orbit`
+    /// creates the body at the origin and then calls this before returning, so
+    /// no deck is ever observable at a position the hierarchy did not decide.
+    ///
+    /// A deck always has a placement: it is created with a `Local` and a live
+    /// hub and neither is ever removed. That is asserted rather than papered
+    /// over, because the two ways of papering over it disagree — skipping
+    /// `set_transform` leaves the collider at the origin while the digest would
+    /// read the hierarchy, and a deck whose collision and whose reported
+    /// position differ is precisely the bug this whole arrangement prevents.
+    fn place_decks(&mut self) {
+        let counts = propagate(
+            &mut self.scratch,
+            &self.entities,
+            &self.parents,
+            &self.locals,
+            &mut self.globals,
+        );
+        debug_assert_eq!(
+            counts.orphaned + counts.cyclic,
+            0,
+            "a deck hangs off one live hub and nothing else"
+        );
+        for orbiting in &self.orbits {
+            let placed = self.globals.get(orbiting.deck.index()).copied();
+            debug_assert!(placed.is_some(), "every deck keeps its placement");
+            if let Some(placed) = placed {
+                self.physics.set_transform(
+                    orbiting.deck,
+                    Transform {
+                        translation: placed.translation(),
+                        rotation: placed.rotation(),
+                    },
+                );
+            }
         }
     }
 
     /// Advance one tick.
     pub fn step(&mut self, intent: Intent) {
         self.tick += 1;
+
+        // Platforms move first, so the character's sweep this tick meets them
+        // where they now are. Moving them afterwards would let a deck pass
+        // through a character that had already committed to standing still.
+        self.advance_orbits();
 
         // Horizontal velocity is set, not accumulated: a platformer whose
         // character keeps sliding after the key is released feels broken, and
@@ -356,6 +501,40 @@ impl Leap {
         self.footing
     }
 
+    /// Where a deck currently is, for anything drawing the world.
+    ///
+    /// Reads the composed placement rather than the physics body, so a caller
+    /// asking "where is it" and the collision it is about to have cannot
+    /// answer differently.
+    #[must_use]
+    pub fn deck_placement(&self, deck: Entity) -> Option<(Vec2, Angle)> {
+        self.globals
+            .get(deck.index())
+            .map(|placed| (placed.translation(), placed.rotation()))
+    }
+
+    /// Where the collision world thinks a deck is.
+    ///
+    /// The counterpart to [`Leap::deck_placement`], which reads the hierarchy.
+    /// Exposed so a test can hold the two against each other: the same formula
+    /// is written once here and once in the collision crate, and a deck that
+    /// collided somewhere other than where it says it is would be the one
+    /// failure this whole arrangement exists to prevent.
+    #[must_use]
+    pub fn deck_transform(&self, deck: Entity) -> Option<(Vec2, Angle)> {
+        self.physics
+            .transform(deck)
+            .map(|at| (at.translation, at.rotation))
+    }
+
+    /// Every moving deck, in the order it was added.
+    ///
+    /// No `#[must_use]`: the iterator it returns already carries one, and
+    /// doubling it is a lint error rather than extra safety.
+    pub fn decks(&self) -> impl Iterator<Item = Entity> + '_ {
+        self.orbits.iter().map(|orbiting| orbiting.deck)
+    }
+
     /// How many ticks have run.
     #[must_use]
     pub const fn tick(&self) -> u64 {
@@ -364,17 +543,26 @@ impl Leap {
 
     /// A hash over every value that can change future behaviour.
     ///
-    /// **Position, velocity, footing and the jump latch, and nothing else.**
-    /// The platform list cannot change, the tuning is fixed at construction,
-    /// and the entity allocator's internals are not observable — including
-    /// them would make the digest sensitive to things a replay does not
-    /// reproduce. Leaving out something that *does* change behaviour is the
-    /// failure that matters, which is why the jump latch is here: without it
-    /// two worlds with identical positions can diverge on the next tick.
+    /// **Position, velocity, footing, the jump latch, and every moving deck's
+    /// placement — and nothing else.** The static platform list cannot change,
+    /// the tuning is fixed at construction, and the entity allocator's
+    /// internals are not observable; including any of them would make the
+    /// digest sensitive to things a replay does not reproduce. Leaving out
+    /// something that *does* change behaviour is the failure that matters,
+    /// which is why the jump latch is here: without it two worlds with
+    /// identical positions can diverge on the next tick.
+    ///
+    /// **What the deck placements stand in for.** The only mutable state in the
+    /// hierarchy is each hub's rotation, and it is absorbed *directly* rather
+    /// than left to be inferred. It would in fact be recoverable today from the
+    /// deck's composed rotation, because `add_orbit` always gives a deck a zero
+    /// local rotation — but that is an accident of one constructor, and a
+    /// digest resting on it would silently stop covering the hub the day a deck
+    /// gained a rotation of its own.
     #[must_use]
     pub fn digest(&self) -> u64 {
         let position = self.position();
-        StateHash::new()
+        let mut hash = StateHash::new()
             .absorb_u64(self.tick)
             .absorb_u64(position.x.to_bits().cast_unsigned())
             .absorb_u64(position.y.to_bits().cast_unsigned())
@@ -383,11 +571,34 @@ impl Leap {
             .absorb_u32(u32::from(self.footing.grounded))
             .absorb_u32(u32::from(self.footing.against_wall))
             .absorb_u32(self.footing.ticks_airborne)
-            .absorb_u32(u32::from(self.jump_was_held))
-            .finish()
+            .absorb_u32(u32::from(self.jump_was_held));
+
+        // Every hub angle and every deck placement, because a platform
+        // somewhere else next tick is a different world. A level with no moving
+        // parts absorbs nothing here and digests exactly as it did before they
+        // existed, which is what let this arrive without restating a single
+        // recorded hash.
+        for orbiting in &self.orbits {
+            let turned = self
+                .locals
+                .get(orbiting.hub.index())
+                .map_or(Angle::ZERO, |hub| hub.rotation);
+            let placed = self
+                .globals
+                .get(orbiting.deck.index())
+                .copied()
+                .unwrap_or(Global::IDENTITY);
+            hash = hash
+                .absorb_u32(turned.to_bits())
+                .absorb_u64(placed.translation().x.to_bits().cast_unsigned())
+                .absorb_u64(placed.translation().y.to_bits().cast_unsigned())
+                .absorb_u32(placed.rotation().to_bits());
+        }
+        hash.finish()
     }
 
-    /// How many entities the world holds — the character plus its platforms.
+    /// How many entities the world holds — the character, its static platforms,
+    /// and two more for each moving one (a hub and the deck that hangs off it).
     ///
     /// Exposed so a test can hold it flat over a long run: a world that leaked
     /// a slot per tick would still simulate correctly and still digest

--- a/samples/leap/world/tests/orbits.rs
+++ b/samples/leap/world/tests/orbits.rs
@@ -1,0 +1,448 @@
+//! Moving platforms: what the hierarchy decides, and what the character then
+//! runs into.
+//!
+//! These are the sample's half of the parenting crate's evidence. The crate's
+//! own suite proves the composition against a reference; this proves that a
+//! game driving it gets a platform that is somewhere real — that the placement
+//! reaches the collision world, that it reaches the digest, and that a replay
+//! of the same inputs puts it in the same place.
+
+use std::collections::BTreeSet;
+
+use renew_fixed::{Angle, Fixed, Vec2};
+use renew_sample_leap_world::{Intent, Leap, Orbit, Platform, Tuning};
+
+fn v(x: i32, y: i32) -> Vec2 {
+    Vec2::new(Fixed::from_int(x), Fixed::from_int(y))
+}
+
+fn floor() -> [Platform; 1] {
+    [Platform::new(0, -2, 20, 1)]
+}
+
+/// A hub at the origin with a four-unit arm, turning a quarter of a turn every
+/// four ticks — chosen so the deck visits exact axis positions rather than
+/// numbers a test would have to round.
+fn quarter_turn_orbit() -> Orbit {
+    Orbit {
+        pivot: v(0, 8),
+        arm: v(4, 0),
+        half_extents: Vec2::new(Fixed::from_int(2), Fixed::from_ratio(1, 2)),
+        turn_per_tick: Angle::from_degrees(90),
+    }
+}
+
+/// The deck starts where composition says, not where the caller guessed. The
+/// body is created at the origin, so a deck that had merely been seeded with
+/// `pivot + arm` and never composed would read `(0, 0)` here.
+#[test]
+fn a_deck_is_placed_before_the_first_tick() {
+    let mut world = Leap::new(Tuning::default(), v(0, 0), &floor());
+    let deck = world.add_orbit(quarter_turn_orbit());
+
+    let (at, turn) = world.deck_placement(deck).expect("the deck is placed");
+    assert_eq!(at, v(4, 8), "pivot plus arm, with the hub not yet turned");
+    assert_eq!(turn, Angle::ZERO);
+}
+
+/// Four ticks of a quarter turn each walk the deck round the four axes and
+/// back. This is the assertion that separates composing from adding: an
+/// implementation that added the arm to the pivot would leave the deck at
+/// `(4, 8)` for ever.
+#[test]
+fn a_deck_travels_round_its_pivot() {
+    let mut world = Leap::new(Tuning::default(), v(0, 0), &floor());
+    let deck = world.add_orbit(quarter_turn_orbit());
+
+    let expected = [v(0, 12), v(-4, 8), v(0, 4), v(4, 8)];
+    for (index, want) in expected.into_iter().enumerate() {
+        world.step(Intent::IDLE);
+        let (at, turn) = world.deck_placement(deck).expect("placed");
+        assert_eq!(at, want, "after {} tick(s)", index + 1);
+        let turns = u32::try_from(index + 1).expect("four ticks fit in a u32");
+        assert_eq!(
+            turn,
+            Angle::from_bits(Angle::from_degrees(90).to_bits().wrapping_mul(turns)),
+            "the deck carries the hub's turn, not just its position"
+        );
+    }
+
+    // A full circuit returns to exactly the start — integer angles, so this is
+    // equality rather than a tolerance.
+    let (at, turn) = world.deck_placement(deck).expect("placed");
+    assert_eq!(at, v(4, 8));
+    assert_eq!(turn, Angle::ZERO);
+}
+
+/// The placement is not just reported — it is what the character collides
+/// with. A deck parked in the fall path must catch the character above the
+/// floor, at the height composition put it.
+///
+/// **The arm and pivot must not cancel.** `add_orbit` creates the body at the
+/// origin and then composes; a hub at `(0, 3)` with an arm of `(0, -3)` puts
+/// the deck at exactly the origin too, so severing the composition from the
+/// physics world would change nothing and this test would pass against it.
+/// Composing to `(0, 4)` is what makes the assertion mean anything.
+#[test]
+fn a_deck_is_solid_where_the_hierarchy_puts_it() {
+    let mut world = Leap::new(Tuning::default(), v(0, 9), &floor());
+    world.add_orbit(Orbit {
+        pivot: v(0, 6),
+        arm: v(0, -2),
+        half_extents: Vec2::new(Fixed::from_int(4), Fixed::from_ratio(1, 2)),
+        turn_per_tick: Angle::ZERO,
+    });
+
+    // The hub is at y = 6 with an arm reaching 2 down, so the deck sits at
+    // y = 4 — a height stated nowhere, only composed. Its top face is at 4.5
+    // and the character is one unit tall from its centre, so a character
+    // resting on it stands near y = 5.5. The floor would leave it at 1.5,
+    // and a deck left at the origin would leave it at 1.5 as well.
+    for _ in 0..80 {
+        world.step(Intent::IDLE);
+    }
+
+    assert!(world.footing().grounded, "the character came to rest");
+    let resting = world.position().y;
+    assert!(
+        resting > Fixed::from_ratio(53, 10),
+        "it stopped on the deck, not on the floor below it (y = {resting:?})"
+    );
+    assert!(
+        resting < Fixed::from_ratio(57, 10),
+        "and on top of the deck rather than inside it (y = {resting:?})"
+    );
+}
+
+/// The deck's placement reaches the digest, so two worlds whose platforms are
+/// in different places are different worlds — even when the character is doing
+/// exactly the same thing in both.
+#[test]
+fn a_moving_deck_changes_the_digest() {
+    let mut still = Leap::new(Tuning::default(), v(0, 0), &floor());
+    still.add_orbit(Orbit {
+        turn_per_tick: Angle::ZERO,
+        ..quarter_turn_orbit()
+    });
+    let mut turning = Leap::new(Tuning::default(), v(0, 0), &floor());
+    turning.add_orbit(quarter_turn_orbit());
+
+    // Premise: the character must be doing the same thing in both, or the
+    // digests would differ for a reason that has nothing to do with decks.
+    for _ in 0..3 {
+        still.step(Intent::IDLE);
+        turning.step(Intent::IDLE);
+    }
+    assert_eq!(
+        still.position(),
+        turning.position(),
+        "premise: the characters must agree, so only the decks can differ"
+    );
+    assert_ne!(
+        still.digest(),
+        turning.digest(),
+        "a platform somewhere else is a different world"
+    );
+}
+
+/// The sharper half of the same claim: two decks that are turned *identically*
+/// and differ only in where they are must still digest differently.
+///
+/// Without this the absorption of a deck's translation is never load-bearing —
+/// the test above contrasts a still deck with a turning one, whose rotations
+/// already differ, so deleting the two translation lines from the digest leaves
+/// the whole suite green.
+#[test]
+fn two_decks_in_different_places_digest_differently() {
+    let build = |reach: i32| {
+        let mut world = Leap::new(Tuning::default(), v(0, 0), &floor());
+        world.add_orbit(Orbit {
+            pivot: v(0, 30),
+            arm: v(reach, 0),
+            half_extents: Vec2::new(Fixed::from_int(2), Fixed::from_ratio(1, 2)),
+            turn_per_tick: Angle::from_degrees(90),
+        });
+        for _ in 0..3 {
+            world.step(Intent::IDLE);
+        }
+        world
+    };
+
+    let near = build(4);
+    let far = build(9);
+
+    // Premise: same turn rate from the same start means identical orientation
+    // every tick, so only the place can account for a difference.
+    let (near_at, near_turn) = near
+        .deck_placement(near.decks().next().expect("one deck"))
+        .expect("placed");
+    let (far_at, far_turn) = far
+        .deck_placement(far.decks().next().expect("one deck"))
+        .expect("placed");
+    assert_eq!(near_turn, far_turn, "premise: the orientations must agree");
+    assert_ne!(near_at, far_at, "premise: the places must differ");
+
+    assert_ne!(near.digest(), far.digest());
+}
+
+/// And the mirror: two decks in the same place, turned differently, must also
+/// digest differently — which is what covers each hub's own angle.
+#[test]
+fn two_decks_turned_differently_digest_differently() {
+    let build = |turn: i32| {
+        let mut world = Leap::new(Tuning::default(), v(0, 0), &floor());
+        world.add_orbit(Orbit {
+            pivot: v(0, 30),
+            arm: Vec2::ZERO,
+            half_extents: Vec2::new(Fixed::from_int(2), Fixed::from_ratio(1, 2)),
+            turn_per_tick: Angle::from_degrees(turn),
+        });
+        for _ in 0..3 {
+            world.step(Intent::IDLE);
+        }
+        world
+    };
+
+    let slow = build(10);
+    let fast = build(40);
+
+    // Premise: a zero-length arm means the deck never moves, so place cannot
+    // account for the difference and only the turn can.
+    let slow_at = slow
+        .deck_placement(slow.decks().next().expect("one deck"))
+        .expect("placed")
+        .0;
+    let fast_at = fast
+        .deck_placement(fast.decks().next().expect("one deck"))
+        .expect("placed")
+        .0;
+    assert_eq!(slow_at, fast_at, "premise: the places must agree");
+
+    assert_ne!(slow.digest(), fast.digest());
+}
+
+/// A level with no moving parts must digest exactly as it did before moving
+/// parts existed — the property that let this land without restating a single
+/// recorded hash.
+///
+/// **Pinned to a literal, because nothing else in the tree pins one.** The
+/// original version of this test asserted only that a pure function equals
+/// itself and that a world nobody added an orbit to has no orbits; both are
+/// tautologies, and adding a constant to the digest left them green. The
+/// number below is the whole assertion: it was computed before moving
+/// platforms existed, and every quantity reaching it is fixed-point, so it is
+/// the same on every target and in every profile.
+#[test]
+fn a_level_without_orbits_digests_as_if_they_did_not_exist() {
+    let mut plain = Leap::new(Tuning::default(), v(0, 6), &floor());
+    for _ in 0..20 {
+        plain.step(Intent::running(1));
+    }
+    assert_eq!(plain.decks().count(), 0, "premise: nothing was added");
+    assert_eq!(
+        plain.digest(),
+        ORBIT_FREE_DIGEST,
+        "an orbit-free world reaches none of the deck absorption"
+    );
+}
+
+/// A twenty-tick run to the right on the floor alone.
+///
+/// Measured on the revision before moving platforms existed, by building this
+/// same world there and printing its digest — not copied from a run of the
+/// code it is meant to constrain, which would only prove that the code agrees
+/// with itself.
+const ORBIT_FREE_DIGEST: u64 = 0xab37_f973_3b94_049b;
+
+/// Same inputs, same placements, bit for bit — the replay property, extended
+/// to cover the hierarchy.
+#[test]
+fn orbits_replay_exactly() {
+    let run = || {
+        let mut world = Leap::new(Tuning::default(), v(0, 6), &floor());
+        let deck = world.add_orbit(Orbit {
+            turn_per_tick: Angle::from_degrees(7),
+            ..quarter_turn_orbit()
+        });
+        let mut trace = Vec::new();
+        for tick in 0..120 {
+            world.step(if tick % 3 == 0 {
+                Intent::running(1)
+            } else {
+                Intent::jumping(-1)
+            });
+            trace.push((world.digest(), world.deck_placement(deck)));
+        }
+        trace
+    };
+
+    let first = run();
+    let second = run();
+    assert_eq!(first, second);
+
+    // Premise: a deck that never moved would replay exactly too, so the trace
+    // has to be shown to contain many *different* placements. Comparing whole
+    // trace entries would not do it — each carries the digest, which absorbs
+    // the tick counter and so differs unconditionally. Only the placements are
+    // compared here, and they are counted rather than sampled.
+    let places: BTreeSet<_> = first
+        .iter()
+        .map(|(_, at)| {
+            at.map(|(translation, rotation)| {
+                (
+                    translation.x.to_bits(),
+                    translation.y.to_bits(),
+                    rotation.to_bits(),
+                )
+            })
+        })
+        .collect();
+    assert_eq!(
+        first.iter().filter(|(_, at)| at.is_some()).count(),
+        first.len(),
+        "every tick placed the deck"
+    );
+    assert!(
+        places.len() > 100,
+        "premise: the deck must actually have travelled, and it visited {} places",
+        places.len()
+    );
+}
+
+/// The two crates hold the same composition formula — this one in
+/// `renew_scene::Global`, the collision world's in its own `Transform` — and a
+/// deck's placement is copied field-for-field from one into the other. If those
+/// ever stopped agreeing, a deck would collide somewhere other than where it
+/// says it is, which is the single bug this whole arrangement exists to
+/// prevent, and nothing else in either crate would notice.
+#[test]
+fn the_collision_world_agrees_with_the_composed_placement() {
+    let mut world = Leap::new(Tuning::default(), v(0, 40), &floor());
+    let deck = world.add_orbit(Orbit {
+        pivot: v(-5, 12),
+        arm: v(3, 2),
+        half_extents: Vec2::new(Fixed::from_int(2), Fixed::from_ratio(1, 2)),
+        turn_per_tick: Angle::from_degrees(11),
+    });
+
+    for _ in 0..40 {
+        world.step(Intent::IDLE);
+        let (at, turn) = world.deck_placement(deck).expect("placed");
+        let body = world.deck_transform(deck).expect("the body exists");
+        assert_eq!(body.0, at, "the collider is where composition says");
+        assert_eq!(body.1, turn, "and turned the way composition says");
+    }
+}
+
+/// **A moving deck's travel does not reach its rider, and that is measured
+/// rather than assumed.** A kinematic body is placed by writing its transform;
+/// nothing transfers that motion to whatever is standing on it. The character
+/// keeps touching the deck while the surface is still beneath it, so it does
+/// not simply drop — but the deck's travel never reaches it, and it slides off
+/// the way the geometry tilts.
+///
+/// **This is a statement about travel, not about the rider being undisturbed.**
+/// A deck that moves *into* a character is a different matter: the next sweep
+/// depenetrates the overlap, which can displace a rider instantly and by any
+/// distance. `a_deck_that_moves_into_a_rider_displaces_it_at_once` measures
+/// that, and the two together are the honest description.
+///
+/// The assertion here is about horizontal transfer rather than the grounded
+/// flag, because a tilting surface makes contact flicker on and off from tick
+/// to tick; travel is the unambiguous quantity, and it is the one a rider would
+/// gain if this were fixed.
+///
+/// Pinned as an assertion rather than described in a comment, so the day rider
+/// transfer arrives this test fails and the record has to be corrected instead
+/// of quietly going stale.
+#[test]
+fn a_rider_is_not_carried_by_a_moving_deck() {
+    let mut world = Leap::new(Tuning::default(), v(0, 12), &[Platform::new(0, -20, 40, 1)]);
+    let deck = world.add_orbit(Orbit {
+        pivot: v(0, 9),
+        arm: v(0, -3),
+        half_extents: Vec2::new(Fixed::from_int(4), Fixed::from_ratio(1, 2)),
+        turn_per_tick: Angle::from_degrees(1),
+    });
+
+    // Land on it first — without this the test would prove only that a
+    // character in mid-air falls.
+    for _ in 0..20 {
+        world.step(Intent::IDLE);
+    }
+    assert!(
+        world.footing().grounded,
+        "premise: the character must be standing on the deck before it is asked \
+         whether the deck takes it anywhere"
+    );
+    let rider_before = world.position().x;
+    // Measured from the *collider*, not the hierarchy. Reading the composed
+    // placement here would let this test pass on a world where the deck the
+    // character stands on never moved at all — the hierarchy would report
+    // travel, the rider would report none, and the conclusion would be right
+    // for entirely the wrong reason.
+    let deck_before = world.deck_transform(deck).expect("the body exists").0.x;
+
+    for _ in 0..30 {
+        world.step(Intent::IDLE);
+    }
+    let rider_travel = world.position().x - rider_before;
+    let deck_travel = world.deck_transform(deck).expect("the body exists").0.x - deck_before;
+
+    // Premise: the deck must actually have gone somewhere.
+    assert!(
+        deck_travel > Fixed::ONE,
+        "premise: the deck travelled {deck_travel:?}, too little to conclude anything"
+    );
+    assert!(
+        rider_travel.abs() < Fixed::from_ratio(1, 10),
+        "the deck's travel did not reach the rider (deck {deck_travel:?}, \
+         rider {rider_travel:?})"
+    );
+}
+
+/// The other half of the rider story, and the sharper one: a deck placed into a
+/// standing character does not push it gradually, it teleports it.
+///
+/// `set_transform` moves a kinematic body with no sweep, so an overlap simply
+/// exists on the next tick and the character's own move resolves it in one
+/// step. Measured: a character resting at the origin is lifted to exactly the
+/// deck's top face in a single tick, having travelled 1.5 units with nothing
+/// in between. This is why the record says a deck's *travel* is not
+/// transferred rather than that a deck cannot move its rider.
+#[test]
+fn a_deck_that_moves_into_a_rider_displaces_it_at_once() {
+    // The floor sits high on purpose, so the character settles at y = 5 rather
+    // than at the origin. A deck composed to the origin is where `add_orbit`
+    // creates the body regardless, so a case built down there would pass even
+    // if the composition never reached the collision world.
+    let mut world = Leap::new(Tuning::default(), v(0, 11), &[Platform::new(0, 3, 40, 1)]);
+    for _ in 0..60 {
+        world.step(Intent::IDLE);
+    }
+    let settled = world.position().y;
+    assert!(
+        world.footing().grounded,
+        "premise: the character must be standing on the floor first"
+    );
+    assert!(
+        settled > Fixed::from_int(4),
+        "premise: it must have settled well away from the origin ({settled:?})"
+    );
+
+    // A deck materialising exactly where the character is standing — composed
+    // to (0, 5) from a hub three units above it.
+    world.add_orbit(Orbit {
+        pivot: v(0, 8),
+        arm: v(0, -3),
+        half_extents: Vec2::new(Fixed::from_int(4), Fixed::from_ratio(1, 2)),
+        turn_per_tick: Angle::ZERO,
+    });
+
+    world.step(Intent::IDLE);
+    let lifted = world.position().y - settled;
+    assert!(
+        lifted > Fixed::ONE,
+        "one tick moved the character {lifted:?}, with no sweep in between"
+    );
+}


### PR DESCRIPTION
Adds `renew-scene`: a `Local` placement and a `Parent` link held as
components, and a pass that composes them into `Global` world placements
resolving every parent before its children.

Two mechanics decide correctness and both are held by tests. A parent is
stored as a whole entity handle rather than a slot, because slots are
recycled and a bare index would silently re-attach an orphan to whatever
moved in next. And resolution order is not slot order: the entity
allocator hands recycled slots back newest-first, so a child can hold a
lower slot than its parent, and a single ascending pass would compose it
against the parent's previous-tick placement — reproducible, and so
invisible to every determinism test.

`Global` has no public fields and no way to build one from a translation
and a rotation, deliberately including no `Default`, so the only
placements that exist are derived ones and the world origin.

The pass is total: every live node gets a placement, including orphans
and loop members, and the returned counts report each category. For a
forest the result depends on the hierarchy's shape and nothing else,
which a property test holds by permuting the slot assignment. Inside a
loop it does not, and the docs say so rather than hedging.

The platformer sample gains moving platforms as the first consumer: a hub
turns, a deck hangs off it at a fixed arm, and the deck's collision
transform is whatever composing those two gives. Nothing writes a deck
position down. A level with no moving parts digests byte-for-byte as
before, verified against the prior revision.

Two limits are measured and documented rather than assumed: a deck's
travel is not transferred to a rider, and a deck placed into one
displaces it instantly because writing a transform does not sweep.