### PR TITLE
docs: crate READMEs link to files by absolute URL

### DIFF
--- a/crates/asset/README.md
+++ b/crates/asset/README.md
@@ -10,7 +10,7 @@ reader that trusts nothing the file tells it.
   name before writing, so the order they were added in — and therefore the
   order a directory happened to be walked in — never reaches the bytes.
   Nothing here reads a clock, a path, or the environment, and the crate's
-  [clippy.toml](clippy.toml) rejects all three at lint time rather than by
+  [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/asset/clippy.toml) rejects all three at lint time rather than by
   review.
 - **Names are unique and sorted.** Enforced when writing and re-checked
   when reading, because a reader must not assume the file in front of it
@@ -90,7 +90,7 @@ implicit.
 
 `bootstrap`. The container is settled enough to build on; what is stored
 in it is not. The `[package.metadata.renew]` table in
-[Cargo.toml](Cargo.toml) is authoritative for maturity and manifest
+[Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/asset/Cargo.toml) is authoritative for maturity and manifest
 metadata.
 
 ## Key decisions

--- a/crates/core/diag/README.md
+++ b/crates/core/diag/README.md
@@ -62,9 +62,9 @@ process-isolated install/emit integration binaries, all present.
 Settled enough to depend on: the record shape and macro surface are
 what other crates in this workspace build against, and breaking them
 is avoided; examples and a performance narrative are still to come.
-The `[package.metadata.renew]` table in [Cargo.toml](Cargo.toml) is
+The `[package.metadata.renew]` table in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/core/diag/Cargo.toml) is
 authoritative for maturity and all manifest metadata. The crate's
-contract lints live in [clippy.toml](clippy.toml): clock and
+contract lints live in [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/core/diag/clippy.toml): clock and
 filesystem access are rejected at lint time, not by review.
 
 ## Key decisions

--- a/crates/core/math/README.md
+++ b/crates/core/math/README.md
@@ -16,7 +16,7 @@ column-major `Mat4`, a rotation `Quat`, and an axis-aligned `Aabb3` — all
   results for the same build on the same platform. No clock, no
   filesystem, no allocation, no hashing anywhere in the crate — the
   clock/filesystem half is rejected at lint time via
-  [clippy.toml](clippy.toml), not by review.
+  [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/core/math/clippy.toml), not by review.
 - **`normalize` requires a positive squared length** (debug assertion);
   the vector types offer `try_normalize`, returning `Option` where absence
   of a usable direction is a normal outcome — accurate across the full
@@ -48,7 +48,7 @@ Settled enough to depend on: the type surface is what other crates in
 this workspace build against, and breaking it is avoided; operations
 are still added when a consumer needs them, not speculatively —
 examples and a performance narrative are still to come. The
-`[package.metadata.renew]` table in [Cargo.toml](Cargo.toml) is
+`[package.metadata.renew]` table in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/core/math/Cargo.toml) is
 authoritative for maturity and manifest metadata.
 
 ## Key decisions

--- a/crates/core/memory/README.md
+++ b/crates/core/memory/README.md
@@ -69,7 +69,7 @@ Settled enough to depend on: these surfaces are what other crates in
 this workspace build against, and breaking them is avoided; they still
 grow when a consumer needs them — examples and a performance narrative
 are still to come. The `[package.metadata.renew]` table in
-[Cargo.toml](Cargo.toml) is authoritative for maturity and manifest
+[Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/core/memory/Cargo.toml) is authoritative for maturity and manifest
 metadata. `unsafe` is confined to the allocator internals with the
 invariant stated at every block; the arena is `Copy`-only until a
 consumer needs drop-aware allocation.

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -99,7 +99,7 @@ workspace build against, and breaking them is avoided; surfaces still
 grow when a consumer needs them (streaming I/O arrives with the asset
 pipeline; dynamic-library loading stays deferred until something loads
 one) — examples and a performance narrative are still to come. The
-`[package.metadata.renew]` table in [Cargo.toml](Cargo.toml) is
+`[package.metadata.renew]` table in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/core/platform/Cargo.toml) is
 authoritative for maturity and manifest metadata. This crate contains
 no `unsafe` code.
 

--- a/crates/ecs/README.md
+++ b/crates/ecs/README.md
@@ -30,7 +30,7 @@ consequence of the layout.
   tight, and `Store::iter_unordered` exists for systems that genuinely do
   not care about order — its name is the warning.
 - **Nothing here reads a clock, opens a file, or spawns a thread**, and
-  the crate's [clippy.toml](clippy.toml) rejects all three at lint time.
+  the crate's [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/ecs/clippy.toml) rejects all three at lint time.
   `HashMap` is banned for the same reason: its hasher is seeded per
   process, so iterating one would make the order differ every run.
 
@@ -88,7 +88,7 @@ sorted whatever the churn.
 
 `bootstrap`. Storage and handles are settled; everything above them —
 systems, scheduling, a type map — is not. The `[package.metadata.renew]`
-table in [Cargo.toml](Cargo.toml) is authoritative for maturity.
+table in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/ecs/Cargo.toml) is authoritative for maturity.
 
 ## Key decisions
 

--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -4,7 +4,7 @@ Fixed-point arithmetic for simulation code whose output has to reproduce
 bit-for-bit on every target.
 
 **Status: `bootstrap`.** Interface churn expected. See
-[`Cargo.toml`](Cargo.toml) for the machine-readable manifest — maturity,
+[`Cargo.toml`](https://github.com/renew-engine/renew/blob/main/crates/fixed/Cargo.toml) for the machine-readable manifest — maturity,
 dependencies and core status live there, not here.
 
 ## Why this exists

--- a/crates/frame/README.md
+++ b/crates/frame/README.md
@@ -142,8 +142,8 @@ them), and Miri (no `unsafe` anywhere in the crate).
 ## Status
 
 Early-stage. The `[package.metadata.renew]` table in
-[Cargo.toml](Cargo.toml) is authoritative for maturity and all manifest
-metadata. The crate's contract lints live in [clippy.toml](clippy.toml):
+[Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/frame/Cargo.toml) is authoritative for maturity and all manifest
+metadata. The crate's contract lints live in [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/frame/clippy.toml):
 clock reads, thread spawning, filesystem access and randomly seeded hash
 containers are rejected at lint time, because this is the tree's first
 crate designated as simulation code and one `Instant::now` inside

--- a/crates/input/README.md
+++ b/crates/input/README.md
@@ -26,7 +26,7 @@ action, and the set of inputs currently down. Lookup is a binary search;
 at the size a binding table actually reaches, that beats a map and cannot
 surprise anyone with its iteration order.
 
-`HashMap` is banned by the crate's [clippy.toml](clippy.toml), and here it
+`HashMap` is banned by the crate's [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/input/clippy.toml), and here it
 is a real temptation rather than a theoretical one — a binding table is
 the textbook use for one. Its hasher is seeded per process, so resolving
 which action an input drives could differ between runs.
@@ -86,7 +86,7 @@ order does not change behaviour.
 `bootstrap`. Bindings and edges are settled; anything above them — axes,
 chords, gamepads, runtime rebinding UI, serialised binding sets — is not,
 and none of it has a consumer asking yet. The `[package.metadata.renew]`
-table in [Cargo.toml](Cargo.toml) is authoritative for maturity; the word
+table in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/input/Cargo.toml) is authoritative for maturity; the word
 above is a convenience and that table decides.
 
 **It has a consumer now**, which is the more useful fact: the input-echo

--- a/crates/jobs/README.md
+++ b/crates/jobs/README.md
@@ -67,9 +67,9 @@ site).
 Early-stage: the surface is exactly a pool plus parallel-for; work
 stealing, job handles, and dependency graphs are deliberately absent
 until a consumer demands them. The `[package.metadata.renew]` table in
-[Cargo.toml](Cargo.toml) is authoritative for maturity and all manifest
+[Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/jobs/Cargo.toml) is authoritative for maturity and all manifest
 metadata. The crate's contract lints live in
-[clippy.toml](clippy.toml): raw thread spawning, clock reads, and
+[clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/jobs/clippy.toml): raw thread spawning, clock reads, and
 filesystem access are rejected at lint time.
 
 ## Key decisions

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -60,7 +60,7 @@ display server, and the golden-image tests attest the bytes.
   triangle, textured full-target quads over one and two sampled slots,
   instanced quads with and without per-instance depth, the particle
   billboard, and the mesh pairs (sources and compile record in
-  [shaders/](shaders/README.md)).
+  [shaders/](https://github.com/renew-engine/renew/blob/main/crates/rhi/shaders/README.md)).
 - `Binding` — one written descriptor set behind the device's one
   canonical layout (a combined image sampler at binding 0): a texture
   or render image, the sampler that reads it, and shared ownership of
@@ -161,8 +161,8 @@ when a consumer demands it. Mesh memory is
 host-visible rather than device-local, which is a recorded decision with
 a written reopening trigger (a real-GPU frame-time measurement showing
 vertex fetch matters) and not an oversight. The `[package.metadata.renew]` table
-in [Cargo.toml](Cargo.toml) is authoritative for maturity and manifest
-metadata. Contract lints live in [clippy.toml](clippy.toml): thread
+in [Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/rhi/Cargo.toml) is authoritative for maturity and manifest
+metadata. Contract lints live in [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/rhi/clippy.toml): thread
 spawning, clock reads, and filesystem access are rejected at lint time.
 `unsafe` is confined to `src/vk/`; the safe modules deny it, and every
 site carries a `// SAFETY:` comment (lint-enforced).

--- a/crates/trace/README.md
+++ b/crates/trace/README.md
@@ -239,11 +239,11 @@ and Miri (no `unsafe` anywhere in the crate).
 ## Status
 
 Early-stage. The `[package.metadata.renew]` table in
-[Cargo.toml](Cargo.toml) is authoritative for maturity and all manifest
+[Cargo.toml](https://github.com/renew-engine/renew/blob/main/crates/trace/Cargo.toml) is authoritative for maturity and all manifest
 metadata. `extension_points = []` is honest: no trait, no `dyn`, no
 runtime polymorphism.
 
-The contract lints live in [clippy.toml](clippy.toml): filesystem calls,
+The contract lints live in [clippy.toml](https://github.com/renew-engine/renew/blob/main/crates/trace/clippy.toml): filesystem calls,
 file handles, path types, clock reads, thread spawning, environment reads
 and randomly seeded hash containers are all rejected at lint time,
 because *the codec does no I/O* is a property the whole design rests on


### PR DESCRIPTION
A crate README is rendered in three places — the repository, the registry crate page, and the generated documentation — and only the first resolves a relative path the way the author meant.

Every `[Cargo.toml](Cargo.toml)` and `[clippy.toml](clippy.toml)` in a crate README therefore rendered as a dead link on the crate page, resolving against the registry host instead of the repository. 22 links across 12 READMEs, now absolute.

No content changes — link targets only.