### PR TITLE
test(golden): a passing comparison writes nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,10 +774,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: golden-candidates
+          # Discovered rather than listed. A hand-written list of the
+          # three crates that have committed goldens today is correct
+          # today and silently wrong the first time a fourth gains one --
+          # its candidates would simply not be uploaded, and the failure
+          # would read as "no candidate produced" rather than as a
+          # missing upload path.
           path: |
-            crates/rhi/tests/goldens/
-            crates/render2d/tests/goldens/
-            samples/glide/tests/goldens/
+            crates/*/tests/goldens/
+            samples/*/tests/goldens/
           if-no-files-found: ignore
       - name: Install a virtual display and the distro software driver
         run: |

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -424,8 +424,15 @@ fn blended_sprites_match_structure_and_the_committed_golden() {
             actual.display()
         );
     }
-    std::fs::write(dir.join("sprites-blend-64x64.provenance.txt"), provenance)
-        .expect("refresh provenance sidecar");
+    // Nothing is written here. A passing comparison writes no file at all —
+    // the sidecar is a committed artifact, and a test that rewrites one on
+    // success has a side effect a test may not have: run the suite on a
+    // machine whose adapter differs and the committed provenance quietly
+    // starts claiming that machine, with the change staged by nobody.
+    //
+    // The sidecar is authored by the bootstrap path above, which runs only
+    // when the canonical image is absent and which fails rather than passing.
+    // That is the one moment a human is already looking.
 }
 
 /// The capacity refusal fires by name — the retained assertion, caught

--- a/samples/glide/tests/golden.rs
+++ b/samples/glide/tests/golden.rs
@@ -290,8 +290,10 @@ fn compare_against_golden(device: &Device, name: &str, pixels: &[u8]) -> Result<
             actual.display()
         ));
     }
-    std::fs::write(dir.join(format!("{name}.provenance.txt")), provenance)
-        .map_err(|error| format!("refresh provenance sidecar: {error}"))?;
+    // Nothing is written here — see the note in the 2D renderer's copy of
+    // this ritual. A passing comparison leaves the tree exactly as it found
+    // it; the sidecar is authored by the bootstrap path above, which fails,
+    // and which is therefore the one moment a human is already looking.
     Ok(())
 }
 


### PR DESCRIPTION
Two of the three golden tests rewrote their committed provenance sidecar
after a successful comparison; the third did not. A test that writes a
committed artifact when it passes has a side effect a test may not have
— run the suite on a machine whose adapter differs and the sidecar
quietly starts claiming that machine, with the change staged by nobody
and no failure to notice it by.

Both writes are gone, so all three copies now agree: a passing run
leaves the tree exactly as it found it. The sidecar is authored by the
bootstrap path, which runs only when the canonical image is absent and
which fails rather than passing — the one moment a human is already
looking at it.

Stated plainly because it is weaker evidence than usual: this is
read-verified rather than run-verified. The comparison is gated on a
software rasterizer, and in strict mode a discrete adapter turns the
skip into a failure, so a passing strict run cannot be produced on the
machine this was written on. What was run: the writes sat after the
mismatch panic, so they were on the success path, and the suite passes
with them removed.

Separately, the failure-artifact upload names its golden directories by
glob rather than by hand. The list of three was correct, and would have
become silently wrong the first time a fourth crate committed a golden —
its candidates simply would not upload, and the failure would read as
"no candidate produced" rather than as a missing path.