### PR TITLE
test(render): expectations follow the target format

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -101,7 +101,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1058, 1059, 1060]
+lines = [1102, 1103, 1104]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -38,7 +38,35 @@ const CLEAR: Color = Color {
     b: 153.0 / 255.0,
     a: 1.0,
 };
-const CLEAR_BYTES: [u8; 4] = [51, 102, 153, 255];
+/// The format every target in this file is created with.
+///
+/// Named once so the expectations below can be a function of it. When the
+/// working space changes, this constant moves and every byte derived from
+/// it follows — rather than a scatter of literals each of which is wrong
+/// in the same way and none of which says why.
+const TARGET: TargetFormat = TargetFormat::Rgba8Unorm;
+
+/// What the attachment stores for the clear above.
+///
+/// Derived rather than written down. Under UNORM this is exactly
+/// `[51, 102, 153, 255]`, which is what it always was — an authored byte
+/// survives `round(255 x b/255)` unchanged. The point is what happens when
+/// the format changes: these bytes follow it, and the corner assertions
+/// that read them do not panic before the golden bootstrap path can write
+/// a candidate.
+#[allow(
+    clippy::expect_used,
+    reason = "a colour target that stores no colour is the defect"
+)]
+fn clear_bytes() -> [u8; 4] {
+    let channel = |value: f32| TARGET.stores(value).expect("a color target stores color");
+    [
+        channel(CLEAR.r),
+        channel(CLEAR.g),
+        channel(CLEAR.b),
+        channel(CLEAR.a),
+    ]
+}
 
 /// The 4×4 test atlas, four 2×2 solid regions: opaque red, opaque
 /// green, opaque blue, and half-alpha red — premultiplied, as every
@@ -164,7 +192,7 @@ fn renderer(device: &Device, atlas: &[u8], max_sprites: u32) -> Result<SpriteRen
         device,
         &AtlasDesc::new(ATLAS_EXTENT, atlas),
         canvas,
-        TargetFormat::Rgba8Unorm,
+        TARGET,
         capacity,
     )
     .map_err(|error| error.to_string())
@@ -232,7 +260,7 @@ fn opaque_sprites_match_the_computed_image_exactly() {
     // fill promises: clear, then each sprite's rectangle in push order.
     let mut expected = Vec::with_capacity((SIZE * SIZE * 4) as usize);
     for _ in 0..SIZE * SIZE {
-        expected.extend_from_slice(&CLEAR_BYTES);
+        expected.extend_from_slice(&clear_bytes());
     }
     paint(&mut expected, 8, 8, 16, 16, [255, 0, 0, 255]);
     paint(&mut expected, 32, 8, 16, 16, [0, 255, 0, 255]);
@@ -322,10 +350,10 @@ fn blended_sprites_match_structure_and_the_committed_golden() {
         ]
     };
     for (x, y) in [(0, 0), (SIZE - 1, 0), (0, SIZE - 1), (SIZE - 1, SIZE - 1)] {
-        assert_eq!(pixel_at(x, y), CLEAR_BYTES, "corner ({x},{y}) not clear");
+        assert_eq!(pixel_at(x, y), clear_bytes(), "corner ({x},{y}) not clear");
     }
     let over_clear = pixel_at(36, 36); // half-red over clear only
-    assert_ne!(over_clear, CLEAR_BYTES, "half-alpha sprite left no trace");
+    assert_ne!(over_clear, clear_bytes(), "half-alpha sprite left no trace");
     assert_ne!(
         over_clear,
         [128, 0, 0, 128],

--- a/crates/render2d/tests/zero_alloc.rs
+++ b/crates/render2d/tests/zero_alloc.rs
@@ -26,9 +26,35 @@ const SIZE: u32 = 64;
 /// from a fixed table, so the packed bytes differ frame to frame and
 /// the copy path cannot be skipped by a caching driver.
 const WANDER: [f32; 4] = [24.0, 28.0, 32.0, 36.0];
-/// The clear's exact bytes; the conversion is unambiguous by choice of
-/// channel values, so any adapter must land on them.
-const CLEAR_BYTES: [u8; 4] = [51, 102, 153, 255];
+/// The colour this file clears to, named once so the expectation below can
+/// be derived from it rather than restating its bytes.
+const CLEAR: Color = Color {
+    r: 51.0 / 255.0,
+    g: 102.0 / 255.0,
+    b: 153.0 / 255.0,
+    a: 1.0,
+};
+
+/// The format this file's target is created with, named once so the
+/// expectation below follows it rather than restating it.
+const TARGET: TargetFormat = TargetFormat::Rgba8Unorm;
+
+/// The clear's exact bytes, derived from the format rather than written
+/// down; the conversion is unambiguous by choice of channel values, so any
+/// adapter must land on them.
+#[allow(
+    clippy::expect_used,
+    reason = "a colour target that stores no colour is the defect"
+)]
+fn clear_bytes() -> [u8; 4] {
+    let channel = |value: f32| TARGET.stores(value).expect("a color target stores color");
+    [
+        channel(CLEAR.r),
+        channel(CLEAR.g),
+        channel(CLEAR.b),
+        channel(CLEAR.a),
+    ]
+}
 const RED: Region = Region {
     x: 0,
     y: 0,
@@ -88,7 +114,7 @@ fn steady_state_fill_and_render_allocates_nothing() {
             &atlas,
         ),
         Canvas::new(SIZE, SIZE).expect("nonzero canvas"),
-        TargetFormat::Rgba8Unorm,
+        TARGET,
         core::num::NonZeroU32::new(16).expect("nonzero capacity"),
     )
     .expect("sprite renderer");
@@ -100,7 +126,7 @@ fn steady_state_fill_and_render_allocates_nothing() {
         .expect("offscreen target");
     // 51/255, 102/255, 153/255: unambiguous UNORM conversions, so the
     // liveness checks below can demand exact bytes on any adapter.
-    let clear = Color::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0, 1.0);
+    let clear = CLEAR;
     let mut pixels = vec![0u8; target.byte_len()];
 
     // The premise assertions the vacuity lesson requires. The fixed red
@@ -138,7 +164,7 @@ fn steady_state_fill_and_render_allocates_nothing() {
         );
         assert_eq!(
             pixel_at(pixels, 20, 44),
-            CLEAR_BYTES,
+            clear_bytes(),
             "{when}: a pixel every wander position leaves clear is not clear"
         );
     };

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -51,6 +51,50 @@ impl TargetFormat {
             Self::DepthOnly => None,
         }
     }
+
+    /// The byte this attachment stores for one float color channel, or
+    /// `None` for a format with no color attachment at all.
+    ///
+    /// **This exists so an expectation can be a function of the format
+    /// rather than a literal beside it.** A test that writes `[51, 102,
+    /// 153, 255]` is asserting two things at once — the value it cleared
+    /// to, and the rule the hardware used to store it — and only the
+    /// first is the test's subject. When the storage rule changes, every
+    /// such literal is wrong, and it is wrong *before* any golden
+    /// bootstrap path runs: the corner assertions panic first, so no
+    /// candidate image is written and a refresh that had already deleted
+    /// its goldens has nothing to replace them with. Deriving the byte
+    /// from the format makes that class of failure impossible to reach.
+    ///
+    /// A UNORM attachment stores `round(255 x channel)`, which is what
+    /// makes an authored byte survive a round trip unchanged. An sRGB
+    /// attachment would apply the transfer function instead — that arm
+    /// arrives with the format, and every caller of this follows it
+    /// without being edited.
+    ///
+    /// Values outside `0..=1` clamp, which is what the hardware does.
+    #[must_use]
+    pub fn stores(self, channel: f32) -> Option<u8> {
+        match self {
+            Self::Rgba8Unorm | Self::Bgra8Unorm => {
+                // NaN clamps to zero rather than propagating: `f32::clamp`
+                // panics on a NaN bound but returns NaN for a NaN input,
+                // and `as u8` would then saturate to zero silently. Saying
+                // so here costs one comparison and removes the surprise.
+                let channel = if channel.is_nan() { 0.0 } else { channel };
+                let scaled = channel.clamp(0.0, 1.0) * 255.0;
+                // `round` then truncate: the cast alone truncates, which
+                // would store 50 for a channel authored as 51/255.
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    reason = "clamped to 0..=255 and rounded on the line above"
+                )]
+                Some(scaled.round() as u8)
+            }
+            Self::DepthOnly => None,
+        }
+    }
 }
 
 /// One vertex attribute, in declaration order.
@@ -1310,6 +1354,66 @@ impl Device {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The store rule, at the values an expectation is built from.
+    ///
+    /// The load-bearing case is the round trip: a channel authored as
+    /// `b / 255` must store back as exactly `b`. Every golden clear in the
+    /// tree is written that way, so if this rounds down instead of to
+    /// nearest, `51 / 255` stores as 50 and each of those tests fails by
+    /// one — which is the shape of failure that reads as a driver
+    /// difference and is not one.
+    #[test]
+    fn a_unorm_target_stores_an_authored_byte_unchanged() {
+        for byte in 0..=255u8 {
+            let channel = f32::from(byte) / 255.0;
+            assert_eq!(
+                TargetFormat::Rgba8Unorm.stores(channel),
+                Some(byte),
+                "channel {channel} came from byte {byte}"
+            );
+        }
+    }
+
+    /// Both colour formats store the same way; only their channel order
+    /// differs, and that is the caller's business rather than this rule's.
+    #[test]
+    fn both_colour_formats_agree_on_the_rule() {
+        for byte in [0u8, 1, 51, 128, 254, 255] {
+            let channel = f32::from(byte) / 255.0;
+            assert_eq!(
+                TargetFormat::Rgba8Unorm.stores(channel),
+                TargetFormat::Bgra8Unorm.stores(channel)
+            );
+        }
+    }
+
+    /// A depth-only target has no colour attachment, so there is no byte
+    /// to name — reported rather than invented.
+    #[test]
+    fn a_depth_only_target_stores_no_colour() {
+        assert_eq!(TargetFormat::DepthOnly.stores(0.5), None);
+    }
+
+    /// Out of range clamps the way the hardware does, and a NaN lands on
+    /// zero rather than propagating into a byte by way of a saturating
+    /// cast nobody wrote down.
+    #[test]
+    fn out_of_range_clamps_and_a_nan_is_zero() {
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(-1.0), Some(0));
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(2.0), Some(255));
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(f32::NAN), Some(0));
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(f32::INFINITY), Some(255));
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(f32::NEG_INFINITY), Some(0));
+    }
+
+    /// Rounding is to nearest, not toward zero: the midpoint between two
+    /// stored bytes must land on the upper one.
+    #[test]
+    fn the_rule_rounds_to_nearest_rather_than_truncating() {
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(0.5 / 255.0), Some(1));
+        assert_eq!(TargetFormat::Rgba8Unorm.stores(0.49 / 255.0), Some(0));
+    }
 
     /// The converters, both arms of each, with no device involved.
     ///

--- a/crates/ui-render/tests/golden.rs
+++ b/crates/ui-render/tests/golden.rs
@@ -28,7 +28,34 @@ const CLEAR: Color = Color {
     b: 153.0 / 255.0,
     a: 1.0,
 };
-const CLEAR_BYTES: [u8; 4] = [51, 102, 153, 255];
+/// The format every target in this file is created with.
+///
+/// Named once so the expectations below can be a function of it. When the
+/// working space changes, this constant moves and every byte derived from
+/// it follows — rather than a scatter of literals each of which is wrong
+/// in the same way and none of which says why.
+const TARGET: TargetFormat = TargetFormat::Rgba8Unorm;
+
+/// What the attachment stores for the clear above.
+///
+/// Derived rather than written down. Under UNORM this is exactly
+/// `[51, 102, 153, 255]`, which is what it always was — an authored byte
+/// survives `round(255 x b/255)` unchanged. The point is what happens when
+/// the format changes: these bytes follow it, and the assertions that read
+/// them do not fail before a golden bootstrap path can write a candidate.
+#[allow(
+    clippy::expect_used,
+    reason = "a colour target that stores no colour is the defect"
+)]
+fn clear_bytes() -> [u8; 4] {
+    let channel = |value: f32| TARGET.stores(value).expect("a color target stores color");
+    [
+        channel(CLEAR.r),
+        channel(CLEAR.g),
+        channel(CLEAR.b),
+        channel(CLEAR.a),
+    ]
+}
 const RED: [u8; 4] = [255, 0, 0, 255];
 const BLUE: [u8; 4] = [0, 0, 255, 255];
 
@@ -120,7 +147,7 @@ fn a_presented_tree_lands_in_computed_pixels() {
             &atlas::pixels(),
         ),
         canvas,
-        TargetFormat::Rgba8Unorm,
+        TARGET,
         capacity,
     )
     .expect("sprite renderer");
@@ -143,7 +170,7 @@ fn a_presented_tree_lands_in_computed_pixels() {
 
     let mut expected = Vec::with_capacity((SIZE * SIZE * 4) as usize);
     for _ in 0..SIZE * SIZE {
-        expected.extend_from_slice(&CLEAR_BYTES);
+        expected.extend_from_slice(&clear_bytes());
     }
     // Painted from the rectangles the solver itself answers, so the
     // oracle and the picture share one source of truth; the corner
@@ -216,7 +243,7 @@ fn text_lands_inside_its_measured_box() {
             &atlas::pixels(),
         ),
         canvas,
-        TargetFormat::Rgba8Unorm,
+        TARGET,
         capacity,
     )
     .expect("sprite renderer");
@@ -248,7 +275,7 @@ fn text_lands_inside_its_measured_box() {
     let mut inked = 0u32;
     for y in 4..4 + line_height {
         for x in 4..4 + width {
-            if texel(x, y) != CLEAR_BYTES {
+            if texel(x, y) != clear_bytes() {
                 inked += 1;
             }
         }
@@ -271,7 +298,7 @@ fn text_lands_inside_its_measured_box() {
             if !inside {
                 assert_eq!(
                     texel(x, y),
-                    CLEAR_BYTES,
+                    clear_bytes(),
                     "ink outside the measured box at ({x}, {y}) — measurement and picture disagree"
                 );
             }


### PR DESCRIPTION
A golden expectation written as `[51, 102, 153, 255]` asserts two
things at once — the colour the test cleared to, and the rule the
hardware used to store it — and only the first is the test's subject.
So the second is now derived: `TargetFormat::stores` answers what byte
an attachment keeps for a float channel, and every clear expectation
calls it instead of restating the answer.

Nothing moves. Under a UNORM target the rule is `round(255 x channel)`,
so an authored `51 / 255` stores back as exactly 51 and every derived
byte equals the literal it replaced — which is what the passing
computed-image comparisons prove, since they compare whole frames.

The reason to do this ahead of a format change rather than during one:
these expectations are read by corner assertions that run *before* the
golden bootstrap path. Change the storage rule with the bytes written
down, and those assertions fail first, so no candidate image is ever
written — and a refresh that has already deleted its goldens has
nothing to put back. Deriving the byte from the format makes that
sequence unreachable; each test now names its format once, and the
expectations follow it.

`stores` reports `None` for a depth-only target rather than inventing a
byte for an attachment that does not exist, clamps out-of-range input
the way the hardware does, and rounds to nearest — truncating would
store 50 for a channel authored as 51/255, a one-byte error that reads
like an adapter difference and is not one. Five unit tests cover it,
including the full 256-code round trip.