### PR TITLE
build: engine crates carry the metadata a registry indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/renew-engine/renew"
+homepage = "https://renew-engine.github.io/renew/"
 rust-version = "1.97"
 
 [workspace.lints.rust]

--- a/crates/asset/Cargo.toml
+++ b/crates/asset/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "assets", "deterministic", "engine", "content-addressed"]
+categories = ["game-development", "encoding"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The runtime asset pack format: a content-addressed container, a writer whose output is byte-identical for the same inputs, and a reader that trusts nothing the header claims."

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "audio", "mixer", "wav", "engine"]
+categories = ["multimedia::audio", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Sound as arithmetic: a fixed-voice mixer with no steady-state allocation, a command ring a game thread can push into while an audio thread drains it, and a WAV reader that validates every field before it is used. Carrying the samples to a device belongs to the platform crate."

--- a/crates/camera/Cargo.toml
+++ b/crates/camera/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "camera", "projection", "graphics", "engine"]
+categories = ["game-development", "rendering"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Presentation-side camera: view and projection matrices under the engine's clip conventions (y down, z reversed into [0, 1])."
@@ -19,7 +22,7 @@ simulation = false
 # rendering conventions, and the conventions are this crate's own
 # contract rather than a dependency's.
 [dependencies]
-renew-math = { path = "../core/math" }
+renew-math = { version = "0.1.0", path = "../core/math" }
 
 # The projection's monotonicity and range claims are properties over
 # arbitrary points, which is the testing table's row for mathematics.

--- a/crates/core/diag/Cargo.toml
+++ b/crates/core/diag/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["logging", "diagnostics", "gamedev", "engine", "no-std"]
+categories = ["development-tools::debugging", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Log records, severity levels, and the sink interface the rest of the engine reports through."

--- a/crates/core/event/Cargo.toml
+++ b/crates/core/event/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["events", "gamedev", "engine", "input", "no-std"]
+categories = ["game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The event vocabulary — key codes, pointer buttons and event shapes — as dependency-free plain data."

--- a/crates/core/math/Cargo.toml
+++ b/crates/core/math/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["math", "linear-algebra", "vector", "matrix", "gamedev"]
+categories = ["mathematics", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Vector, matrix, quaternion, and bounding-box value types with documented memory layout, and the render interpolation factor."

--- a/crates/core/memory/Cargo.toml
+++ b/crates/core/memory/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["allocator", "arena", "memory", "gamedev", "no-std"]
+categories = ["memory-management", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The engine's allocation seam: explicit arena and pool allocators plus an instrumented global allocator for counting."

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["platform", "windowing", "gamedev", "engine", "os"]
+categories = ["os", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The engine's only doorway to the operating system: clock, filesystem, thread, window, and audio-output seams."
@@ -34,7 +37,7 @@ audio-out = ["dep:cpal"]
 # Unconditional, not behind the `window` feature: a headless build still
 # needs to name a key, and the whole point of the extraction is that
 # taking the vocabulary does not mean taking a clock.
-renew-event = { path = "../event" }
+renew-event = { version = "0.1.0", path = "../event" }
 
 # Explicit feature selection: both Linux backends and the window-handle
 # interop. Wayland client-side decorations are deliberately OFF — the
@@ -63,7 +66,7 @@ cpal = { version = "=0.18.1", optional = true, default-features = false }
 # Not optional: the file sink in `diag.rs` is part of this crate's
 # always-available surface. The audio seam also uses it, which is why
 # this line used to be optional.
-renew-diag = { path = "../diag" }
+renew-diag = { version = "0.1.0", path = "../diag" }
 
 [lints]
 workspace = true

--- a/crates/ecs/Cargo.toml
+++ b/crates/ecs/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["ecs", "gamedev", "entity-component", "deterministic", "engine"]
+categories = ["game-development", "data-structures"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Entity handles with generations, and sparse-set component storage whose iteration order is defined by slot rather than by insertion history."

--- a/crates/fixed/Cargo.toml
+++ b/crates/fixed/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["fixed-point", "deterministic", "math", "gamedev", "no-std"]
+categories = ["mathematics", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The fixed-point number type simulation is written in: Q47.16 in an i64, with no float in any signature and no dependencies."

--- a/crates/frame/Cargo.toml
+++ b/crates/frame/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "fixed-timestep", "game-loop", "deterministic", "engine"]
+categories = ["game-development", "simulation"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Fixed-timestep frame scheduling: the deterministic accumulator, the step budget that bounds a stall, and the exact rational a renderer interpolates by, as integers."

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "input", "bindings", "deterministic", "engine"]
+categories = ["game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Maps physical keys and pointer buttons to caller-named actions, with press and release edges that live on the tick rather than on the event."
@@ -43,7 +46,7 @@ simulation = true
 # a filesystem, OS entropy and process spawning into the test graph. It
 # is a test-only edge and no engine code can reach it, but the claim
 # here is about normal dependencies, not the whole tree.
-renew-event = { path = "../core/event" }
+renew-event = { version = "0.1.0", path = "../core/event" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/jobs/Cargo.toml
+++ b/crates/jobs/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["jobs", "thread-pool", "parallel", "gamedev", "engine"]
+categories = ["concurrency", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Fixed-size worker pool with blocking chunk-granular parallel-for; all engine parallelism routes through it."
@@ -24,8 +27,8 @@ sanitized = []
 # default-features = false: this crate needs only the thread seam, and
 # pulling platform defaults here would compile the windowing stack into
 # every headless consumer of the job pool (feature unification).
-renew-platform = { path = "../core/platform", default-features = false }
-renew-diag = { path = "../core/diag" }
+renew-platform = { version = "0.1.0", path = "../core/platform", default-features = false }
+renew-diag = { version = "0.1.0", path = "../core/diag" }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/particles/Cargo.toml
+++ b/crates/particles/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "particles", "vfx", "deterministic", "engine"]
+categories = ["game-development", "rendering"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Presentation-side particles: a seeded fixed-capacity pool stepped at the simulation cadence, and (behind the render feature) the billboard renderer that draws what it packs."
@@ -19,11 +22,11 @@ simulation = false
 # testable on any machine; the GPU-facing half sits behind the `render`
 # feature with its own dependency below.
 [dependencies]
-renew-rng = { path = "../rng" }
+renew-rng = { version = "0.1.0", path = "../rng" }
 # The GPU half's dependency, behind its feature so the pure half stays
 # device-free and the removability story stays one crate wide: a
 # consumer that only steps pools never compiles a graphics API.
-renew-rhi = { path = "../rhi", default-features = false, optional = true }
+renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false, optional = true }
 
 # Property tests for the pool's bounds and expiry — the containers row
 # of the testing table (the lerp endpoint is a bit-exact unit test

--- a/crates/physics2d/Cargo.toml
+++ b/crates/physics2d/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["physics", "collision", "2d", "deterministic", "gamedev"]
+categories = ["game-development", "simulation"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Bodies, shapes, filtering and collision queries in fixed-point 2D: the collider set, its lifecycle, and the orders that make contacts reproducible."
@@ -19,8 +22,8 @@ extension_points = []
 simulation = true
 
 [dependencies]
-renew-ecs = { path = "../ecs" }
-renew-fixed = { path = "../fixed" }
+renew-ecs = { version = "0.1.0", path = "../ecs" }
+renew-fixed = { version = "0.1.0", path = "../fixed" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/physics3d/Cargo.toml
+++ b/crates/physics3d/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["physics", "collision", "3d", "deterministic", "gamedev"]
+categories = ["game-development", "simulation"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Bodies, shapes, filtering and collision queries in fixed-point 3D: the collider set, its lifecycle, and the orders that make contacts reproducible."
@@ -18,8 +21,8 @@ extension_points = []
 simulation = true
 
 [dependencies]
-renew-ecs = { path = "../ecs" }
-renew-fixed = { path = "../fixed" }
+renew-ecs = { version = "0.1.0", path = "../ecs" }
+renew-fixed = { version = "0.1.0", path = "../fixed" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/png/Cargo.toml
+++ b/crates/png/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["png", "encoding", "image", "gamedev", "no-std"]
+categories = ["multimedia::images", "encoding"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "PNG encoding with no dependencies: RGBA pixels in, the bytes of a file out. It never touches the filesystem."

--- a/crates/render2d/Cargo.toml
+++ b/crates/render2d/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "2d", "sprites", "rendering", "vulkan"]
+categories = ["rendering", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Batched 2D sprites over the rendering crate: one atlas, one pipeline, one instanced draw per frame."
@@ -20,8 +23,8 @@ simulation = false
 # windowing crates into every consumer's graph. The math crate carries
 # the ortho and UV maps.
 [dependencies]
-renew-math = { path = "../core/math" }
-renew-rhi = { path = "../rhi", default-features = false }
+renew-math = { version = "0.1.0", path = "../core/math" }
+renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/render3d/Cargo.toml
+++ b/crates/render3d/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "3d", "mesh", "rendering", "vulkan"]
+categories = ["rendering", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Indexed 3D geometry over the rendering crate: mesh pipelines with and without a camera or a texture, depth-tested, indexed draws in submission order."
@@ -19,7 +22,7 @@ simulation = false
 # geometry and describes draws, it never presents, and taking the default
 # would drag windowing crates into every consumer's graph.
 [dependencies]
-renew-rhi = { path = "../rhi", default-features = false }
+renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false }
 
 # `Scene` is index-and-offset arithmetic over a byte container, which is
 # the row in the testing table that asks for properties rather than

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["replay", "deterministic", "gamedev", "input", "engine"]
+categories = ["game-development", "simulation"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Replaying recorded input deterministically: event-to-trace translation both ways, a tick-indexed trace loader, and the recorder that produces replayable traces."
@@ -20,8 +23,8 @@ simulation = true
 # so the structure check refuses it a path to the platform crate — where
 # the text comes from and where it goes is its caller's business.
 [dependencies]
-renew-event = { path = "../core/event" }
-renew-trace = { path = "../trace" }
+renew-event = { version = "0.1.0", path = "../core/event" }
+renew-trace = { version = "0.1.0", path = "../trace" }
 
 [lints]
 workspace = true

--- a/crates/rhi/Cargo.toml
+++ b/crates/rhi/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["vulkan", "rendering", "gpu", "graphics", "gamedev"]
+categories = ["rendering::graphics-api", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The engine's only doorway to the GPU: device bring-up, window and offscreen render targets, and the draw path from a clear through indexed geometry and a sampled texture."
@@ -34,7 +37,7 @@ ash = { version = "=0.38.0", default-features = false, features = [
 ] }
 ash-window = { version = "=0.13.0", optional = true }
 raw-window-handle = { version = "=0.6.2", optional = true }
-renew-diag = { path = "../core/diag" }
+renew-diag = { version = "0.1.0", path = "../core/diag" }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["rng", "pcg32", "deterministic", "random", "gamedev"]
+categories = ["algorithms", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Seeded, reproducible pseudo-random numbers for simulation: PCG32 with per-domain streams derived from one master seed, and bounded draws with no modulo bias."

--- a/crates/scene/Cargo.toml
+++ b/crates/scene/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "scene-graph", "transform", "ecs", "engine"]
+categories = ["game-development", "data-structures"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Local placements and parent links held as components, and the pass that composes them into world placements, resolving a parent before its children wherever the links form a forest and cutting each loop in exactly one place where they do not."
@@ -22,8 +25,8 @@ simulation = true
 # crate. One would make the GPU cell strip the hierarchy, so the
 # engine's own evidence would read "no parenting without a GPU".
 [dependencies]
-renew-ecs = { path = "../ecs" }
-renew-fixed = { path = "../fixed" }
+renew-ecs = { version = "0.1.0", path = "../ecs" }
+renew-fixed = { version = "0.1.0", path = "../fixed" }
 
 # The propagation is a relation over arbitrary trees, which is the
 # testing table's row for properties rather than examples. The counting

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["gamedev", "interpolation", "snapshot", "deterministic", "engine"]
+categories = ["game-development", "simulation"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "Two captures of one slot space blended by the interpolation factor, keyed by (slot, generation) so a recycled slot's new tenant never inherits the old tenant's motion."
@@ -21,7 +24,7 @@ simulation = false
 # which is what mechanically refuses every simulation crate an edge to
 # it.
 [dependencies]
-renew-math = { path = "../core/math" }
+renew-math = { version = "0.1.0", path = "../core/math" }
 
 # The classification is a property over arbitrary (slot, generation,
 # value) sequences, which is the testing table's containers row. The

--- a/crates/trace/Cargo.toml
+++ b/crates/trace/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["input-trace", "replay", "deterministic", "codec", "gamedev"]
+categories = ["encoding", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The input-trace codec: a line-oriented text format for recorded input, a reader that refuses everything it does not understand, and a writer that is its exact inverse."

--- a/crates/ui-render/Cargo.toml
+++ b/crates/ui-render/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["ui", "rendering", "gamedev", "sprites", "engine"]
+categories = ["rendering", "gui"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The presentation half of the UI: snapshot pairs of the solved widget tree, blended at display rate by the ratified interpolation factor, clipped to ancestor boxes on the CPU, and emitted as premultiplied sprites through the 2D renderer from one generated atlas."
@@ -21,13 +24,13 @@ workspace = true
 [dependencies]
 # The tree being presented: rectangles, styles, and the (slot,
 # generation) identity the snapshot pair is keyed by.
-renew-ui = { path = "../ui" }
+renew-ui = { version = "0.1.0", path = "../ui" }
 # The display-rate half: the interpolation factor and float vectors —
 # the crate a simulation is forbidden from reaching, which is exactly
 # why the presenter may.
-renew-math = { path = "../core/math" }
+renew-math = { version = "0.1.0", path = "../core/math" }
 # The emission surface: sprites over one atlas, one buffer, one item.
-renew-render2d = { path = "../render2d" }
+renew-render2d = { version = "0.1.0", path = "../render2d" }
 
 # The golden oracle needs a device; the counting allocator gates the
 # steady state; property tests drive the clipper.

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -6,7 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
+keywords = ["ui", "layout", "gamedev", "retained-mode", "engine"]
+categories = ["gui", "game-development"]
+readme = "README.md"
+homepage.workspace = true
 
 [package.metadata.renew]
 purpose = "The simulation-side widget tree, its Q47.16 flex-subset layout solver, its integer-only interaction surface, and the versioned document blob trees are read from: generationally addressed nodes solved into pixel rectangles behind a dirty flag, hit-tested for hover/press/focus decisions that fold into the engine state fingerprint."
@@ -21,10 +24,10 @@ workspace = true
 [dependencies]
 # The layout solver's arithmetic: Q47.16, saturating, bit-identical on
 # every target — the crate simulation numbers are written in.
-renew-fixed = { path = "../fixed" }
+renew-fixed = { version = "0.1.0", path = "../fixed" }
 # The digest the tree's decisions fold into — the same explicit-order
 # fingerprint every simulation state answers with.
-renew-frame = { path = "../frame" }
+renew-frame = { version = "0.1.0", path = "../frame" }
 
 # Property tests for the tree's invariants — the containers row of the
 # testing table — and the engine's counting allocator for the


### PR DESCRIPTION
Every engine crate can now be packaged for a registry, and carries the fields
a registry indexes it by.

## What changes

- `keywords` and `categories` on each of the 27 engine crates, chosen per crate
  rather than repeated, so the set does not collapse into a single term.
- `readme` and an inherited `homepage` on each crate; `homepage` is declared once
  on `[workspace.package]`.
- The flag that held each crate back from a registry is removed.
- Path dependencies gain the `version` a packaged manifest requires.
  Development dependencies keep their bare path deliberately: packaging strips
  those, and a version there would impose a publish order they do not need.

## Scope

Additive manifest metadata only. No public API, dependency graph, or build
behaviour changes, so the module DAG and the removability configurations are
untouched. Benchmarks N/A — no code path is affected.

## Evidence

- `cargo metadata` resolves.
- `cargo check --workspace --all-targets` is clean.
- `renew check` reports the workspace structure healthy.
- `cargo publish --dry-run -p renew-event` packages and verifies a leaf crate.

Every category slug is checked against the registry's own category list; an
unknown one is rejected at publish time rather than at build time.