### PR TITLE
release: 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hello-engine"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-frame",
 ]
@@ -1582,14 +1582,14 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "renew-asset"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "renew-audio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "renew-bench"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "renew-ecs",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "renew-camera"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-math",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "renew-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-asset",
@@ -1632,11 +1632,11 @@ dependencies = [
 
 [[package]]
 name = "renew-diag"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "renew-ecs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1644,18 +1644,18 @@ dependencies = [
 
 [[package]]
 name = "renew-event"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "renew-fixed"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "renew-frame"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "renew-input"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-event",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "renew-jobs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-diag",
@@ -1681,21 +1681,21 @@ dependencies = [
 
 [[package]]
 name = "renew-math"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "renew-memory"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "renew-particles"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "renew-physics2d"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-ecs",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "renew-physics3d"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-ecs",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "renew-platform"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "raw-window-handle",
@@ -1734,14 +1734,14 @@ dependencies = [
 
 [[package]]
 name = "renew-png"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "renew-render2d"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-math",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "renew-render3d"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "renew-replay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-event",
  "renew-trace",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "renew-rhi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ash",
  "ash-window",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "renew-rng"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-chess"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-platform",
  "renew-sample-chess-rules",
@@ -1797,14 +1797,14 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-chess-rules"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-frame",
 ]
 
 [[package]]
 name = "renew-sample-cube"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-camera",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-cube-world"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-fixed",
  "renew-frame",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-glide"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-audio",
  "renew-event",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-glide-world"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-ecs",
  "renew-frame",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-hello-triangle"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-frame",
  "renew-math",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-input-echo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-frame",
  "renew-input",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-leap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-fixed",
  "renew-platform",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "renew-sample-leap-world"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "renew-ecs",
  "renew-fixed",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "renew-scene"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-ecs",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "renew-snapshot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-math",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "renew-trace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-memory",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "renew-ui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-fixed",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "renew-ui-render"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proptest",
  "renew-fixed",
@@ -2295,7 +2295,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vk-fault-layer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crat
     "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/scene", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/renew-engine/renew"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cargo run --bin hello-engine
 
 ```console
 $ cargo run --bin hello-engine
-hello-engine 0.1.0
+hello-engine 0.1.1
 fixed timestep: 16666667 ns
 frames simulated: 60
 time submitted: 1245000015 ns

--- a/crates/camera/Cargo.toml
+++ b/crates/camera/Cargo.toml
@@ -22,7 +22,7 @@ simulation = false
 # rendering conventions, and the conventions are this crate's own
 # contract rather than a dependency's.
 [dependencies]
-renew-math = { version = "0.1.0", path = "../core/math" }
+renew-math = { version = "0.1.1", path = "../core/math" }
 
 # The projection's monotonicity and range claims are properties over
 # arbitrary points, which is the testing table's row for mathematics.

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -37,7 +37,7 @@ audio-out = ["dep:cpal"]
 # Unconditional, not behind the `window` feature: a headless build still
 # needs to name a key, and the whole point of the extraction is that
 # taking the vocabulary does not mean taking a clock.
-renew-event = { version = "0.1.0", path = "../event" }
+renew-event = { version = "0.1.1", path = "../event" }
 
 # Explicit feature selection: both Linux backends and the window-handle
 # interop. Wayland client-side decorations are deliberately OFF — the
@@ -66,7 +66,7 @@ cpal = { version = "=0.18.1", optional = true, default-features = false }
 # Not optional: the file sink in `diag.rs` is part of this crate's
 # always-available surface. The audio seam also uses it, which is why
 # this line used to be optional.
-renew-diag = { version = "0.1.0", path = "../diag" }
+renew-diag = { version = "0.1.1", path = "../diag" }
 
 [lints]
 workspace = true

--- a/crates/input/Cargo.toml
+++ b/crates/input/Cargo.toml
@@ -46,7 +46,7 @@ simulation = true
 # a filesystem, OS entropy and process spawning into the test graph. It
 # is a test-only edge and no engine code can reach it, but the claim
 # here is about normal dependencies, not the whole tree.
-renew-event = { version = "0.1.0", path = "../core/event" }
+renew-event = { version = "0.1.1", path = "../core/event" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/jobs/Cargo.toml
+++ b/crates/jobs/Cargo.toml
@@ -27,8 +27,8 @@ sanitized = []
 # default-features = false: this crate needs only the thread seam, and
 # pulling platform defaults here would compile the windowing stack into
 # every headless consumer of the job pool (feature unification).
-renew-platform = { version = "0.1.0", path = "../core/platform", default-features = false }
-renew-diag = { version = "0.1.0", path = "../core/diag" }
+renew-platform = { version = "0.1.1", path = "../core/platform", default-features = false }
+renew-diag = { version = "0.1.1", path = "../core/diag" }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/particles/Cargo.toml
+++ b/crates/particles/Cargo.toml
@@ -22,11 +22,11 @@ simulation = false
 # testable on any machine; the GPU-facing half sits behind the `render`
 # feature with its own dependency below.
 [dependencies]
-renew-rng = { version = "0.1.0", path = "../rng" }
+renew-rng = { version = "0.1.1", path = "../rng" }
 # The GPU half's dependency, behind its feature so the pure half stays
 # device-free and the removability story stays one crate wide: a
 # consumer that only steps pools never compiles a graphics API.
-renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false, optional = true }
+renew-rhi = { version = "0.1.1", path = "../rhi", default-features = false, optional = true }
 
 # Property tests for the pool's bounds and expiry — the containers row
 # of the testing table (the lerp endpoint is a bit-exact unit test

--- a/crates/physics2d/Cargo.toml
+++ b/crates/physics2d/Cargo.toml
@@ -22,8 +22,8 @@ extension_points = []
 simulation = true
 
 [dependencies]
-renew-ecs = { version = "0.1.0", path = "../ecs" }
-renew-fixed = { version = "0.1.0", path = "../fixed" }
+renew-ecs = { version = "0.1.1", path = "../ecs" }
+renew-fixed = { version = "0.1.1", path = "../fixed" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/physics3d/Cargo.toml
+++ b/crates/physics3d/Cargo.toml
@@ -21,8 +21,8 @@ extension_points = []
 simulation = true
 
 [dependencies]
-renew-ecs = { version = "0.1.0", path = "../ecs" }
-renew-fixed = { version = "0.1.0", path = "../fixed" }
+renew-ecs = { version = "0.1.1", path = "../ecs" }
+renew-fixed = { version = "0.1.1", path = "../fixed" }
 
 [dev-dependencies]
 proptest = "1.11"

--- a/crates/render2d/Cargo.toml
+++ b/crates/render2d/Cargo.toml
@@ -23,8 +23,8 @@ simulation = false
 # windowing crates into every consumer's graph. The math crate carries
 # the ortho and UV maps.
 [dependencies]
-renew-math = { version = "0.1.0", path = "../core/math" }
-renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false }
+renew-math = { version = "0.1.1", path = "../core/math" }
+renew-rhi = { version = "0.1.1", path = "../rhi", default-features = false }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/render3d/Cargo.toml
+++ b/crates/render3d/Cargo.toml
@@ -22,7 +22,7 @@ simulation = false
 # geometry and describes draws, it never presents, and taking the default
 # would drag windowing crates into every consumer's graph.
 [dependencies]
-renew-rhi = { version = "0.1.0", path = "../rhi", default-features = false }
+renew-rhi = { version = "0.1.1", path = "../rhi", default-features = false }
 
 # `Scene` is index-and-offset arithmetic over a byte container, which is
 # the row in the testing table that asks for properties rather than

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -23,8 +23,8 @@ simulation = true
 # so the structure check refuses it a path to the platform crate — where
 # the text comes from and where it goes is its caller's business.
 [dependencies]
-renew-event = { version = "0.1.0", path = "../core/event" }
-renew-trace = { version = "0.1.0", path = "../trace" }
+renew-event = { version = "0.1.1", path = "../core/event" }
+renew-trace = { version = "0.1.1", path = "../trace" }
 
 [lints]
 workspace = true

--- a/crates/rhi/Cargo.toml
+++ b/crates/rhi/Cargo.toml
@@ -37,7 +37,7 @@ ash = { version = "=0.38.0", default-features = false, features = [
 ] }
 ash-window = { version = "=0.13.0", optional = true }
 raw-window-handle = { version = "=0.6.2", optional = true }
-renew-diag = { version = "0.1.0", path = "../core/diag" }
+renew-diag = { version = "0.1.1", path = "../core/diag" }
 
 [dev-dependencies]
 renew-memory = { path = "../core/memory" }

--- a/crates/scene/Cargo.toml
+++ b/crates/scene/Cargo.toml
@@ -25,8 +25,8 @@ simulation = true
 # crate. One would make the GPU cell strip the hierarchy, so the
 # engine's own evidence would read "no parenting without a GPU".
 [dependencies]
-renew-ecs = { version = "0.1.0", path = "../ecs" }
-renew-fixed = { version = "0.1.0", path = "../fixed" }
+renew-ecs = { version = "0.1.1", path = "../ecs" }
+renew-fixed = { version = "0.1.1", path = "../fixed" }
 
 # The propagation is a relation over arbitrary trees, which is the
 # testing table's row for properties rather than examples. The counting

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -24,7 +24,7 @@ simulation = false
 # which is what mechanically refuses every simulation crate an edge to
 # it.
 [dependencies]
-renew-math = { version = "0.1.0", path = "../core/math" }
+renew-math = { version = "0.1.1", path = "../core/math" }
 
 # The classification is a property over arbitrary (slot, generation,
 # value) sequences, which is the testing table's containers row. The

--- a/crates/ui-render/Cargo.toml
+++ b/crates/ui-render/Cargo.toml
@@ -24,13 +24,13 @@ workspace = true
 [dependencies]
 # The tree being presented: rectangles, styles, and the (slot,
 # generation) identity the snapshot pair is keyed by.
-renew-ui = { version = "0.1.0", path = "../ui" }
+renew-ui = { version = "0.1.1", path = "../ui" }
 # The display-rate half: the interpolation factor and float vectors —
 # the crate a simulation is forbidden from reaching, which is exactly
 # why the presenter may.
-renew-math = { version = "0.1.0", path = "../core/math" }
+renew-math = { version = "0.1.1", path = "../core/math" }
 # The emission surface: sprites over one atlas, one buffer, one item.
-renew-render2d = { version = "0.1.0", path = "../render2d" }
+renew-render2d = { version = "0.1.1", path = "../render2d" }
 
 # The golden oracle needs a device; the counting allocator gates the
 # steady state; property tests drive the clipper.

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -24,10 +24,10 @@ workspace = true
 [dependencies]
 # The layout solver's arithmetic: Q47.16, saturating, bit-identical on
 # every target — the crate simulation numbers are written in.
-renew-fixed = { version = "0.1.0", path = "../fixed" }
+renew-fixed = { version = "0.1.1", path = "../fixed" }
 # The digest the tree's decisions fold into — the same explicit-order
 # fingerprint every simulation state answers with.
-renew-frame = { version = "0.1.0", path = "../frame" }
+renew-frame = { version = "0.1.1", path = "../frame" }
 
 # Property tests for the tree's invariants — the containers row of the
 # testing table — and the engine's counting allocator for the


### PR DESCRIPTION
0.1.0 packages went to the registry without the license text and with README links that resolved against the registry host rather than the repository. Both are fixed on `main` now, and a published version is immutable, so the fixes only reach anyone through a new version.

## What changes

- Workspace version 0.1.0 to 0.1.1, and the 26 intra-workspace dependency pins with it.
- `README.md` updates the recorded `hello-engine` banner, which prints the crate version and therefore changes with it.

## What 0.1.1 carries that 0.1.0 did not

- `LICENSE` in all 27 crate packages, and `NOTICE` in the two carrying Arimo-derived data (#225).
- Crate README links that resolve from the registry and the generated documentation, not only from the repository (#223).

## Evidence

`cargo metadata` resolves, `cargo check --workspace --all-targets` is clean, `renew check` reports the workspace healthy, and `cargo run --bin hello-engine` prints the banner as recorded in the README.

Nothing asserts the version string: the `0.1.0` literals under `tools/cli/tests` are synthetic fixture manifests, unrelated to the workspace version.