### PR TITLE
ci: the contributor agreement is checked rather than assumed

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -46,6 +46,17 @@ jobs:
             echo "Author is a bot; the agreement does not apply."
             exit 0
           fi
+          # CLA.md names the Owner as a person, so this does too. Deriving it
+          # from `author_association` alone is not reliable: an organisation
+          # member whose membership is private reports as CONTRIBUTOR, which
+          # is how the Owner failed their own check the first time this ran.
+          OWNER_LOGIN=CagdasErturk
+
+          echo "author=$AUTHOR association=$ASSOCIATION"
+          if [ "$AUTHOR" = "$OWNER_LOGIN" ]; then
+            echo "Author is the Owner; there is no agreement to make with oneself."
+            exit 0
+          fi
           case "$ASSOCIATION" in
             OWNER|MEMBER)
               echo "Author is $ASSOCIATION of this repository; treated as the Owner."

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,93 @@
+name: CLA
+
+# The agreement in CLA.md is what makes the project's licensing decisions
+# possible at all: section 2 grants the rights, and without a record that a
+# contributor accepted it, their code sits in the tree under no grant but the
+# repository's own licence. That record is a line in a pull request body, and
+# a record no one checks is a record that will eventually be missing.
+#
+# The agreement is given once and covers everything afterwards, so this job
+# accepts either the line on this pull request or the line on an earlier one
+# from the same author.
+#
+# Deliberately `pull_request` rather than `pull_request_target`: this job
+# needs to read pull request bodies and nothing else, and the fork-writable
+# variant would hand a token to a context it has no use for.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  agreement:
+    name: Contributor agreement on record
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look for the agreement on this or an earlier pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # The Owner is the counterparty to the agreement and does not enter
+          # into it with themselves; bots author no copyrightable work. Both
+          # facts are already in the event payload, so neither costs a call.
+          if [ "$AUTHOR_TYPE" = "Bot" ]; then
+            echo "Author is a bot; the agreement does not apply."
+            exit 0
+          fi
+          case "$ASSOCIATION" in
+            OWNER|MEMBER)
+              echo "Author is $ASSOCIATION of this repository; treated as the Owner."
+              exit 0
+              ;;
+          esac
+
+          # Matched loosely on purpose: the sentence is the consent, and a
+          # contributor should not fail this over capitalisation or a stray
+          # space they cannot see in rendered Markdown.
+          PATTERN='i have read cla\.md and i agree to its terms'
+          normalise() { tr -d '\r' | tr '[:upper:]' '[:lower:]' | tr -s ' '; }
+
+          if printf '%s' "$BODY" | normalise | grep -Eq "$PATTERN"; then
+            echo "Agreement found on this pull request."
+            exit 0
+          fi
+
+          echo "Not on this pull request; checking earlier ones by $AUTHOR."
+          earlier=$(gh pr list --repo "$REPO" --author "$AUTHOR" --state all \
+                      --limit 200 --json number,body \
+                      --jq ".[] | select(.number != $NUMBER) | .body" \
+                    | normalise | grep -Ec "$PATTERN" || true)
+
+          if [ "${earlier:-0}" -gt 0 ]; then
+            echo "Agreement found on an earlier pull request; it covers this one."
+            exit 0
+          fi
+
+          cat <<'MSG'
+
+          No contributor agreement is on record for this author.
+
+          Read CLA.md, then add these lines to this pull request's description:
+
+              I have read CLA.md and I agree to its terms.
+              Name: <your full name>
+              Email: <your email>
+              GitHub: @<your username>
+              Date: <YYYY-MM-DD>
+
+          You only do this once. Later pull requests are covered by it, and
+          this check will find the agreement there.
+          MSG
+          exit 1


### PR DESCRIPTION
CLA.md section 2 is what lets the project distribute a contribution at all, and section 9 is what the project promises back. The record that a contributor accepted both is a line in a pull request description, and until now nothing verified that the line was there. A record nobody checks is a record that is eventually missing, and its absence surfaces at the worst possible moment: when the rights matter.

## How it behaves

- Passes when the agreement sentence appears in this pull request's description.
- Passes when it appears on any earlier pull request by the same author, because the agreement is given once and covers everything afterwards.
- Skips bots, and skips authors whose `author_association` is `OWNER` or `MEMBER`, since the Owner is the counterparty and does not agree with themselves.
- Otherwise fails, printing the exact lines to paste and saying it is a one-time step.

Matching is case-insensitive and whitespace-tolerant. The sentence is the consent; nobody should fail this over capitalisation they cannot see in rendered Markdown.

## Notes on the trigger

`pull_request`, not `pull_request_target`. The job reads pull request bodies and does nothing else, so the fork-writable variant would hand out a token for no benefit. The job checks out no code.

Permissions are `contents: read` and `pull-requests: read`.

## Evidence

Workflow YAML parses. The matcher was exercised against the exact sentence, a lowercased form, a form with collapsed whitespace, and the sentence embedded in a full description: all matched. An empty description and the truncated `I have read CLA.md` did not.