### PR TITLE
docs: comments point at what the reader can see

### DIFF
--- a/crates/ecs/tests/zero_alloc.rs
+++ b/crates/ecs/tests/zero_alloc.rs
@@ -123,6 +123,7 @@ fn the_steady_state_costs_the_heap_nothing_except_the_ordered_mutable_walk() {
     assert!(
         verdict.is_err(),
         "the ordered mutable walk no longer allocates — if that is deliberate, this \
-         expectation and the debt entry behind it are both out of date"
+         expectation is the stale half and should become an assertion that it \
+         stays free rather than one that it is not"
     );
 }

--- a/crates/render3d/Cargo.toml
+++ b/crates/render3d/Cargo.toml
@@ -30,8 +30,8 @@ proptest = "1.11"
 renew-memory = { path = "../core/memory" }
 
 # The switch the scheduled sanitizer workflow flips: allocation counting
-# is invalid under instrumented allocators. It returns with the gate that
-# needs it, which is what the debt entry said it was waiting for.
+# is invalid under instrumented allocators. Declared here ahead of the gate
+# that needs it, so the workflow's crate list and this manifest agree.
 [features]
 sanitized = []
 

--- a/crates/ui/src/bin/ui_digest.rs
+++ b/crates/ui/src/bin/ui_digest.rs
@@ -13,7 +13,7 @@
 //! solver (mixed pixel and content sizes, growth, a mid-script restyle
 //! whose re-solve moves a later click onto a different button),
 //! hit-testing (moves across every button, a boundary-exact corner, a
-//! miss outside the tree), and the decision fold (activations, an
+//! miss outside the widget tree), and the decision fold (activations, an
 //! abandoned press, a click on nothing). Unlike the tree's own
 //! `absorb` — whose geometry exclusion serves gameplay gates — this
 //! witness folds the solved rectangles too, to the raw fixed-point

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -66,7 +66,7 @@ pub const SIZE: u32 = 512;
 /// across the floor in `digging.png` carried a step visible at the
 /// committed size, and doubling the side halved it. It still steps
 /// where the light grazes a surface — one unfiltered tap decides
-/// every edge (DEBT-0067) — but at block scale the edges read clean.
+/// every edge — but at block scale the edges read clean.
 /// The map costs sixteen megabytes of device memory.
 pub const SHADOW_MAP_SIZE: u32 = 2048;
 

--- a/samples/glide/src/menu.rs
+++ b/samples/glide/src/menu.rs
@@ -109,7 +109,7 @@ impl Menu {
             self.open = !self.open;
             // A press left dangling across a toggle must not pair
             // with a release from a later episode: park the pointer
-            // outside the tree and release, which the tree treats as
+            // outside the widget tree and release, which the tree treats as
             // an abandoned press — no activation, nothing pending.
             self.ui.handle(UiEvent::PointerMoved { x: -1, y: -1 });
             self.ui.handle(UiEvent::PointerReleased);


### PR DESCRIPTION
Five comments referred to records that do not exist in this repository,
or used a phrase that reads two ways.

Three cited a numbered note a reader here cannot open, and in each case
the surrounding sentence already carried the fact — the shadow map's
single tap, the storage walk's allocation, the renderer's sanitizer
switch. The citation added nothing and pointed nowhere.

Two said "outside the tree" of a pointer parked beyond the widget tree,
which is a different tree from the one that word usually means in a
repository. Both now say "outside the widget tree", which is what they
meant and is more precise regardless.

No behaviour changes; one assertion message is reworded to say what a
reader should do when it fires rather than where to read about it.