### PR TITLE
feat(net): the lockstep datagram format, and one spelling per fact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,21 @@ jobs:
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-rng $sel
           cargo build $sel
           cargo test $sel
+      # The lockstep codec removed entirely. Nothing depends on it yet,
+      # so the exclude list is the crate alone — and that is a fact with
+      # a shelf life: the day a sample takes the dependency, the guard
+      # below reports the crate still in the graph and names the sample
+      # that kept it there, exactly as it did for the trace codec in the
+      # change right after that cell's list was written. Grow this list
+      # then; do not pre-empt it now, because an exclude for a
+      # dependency that does not exist proves nothing and reads as if it
+      # does.
+      - name: Build and test without the lockstep codec
+        run: |
+          sel="--workspace --exclude renew-net"
+          bash "$RUNNER_TEMP/absent-from-graph.sh" renew-net $sel
+          cargo build $sel
+          cargo test $sel
       # The trace codec removed entirely, and with it the sample that
       # records traces. The comment here used to say the list was the
       # crate alone and would fail first the day a sample reached it.
@@ -476,7 +491,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot renew-scene; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot renew-scene renew-net; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
       - name: Build and test the minimal core alone
         run: |
           sel="-p renew-platform -p renew-diag -p renew-event -p renew-memory -p renew-math"
-          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot renew-scene renew-net; do
+          for optional in renew-rhi renew-render2d renew-render3d renew-camera renew-particles renew-png renew-jobs renew-frame renew-rng renew-trace renew-asset renew-ecs renew-input renew-replay renew-audio renew-fixed renew-physics2d renew-physics3d renew-ui renew-ui-render renew-snapshot renew-scene renew-volume renew-net; do
             bash "$RUNNER_TEMP/absent-from-graph.sh" "$optional" $sel
           done
           cargo build $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "renew-net"
+version = "0.1.1"
+
+[[package]]
 name = "renew-particles"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 # stable build every merge depends on would break it.
 exclude = ["fuzz"]
 members = ["bench/suite", "crates/asset", "crates/audio", "crates/camera", "crates/core/diag", "crates/core/event", "crates/core/math", "crates/core/memory", "crates/core/platform", "crates/ecs", "crates/fixed", "crates/frame", "crates/physics2d",
-    "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/scene", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "crates/volume", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
+    "crates/net", "crates/png", "crates/physics3d", "crates/input", "crates/jobs", "crates/particles", "crates/render2d", "crates/render3d", "crates/replay", "crates/rhi", "crates/rng", "crates/scene", "crates/snapshot", "crates/trace", "crates/ui", "crates/ui-render", "crates/volume", "hello-engine", "samples/chess", "samples/chess/rules", "samples/cube", "samples/cube/world", "samples/glide", "samples/leap", "samples/leap/world", "samples/glide/world", "samples/hello_triangle", "samples/input_echo", "tools/cli", "tools/vk-fault-layer"]
 
 [workspace.package]
 version = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ time pending: 11666657 ns
 ## Modules
 
 Every module is independently buildable, testable, and — outside the minimal core —
-removable. CI proves the last part on every commit, and proves it *one crate at a time*: twenty-three
+removable. CI proves the last part on every commit, and proves it *one crate at a time*: twenty-four
 configurations, each with one optional crate and everything that depends on it excluded, every one
-built **and** tested. A twenty-fourth builds the minimal core alone and asserts that no optional crate
+built **and** tested. A twenty-fifth builds the minimal core alone and asserts that no optional crate
 reached its graph. The platform crate is built again with its windowing feature compiled away, and
 the game is built with no graphics crate in its dependency graph at all — which is the removability
 claim from the other side, and the reason the window is a feature rather than a default.
@@ -112,8 +112,9 @@ claim from the other side, and the reason the window is a feature rather than a 
 | **`renew-audio`** | Mixing and playback, behind the platform's device seam | `bootstrap` · optional |
 | **`renew-asset`** | Content-addressed asset packs, with every entry verifiable against its digest | `bootstrap` · optional |
 | **`renew-png`** | PNG encoding with no dependencies — pixels in, the bytes of a file out, so a sample can commit a picture of itself | `bootstrap` · optional |
+| **`renew-net`** | Inputs-only lockstep datagrams: one byte string per fact, and a reader that proves it rather than trusting it | `bootstrap` · optional |
 
-Twenty-eight engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
+Twenty-nine engine crates, five of them core. Six samples and two tools sit beside them; `renew modules`
 prints the live list with each crate's declared maturity, read from its manifest rather than from
 this table.
 
@@ -179,7 +180,7 @@ Every commit on `main` clears all of these, on Windows, Linux, and macOS:
 | No panicking shortcuts | `unwrap`, `expect`, `panic`, `todo`, `dbg!` denied outside tests |
 | `unsafe` denied by default | workspace-wide `unsafe_code = "deny"`; the crates that need it opt in per crate, and `undocumented_unsafe_blocks = "deny"` makes every block state the invariant that keeps it sound |
 | Module graph is a DAG | crate manifest and dependency-graph check (`renew check`) |
-| Optional modules stay removable | twenty-three configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
+| Optional modules stay removable | twenty-four configurations, each excluding one optional crate and its dependents, all built and tested; plus the minimal core alone, asserted to contain no optional crate |
 | Licenses and advisories | `cargo-deny`, over the full dependency tree including dev-dependencies |
 | Sanitizers and Miri | scheduled nightly runs (ASan, TSan, Miri) |
 

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -163,3 +163,8 @@ reason = "The menu-open half of the draw: the presenter's snapshots advanced and
 file = "crates/volume/src/volume.rs"
 lines = [248, 268]
 reason = "Two restatements of a bound already proved, re-anchored from 220 and 240 by content rather than by arithmetic. `index_of` returns only indices inside the cells vector, and the chunk is that index divided by the chunk size, so neither the slot lookup at 248 nor the version lookup at 268 can be absent. The let-else and the if-let say so without a banned expect, which is the shape the sibling exemptions in the rendering crate record for the same reason. Driving either would mean breaking the bounds check they stand behind."
+
+[[exempt]]
+file = "crates/net/src/wire.rs"
+lines = [147]
+reason = "The overflow arm of the Inputs body-size product. Both factors are u8, so the product peaks at 65,025 and cannot leave u64 — no datagram, and no fuzzer, can drive it. The check is written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and this one is reached from a reader parsing hostile bytes. It cannot be folded away either: `Option::and_then` is not callable in a const fn, so the arm has to be spelled out."

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "renew-net"
+description = "The lockstep datagram codec: a self-describing wire format for inputs-only multiplayer, and a reader that refuses everything it does not understand"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+keywords = ["gamedev", "netcode", "lockstep", "deterministic", "engine"]
+categories = ["game-development", "network-programming"]
+readme = "README.md"
+homepage.workspace = true
+
+[package.metadata.renew]
+purpose = "The wire half of inputs-only lockstep: a fixed-width little-endian datagram format with one accepted spelling per fact, a total reader that is a pure function of its bytes, and writers that cannot mint what the reader would refuse. It names peers by index, owns no socket, reads no clock, and spawns nothing."
+maturity = "bootstrap"
+core = false
+extension_points = []
+simulation = true
+
+[lints]
+workspace = true
+
+# Deliberately empty, and load-bearing. This crate declares
+# `simulation = true`, which denies it a dependency path to the platform
+# crate at any depth and in any dependency kind — dev edges included. An
+# empty list makes that promise structural rather than contractual: there
+# is no crate here that could offer a socket, a clock, or a randomly
+# seeded hasher, so there is nothing for a future edit to launder one
+# through.
+#
+# The session state machine arrives with `renew-frame`, for the digest
+# fold. It is not taken now, because nothing here folds one yet and a
+# dependency nothing depends on is a claim about the graph that is not
+# true.
+[dependencies]

--- a/crates/net/LICENSE
+++ b/crates/net/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -9,23 +9,30 @@ and this crate is the half of it that turns button presses into bytes and
 back without ever learning what a button means.
 
 ```rust
+use core::num::NonZeroU64;
 use renew_net::{MAX_DATAGRAM_BYTES, PeerId, wire};
 
 let sender = PeerId::new(0).expect("seat zero is always in range");
-let header = wire::Header { kind: wire::Kind::Inputs, sender, session: 0x51e3 };
+let session = NonZeroU64::new(0x51e3).expect("zero is the pinned illegal session");
+// No kind here: each writer knows the kind it writes, so a datagram whose
+// bytes disagree with the function that made them cannot be expressed.
+let addressing = wire::Addressing { sender, session };
 
-// Three ticks of one-byte inputs, sent as one datagram. The last eight
-// frames ride along in every send, so eight consecutive losses of this
-// peer's stream cost nothing and no round trip recovers them.
+// Three ticks of one-byte inputs, sent as one datagram. Up to eight
+// frames ride in every send — the newest plus seven repeats — so seven
+// consecutive losses of this peer's stream cost nothing, and no round
+// trip recovers them.
 let mut out = [0u8; MAX_DATAGRAM_BYTES];
-let len = wire::write_inputs(&mut out, header, 4_000, 1, 3, &[0b0001, 0b0001, 0b0101])?;
+let len = wire::write_inputs(&mut out, addressing, 4_000, 3, 1, &[0b0001, 0b0001, 0b0101])
+    .expect("three one-byte frames fit a datagram");
 
-let wire::Body::Inputs(body) = wire::read(&out[..len])?.body else { unreachable!() };
+let wire::Body::Inputs(body) = wire::read(&out[..len]).expect("what we just wrote").body else {
+    unreachable!()
+};
 for (tick, frame) in body.iter() {
     // (4000, [0b0001]), (4001, [0b0001]), (4002, [0b0101])
     let _ = (tick, frame);
 }
-# Ok::<(), Box<dyn core::error::Error>>(())
 ```
 
 ## Status
@@ -33,10 +40,10 @@ for (tick, frame) in body.iter() {
 **`bootstrap`.** Interface churn expected; breaking its API costs nothing
 yet. What exists today is the wire format alone — the session state
 machine, the input ring and the digest exchange arrive next, and the
-socket that carries any of it is not here and never will be (see *The
-socket is somewhere else*).
+socket that will carry any of it is not here and never will be (see *The
+socket belongs somewhere else*).
 
-The manifest in [`Cargo.toml`](Cargo.toml) is authoritative for maturity,
+The manifest in [`Cargo.toml`](https://github.com/renew-engine/renew/blob/main/crates/net/Cargo.toml) is authoritative for maturity,
 dependencies and core status. This file does not restate them.
 
 ## Contract
@@ -67,9 +74,9 @@ dependencies and core status. This file does not restate them.
 |---|---|---|
 | `MAX_PEERS` | 8 | **a type decision.** `PeerSet` is one byte because of it, and so is a tick's arrival mask. A ninth seat is a change to those types, not an edit to a number |
 | `MAX_INPUT_BYTES` | 16 | the widest one peer's input may be, per tick |
-| `INPUT_REDUNDANCY` | 8 | how many past frames every datagram repeats — the whole of the loss story |
+| `INPUT_REDUNDANCY` | 8 | the most frames one datagram may carry — the newest plus up to seven repeats, which is the whole of the loss story |
 | `INPUT_WINDOW` | 64 | how far ahead of the pending tick a peer's inputs may buffer; a power of two so a ring index is a mask |
-| `MAX_DATAGRAM_BYTES` | 156 | derived from the four above, not chosen, and asserted against the composition |
+| `MAX_DATAGRAM_BYTES` | 156 | derived rather than chosen: the sixteen-byte header and an `Inputs` body's twelve-byte fixed part, plus `INPUT_REDUNDANCY` frames of `MAX_INPUT_BYTES` each. The composition is asserted where it is defined |
 
 156 bytes sits well inside `MTU_FLOOR`, the 1,200-byte path this protocol
 assumes. Nothing enforces that at run time — it is asserted at compile
@@ -77,15 +84,17 @@ time, because a ceiling raised past it would produce datagrams that vanish
 on some paths and arrive on others, and that reads as a bug in the
 simulation rather than one in the network.
 
-## The socket is somewhere else, and that is the design
+## The socket belongs somewhere else, and that is the design
 
 This crate declares itself simulation code. The engine's structure check
 therefore denies it a dependency path to the platform crate at any depth,
 in any dependency kind — a graph property rather than a lint, because a
-lint matching a definition path is exactly one wrapper deep. So the socket
-cannot be here, and it is not: it lives behind a default-off feature on
+lint matching a definition path is exactly one wrapper deep. So the socket cannot
+be here, and it will not be: it belongs behind a default-off feature on
 the platform crate, with no dependency edge between the two halves in
-either direction. An application holds both and moves bytes across.
+either direction, and an application holding both and moving bytes across.
+**That half is not built yet** — today this crate is the format and
+nothing more.
 
 What that buys is not tidiness. It is that every step of the security
 roadmap — an entropy source, a keyed authentication tag, encryption —
@@ -104,6 +113,13 @@ detects a datagram modified in flight.
 among people who trust each other, over a path the participants control.**
 Not public matchmaking, not untrusted peers, not a listening port on an
 open host.
+
+**A forged digest can end a session, and blame the wrong peer.** Nothing
+authenticates a sender, so a spoofed digest datagram is accepted as that
+peer's — and because a digest mismatch is how this protocol detects
+divergence, one such packet halts the run for everyone and names an
+innocent peer in the report. It is the one remaining single-packet denial
+and it is not defended here.
 
 **Cheating is out of scope, and specifically:** information cheating —
 seeing what you should not — is *unpreventable* in any inputs-only design,
@@ -135,7 +151,48 @@ Discriminants start at one and the session id is never zero, so an
 all-zero buffer names nothing. There is no padding in the header: the
 sender byte occupies what would otherwise be one.
 
-Four bodies follow it — parameters at the handshake, a run of consecutive
-per-tick inputs, a pair of fingerprints, and a departure that names the
-tick it happened at. The exact layouts are in
-[`wire.rs`](src/wire.rs), one named constant per offset.
+Four bodies follow it. Offsets below are from the start of the body, so
+add sixteen for the offset in the datagram.
+
+**`Hello` — 40 bytes.** The parameters a peer claims it is playing under.
+They are redundant with the agreement digest by construction, and carried
+anyway: the digest decides, the plaintext explains, so a refusal can name
+*which* parameter differs.
+
+| off | size | field |
+|---|---|---|
+| 0 | 8 | `agreement_digest` |
+| 8 | 8 | `content` — what assets, an opaque number the engine never computes |
+| 16 | 8 | `rules` — what code, the same |
+| 24 | 8 | `seed` |
+| 32 | 1 | `peer_count` — 2 to 8 |
+| 33 | 1 | `input_bytes` — 1 to 16 |
+| 34 | 1 | `input_delay` — below 64 |
+| 35 | 1 | `digest_period` — at least 1 |
+| 36 | 4 | reserved, must be zero |
+
+**`Inputs` — 12 bytes, then `count × input_bytes` more.**
+
+| off | size | field |
+|---|---|---|
+| 0 | 8 | `first_tick` |
+| 8 | 1 | `count` — 1 to 8, the whole run including the newest frame |
+| 9 | 1 | `input_bytes` — 1 to 16 |
+| 10 | 2 | reserved, must be zero |
+| 12 | `count × input_bytes` | the frames, ascending from `first_tick` |
+
+The width rides along so the codec is self-describing and can be fuzzed
+with no session at all; a session then proves it against its own
+parameter, rather than trusting what arrived.
+
+**`Digest` — 24 bytes.** `tick` at 0, the world's own fingerprint after
+that tick at 8, and the sender's running fold of every confirmed input set
+at 16.
+
+**`Bye` — 8 bytes.** `tick` at 0: the last tick this peer confirmed.
+
+The same offsets appear in
+[`wire.rs`](https://github.com/renew-engine/renew/blob/main/crates/net/src/wire.rs)
+as one named constant each, and a test types a whole datagram out by hand
+from *this* table and holds the codec against it — so the two halves of
+the crate cannot agree on a layout that this page denies.

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -1,0 +1,141 @@
+# renew-net
+
+The lockstep datagram codec: a self-describing wire format for inputs-only
+multiplayer, and a reader that refuses everything it does not understand.
+
+A world too large to replicate as state is nearly free to replicate as
+"everybody pressed these buttons". That is the whole premise of lockstep,
+and this crate is the half of it that turns button presses into bytes and
+back without ever learning what a button means.
+
+```rust
+use renew_net::{MAX_DATAGRAM_BYTES, PeerId, wire};
+
+let sender = PeerId::new(0).expect("seat zero is always in range");
+let header = wire::Header { kind: wire::Kind::Inputs, sender, session: 0x51e3 };
+
+// Three ticks of one-byte inputs, sent as one datagram. The last eight
+// frames ride along in every send, so eight consecutive losses of this
+// peer's stream cost nothing and no round trip recovers them.
+let mut out = [0u8; MAX_DATAGRAM_BYTES];
+let len = wire::write_inputs(&mut out, header, 4_000, 1, 3, &[0b0001, 0b0001, 0b0101])?;
+
+let wire::Body::Inputs(body) = wire::read(&out[..len])?.body else { unreachable!() };
+for (tick, frame) in body.iter() {
+    // (4000, [0b0001]), (4001, [0b0001]), (4002, [0b0101])
+    let _ = (tick, frame);
+}
+# Ok::<(), Box<dyn core::error::Error>>(())
+```
+
+## Status
+
+**`bootstrap`.** Interface churn expected; breaking its API costs nothing
+yet. What exists today is the wire format alone — the session state
+machine, the input ring and the digest exchange arrive next, and the
+socket that carries any of it is not here and never will be (see *The
+socket is somewhere else*).
+
+The manifest in [`Cargo.toml`](Cargo.toml) is authoritative for maturity,
+dependencies and core status. This file does not restate them.
+
+## Contract
+
+- **State never crosses this wire.** Only inputs do. What a legal input
+  *is* remains the game's question: inputs are opaque fixed-width bytes
+  here.
+- **Every frame is addressed by an absolute tick**, never a delta and
+  never a sequence number. Arrival order, duplication and loss cannot
+  reach any value this crate hands out.
+- **One byte string per fact.** The format admits exactly one spelling of
+  anything it can carry, and `read` *proves* that rather than trusting it:
+  length equality rather than a lower bound, one accepted version, closed
+  enumerations, and every reserved byte proven zero. A test flips every
+  bit of every byte of every kind and asserts that no mutation yields a
+  second spelling of the same datagram.
+- **The reader is total** over every possible byte string. It allocates
+  nothing, panics on nothing, and holds no state.
+- **A writer cannot mint what the reader would refuse** — the ceilings are
+  enforced in argument types where they can be, and in a refusal where
+  they cannot. `write_inputs` refuses rather than truncating, because a
+  silently shorter run would be a second spelling of a shorter fact.
+- **This crate owns no socket, reads no clock, and spawns nothing.**
+
+## Ceilings, and which of them are types
+
+| | | |
+|---|---|---|
+| `MAX_PEERS` | 8 | **a type decision.** `PeerSet` is one byte because of it, and so is a tick's arrival mask. A ninth seat is a change to those types, not an edit to a number |
+| `MAX_INPUT_BYTES` | 16 | the widest one peer's input may be, per tick |
+| `INPUT_REDUNDANCY` | 8 | how many past frames every datagram repeats — the whole of the loss story |
+| `INPUT_WINDOW` | 64 | how far ahead of the pending tick a peer's inputs may buffer; a power of two so a ring index is a mask |
+| `MAX_DATAGRAM_BYTES` | 156 | derived from the four above, not chosen, and asserted against the composition |
+
+156 bytes sits well inside `MTU_FLOOR`, the 1,200-byte path this protocol
+assumes. Nothing enforces that at run time — it is asserted at compile
+time, because a ceiling raised past it would produce datagrams that vanish
+on some paths and arrive on others, and that reads as a bug in the
+simulation rather than one in the network.
+
+## The socket is somewhere else, and that is the design
+
+This crate declares itself simulation code. The engine's structure check
+therefore denies it a dependency path to the platform crate at any depth,
+in any dependency kind — a graph property rather than a lint, because a
+lint matching a definition path is exactly one wrapper deep. So the socket
+cannot be here, and it is not: it lives behind a default-off feature on
+the platform crate, with no dependency edge between the two halves in
+either direction. An application holds both and moves bytes across.
+
+What that buys is not tidiness. It is that every step of the security
+roadmap — an entropy source, a keyed authentication tag, encryption —
+lands at the socket seam and changes no line of the code that decides what
+a tick means.
+
+## What this is not, stated plainly
+
+**There is no authentication, no confidentiality, and no integrity
+protection.** Peer identity is a source address plus a session id.
+Anything on the path, or anything able to spoof a rostered peer's address,
+is indistinguishable from that peer. Nothing is encrypted, and nothing
+detects a datagram modified in flight.
+
+**The deployment this is built for is a LAN, or an explicit invitation
+among people who trust each other, over a path the participants control.**
+Not public matchmaking, not untrusted peers, not a listening port on an
+open host.
+
+**Cheating is out of scope, and specifically:** information cheating —
+seeing what you should not — is *unpreventable* in any inputs-only design,
+because every peer necessarily holds the whole world. That is the premise
+that makes a large world affordable at all. What the model does give is
+narrower and real: state never crosses the wire, so **a cheater can lie to
+himself and cannot lie to anyone else.** Nothing a peer sends can change
+another peer's world except an input the rules would have accepted from
+them.
+
+A reader who assumes lockstep implies anti-cheat will be wrong in an
+expensive way, which is why this section is here rather than in a document
+nobody downstream reads.
+
+## The format
+
+Little-endian throughout, fixed width, no varints, no optional fields.
+Every datagram opens with the same sixteen bytes:
+
+| off | size | field |
+|---|---|---|
+| 0 | 4 | magic `RNWL` |
+| 4 | 2 | wire version — exactly one value is accepted |
+| 6 | 1 | kind — `1` Hello, `2` Inputs, `3` Digest, `4` Bye |
+| 7 | 1 | the claimed sender's seat |
+| 8 | 8 | session id — never zero |
+
+Discriminants start at one and the session id is never zero, so an
+all-zero buffer names nothing. There is no padding in the header: the
+sender byte occupies what would otherwise be one.
+
+Four bodies follow it — parameters at the handshake, a run of consecutive
+per-tick inputs, a pair of fingerprints, and a departure that names the
+tick it happened at. The exact layouts are in
+[`wire.rs`](src/wire.rs), one named constant per offset.

--- a/crates/net/clippy.toml
+++ b/crates/net/clippy.toml
@@ -1,0 +1,50 @@
+# Crate-local lint configuration (a crate-local file fully replaces the
+# workspace one, so the test allowances are repeated).
+#
+# This crate is a codec and nothing else: bytes in, a validated view out;
+# a value in, bytes out. It opens nothing, reads no clock, and spawns
+# nothing. The graph half of that promise is the structure check's
+# simulation-closure rule, which denies this crate any path to the
+# platform crate at any depth; this file is the source half, and it
+# exists because a graph rule cannot see a call that needs no dependency
+# to make.
+#
+# `std::net` is deliberately NOT banned here, and the omission is the
+# point. A definition-path ban is exactly one wrapper deep, which is the
+# evasion the graph rule exists to close — and the graph rule already
+# forbids this crate every path to the only crate ADR-0025 permits to
+# spell `std::net` at all. A ban here would read as the defence when it
+# would be the weaker half of one.
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
+    { path = "std::time::SystemTime::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded until an accepted decision record defines a deterministic parallel-scheduling contract, and this crate is not that record" },
+    { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
+    { path = "std::fs::read", reason = "this crate never touches the filesystem: it takes bytes a caller already holds" },
+    { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the seam that can refuse an oversized file, which is not here" },
+    { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },
+    { path = "std::io::Read::read_to_end", reason = "the same unbounded read by the other road" },
+    { path = "std::fs::write", reason = "this crate never touches the filesystem: it returns bytes for a caller to send" },
+    { path = "std::fs::File::open", reason = "this crate never touches the filesystem" },
+    { path = "std::fs::File::create", reason = "this crate never touches the filesystem" },
+    { path = "std::env::var", reason = "a session is a pure function of its parameters and its inputs; a value read from the environment would make one peer differ from the next with nothing on the wire to explain it" },
+]
+
+disallowed-types = [
+    { path = "std::hash::RandomState", reason = "it seeds itself from the operating system, so any value derived from it differs between runs — unseeded randomness, which simulation code may not contain" },
+    { path = "std::collections::hash_map::DefaultHasher", reason = "the same road to the same entropy: it is built from RandomState" },
+    { path = "std::collections::HashMap", reason = "the default hasher is seeded per instance, so iteration order varies between runs; peers are a dense index-keyed array here and always will be" },
+    { path = "std::collections::HashSet", reason = "the default hasher is seeded per instance, so iteration order varies between runs" },
+    { path = "std::fs::File", reason = "the crate opens nothing; banning the type catches every road to a handle, not only the two obvious calls" },
+    { path = "std::fs::OpenOptions", reason = "the long way to the same handle" },
+    { path = "std::path::Path", reason = "this crate takes bytes, never a path: a function that can name a file will eventually open one" },
+    { path = "std::path::PathBuf", reason = "this crate takes bytes, never a path" },
+]
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -8,16 +8,21 @@
 //! without ever learning what a button means.
 //!
 //! ```
+//! use core::num::NonZeroU64;
 //! use renew_net::{PeerId, wire};
 //!
 //! let sender = PeerId::new(0).expect("seat zero is always in range");
-//! let header = wire::Header { kind: wire::Kind::Bye, sender, session: 7 };
+//! let session = NonZeroU64::new(7).expect("zero is the pinned illegal session");
+//! let addressing = wire::Addressing { sender, session };
 //!
 //! let mut out = [0u8; renew_net::MAX_DATAGRAM_BYTES];
-//! let len = wire::write_bye(&mut out, header, &wire::ByeBody { tick: 900 });
+//! let len = wire::write_bye(&mut out, addressing, &wire::ByeBody { tick: 900 });
 //!
 //! let read = wire::read(&out[..len]).expect("a datagram this crate wrote");
-//! assert_eq!(read.header, header);
+//! // The kind is the writer's, never the caller's — so the header that
+//! // comes back names the function that was called.
+//! assert_eq!(read.header.kind, wire::Kind::Bye);
+//! assert_eq!(read.header.addressing(), addressing);
 //! ```
 //!
 //! # Contract
@@ -90,14 +95,20 @@ pub const MAX_PEERS: u8 = 8;
 /// multiplying anything by anything*.
 pub const MAX_INPUT_BYTES: u8 = 16;
 
-/// How many past frames every `Inputs` datagram repeats, and therefore
-/// how many consecutive losses of one peer's stream cost nothing.
+/// The most frames one `Inputs` datagram may carry: the newest tick, plus
+/// up to seven older ones repeated behind it.
 ///
-/// This is the whole of the loss story: no acknowledgements, no
-/// retransmit requests, no sequence windows. Seven bytes of tail on a
-/// one-byte input repairs seven consecutive losses with zero round trips,
-/// where a retransmit protocol would spend a round trip recovering data
-/// that has already expired.
+/// **A total, not a tail** — [`wire::read`] bounds the whole run by this
+/// number, and the widest datagram multiplies by it. So the repair it buys
+/// is *seven* consecutive losses of one peer's stream, not eight: the
+/// datagram for tick T carries T−7 through T, and if every datagram from T
+/// through T+7 is lost then tick T is never heard.
+///
+/// This is the whole of the loss story: no acknowledgements, no retransmit
+/// requests, no sequence windows. Seven bytes of tail on a one-byte input
+/// repairs seven consecutive losses with zero round trips, where a
+/// retransmit protocol would spend a round trip recovering data that has
+/// already expired.
 pub const INPUT_REDUNDANCY: u8 = 8;
 
 /// The depth of a peer's input ring, and the ceiling on how far ahead of

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -1,0 +1,168 @@
+//! The lockstep datagram codec: a self-describing wire format for
+//! inputs-only multiplayer, and a reader that refuses everything it does
+//! not understand.
+//!
+//! A world too large to replicate as state is nearly free to replicate as
+//! "everybody pressed these buttons". That is the whole premise, and this
+//! crate is the half of it that turns button presses into bytes and back
+//! without ever learning what a button means.
+//!
+//! ```
+//! use renew_net::{PeerId, wire};
+//!
+//! let sender = PeerId::new(0).expect("seat zero is always in range");
+//! let header = wire::Header { kind: wire::Kind::Bye, sender, session: 7 };
+//!
+//! let mut out = [0u8; renew_net::MAX_DATAGRAM_BYTES];
+//! let len = wire::write_bye(&mut out, header, &wire::ByeBody { tick: 900 });
+//!
+//! let read = wire::read(&out[..len]).expect("a datagram this crate wrote");
+//! assert_eq!(read.header, header);
+//! ```
+//!
+//! # Contract
+//!
+//! - **State never crosses this wire.** Only inputs do. What a legal
+//!   input *is* remains the game's question: inputs are opaque
+//!   fixed-width bytes here, exactly as the trace codec declines to know
+//!   what a seed does.
+//! - **Every frame is addressed by an absolute tick**, never by a delta
+//!   and never by a sequence number. Arrival order, duplication and loss
+//!   therefore cannot reach any value this crate hands out.
+//! - **One byte string per fact.** The format admits exactly one spelling
+//!   of anything it can carry, and [`wire::read`] proves that rather than
+//!   trusting it: length equality rather than a lower bound, one accepted
+//!   version, closed enumerations, and every byte the semantics do not
+//!   read proven zero.
+//! - **The reader is total.** It is a pure function over every possible
+//!   byte string. It allocates nothing, panics on nothing, and holds no
+//!   state. Everything decidable from the bytes alone is decided here;
+//!   everything session-relative — whether this is *our* session, whether
+//!   that seat is in *our* roster — belongs to the session, which knows
+//!   the session.
+//! - **A writer cannot mint what the reader would refuse.** Every ceiling
+//!   the reader enforces, a writer enforces first, in its argument types
+//!   where it can and in a refusal where it cannot.
+//! - **This crate owns no socket, reads no clock, and spawns nothing.**
+//!   It cannot: it declares `simulation = true`, which denies it a
+//!   dependency path to the platform crate at any depth, in any
+//!   dependency kind. Bytes arrive as slices and leave as slices.
+//!
+//! Machine-readable facts about this crate — maturity, dependencies, core
+//! status, whether it is simulation code — live in `Cargo.toml` under
+//! `[package.metadata.renew]`, which is authoritative. This file does not
+//! restate them.
+
+// The engine-crate pair: diagnostics leave through sinks, never through a
+// process's standard streams.
+#![deny(clippy::print_stdout, clippy::print_stderr)]
+// Required today by nothing that runs: the float-closure rule asks a
+// crate a simulation *reaches* for this deny and never asks the
+// declaring crate itself. Written by hand until that rule gains the half
+// it is missing.
+#![deny(clippy::float_arithmetic)]
+// Every byte this crate reads can come off a hostile wire, and a release
+// build aborts on panic. An unchecked index is therefore a remote process
+// abort and an unchecked add is a remote abort in debug and a wrong
+// answer in release — and the workspace lint table denies neither. Both
+// bans are load-bearing rather than stylistic, which is why they sit at
+// the root instead of at the two functions that obviously need them.
+#![deny(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
+
+mod peer;
+pub mod wire;
+
+pub use peer::{PeerId, PeerSet, peers};
+
+/// The most peers one session may hold.
+///
+/// Eight is the roster co-operative play is built for, and it is a **type
+/// decision rather than a tunable**: [`PeerSet`] is one byte because of
+/// it, and so is a tick's arrival mask. Nine peers is a change to those
+/// types, not an edit to this number, and the README says so where a
+/// reader will meet it.
+pub const MAX_PEERS: u8 = 8;
+
+/// The widest input one peer may submit per tick.
+///
+/// A ceiling, not a target: two trits and three bits fit in one byte, and
+/// a quantised aim pair adds two. The reader refuses past it *before
+/// multiplying anything by anything*.
+pub const MAX_INPUT_BYTES: u8 = 16;
+
+/// How many past frames every `Inputs` datagram repeats, and therefore
+/// how many consecutive losses of one peer's stream cost nothing.
+///
+/// This is the whole of the loss story: no acknowledgements, no
+/// retransmit requests, no sequence windows. Seven bytes of tail on a
+/// one-byte input repairs seven consecutive losses with zero round trips,
+/// where a retransmit protocol would spend a round trip recovering data
+/// that has already expired.
+pub const INPUT_REDUNDANCY: u8 = 8;
+
+/// The depth of a peer's input ring, and the ceiling on how far ahead of
+/// the pending tick that peer's inputs may be buffered.
+///
+/// Flow control and memory bound in one: a frame past it is refused
+/// rather than stored, which is what stops the fastest machine spending
+/// the slowest machine's memory. **A power of two on purpose** — a ring
+/// index is `tick & (INPUT_WINDOW - 1)`, and `%` would trip this crate's
+/// arithmetic deny where a mask does not.
+pub const INPUT_WINDOW: u32 = 64;
+
+/// The largest datagram this protocol can produce, in bytes.
+///
+/// Derived, not chosen: a header plus the widest body, which is an
+/// `Inputs` datagram at both of its ceilings. A unit test asserts the
+/// composition, so raising a ceiling cannot silently mint a datagram no
+/// path carries.
+pub const MAX_DATAGRAM_BYTES: usize = wire::HEADER_BYTES
+    + wire::INPUTS_BODY_BYTES
+    + (INPUT_REDUNDANCY as usize) * (MAX_INPUT_BYTES as usize);
+
+/// The smallest maximum transmission unit this protocol assumes a path
+/// will carry, in bytes: the IPv6 minimum, less generous room for headers
+/// and tunnels.
+///
+/// **Nothing enforces this at run time** — there is no path-MTU discovery
+/// here, and a datagram is never fragmented by this crate. It exists so
+/// that a unit test can hold [`MAX_DATAGRAM_BYTES`] against it, because a
+/// ceiling raised past this line would produce datagrams that vanish on
+/// some paths and arrive on others, which is the worst failure this
+/// protocol could have: one that looks like a bug in the simulation.
+pub const MTU_FLOOR: usize = 1200;
+
+// Two facts a test could only report after the build that broke them
+// succeeded. They are asserted where they are decided instead: raising a
+// ceiling past either of these lines fails compilation, with the reason
+// printed at the constant that caused it.
+const _: () = assert!(
+    MAX_DATAGRAM_BYTES <= MTU_FLOOR,
+    "a datagram wider than the smallest assumed path would vanish on some routes and arrive on \
+     others, which reads as a bug in the simulation rather than one in the network"
+);
+const _: () = assert!(
+    MAX_PEERS <= 8,
+    "PeerSet and a tick's arrival mask are each one byte; a ninth seat is a change to those types, \
+     not an edit to this constant"
+);
+
+#[cfg(test)]
+mod tests {
+    use super::{INPUT_REDUNDANCY, MAX_DATAGRAM_BYTES, MAX_INPUT_BYTES, wire};
+
+    #[test]
+    fn the_widest_datagram_is_the_sum_of_its_parts() {
+        let widest = wire::HEADER_BYTES
+            + wire::INPUTS_BODY_BYTES
+            + usize::from(INPUT_REDUNDANCY) * usize::from(MAX_INPUT_BYTES);
+        assert_eq!(
+            MAX_DATAGRAM_BYTES, widest,
+            "the ceiling and the composition it is derived from have parted"
+        );
+        assert_eq!(
+            MAX_DATAGRAM_BYTES, 156,
+            "the number a reader can check by hand"
+        );
+    }
+}

--- a/crates/net/src/peer.rs
+++ b/crates/net/src/peer.rs
@@ -1,0 +1,197 @@
+//! Who is in a session, and in what order they are always visited.
+
+use crate::MAX_PEERS;
+
+/// One seat in a session, by index.
+///
+/// **Never an address.** The mapping from "where these bytes came from"
+/// to "which seat sent them" belongs to the driver, held in whatever
+/// table its transport gives it. This crate compares seats, orders them,
+/// and does nothing else with them — which is what lets the same session
+/// run over a mesh, over a relayed link, or over no socket at all in a
+/// test, without learning that any of those exist.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeerId(u8);
+
+impl PeerId {
+    /// A seat by index, or `None` at or past [`MAX_PEERS`].
+    ///
+    /// The only constructor. A seat that cannot be built out of range is
+    /// a seat no later check has to remember to reject.
+    #[must_use]
+    pub const fn new(index: u8) -> Option<Self> {
+        if index < MAX_PEERS {
+            Some(Self(index))
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub const fn index(self) -> u8 {
+        self.0
+    }
+}
+
+/// Every seat, ascending, whether or not a session holds them all.
+///
+/// The iteration order of the whole type, exported so a caller writing
+/// its own per-seat loop cannot choose a different one by accident.
+pub fn peers() -> impl Iterator<Item = PeerId> {
+    (0..MAX_PEERS).filter_map(PeerId::new)
+}
+
+/// A set of seats, as one byte.
+///
+/// **Iteration is ascending by index, always** — the same contract
+/// `renew-ecs` makes about slot order, and for the same reason: a set
+/// that iterated in any other order could put arrival time into digested
+/// state, and every peer would diverge from every other while each ran
+/// correct code. Making the container incapable of another order is
+/// cheaper than a rule every future contributor has to remember and every
+/// reviewer has to catch.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PeerSet(u8);
+
+impl PeerSet {
+    /// No seats.
+    pub const EMPTY: Self = Self(0);
+
+    /// The first `count` seats.
+    ///
+    /// A `count` above [`MAX_PEERS`] is **clamped**, not refused: a roster
+    /// is validated where it is declared — at the handshake, which can
+    /// name the peer that lied about it — and a set that silently held a
+    /// ninth seat here would be worse than one that holds eight.
+    #[must_use]
+    pub const fn of_count(count: u8) -> Self {
+        let held = if count < MAX_PEERS { count } else { MAX_PEERS };
+        // `1 << 8` would overflow the byte; the clamp above is what makes
+        // the shift total, and the mask is written rather than computed
+        // for the same reason.
+        if held >= MAX_PEERS {
+            Self(u8::MAX)
+        } else {
+            Self((1u8 << held).wrapping_sub(1))
+        }
+    }
+
+    #[must_use]
+    pub const fn contains(self, peer: PeerId) -> bool {
+        self.0 & (1u8 << peer.index()) != 0
+    }
+
+    #[must_use]
+    pub const fn with(self, peer: PeerId) -> Self {
+        Self(self.0 | (1u8 << peer.index()))
+    }
+
+    #[must_use]
+    pub const fn without(self, peer: PeerId) -> Self {
+        Self(self.0 & !(1u8 << peer.index()))
+    }
+
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// How many seats are in the set.
+    ///
+    /// `u32` rather than `usize`, and deliberately: no pointer-width value
+    /// may enter a digest, and this one can.
+    #[must_use]
+    pub const fn count(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// The raw bits, for a caller folding this set into a fingerprint.
+    #[must_use]
+    pub const fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// The seats in the set, ascending by index. The only order this type
+    /// ever hands out.
+    pub fn iter(self) -> impl Iterator<Item = PeerId> {
+        peers().filter(move |peer| self.contains(*peer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PeerId, PeerSet, peers};
+    use crate::MAX_PEERS;
+
+    fn seat(index: u8) -> PeerId {
+        PeerId::new(index).expect("a seat the test chose in range")
+    }
+
+    #[test]
+    fn a_seat_past_the_ceiling_cannot_be_built() {
+        assert!(PeerId::new(MAX_PEERS).is_none());
+        assert!(PeerId::new(u8::MAX).is_none());
+        assert!(PeerId::new(MAX_PEERS.saturating_sub(1)).is_some());
+    }
+
+    #[test]
+    fn the_whole_roster_is_a_full_byte() {
+        assert_eq!(PeerSet::of_count(MAX_PEERS).bits(), u8::MAX);
+        assert_eq!(PeerSet::of_count(MAX_PEERS).count(), u32::from(MAX_PEERS));
+    }
+
+    #[test]
+    fn an_oversized_roster_clamps_rather_than_overflowing() {
+        // The shift that builds the mask is only total because of this
+        // clamp, so the test is about the arithmetic and not only the API.
+        assert_eq!(PeerSet::of_count(u8::MAX), PeerSet::of_count(MAX_PEERS));
+        assert_eq!(
+            PeerSet::of_count(MAX_PEERS.saturating_add(1)).count(),
+            u32::from(MAX_PEERS)
+        );
+    }
+
+    #[test]
+    fn a_partial_roster_holds_exactly_its_prefix() {
+        let two = PeerSet::of_count(2);
+        assert!(two.contains(seat(0)) && two.contains(seat(1)));
+        assert!(!two.contains(seat(2)));
+        assert_eq!(two.count(), 2);
+    }
+
+    #[test]
+    fn the_empty_set_is_empty_and_the_only_one() {
+        assert!(PeerSet::EMPTY.is_empty());
+        assert_eq!(PeerSet::EMPTY, PeerSet::of_count(0));
+        assert_eq!(PeerSet::EMPTY, PeerSet::default());
+        assert_eq!(PeerSet::EMPTY.iter().count(), 0);
+    }
+
+    #[test]
+    fn adding_and_removing_a_seat_are_inverse() {
+        let set = PeerSet::EMPTY.with(seat(3)).with(seat(5));
+        assert_eq!(set.count(), 2);
+        assert_eq!(set.without(seat(5)).without(seat(3)), PeerSet::EMPTY);
+        // Idempotent in both directions: a set is a set.
+        assert_eq!(set.with(seat(3)), set);
+        assert_eq!(set.without(seat(1)), set);
+    }
+
+    #[test]
+    fn iteration_ascends_whatever_order_the_seats_were_added_in() {
+        let forwards = PeerSet::EMPTY.with(seat(1)).with(seat(4)).with(seat(6));
+        let backwards = PeerSet::EMPTY.with(seat(6)).with(seat(4)).with(seat(1));
+        let order: Vec<u8> = forwards.iter().map(PeerId::index).collect();
+        assert_eq!(order, vec![1, 4, 6]);
+        assert_eq!(
+            order,
+            backwards.iter().map(PeerId::index).collect::<Vec<u8>>()
+        );
+    }
+
+    #[test]
+    fn every_seat_is_visited_once_and_in_order() {
+        let all: Vec<u8> = peers().map(PeerId::index).collect();
+        assert_eq!(all, (0..MAX_PEERS).collect::<Vec<u8>>());
+    }
+}

--- a/crates/net/src/wire.rs
+++ b/crates/net/src/wire.rs
@@ -1,0 +1,934 @@
+//! The datagram codec: a pure function from bytes to a validated view,
+//! and its exact inverse.
+//!
+//! **Everything decidable from the bytes alone is decided here.**
+//! Session-relative refusals — wrong session, a sender outside *this*
+//! roster, a tick past *this* window — belong to the session, which knows
+//! the session. Keeping the split at that line is what makes this module
+//! fuzzable and unit-testable with no session at all, and it is why a
+//! `sender` past the type's ceiling is refused here while a `sender` who
+//! is merely not playing is not.
+
+use crate::{
+    INPUT_REDUNDANCY, INPUT_WINDOW, MAX_DATAGRAM_BYTES, MAX_INPUT_BYTES, MAX_PEERS, PeerId,
+};
+
+/// Four bytes rather than the document format's eight: a datagram at
+/// sixty hertz pays for every byte, and the session id below discriminates
+/// far better than magic can.
+pub const MAGIC: [u8; 4] = *b"RNWL";
+
+/// Exactly one accepted value; everything else is refused outright.
+///
+/// Version negotiation is a writer's job, not a reader's. This number
+/// moves when a byte layout or a vocabulary word moves, and **not** when
+/// a caller adds a parameter — the trace codec's rule. It is folded into
+/// the session's agreement digest, so a version skew becomes a named
+/// handshake refusal at tick zero rather than a mystery at tick four
+/// hundred.
+pub const WIRE_VERSION: u16 = 1;
+
+/// The bytes every datagram begins with, whatever its kind.
+pub const HEADER_BYTES: usize = 16;
+
+/// A `Hello` body.
+pub const HELLO_BODY_BYTES: usize = 40;
+/// An `Inputs` body's fixed part, before the frames it carries.
+pub const INPUTS_BODY_BYTES: usize = 12;
+/// A `Digest` body.
+pub const DIGEST_BODY_BYTES: usize = 24;
+/// A `Bye` body.
+pub const BYE_BODY_BYTES: usize = 8;
+
+/// A whole `Hello` datagram. Fixed: there is nothing in it that varies.
+pub const HELLO_DATAGRAM_BYTES: usize = HEADER_BYTES + HELLO_BODY_BYTES;
+/// A whole `Digest` datagram.
+pub const DIGEST_DATAGRAM_BYTES: usize = HEADER_BYTES + DIGEST_BODY_BYTES;
+/// A whole `Bye` datagram.
+pub const BYE_DATAGRAM_BYTES: usize = HEADER_BYTES + BYE_BODY_BYTES;
+/// The smallest an `Inputs` datagram can be: its fixed part, carrying no
+/// frames at all — a shape [`read`] refuses, but only after proving the
+/// fixed part is present, because the declared size is computed from two
+/// bytes inside it.
+pub const INPUTS_MIN_DATAGRAM_BYTES: usize = HEADER_BYTES + INPUTS_BODY_BYTES;
+
+const MAGIC_AT: usize = 0;
+const VERSION_AT: usize = 4;
+const KIND_AT: usize = 6;
+const SENDER_AT: usize = 7;
+const SESSION_AT: usize = 8;
+
+const HELLO_AGREEMENT_AT: usize = HEADER_BYTES;
+const HELLO_CONTENT_AT: usize = HEADER_BYTES + 8;
+const HELLO_RULES_AT: usize = HEADER_BYTES + 16;
+const HELLO_SEED_AT: usize = HEADER_BYTES + 24;
+const HELLO_PEER_COUNT_AT: usize = HEADER_BYTES + 32;
+const HELLO_INPUT_BYTES_AT: usize = HEADER_BYTES + 33;
+const HELLO_INPUT_DELAY_AT: usize = HEADER_BYTES + 34;
+const HELLO_DIGEST_PERIOD_AT: usize = HEADER_BYTES + 35;
+const HELLO_PAD_AT: usize = HEADER_BYTES + 36;
+const HELLO_PAD_BYTES: usize = 4;
+
+const INPUTS_FIRST_TICK_AT: usize = HEADER_BYTES;
+const INPUTS_COUNT_AT: usize = HEADER_BYTES + 8;
+const INPUTS_WIDTH_AT: usize = HEADER_BYTES + 9;
+const INPUTS_PAD_AT: usize = HEADER_BYTES + 10;
+const INPUTS_PAD_BYTES: usize = 2;
+const INPUTS_FRAMES_AT: usize = HEADER_BYTES + INPUTS_BODY_BYTES;
+
+const DIGEST_TICK_AT: usize = HEADER_BYTES;
+const DIGEST_STATE_AT: usize = HEADER_BYTES + 8;
+const DIGEST_INPUT_AT: usize = HEADER_BYTES + 16;
+
+const BYE_TICK_AT: usize = HEADER_BYTES;
+
+/// The smallest roster a session can be: one peer is not multiplayer, and
+/// a `Hello` claiming it is malformed rather than lonely.
+const MIN_PEER_COUNT: u8 = 2;
+
+/// What a datagram is.
+///
+/// Discriminants start at one, so an all-zero buffer names no kind — a
+/// zeroed page and a dropped connection are the two things most likely to
+/// arrive by accident, and neither should decode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Kind {
+    /// I am here, and these are the parameters I believe we agreed.
+    Hello = 1,
+    /// My inputs for a run of consecutive ticks, oldest first.
+    Inputs = 2,
+    /// What my world hashed to after a tick, and what my inputs hashed to.
+    Digest = 3,
+    /// I am leaving, at this tick.
+    Bye = 4,
+}
+
+impl Kind {
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        self as u8
+    }
+
+    /// `None` for an unknown code. Closed, never skipped: skipping is how
+    /// a format silently forks.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Hello),
+            2 => Some(Self::Inputs),
+            3 => Some(Self::Digest),
+            4 => Some(Self::Bye),
+            _ => None,
+        }
+    }
+
+    /// The body length of a datagram of this kind, given the record counts
+    /// it declares.
+    ///
+    /// `None` when the product would not fit a `u64` — which the ceilings
+    /// make unreachable, and which is therefore *checked* rather than
+    /// assumed, because a size computation that trusts its own ceilings is
+    /// the one that stops being true when a ceiling moves.
+    #[must_use]
+    #[allow(
+        clippy::cast_lossless,
+        reason = "`u64::from` is not callable in a const fn while const trait impls are unstable, so the widening is written as a cast — the same accommodation the frame crate's digest makes"
+    )]
+    pub const fn body_bytes(self, count: u8, input_bytes: u8) -> Option<u64> {
+        match self {
+            Self::Hello => Some(HELLO_BODY_BYTES as u64),
+            Self::Digest => Some(DIGEST_BODY_BYTES as u64),
+            Self::Bye => Some(BYE_BODY_BYTES as u64),
+            Self::Inputs => match (count as u64).checked_mul(input_bytes as u64) {
+                Some(frames) => (INPUTS_BODY_BYTES as u64).checked_add(frames),
+                None => None,
+            },
+        }
+    }
+}
+
+/// The sixteen bytes every datagram begins with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Header {
+    pub kind: Kind,
+    /// The claimed sender, in every kind.
+    ///
+    /// A session refuses any datagram whose `sender` disagrees with the
+    /// seat its transport attributed the bytes to, which is why the field
+    /// is here rather than in the three bodies that would otherwise need
+    /// it: a check in one place cannot be forgotten by a reader that only
+    /// looks at a body.
+    pub sender: PeerId,
+    /// Never zero. Zero is the pinned illegal value, so a zeroed buffer
+    /// that somehow cleared magic and version still dies here.
+    pub session: u64,
+}
+
+/// The parameters a peer claims it is playing under.
+///
+/// Redundant with `agreement_digest` by construction, and carried anyway:
+/// **the digest decides, the plaintext explains.** A refusal can then name
+/// *which* parameter differs instead of only reporting that two numbers
+/// did not match.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HelloBody {
+    pub agreement_digest: u64,
+    /// What content this peer is running. **This crate cannot compute one
+    /// and never validates it**; it carries the number and lets a session
+    /// prove everyone supplied the same one.
+    pub content: u64,
+    /// What rules this peer is running, as distinct from what assets. Two
+    /// numbers rather than one so a refusal can name which half.
+    pub rules: u64,
+    /// The run's master seed.
+    pub seed: u64,
+    /// `2..=MAX_PEERS`.
+    pub peer_count: u8,
+    /// `1..=MAX_INPUT_BYTES`.
+    pub input_bytes: u8,
+    /// Strictly below `INPUT_WINDOW`.
+    pub input_delay: u8,
+    /// At least one.
+    pub digest_period: u8,
+}
+
+/// A run of consecutive per-tick inputs from one peer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InputsBody<'a> {
+    /// The tick the first frame belongs to.
+    pub first_tick: u64,
+    /// How many frames follow. `1..=INPUT_REDUNDANCY`.
+    pub count: u8,
+    /// How wide each frame is. `1..=MAX_INPUT_BYTES`.
+    pub input_bytes: u8,
+    frames: &'a [u8],
+}
+
+impl<'a> InputsBody<'a> {
+    /// The `index`-th frame, or `None` at or past [`InputsBody::count`].
+    #[must_use]
+    pub fn frame(&self, index: u8) -> Option<&'a [u8]> {
+        if index >= self.count {
+            return None;
+        }
+        let width = usize::from(self.input_bytes);
+        let start = usize::from(index).checked_mul(width)?;
+        self.frames.get(start..)?.get(..width)
+    }
+
+    /// Every frame as `(tick, bytes)`, ascending from
+    /// [`InputsBody::first_tick`].
+    pub fn iter(&self) -> impl Iterator<Item = (u64, &'a [u8])> + 'a {
+        let first = self.first_tick;
+        let count = self.count;
+        let width = usize::from(self.input_bytes);
+        let frames = self.frames;
+        (0..u32::from(count)).filter_map(move |index| {
+            let start = usize::try_from(index).ok()?.checked_mul(width)?;
+            let bytes = frames.get(start..)?.get(..width)?;
+            Some((first.checked_add(u64::from(index))?, bytes))
+        })
+    }
+
+    /// The frame bytes as one run, for a caller that wants to copy them
+    /// whole rather than one tick at a time.
+    #[must_use]
+    pub const fn frames(&self) -> &'a [u8] {
+        self.frames
+    }
+}
+
+/// One peer's fingerprints for one tick.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DigestBody {
+    pub tick: u64,
+    /// The consuming simulation's own digest after `tick`.
+    pub state_digest: u64,
+    /// This peer's running fold of every confirmed input set up to and
+    /// including `tick`. Eight bytes, and they are the difference between
+    /// "we diverged" and "we diverged, and here is which half".
+    pub input_digest: u64,
+}
+
+/// A departure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ByeBody {
+    /// The last tick this peer confirmed.
+    ///
+    /// Tick-addressed on purpose: a departure naming no tick would leave
+    /// every remaining peer to guess when it happened, which is the
+    /// consensus problem this design declines to solve.
+    pub tick: u64,
+}
+
+/// What a validated datagram turned out to say.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Body<'a> {
+    Hello(HelloBody),
+    Inputs(InputsBody<'a>),
+    Digest(DigestBody),
+    Bye(ByeBody),
+}
+
+/// A validated datagram, borrowing the bytes it was read from.
+///
+/// Validation happens once, at [`read`]. Every accessor below it is total
+/// because of that, and nothing here re-checks what the reader proved.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Datagram<'a> {
+    pub header: Header,
+    pub body: Body<'a>,
+}
+
+/// Why a datagram was refused. One variant per rule, each carrying what
+/// was seen — "invalid" teaches a reader nothing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WireError {
+    /// Shorter than the region a reader needed.
+    ///
+    /// Raised by the header-length check, and — unreachably, by
+    /// construction — by any later read whose region the size check has
+    /// already proven present. That second road exists so an impossible
+    /// miss becomes a refusal rather than a panic: fail closed, not
+    /// sideways.
+    TooShort {
+        len: usize,
+    },
+    /// Longer than any legal datagram, checked before anything that could
+    /// depend on a length.
+    TooLong {
+        len: usize,
+    },
+    BadMagic {
+        saw: [u8; 4],
+    },
+    BadVersion {
+        saw: u16,
+    },
+    UnknownKind {
+        saw: u8,
+    },
+    /// The claimed sender is at or past `MAX_PEERS`. Decidable from the
+    /// bytes; whether that seat is in *this session's* roster is not, and
+    /// belongs to the session.
+    SenderPastCeiling {
+        saw: u8,
+        ceiling: u8,
+    },
+    /// Zero is the pinned illegal session id.
+    SessionZero,
+    /// The declared datagram length is not the actual one.
+    ///
+    /// Equality, never a lower bound: trailing bytes are a refusal,
+    /// because a format that tolerates them admits two spellings of one
+    /// fact. The arithmetic is done in `u64` so the check does not depend
+    /// on the ceilings staying small forever.
+    SizeMismatch {
+        kind: Kind,
+        declared: u64,
+        actual: usize,
+    },
+    /// A byte the semantics do not read was not zero.
+    ///
+    /// Every reserved region is pinned, which is what stops a second
+    /// spelling of the same datagram existing — and closes the
+    /// covert-channel road as a side effect.
+    PadNotZero {
+        offset: usize,
+        saw: u8,
+    },
+    /// An `Inputs` run of zero frames: a datagram that says nothing and
+    /// costs a parse. Refused rather than accepted as empty.
+    FrameCountZero,
+    FrameCountPastRedundancy {
+        saw: u8,
+        ceiling: u8,
+    },
+    InputBytesZero,
+    InputBytesPastCeiling {
+        saw: u8,
+        ceiling: u8,
+    },
+    /// `first_tick + count` would leave `u64`.
+    TickOverflow {
+        first_tick: u64,
+        count: u8,
+    },
+    /// A `Hello` declaring a roster this crate cannot hold, or one too
+    /// small to be a session at all.
+    PeerCountOutOfRange {
+        saw: u8,
+        floor: u8,
+        ceiling: u8,
+    },
+    /// A `Hello` declaring a delay this crate cannot buffer.
+    InputDelayPastWindow {
+        saw: u8,
+        window: u32,
+    },
+    /// A `Hello` declaring a zero digest period: every tick would owe a
+    /// digest, which is a bandwidth decision nobody makes on purpose and a
+    /// division by zero if it were honoured.
+    DigestPeriodZero,
+}
+
+impl core::fmt::Display for WireError {
+    fn fmt(&self, out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::TooShort { len } => {
+                write!(
+                    out,
+                    "{len} bytes is shorter than the {HEADER_BYTES}-byte header"
+                )
+            }
+            Self::TooLong { len } => {
+                write!(
+                    out,
+                    "{len} bytes is longer than the {MAX_DATAGRAM_BYTES}-byte ceiling"
+                )
+            }
+            Self::BadMagic { saw } => write!(out, "magic {saw:?}, expected {MAGIC:?}"),
+            Self::BadVersion { saw } => {
+                write!(
+                    out,
+                    "wire version {saw}, and only {WIRE_VERSION} is accepted"
+                )
+            }
+            Self::UnknownKind { saw } => write!(out, "datagram kind {saw} names nothing"),
+            Self::SenderPastCeiling { saw, ceiling } => {
+                write!(
+                    out,
+                    "sender seat {saw} is at or past the ceiling of {ceiling}"
+                )
+            }
+            Self::SessionZero => write!(out, "session id zero is the pinned illegal value"),
+            Self::SizeMismatch {
+                kind,
+                declared,
+                actual,
+            } => write!(
+                out,
+                "a {kind:?} declaring {declared} bytes arrived as {actual}"
+            ),
+            Self::PadNotZero { offset, saw } => {
+                write!(
+                    out,
+                    "reserved byte at offset {offset} is {saw}, and must be zero"
+                )
+            }
+            Self::FrameCountZero => write!(out, "an inputs run of zero frames says nothing"),
+            Self::FrameCountPastRedundancy { saw, ceiling } => {
+                write!(
+                    out,
+                    "{saw} frames is past the redundancy ceiling of {ceiling}"
+                )
+            }
+            Self::InputBytesZero => write!(out, "an input width of zero carries no input"),
+            Self::InputBytesPastCeiling { saw, ceiling } => {
+                write!(
+                    out,
+                    "an input width of {saw} is past the ceiling of {ceiling}"
+                )
+            }
+            Self::TickOverflow { first_tick, count } => {
+                write!(
+                    out,
+                    "{count} frames from tick {first_tick} would leave the tick space"
+                )
+            }
+            Self::PeerCountOutOfRange {
+                saw,
+                floor,
+                ceiling,
+            } => {
+                write!(out, "a roster of {saw} is outside {floor}..={ceiling}")
+            }
+            Self::InputDelayPastWindow { saw, window } => {
+                write!(
+                    out,
+                    "an input delay of {saw} does not fit a window of {window}"
+                )
+            }
+            Self::DigestPeriodZero => {
+                write!(out, "a digest period of zero would digest every tick")
+            }
+        }
+    }
+}
+
+impl core::error::Error for WireError {}
+
+/// Why a writer refused. Four rules, each carrying what was asked for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WriteError {
+    /// Zero frames, or more than the redundancy ceiling. One variant for
+    /// both because they are one mistake: a run that is not a run.
+    FrameCount {
+        saw: u8,
+        ceiling: u8,
+    },
+    /// Zero width, or more than the input ceiling.
+    InputBytes {
+        saw: u8,
+        ceiling: u8,
+    },
+    FramesLength {
+        saw: usize,
+        expected: usize,
+    },
+    TickOverflow {
+        first_tick: u64,
+        count: u8,
+    },
+}
+
+impl core::fmt::Display for WriteError {
+    fn fmt(&self, out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::FrameCount { saw, ceiling } => {
+                write!(out, "{saw} frames is not within 1..={ceiling}")
+            }
+            Self::InputBytes { saw, ceiling } => {
+                write!(out, "an input width of {saw} is not within 1..={ceiling}")
+            }
+            Self::FramesLength { saw, expected } => {
+                write!(
+                    out,
+                    "{saw} bytes of frames where the counts imply {expected}"
+                )
+            }
+            Self::TickOverflow { first_tick, count } => {
+                write!(
+                    out,
+                    "{count} frames from tick {first_tick} would leave the tick space"
+                )
+            }
+        }
+    }
+}
+
+impl core::error::Error for WriteError {}
+
+/// Read a datagram.
+///
+/// Everything decidable from the bytes alone, in the order a reader should
+/// decide it: cheapest and most discriminating first, and region slicing
+/// only after a size equality has proven both bounds.
+///
+/// **This function is total over every possible byte string.** It
+/// allocates nothing, panics on nothing, and touches no state.
+///
+/// # Errors
+///
+/// One [`WireError`] variant per rule, each carrying what was seen.
+pub fn read(bytes: &[u8]) -> Result<Datagram<'_>, WireError> {
+    let len = bytes.len();
+    if len < HEADER_BYTES {
+        return Err(WireError::TooShort { len });
+    }
+    if len > MAX_DATAGRAM_BYTES {
+        return Err(WireError::TooLong { len });
+    }
+
+    let magic = region(bytes, MAGIC_AT, MAGIC.len()).ok_or(WireError::TooShort { len })?;
+    if magic != MAGIC {
+        let mut saw = [0u8; 4];
+        // Proven four bytes wide one line above; a mismatch here would be
+        // the slice helper lying, so it fails closed onto the same refusal.
+        if let Some(seen) = magic.get(..4) {
+            saw.copy_from_slice(seen);
+        }
+        return Err(WireError::BadMagic { saw });
+    }
+
+    let version = u16_at(bytes, VERSION_AT).ok_or(WireError::TooShort { len })?;
+    if version != WIRE_VERSION {
+        return Err(WireError::BadVersion { saw: version });
+    }
+
+    let kind_code = byte_at(bytes, KIND_AT).ok_or(WireError::TooShort { len })?;
+    let kind = Kind::from_code(kind_code).ok_or(WireError::UnknownKind { saw: kind_code })?;
+
+    let sender_index = byte_at(bytes, SENDER_AT).ok_or(WireError::TooShort { len })?;
+    let sender = PeerId::new(sender_index).ok_or(WireError::SenderPastCeiling {
+        saw: sender_index,
+        ceiling: MAX_PEERS,
+    })?;
+
+    let session = u64_at(bytes, SESSION_AT).ok_or(WireError::TooShort { len })?;
+    if session == 0 {
+        return Err(WireError::SessionZero);
+    }
+
+    let header = Header {
+        kind,
+        sender,
+        session,
+    };
+    let body = match kind {
+        Kind::Hello => Body::Hello(read_hello(bytes, len)?),
+        Kind::Inputs => Body::Inputs(read_inputs(bytes, len)?),
+        Kind::Digest => Body::Digest(read_digest(bytes, len)?),
+        Kind::Bye => Body::Bye(read_bye(bytes, len)?),
+    };
+    Ok(Datagram { header, body })
+}
+
+fn read_hello(bytes: &[u8], len: usize) -> Result<HelloBody, WireError> {
+    expect_exactly(Kind::Hello, HELLO_DATAGRAM_BYTES, len)?;
+
+    let peer_count = byte_at(bytes, HELLO_PEER_COUNT_AT).ok_or(WireError::TooShort { len })?;
+    if !(MIN_PEER_COUNT..=MAX_PEERS).contains(&peer_count) {
+        return Err(WireError::PeerCountOutOfRange {
+            saw: peer_count,
+            floor: MIN_PEER_COUNT,
+            ceiling: MAX_PEERS,
+        });
+    }
+
+    let input_bytes = byte_at(bytes, HELLO_INPUT_BYTES_AT).ok_or(WireError::TooShort { len })?;
+    check_input_width(input_bytes)?;
+
+    let input_delay = byte_at(bytes, HELLO_INPUT_DELAY_AT).ok_or(WireError::TooShort { len })?;
+    if u32::from(input_delay) >= INPUT_WINDOW {
+        return Err(WireError::InputDelayPastWindow {
+            saw: input_delay,
+            window: INPUT_WINDOW,
+        });
+    }
+
+    let digest_period =
+        byte_at(bytes, HELLO_DIGEST_PERIOD_AT).ok_or(WireError::TooShort { len })?;
+    if digest_period == 0 {
+        return Err(WireError::DigestPeriodZero);
+    }
+
+    expect_zeroes(bytes, HELLO_PAD_AT, HELLO_PAD_BYTES)?;
+
+    Ok(HelloBody {
+        agreement_digest: u64_at(bytes, HELLO_AGREEMENT_AT).ok_or(WireError::TooShort { len })?,
+        content: u64_at(bytes, HELLO_CONTENT_AT).ok_or(WireError::TooShort { len })?,
+        rules: u64_at(bytes, HELLO_RULES_AT).ok_or(WireError::TooShort { len })?,
+        seed: u64_at(bytes, HELLO_SEED_AT).ok_or(WireError::TooShort { len })?,
+        peer_count,
+        input_bytes,
+        input_delay,
+        digest_period,
+    })
+}
+
+fn read_inputs(bytes: &[u8], len: usize) -> Result<InputsBody<'_>, WireError> {
+    // The declared size is a function of two bytes inside the fixed part,
+    // so the fixed part's presence is proven before either is read. This
+    // is the one kind whose length check cannot come first, and the
+    // ordering is stated here rather than left to be re-derived.
+    if len < INPUTS_MIN_DATAGRAM_BYTES {
+        return Err(WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared: widen(INPUTS_MIN_DATAGRAM_BYTES),
+            actual: len,
+        });
+    }
+
+    let count = byte_at(bytes, INPUTS_COUNT_AT).ok_or(WireError::TooShort { len })?;
+    if count == 0 {
+        return Err(WireError::FrameCountZero);
+    }
+    if count > INPUT_REDUNDANCY {
+        return Err(WireError::FrameCountPastRedundancy {
+            saw: count,
+            ceiling: INPUT_REDUNDANCY,
+        });
+    }
+
+    let input_bytes = byte_at(bytes, INPUTS_WIDTH_AT).ok_or(WireError::TooShort { len })?;
+    check_input_width(input_bytes)?;
+
+    // Both ceilings are proven above, so the product cannot overflow — and
+    // it is computed in `u64` and checked anyway, because a size
+    // computation that trusts its own ceilings stops being true the day
+    // one of them moves.
+    let body = Kind::Inputs
+        .body_bytes(count, input_bytes)
+        .ok_or(WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared: u64::MAX,
+            actual: len,
+        })?;
+    let declared = widen(HEADER_BYTES)
+        .checked_add(body)
+        .ok_or(WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared: u64::MAX,
+            actual: len,
+        })?;
+    if declared != widen(len) {
+        return Err(WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared,
+            actual: len,
+        });
+    }
+
+    expect_zeroes(bytes, INPUTS_PAD_AT, INPUTS_PAD_BYTES)?;
+
+    let first_tick = u64_at(bytes, INPUTS_FIRST_TICK_AT).ok_or(WireError::TooShort { len })?;
+    if first_tick.checked_add(u64::from(count)).is_none() {
+        return Err(WireError::TickOverflow { first_tick, count });
+    }
+
+    let width = usize::from(count)
+        .checked_mul(usize::from(input_bytes))
+        .ok_or(WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared,
+            actual: len,
+        })?;
+    let frames = region(bytes, INPUTS_FRAMES_AT, width).ok_or(WireError::TooShort { len })?;
+
+    Ok(InputsBody {
+        first_tick,
+        count,
+        input_bytes,
+        frames,
+    })
+}
+
+fn read_digest(bytes: &[u8], len: usize) -> Result<DigestBody, WireError> {
+    expect_exactly(Kind::Digest, DIGEST_DATAGRAM_BYTES, len)?;
+    Ok(DigestBody {
+        tick: u64_at(bytes, DIGEST_TICK_AT).ok_or(WireError::TooShort { len })?,
+        state_digest: u64_at(bytes, DIGEST_STATE_AT).ok_or(WireError::TooShort { len })?,
+        input_digest: u64_at(bytes, DIGEST_INPUT_AT).ok_or(WireError::TooShort { len })?,
+    })
+}
+
+fn read_bye(bytes: &[u8], len: usize) -> Result<ByeBody, WireError> {
+    expect_exactly(Kind::Bye, BYE_DATAGRAM_BYTES, len)?;
+    Ok(ByeBody {
+        tick: u64_at(bytes, BYE_TICK_AT).ok_or(WireError::TooShort { len })?,
+    })
+}
+
+fn check_input_width(input_bytes: u8) -> Result<(), WireError> {
+    if input_bytes == 0 {
+        return Err(WireError::InputBytesZero);
+    }
+    if input_bytes > MAX_INPUT_BYTES {
+        return Err(WireError::InputBytesPastCeiling {
+            saw: input_bytes,
+            ceiling: MAX_INPUT_BYTES,
+        });
+    }
+    Ok(())
+}
+
+fn expect_exactly(kind: Kind, declared: usize, actual: usize) -> Result<(), WireError> {
+    if declared == actual {
+        Ok(())
+    } else {
+        Err(WireError::SizeMismatch {
+            kind,
+            declared: widen(declared),
+            actual,
+        })
+    }
+}
+
+fn expect_zeroes(bytes: &[u8], offset: usize, count: usize) -> Result<(), WireError> {
+    let pad = region(bytes, offset, count).ok_or(WireError::TooShort { len: bytes.len() })?;
+    for (step, byte) in pad.iter().enumerate() {
+        if *byte != 0 {
+            return Err(WireError::PadNotZero {
+                offset: offset.saturating_add(step),
+                saw: *byte,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn region(bytes: &[u8], offset: usize, count: usize) -> Option<&[u8]> {
+    bytes.get(offset..)?.get(..count)
+}
+
+fn byte_at(bytes: &[u8], offset: usize) -> Option<u8> {
+    bytes.get(offset).copied()
+}
+
+fn u16_at(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(
+        region(bytes, offset, 2)?.try_into().ok()?,
+    ))
+}
+
+fn u64_at(bytes: &[u8], offset: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(
+        region(bytes, offset, 8)?.try_into().ok()?,
+    ))
+}
+
+/// A length as the size arithmetic sees it. Saturating rather than
+/// panicking, and upward: an impossible conversion becomes a size that
+/// matches nothing, which the equality check then refuses.
+fn widen(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+/// Fills a caller's buffer in order, and refuses to write past its end.
+///
+/// A region that does not fit is not written and does not advance the
+/// cursor, so an impossible miss yields a **short** datagram that [`read`]
+/// refuses on its size equality — never a full-length one carrying a hole.
+/// Fail closed, not sideways.
+struct Cursor<'a> {
+    out: &'a mut [u8],
+    at: usize,
+}
+
+impl Cursor<'_> {
+    fn bytes(&mut self, source: &[u8]) {
+        if let Some(tail) = self.out.get_mut(self.at..)
+            && let Some(slot) = tail.get_mut(..source.len())
+        {
+            slot.copy_from_slice(source);
+            self.at = self.at.saturating_add(source.len());
+        }
+    }
+
+    fn byte(&mut self, value: u8) {
+        self.bytes(&[value]);
+    }
+
+    fn u16(&mut self, value: u16) {
+        self.bytes(&value.to_le_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes(&value.to_le_bytes());
+    }
+
+    fn zeroes(&mut self, count: usize) {
+        const BLANK: [u8; 8] = [0; 8];
+        if let Some(source) = BLANK.get(..count) {
+            self.bytes(source);
+        }
+    }
+
+    fn header(&mut self, header: Header) {
+        self.bytes(&MAGIC);
+        self.u16(WIRE_VERSION);
+        self.byte(header.kind.code());
+        self.byte(header.sender.index());
+        self.u64(header.session);
+    }
+}
+
+/// Write a `Hello`, returning the byte count written.
+///
+/// The writer is the reader's inverse and asserts the same ceilings, so it
+/// cannot mint what the reader would refuse. Every ceiling this one could
+/// violate is enforced by the type of its argument, which is why it
+/// returns no `Result` — the two that are not, [`HelloBody::peer_count`]
+/// and the rest, are the session's to validate before it builds one.
+#[must_use]
+pub fn write_hello(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &HelloBody) -> usize {
+    let mut cursor = Cursor { out, at: 0 };
+    cursor.header(header);
+    cursor.u64(body.agreement_digest);
+    cursor.u64(body.content);
+    cursor.u64(body.rules);
+    cursor.u64(body.seed);
+    cursor.byte(body.peer_count);
+    cursor.byte(body.input_bytes);
+    cursor.byte(body.input_delay);
+    cursor.byte(body.digest_period);
+    cursor.zeroes(HELLO_PAD_BYTES);
+    cursor.at
+}
+
+/// Write a `Digest`, returning the byte count written.
+#[must_use]
+pub fn write_digest(
+    out: &mut [u8; MAX_DATAGRAM_BYTES],
+    header: Header,
+    body: &DigestBody,
+) -> usize {
+    let mut cursor = Cursor { out, at: 0 };
+    cursor.header(header);
+    cursor.u64(body.tick);
+    cursor.u64(body.state_digest);
+    cursor.u64(body.input_digest);
+    cursor.at
+}
+
+/// Write a `Bye`, returning the byte count written.
+#[must_use]
+pub fn write_bye(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &ByeBody) -> usize {
+    let mut cursor = Cursor { out, at: 0 };
+    cursor.header(header);
+    cursor.u64(body.tick);
+    cursor.at
+}
+
+/// Write an `Inputs` run, returning the byte count written.
+///
+/// `frames` is exactly `count × input_bytes` bytes, ascending from
+/// `first_tick`.
+///
+/// # Errors
+///
+/// [`WriteError`] when the arguments could not produce a datagram the
+/// reader would accept. **Refused rather than truncated**, because a
+/// writer that silently produced a shorter run would be a second spelling
+/// of a shorter fact — and the reader's whole canonical-encoding argument
+/// rests on there being no second spelling of anything.
+pub fn write_inputs(
+    out: &mut [u8; MAX_DATAGRAM_BYTES],
+    header: Header,
+    first_tick: u64,
+    input_bytes: u8,
+    count: u8,
+    frames: &[u8],
+) -> Result<usize, WriteError> {
+    if count == 0 || count > INPUT_REDUNDANCY {
+        return Err(WriteError::FrameCount {
+            saw: count,
+            ceiling: INPUT_REDUNDANCY,
+        });
+    }
+    if input_bytes == 0 || input_bytes > MAX_INPUT_BYTES {
+        return Err(WriteError::InputBytes {
+            saw: input_bytes,
+            ceiling: MAX_INPUT_BYTES,
+        });
+    }
+    let expected = usize::from(count)
+        .checked_mul(usize::from(input_bytes))
+        .ok_or(WriteError::FramesLength {
+            saw: frames.len(),
+            expected: usize::MAX,
+        })?;
+    if frames.len() != expected {
+        return Err(WriteError::FramesLength {
+            saw: frames.len(),
+            expected,
+        });
+    }
+    if first_tick.checked_add(u64::from(count)).is_none() {
+        return Err(WriteError::TickOverflow { first_tick, count });
+    }
+
+    let mut cursor = Cursor { out, at: 0 };
+    cursor.header(header);
+    cursor.u64(first_tick);
+    cursor.byte(count);
+    cursor.byte(input_bytes);
+    cursor.zeroes(INPUTS_PAD_BYTES);
+    cursor.bytes(frames);
+    Ok(cursor.at)
+}

--- a/crates/net/src/wire.rs
+++ b/crates/net/src/wire.rs
@@ -9,6 +9,8 @@
 //! `sender` past the type's ceiling is refused here while a `sender` who
 //! is merely not playing is not.
 
+use core::num::NonZeroU64;
+
 use crate::{
     INPUT_REDUNDANCY, INPUT_WINDOW, MAX_DATAGRAM_BYTES, MAX_INPUT_BYTES, MAX_PEERS, PeerId,
 };
@@ -148,21 +150,53 @@ impl Kind {
     }
 }
 
+/// Who a datagram is from, and which session it belongs to.
+///
+/// **The kind is deliberately not here.** Every writer knows the kind it
+/// writes, so taking one as an argument would let a caller ask
+/// [`write_hello`] for a datagram whose kind byte says `Bye` — a
+/// disagreement between which function was called and what the bytes
+/// claim, minted by a writer and refused by the reader. Splitting the
+/// addressing out makes that unrepresentable rather than merely refused,
+/// which is the difference between a contract and a check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Addressing {
+    /// The claimed sender, written into every kind.
+    ///
+    /// A session refuses any datagram whose sender disagrees with the seat
+    /// its transport attributed the bytes to, which is why this is in the
+    /// header rather than in the three bodies that would otherwise need
+    /// it: a check in one place cannot be forgotten by a reader that only
+    /// looks at a body.
+    pub sender: PeerId,
+    /// Never zero, **by type**.
+    ///
+    /// Zero is the pinned illegal value on the wire, so a zeroed buffer
+    /// that somehow cleared magic and version still dies at the reader.
+    /// Making it `NonZeroU64` here means no writer needs a refusal for it
+    /// and no caller can hold one that would be refused.
+    pub session: NonZeroU64,
+}
+
 /// The sixteen bytes every datagram begins with.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Header {
     pub kind: Kind,
-    /// The claimed sender, in every kind.
-    ///
-    /// A session refuses any datagram whose `sender` disagrees with the
-    /// seat its transport attributed the bytes to, which is why the field
-    /// is here rather than in the three bodies that would otherwise need
-    /// it: a check in one place cannot be forgotten by a reader that only
-    /// looks at a body.
+    /// The claimed sender.
     pub sender: PeerId,
-    /// Never zero. Zero is the pinned illegal value, so a zeroed buffer
-    /// that somehow cleared magic and version still dies here.
-    pub session: u64,
+    /// Never zero — the reader proves it, so the type carries the proof.
+    pub session: NonZeroU64,
+}
+
+impl Header {
+    /// The half of this header a writer takes.
+    #[must_use]
+    pub const fn addressing(self) -> Addressing {
+        Addressing {
+            sender: self.sender,
+            session: self.session,
+        }
+    }
 }
 
 /// The parameters a peer claims it is playing under.
@@ -198,7 +232,8 @@ pub struct HelloBody {
 pub struct InputsBody<'a> {
     /// The tick the first frame belongs to.
     pub first_tick: u64,
-    /// How many frames follow. `1..=INPUT_REDUNDANCY`.
+    /// How many frames follow — the whole run, newest last.
+    /// `1..=INPUT_REDUNDANCY`.
     pub count: u8,
     /// How wide each frame is. `1..=MAX_INPUT_BYTES`.
     pub input_bytes: u8,
@@ -484,6 +519,19 @@ pub enum WriteError {
         first_tick: u64,
         count: u8,
     },
+    /// A roster the reader would refuse: below two, or past the ceiling.
+    PeerCount {
+        saw: u8,
+        floor: u8,
+        ceiling: u8,
+    },
+    /// A delay the input window could not buffer.
+    InputDelay {
+        saw: u8,
+        window: u32,
+    },
+    /// Every tick would owe a digest, and the period would divide by zero.
+    DigestPeriodZero,
 }
 
 impl core::fmt::Display for WriteError {
@@ -506,6 +554,22 @@ impl core::fmt::Display for WriteError {
                     out,
                     "{count} frames from tick {first_tick} would leave the tick space"
                 )
+            }
+            Self::PeerCount {
+                saw,
+                floor,
+                ceiling,
+            } => {
+                write!(out, "a roster of {saw} is outside {floor}..={ceiling}")
+            }
+            Self::InputDelay { saw, window } => {
+                write!(
+                    out,
+                    "an input delay of {saw} does not fit a window of {window}"
+                )
+            }
+            Self::DigestPeriodZero => {
+                write!(out, "a digest period of zero would digest every tick")
             }
         }
     }
@@ -559,10 +623,8 @@ pub fn read(bytes: &[u8]) -> Result<Datagram<'_>, WireError> {
         ceiling: MAX_PEERS,
     })?;
 
-    let session = u64_at(bytes, SESSION_AT).ok_or(WireError::TooShort { len })?;
-    if session == 0 {
-        return Err(WireError::SessionZero);
-    }
+    let claimed = u64_at(bytes, SESSION_AT).ok_or(WireError::TooShort { len })?;
+    let session = NonZeroU64::new(claimed).ok_or(WireError::SessionZero)?;
 
     let header = Header {
         kind,
@@ -819,26 +881,56 @@ impl Cursor<'_> {
         }
     }
 
-    fn header(&mut self, header: Header) {
+    /// The kind is the writer's, never the caller's — see [`Addressing`].
+    fn header(&mut self, kind: Kind, addressing: Addressing) {
         self.bytes(&MAGIC);
         self.u16(WIRE_VERSION);
-        self.byte(header.kind.code());
-        self.byte(header.sender.index());
-        self.u64(header.session);
+        self.byte(kind.code());
+        self.byte(addressing.sender.index());
+        self.u64(addressing.session.get());
     }
 }
 
 /// Write a `Hello`, returning the byte count written.
 ///
-/// The writer is the reader's inverse and asserts the same ceilings, so it
-/// cannot mint what the reader would refuse. Every ceiling this one could
-/// violate is enforced by the type of its argument, which is why it
-/// returns no `Result` — the two that are not, [`HelloBody::peer_count`]
-/// and the rest, are the session's to validate before it builds one.
-#[must_use]
-pub fn write_hello(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &HelloBody) -> usize {
+/// # Errors
+///
+/// [`WriteError`] for each of the four parameter ranges [`read`] enforces
+/// on a `Hello`. They are checked here rather than left to a caller
+/// because the alternative is a writer that mints a datagram the reader
+/// refuses, which would make this crate's central claim false — and a
+/// claim under a **Contract** heading is intent, so the code moves to meet
+/// it rather than the sentence retreating to meet the code.
+pub fn write_hello(
+    out: &mut [u8; MAX_DATAGRAM_BYTES],
+    addressing: Addressing,
+    body: &HelloBody,
+) -> Result<usize, WriteError> {
+    if !(MIN_PEER_COUNT..=MAX_PEERS).contains(&body.peer_count) {
+        return Err(WriteError::PeerCount {
+            saw: body.peer_count,
+            floor: MIN_PEER_COUNT,
+            ceiling: MAX_PEERS,
+        });
+    }
+    if body.input_bytes == 0 || body.input_bytes > MAX_INPUT_BYTES {
+        return Err(WriteError::InputBytes {
+            saw: body.input_bytes,
+            ceiling: MAX_INPUT_BYTES,
+        });
+    }
+    if u32::from(body.input_delay) >= INPUT_WINDOW {
+        return Err(WriteError::InputDelay {
+            saw: body.input_delay,
+            window: INPUT_WINDOW,
+        });
+    }
+    if body.digest_period == 0 {
+        return Err(WriteError::DigestPeriodZero);
+    }
+
     let mut cursor = Cursor { out, at: 0 };
-    cursor.header(header);
+    cursor.header(Kind::Hello, addressing);
     cursor.u64(body.agreement_digest);
     cursor.u64(body.content);
     cursor.u64(body.rules);
@@ -848,29 +940,40 @@ pub fn write_hello(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &He
     cursor.byte(body.input_delay);
     cursor.byte(body.digest_period);
     cursor.zeroes(HELLO_PAD_BYTES);
-    cursor.at
+    Ok(cursor.at)
 }
 
 /// Write a `Digest`, returning the byte count written.
+///
+/// Nothing here can be refused: the kind is this function's, the session
+/// is non-zero by type, and both remaining fields are opaque `u64`s the
+/// reader accepts whatever their value. That is what "enforced in the
+/// argument types where it can be" buys, and it is why this one returns no
+/// `Result` while [`write_hello`] does.
 #[must_use]
 pub fn write_digest(
     out: &mut [u8; MAX_DATAGRAM_BYTES],
-    header: Header,
+    addressing: Addressing,
     body: &DigestBody,
 ) -> usize {
     let mut cursor = Cursor { out, at: 0 };
-    cursor.header(header);
+    cursor.header(Kind::Digest, addressing);
     cursor.u64(body.tick);
     cursor.u64(body.state_digest);
     cursor.u64(body.input_digest);
     cursor.at
 }
 
-/// Write a `Bye`, returning the byte count written.
+/// Write a `Bye`, returning the byte count written. Unrefusable for the
+/// same reason as [`write_digest`].
 #[must_use]
-pub fn write_bye(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &ByeBody) -> usize {
+pub fn write_bye(
+    out: &mut [u8; MAX_DATAGRAM_BYTES],
+    addressing: Addressing,
+    body: &ByeBody,
+) -> usize {
     let mut cursor = Cursor { out, at: 0 };
-    cursor.header(header);
+    cursor.header(Kind::Bye, addressing);
     cursor.u64(body.tick);
     cursor.at
 }
@@ -878,7 +981,10 @@ pub fn write_bye(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &ByeB
 /// Write an `Inputs` run, returning the byte count written.
 ///
 /// `frames` is exactly `count × input_bytes` bytes, ascending from
-/// `first_tick`.
+/// `first_tick`. **`count` precedes `input_bytes`** — the order the two
+/// bytes appear in on the wire, the order [`InputsBody`] declares them,
+/// and the order [`Kind::body_bytes`] takes them; two `u8`s whose swap no
+/// compiler can catch are worth spelling the same way everywhere.
 ///
 /// # Errors
 ///
@@ -889,10 +995,10 @@ pub fn write_bye(out: &mut [u8; MAX_DATAGRAM_BYTES], header: Header, body: &ByeB
 /// rests on there being no second spelling of anything.
 pub fn write_inputs(
     out: &mut [u8; MAX_DATAGRAM_BYTES],
-    header: Header,
+    addressing: Addressing,
     first_tick: u64,
-    input_bytes: u8,
     count: u8,
+    input_bytes: u8,
     frames: &[u8],
 ) -> Result<usize, WriteError> {
     if count == 0 || count > INPUT_REDUNDANCY {
@@ -924,7 +1030,7 @@ pub fn write_inputs(
     }
 
     let mut cursor = Cursor { out, at: 0 };
-    cursor.header(header);
+    cursor.header(Kind::Inputs, addressing);
     cursor.u64(first_tick);
     cursor.byte(count);
     cursor.byte(input_bytes);

--- a/crates/net/tests/readme.rs
+++ b/crates/net/tests/readme.rs
@@ -1,0 +1,39 @@
+//! The front page's example, held against the crate.
+//!
+//! A README is not doctested — no crate here includes one as module
+//! documentation — so the example on the front page is the one piece of
+//! code in the crate that nothing compiles. This test is that example,
+//! transcribed, including the claim its comment makes about which tick
+//! each frame belongs to. If the API moves, this fails; if the example
+//! moves, this must move with it.
+
+use renew_net::{MAX_DATAGRAM_BYTES, PeerId, wire};
+
+#[test]
+fn the_front_page_example_compiles_and_says_what_it_claims()
+-> Result<(), Box<dyn core::error::Error>> {
+    let sender = PeerId::new(0).ok_or("seat zero is always in range")?;
+    let header = wire::Header {
+        kind: wire::Kind::Inputs,
+        sender,
+        session: 0x51e3,
+    };
+
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_inputs(&mut out, header, 4_000, 1, 3, &[0b0001, 0b0001, 0b0101])?;
+
+    let wire::Body::Inputs(body) = wire::read(&out[..len])?.body else {
+        return Err("an Inputs decoded as something else".into());
+    };
+
+    let seen: Vec<(u64, u8)> = body
+        .iter()
+        .filter_map(|(tick, frame)| frame.first().map(|byte| (tick, *byte)))
+        .collect();
+    assert_eq!(
+        seen,
+        vec![(4_000, 0b0001), (4_001, 0b0001), (4_002, 0b0101)],
+        "the three pairs the README prints in its comment"
+    );
+    Ok(())
+}

--- a/crates/net/tests/readme.rs
+++ b/crates/net/tests/readme.rs
@@ -7,20 +7,19 @@
 //! each frame belongs to. If the API moves, this fails; if the example
 //! moves, this must move with it.
 
+use core::num::NonZeroU64;
+
 use renew_net::{MAX_DATAGRAM_BYTES, PeerId, wire};
 
 #[test]
 fn the_front_page_example_compiles_and_says_what_it_claims()
 -> Result<(), Box<dyn core::error::Error>> {
     let sender = PeerId::new(0).ok_or("seat zero is always in range")?;
-    let header = wire::Header {
-        kind: wire::Kind::Inputs,
-        sender,
-        session: 0x51e3,
-    };
+    let session = NonZeroU64::new(0x51e3).ok_or("zero is the pinned illegal session")?;
+    let addressing = wire::Addressing { sender, session };
 
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
-    let len = wire::write_inputs(&mut out, header, 4_000, 1, 3, &[0b0001, 0b0001, 0b0101])?;
+    let len = wire::write_inputs(&mut out, addressing, 4_000, 3, 1, &[0b0001, 0b0001, 0b0101])?;
 
     let wire::Body::Inputs(body) = wire::read(&out[..len])?.body else {
         return Err("an Inputs decoded as something else".into());

--- a/crates/net/tests/wire.rs
+++ b/crates/net/tests/wire.rs
@@ -1,0 +1,620 @@
+//! The codec's refusal table, its round-trip oracle, and two sweeps.
+//!
+//! An integration test rather than a unit one, deliberately: every rule
+//! below is reachable through the public API, and a test that can only be
+//! written from inside the crate is a test of an implementation rather
+//! than of a contract. The one thing it costs is the crate root's
+//! `indexing_slicing` deny, which does not reach here — and indexing is
+//! the clearest way to say "this byte, that value" when the subject of
+//! the test is one byte.
+
+use renew_net::wire::{
+    BYE_DATAGRAM_BYTES, Body, ByeBody, DIGEST_DATAGRAM_BYTES, DigestBody, HEADER_BYTES,
+    HELLO_DATAGRAM_BYTES, Header, HelloBody, INPUTS_MIN_DATAGRAM_BYTES, Kind, WIRE_VERSION,
+    WireError, WriteError, read, write_bye, write_digest, write_hello, write_inputs,
+};
+use renew_net::{
+    INPUT_REDUNDANCY, INPUT_WINDOW, MAX_DATAGRAM_BYTES, MAX_INPUT_BYTES, MAX_PEERS, PeerId,
+};
+
+type Buffer = [u8; MAX_DATAGRAM_BYTES];
+
+/// Body offsets, absolute in the datagram, so a test says where it pokes.
+const HELLO_PEER_COUNT: usize = HEADER_BYTES + 32;
+const HELLO_INPUT_BYTES: usize = HEADER_BYTES + 33;
+const HELLO_INPUT_DELAY: usize = HEADER_BYTES + 34;
+const HELLO_DIGEST_PERIOD: usize = HEADER_BYTES + 35;
+const HELLO_PAD: usize = HEADER_BYTES + 36;
+const INPUTS_FIRST_TICK: usize = HEADER_BYTES;
+const INPUTS_COUNT: usize = HEADER_BYTES + 8;
+const INPUTS_WIDTH: usize = HEADER_BYTES + 9;
+const INPUTS_PAD: usize = HEADER_BYTES + 10;
+
+// The three helpers below are the fixture, not the assertion: a refusal
+// here is the fixture itself being wrong, which should stop the run with
+// the reason at the top of the output rather than at whichever test
+// happened to call it first. The same accommodation the trace codec's
+// golden fixture makes.
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn seat(index: u8) -> PeerId {
+    PeerId::new(index).expect("a seat the test chose in range")
+}
+
+fn header(kind: Kind) -> Header {
+    Header {
+        kind,
+        sender: seat(1),
+        session: 0x0123_4567_89ab_cdef,
+    }
+}
+
+fn hello_body() -> HelloBody {
+    HelloBody {
+        agreement_digest: 0xdead_beef_feed_face,
+        content: 0x1111_2222_3333_4444,
+        rules: 0x5555_6666_7777_8888,
+        seed: 99,
+        peer_count: 4,
+        input_bytes: 3,
+        input_delay: 2,
+        digest_period: 30,
+    }
+}
+
+fn a_hello() -> (Buffer, usize) {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = write_hello(&mut out, header(Kind::Hello), &hello_body());
+    (out, len)
+}
+
+/// Three frames of two bytes each, from tick 4,000.
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn an_inputs() -> (Buffer, usize) {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = write_inputs(
+        &mut out,
+        header(Kind::Inputs),
+        4_000,
+        2,
+        3,
+        &[1, 2, 3, 4, 5, 6],
+    )
+    .expect("arguments inside every ceiling");
+    (out, len)
+}
+
+fn a_digest() -> (Buffer, usize) {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let body = DigestBody {
+        tick: 600,
+        state_digest: 0xabcd,
+        input_digest: 0x1234,
+    };
+    let len = write_digest(&mut out, header(Kind::Digest), &body);
+    (out, len)
+}
+
+fn a_bye() -> (Buffer, usize) {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = write_bye(&mut out, header(Kind::Bye), &ByeBody { tick: 0x0102_0304 });
+    (out, len)
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "a datagram that was accepted where a refusal was the subject of the test must say so here, naming the case"
+)]
+fn refusal(bytes: &[u8]) -> WireError {
+    read(bytes).expect_err("these bytes should have been refused")
+}
+
+// ---- round trips: the canonical-encoding oracle ----
+
+#[test]
+fn a_hello_round_trips_to_the_same_bytes() {
+    let (bytes, len) = a_hello();
+    assert_eq!(len, HELLO_DATAGRAM_BYTES);
+
+    let datagram = read(&bytes[..len]).expect("a datagram this crate wrote");
+    assert_eq!(datagram.header, header(Kind::Hello));
+    let Body::Hello(body) = datagram.body else {
+        panic!("a Hello decoded as something else")
+    };
+    assert_eq!(body, hello_body());
+
+    let mut again = [0u8; MAX_DATAGRAM_BYTES];
+    let again_len = write_hello(&mut again, datagram.header, &body);
+    assert_eq!((&again[..again_len], again_len), (&bytes[..len], len));
+}
+
+#[test]
+fn a_digest_round_trips_to_the_same_bytes() {
+    let (bytes, len) = a_digest();
+    assert_eq!(len, DIGEST_DATAGRAM_BYTES);
+
+    let datagram = read(&bytes[..len]).expect("a datagram this crate wrote");
+    let Body::Digest(body) = datagram.body else {
+        panic!("a Digest decoded as something else")
+    };
+    assert_eq!(
+        (body.tick, body.state_digest, body.input_digest),
+        (600, 0xabcd, 0x1234)
+    );
+
+    let mut again = [0u8; MAX_DATAGRAM_BYTES];
+    let again_len = write_digest(&mut again, datagram.header, &body);
+    assert_eq!(&again[..again_len], &bytes[..len]);
+}
+
+#[test]
+fn a_bye_round_trips_to_the_same_bytes() {
+    let (bytes, len) = a_bye();
+    assert_eq!(len, BYE_DATAGRAM_BYTES);
+
+    let datagram = read(&bytes[..len]).expect("a datagram this crate wrote");
+    let Body::Bye(body) = datagram.body else {
+        panic!("a Bye decoded as something else")
+    };
+    assert_eq!(body.tick, 0x0102_0304);
+
+    let mut again = [0u8; MAX_DATAGRAM_BYTES];
+    assert_eq!(write_bye(&mut again, datagram.header, &body), len);
+    assert_eq!(&again[..len], &bytes[..len]);
+}
+
+#[test]
+fn an_inputs_run_round_trips_with_every_frame_at_its_own_tick() {
+    let (bytes, len) = an_inputs();
+    assert_eq!(len, INPUTS_MIN_DATAGRAM_BYTES + 6);
+
+    let datagram = read(&bytes[..len]).expect("a datagram this crate wrote");
+    let Body::Inputs(body) = datagram.body else {
+        panic!("an Inputs decoded as something else")
+    };
+    assert_eq!(
+        (body.first_tick, body.count, body.input_bytes),
+        (4_000, 3, 2)
+    );
+
+    let seen: Vec<(u64, Vec<u8>)> = body
+        .iter()
+        .map(|(tick, frame)| (tick, frame.to_vec()))
+        .collect();
+    assert_eq!(
+        seen,
+        vec![
+            (4_000, vec![1, 2]),
+            (4_001, vec![3, 4]),
+            (4_002, vec![5, 6])
+        ],
+        "frames ascend from first_tick, and each is exactly input_bytes wide"
+    );
+
+    let mut again = [0u8; MAX_DATAGRAM_BYTES];
+    let again_len = write_inputs(
+        &mut again,
+        datagram.header,
+        body.first_tick,
+        body.input_bytes,
+        body.count,
+        body.frames(),
+    )
+    .expect("what the reader accepted, the writer must be able to write");
+    assert_eq!(&again[..again_len], &bytes[..len]);
+}
+
+#[test]
+fn a_frame_index_past_the_count_is_none_rather_than_a_panic() {
+    let (bytes, len) = an_inputs();
+    let datagram = read(&bytes[..len]).expect("valid");
+    let Body::Inputs(body) = datagram.body else {
+        panic!("wrong kind")
+    };
+    assert_eq!(body.frame(0), Some(&[1u8, 2][..]));
+    assert_eq!(body.frame(2), Some(&[5u8, 6][..]));
+    assert_eq!(body.frame(3), None);
+    assert_eq!(body.frame(u8::MAX), None);
+}
+
+// ---- the refusal table: one case per rule ----
+
+#[test]
+fn a_datagram_shorter_than_a_header_is_refused() {
+    let (bytes, _) = a_hello();
+    assert_eq!(
+        refusal(&bytes[..HEADER_BYTES - 1]),
+        WireError::TooShort { len: 15 }
+    );
+    assert_eq!(refusal(&[]), WireError::TooShort { len: 0 });
+}
+
+#[test]
+fn a_datagram_past_the_ceiling_is_refused_before_anything_reads_it() {
+    let oversized = [0u8; MAX_DATAGRAM_BYTES + 1];
+    assert_eq!(
+        refusal(&oversized),
+        WireError::TooLong {
+            len: MAX_DATAGRAM_BYTES + 1
+        },
+        "the ceiling is checked before magic, so an oversized buffer costs one comparison"
+    );
+}
+
+#[test]
+fn an_all_zero_buffer_names_no_datagram() {
+    let zeroes = [0u8; HELLO_DATAGRAM_BYTES];
+    assert_eq!(refusal(&zeroes), WireError::BadMagic { saw: [0, 0, 0, 0] });
+}
+
+#[test]
+fn wrong_magic_is_refused_and_reports_what_it_saw() {
+    let (mut bytes, len) = a_hello();
+    bytes[0] = b'X';
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::BadMagic { saw: *b"XNWL" }
+    );
+}
+
+#[test]
+fn any_version_but_the_one_is_refused_including_zero() {
+    for version in [0u16, WIRE_VERSION + 1, u16::MAX] {
+        let (mut bytes, len) = a_hello();
+        bytes[4..6].copy_from_slice(&version.to_le_bytes());
+        assert_eq!(
+            refusal(&bytes[..len]),
+            WireError::BadVersion { saw: version }
+        );
+    }
+}
+
+#[test]
+fn an_unknown_kind_is_refused_rather_than_skipped() {
+    for code in [0u8, 5, u8::MAX] {
+        let (mut bytes, len) = a_hello();
+        bytes[6] = code;
+        assert_eq!(refusal(&bytes[..len]), WireError::UnknownKind { saw: code });
+    }
+}
+
+#[test]
+fn a_sender_past_the_seat_ceiling_is_refused() {
+    for claimed in [MAX_PEERS, u8::MAX] {
+        let (mut bytes, len) = a_hello();
+        bytes[7] = claimed;
+        assert_eq!(
+            refusal(&bytes[..len]),
+            WireError::SenderPastCeiling {
+                saw: claimed,
+                ceiling: MAX_PEERS
+            }
+        );
+    }
+}
+
+#[test]
+fn session_zero_is_the_pinned_illegal_value() {
+    let (mut bytes, len) = a_hello();
+    bytes[8..16].copy_from_slice(&0u64.to_le_bytes());
+    assert_eq!(refusal(&bytes[..len]), WireError::SessionZero);
+}
+
+#[test]
+fn a_trailing_byte_is_a_refusal_and_not_a_tolerance() {
+    let (bytes, len) = a_hello();
+    let longer = &bytes[..=len];
+    assert_eq!(
+        refusal(longer),
+        WireError::SizeMismatch {
+            kind: Kind::Hello,
+            declared: HELLO_DATAGRAM_BYTES as u64,
+            actual: len + 1,
+        },
+        "equality, never a lower bound: a tolerated tail is a second spelling of one fact"
+    );
+}
+
+#[test]
+fn an_inputs_run_whose_frames_do_not_match_its_counts_is_refused() {
+    let (bytes, len) = an_inputs();
+    assert_eq!(
+        refusal(&bytes[..len - 1]),
+        WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared: len as u64,
+            actual: len - 1
+        }
+    );
+}
+
+#[test]
+fn an_inputs_datagram_too_short_to_declare_its_own_size_is_refused() {
+    let (bytes, _) = an_inputs();
+    assert_eq!(
+        refusal(&bytes[..INPUTS_MIN_DATAGRAM_BYTES - 1]),
+        WireError::SizeMismatch {
+            kind: Kind::Inputs,
+            declared: INPUTS_MIN_DATAGRAM_BYTES as u64,
+            actual: INPUTS_MIN_DATAGRAM_BYTES - 1,
+        },
+        "the two bytes the size is computed from are proven present before either is read"
+    );
+}
+
+#[test]
+fn a_nonzero_reserved_byte_is_refused_in_both_pads() {
+    for step in 0..4 {
+        let (mut bytes, len) = a_hello();
+        bytes[HELLO_PAD + step] = 1;
+        assert_eq!(
+            refusal(&bytes[..len]),
+            WireError::PadNotZero {
+                offset: HELLO_PAD + step,
+                saw: 1
+            }
+        );
+    }
+    for step in 0..2 {
+        let (mut bytes, len) = an_inputs();
+        bytes[INPUTS_PAD + step] = 0x80;
+        assert_eq!(
+            refusal(&bytes[..len]),
+            WireError::PadNotZero {
+                offset: INPUTS_PAD + step,
+                saw: 0x80
+            }
+        );
+    }
+}
+
+#[test]
+fn an_empty_inputs_run_is_refused() {
+    let (mut bytes, len) = an_inputs();
+    bytes[INPUTS_COUNT] = 0;
+    assert_eq!(refusal(&bytes[..len]), WireError::FrameCountZero);
+}
+
+#[test]
+fn a_run_past_the_redundancy_ceiling_is_refused_before_any_multiply() {
+    let (mut bytes, len) = an_inputs();
+    bytes[INPUTS_COUNT] = INPUT_REDUNDANCY + 1;
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::FrameCountPastRedundancy {
+            saw: INPUT_REDUNDANCY + 1,
+            ceiling: INPUT_REDUNDANCY
+        }
+    );
+}
+
+#[test]
+fn an_input_width_outside_its_range_is_refused_in_both_kinds() {
+    let (mut bytes, len) = an_inputs();
+    bytes[INPUTS_WIDTH] = 0;
+    assert_eq!(refusal(&bytes[..len]), WireError::InputBytesZero);
+
+    let (mut bytes, len) = an_inputs();
+    bytes[INPUTS_WIDTH] = MAX_INPUT_BYTES + 1;
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::InputBytesPastCeiling {
+            saw: MAX_INPUT_BYTES + 1,
+            ceiling: MAX_INPUT_BYTES
+        }
+    );
+
+    let (mut bytes, len) = a_hello();
+    bytes[HELLO_INPUT_BYTES] = 0;
+    assert_eq!(refusal(&bytes[..len]), WireError::InputBytesZero);
+
+    let (mut bytes, len) = a_hello();
+    bytes[HELLO_INPUT_BYTES] = MAX_INPUT_BYTES + 1;
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::InputBytesPastCeiling {
+            saw: MAX_INPUT_BYTES + 1,
+            ceiling: MAX_INPUT_BYTES
+        }
+    );
+}
+
+#[test]
+fn a_run_that_would_leave_the_tick_space_is_refused() {
+    // Hand-built, because the writer refuses to mint one. The reader's
+    // rule has to be tested against bytes a hostile peer could send, not
+    // only against bytes this crate can produce.
+    let (mut bytes, len) = an_inputs();
+    bytes[INPUTS_FIRST_TICK..INPUTS_FIRST_TICK + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::TickOverflow {
+            first_tick: u64::MAX,
+            count: 3
+        }
+    );
+}
+
+#[test]
+fn a_roster_outside_its_range_is_refused_at_both_ends() {
+    for count in [0u8, 1, MAX_PEERS + 1, u8::MAX] {
+        let (mut bytes, len) = a_hello();
+        bytes[HELLO_PEER_COUNT] = count;
+        assert_eq!(
+            refusal(&bytes[..len]),
+            WireError::PeerCountOutOfRange {
+                saw: count,
+                floor: 2,
+                ceiling: MAX_PEERS
+            },
+            "one peer is not multiplayer, and nine does not fit the set"
+        );
+    }
+}
+
+#[test]
+fn a_delay_the_window_cannot_buffer_is_refused() {
+    let past = u8::try_from(INPUT_WINDOW).expect("the window fits a byte today");
+    let (mut bytes, len) = a_hello();
+    bytes[HELLO_INPUT_DELAY] = past;
+    assert_eq!(
+        refusal(&bytes[..len]),
+        WireError::InputDelayPastWindow {
+            saw: past,
+            window: INPUT_WINDOW
+        }
+    );
+
+    // The boundary the other way: one below the window is accepted, so the
+    // test pins a range rather than only its outside.
+    let (mut bytes, len) = a_hello();
+    bytes[HELLO_INPUT_DELAY] = past - 1;
+    assert!(read(&bytes[..len]).is_ok());
+}
+
+#[test]
+fn a_zero_digest_period_is_refused() {
+    let (mut bytes, len) = a_hello();
+    bytes[HELLO_DIGEST_PERIOD] = 0;
+    assert_eq!(refusal(&bytes[..len]), WireError::DigestPeriodZero);
+}
+
+// ---- the writers cannot mint what the reader refuses ----
+
+#[test]
+fn the_inputs_writer_refuses_every_argument_the_reader_would_reject() {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let head = header(Kind::Inputs);
+
+    assert_eq!(
+        write_inputs(&mut out, head, 0, 2, 0, &[]),
+        Err(WriteError::FrameCount {
+            saw: 0,
+            ceiling: INPUT_REDUNDANCY
+        })
+    );
+    assert_eq!(
+        write_inputs(&mut out, head, 0, 1, INPUT_REDUNDANCY + 1, &[0; 9]),
+        Err(WriteError::FrameCount {
+            saw: INPUT_REDUNDANCY + 1,
+            ceiling: INPUT_REDUNDANCY
+        })
+    );
+    assert_eq!(
+        write_inputs(&mut out, head, 0, 0, 1, &[]),
+        Err(WriteError::InputBytes {
+            saw: 0,
+            ceiling: MAX_INPUT_BYTES
+        })
+    );
+    assert_eq!(
+        write_inputs(&mut out, head, 0, MAX_INPUT_BYTES + 1, 1, &[0; 17]),
+        Err(WriteError::InputBytes {
+            saw: MAX_INPUT_BYTES + 1,
+            ceiling: MAX_INPUT_BYTES
+        })
+    );
+    assert_eq!(
+        write_inputs(&mut out, head, 0, 2, 3, &[0; 5]),
+        Err(WriteError::FramesLength {
+            saw: 5,
+            expected: 6
+        }),
+        "refused rather than truncated: a short write is a second spelling of a shorter fact"
+    );
+    assert_eq!(
+        write_inputs(&mut out, head, u64::MAX, 1, 2, &[0; 2]),
+        Err(WriteError::TickOverflow {
+            first_tick: u64::MAX,
+            count: 2
+        })
+    );
+}
+
+#[test]
+fn the_widest_legal_run_writes_exactly_the_ceiling() {
+    let frames = [7u8; (INPUT_REDUNDANCY as usize) * (MAX_INPUT_BYTES as usize)];
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = write_inputs(
+        &mut out,
+        header(Kind::Inputs),
+        0,
+        MAX_INPUT_BYTES,
+        INPUT_REDUNDANCY,
+        &frames,
+    )
+    .expect("both ceilings, exactly");
+    assert_eq!(
+        len, MAX_DATAGRAM_BYTES,
+        "the widest datagram is the ceiling, to the byte"
+    );
+    assert!(
+        read(&out[..len]).is_ok(),
+        "and the reader accepts what the writer just minted"
+    );
+}
+
+#[test]
+fn every_refusal_says_something_a_reader_can_act_on() {
+    // A refusal set whose Display arms are untested is a set that can grow
+    // an arm printing nothing, and nothing would notice.
+    let cases: Vec<WireError> = vec![
+        refusal(&[]),
+        refusal(&[0u8; MAX_DATAGRAM_BYTES + 1]),
+        refusal(&[0u8; HELLO_DATAGRAM_BYTES]),
+    ];
+    for case in cases {
+        let text = case.to_string();
+        assert!(!text.is_empty(), "{case:?} printed nothing");
+        assert!(
+            text.chars().any(|character| character.is_ascii_digit()),
+            "{case:?} printed no number: \"{text}\" — a refusal that names no value teaches a \
+             reader nothing"
+        );
+    }
+}
+
+// ---- sweeps ----
+
+#[test]
+fn every_truncation_of_every_kind_is_refused() {
+    for (bytes, len) in [a_hello(), an_inputs(), a_digest(), a_bye()] {
+        for cut in 0..len {
+            assert!(
+                read(&bytes[..cut]).is_err(),
+                "a datagram cut to {cut} of {len} bytes was accepted"
+            );
+        }
+        assert!(
+            read(&bytes[..len]).is_ok(),
+            "and the whole one is still accepted"
+        );
+    }
+}
+
+#[test]
+fn no_single_bit_flip_produces_a_second_spelling_of_the_same_datagram() {
+    // The canonical-encoding claim, tested the only way it can be: no
+    // mutation may yield a different byte string that decodes to the same
+    // datagram. Every kind, every byte, every bit.
+    for (original, len) in [a_hello(), an_inputs(), a_digest(), a_bye()] {
+        let truth = read(&original[..len]).expect("valid before mutation");
+        for offset in 0..len {
+            for bit in 0..8u8 {
+                let mut mutated = original;
+                mutated[offset] ^= 1 << bit;
+                if let Ok(seen) = read(&mutated[..len]) {
+                    assert!(
+                        (seen.header, seen.body) != (truth.header, truth.body),
+                        "byte {offset} bit {bit} produced a second spelling of one datagram"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/net/tests/wire.rs
+++ b/crates/net/tests/wire.rs
@@ -8,9 +8,11 @@
 //! the clearest way to say "this byte, that value" when the subject of
 //! the test is one byte.
 
+use core::num::NonZeroU64;
+
 use renew_net::wire::{
-    BYE_DATAGRAM_BYTES, Body, ByeBody, DIGEST_DATAGRAM_BYTES, DigestBody, HEADER_BYTES,
-    HELLO_DATAGRAM_BYTES, Header, HelloBody, INPUTS_MIN_DATAGRAM_BYTES, Kind, WIRE_VERSION,
+    Addressing, BYE_DATAGRAM_BYTES, Body, ByeBody, DIGEST_DATAGRAM_BYTES, DigestBody, HEADER_BYTES,
+    HELLO_DATAGRAM_BYTES, HelloBody, INPUTS_MIN_DATAGRAM_BYTES, Kind, MAGIC, WIRE_VERSION,
     WireError, WriteError, read, write_bye, write_digest, write_hello, write_inputs,
 };
 use renew_net::{
@@ -43,11 +45,16 @@ fn seat(index: u8) -> PeerId {
     PeerId::new(index).expect("a seat the test chose in range")
 }
 
-fn header(kind: Kind) -> Header {
-    Header {
-        kind,
+const SESSION: u64 = 0x0123_4567_89ab_cdef;
+
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn addressing() -> Addressing {
+    Addressing {
         sender: seat(1),
-        session: 0x0123_4567_89ab_cdef,
+        session: NonZeroU64::new(SESSION).expect("the fixture's session is not zero"),
     }
 }
 
@@ -64,9 +71,14 @@ fn hello_body() -> HelloBody {
     }
 }
 
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
 fn a_hello() -> (Buffer, usize) {
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
-    let len = write_hello(&mut out, header(Kind::Hello), &hello_body());
+    let len = write_hello(&mut out, addressing(), &hello_body())
+        .expect("a body inside every documented range");
     (out, len)
 }
 
@@ -77,15 +89,8 @@ fn a_hello() -> (Buffer, usize) {
 )]
 fn an_inputs() -> (Buffer, usize) {
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
-    let len = write_inputs(
-        &mut out,
-        header(Kind::Inputs),
-        4_000,
-        2,
-        3,
-        &[1, 2, 3, 4, 5, 6],
-    )
-    .expect("arguments inside every ceiling");
+    let len = write_inputs(&mut out, addressing(), 4_000, 3, 2, &[1, 2, 3, 4, 5, 6])
+        .expect("arguments inside every ceiling");
     (out, len)
 }
 
@@ -96,13 +101,13 @@ fn a_digest() -> (Buffer, usize) {
         state_digest: 0xabcd,
         input_digest: 0x1234,
     };
-    let len = write_digest(&mut out, header(Kind::Digest), &body);
+    let len = write_digest(&mut out, addressing(), &body);
     (out, len)
 }
 
 fn a_bye() -> (Buffer, usize) {
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
-    let len = write_bye(&mut out, header(Kind::Bye), &ByeBody { tick: 0x0102_0304 });
+    let len = write_bye(&mut out, addressing(), &ByeBody { tick: 0x0102_0304 });
     (out, len)
 }
 
@@ -122,14 +127,16 @@ fn a_hello_round_trips_to_the_same_bytes() {
     assert_eq!(len, HELLO_DATAGRAM_BYTES);
 
     let datagram = read(&bytes[..len]).expect("a datagram this crate wrote");
-    assert_eq!(datagram.header, header(Kind::Hello));
+    assert_eq!(datagram.header.kind, Kind::Hello);
+    assert_eq!(datagram.header.addressing(), addressing());
     let Body::Hello(body) = datagram.body else {
         panic!("a Hello decoded as something else")
     };
     assert_eq!(body, hello_body());
 
     let mut again = [0u8; MAX_DATAGRAM_BYTES];
-    let again_len = write_hello(&mut again, datagram.header, &body);
+    let again_len = write_hello(&mut again, datagram.header.addressing(), &body)
+        .expect("what the reader accepted, the writer must be able to write");
     assert_eq!((&again[..again_len], again_len), (&bytes[..len], len));
 }
 
@@ -148,7 +155,7 @@ fn a_digest_round_trips_to_the_same_bytes() {
     );
 
     let mut again = [0u8; MAX_DATAGRAM_BYTES];
-    let again_len = write_digest(&mut again, datagram.header, &body);
+    let again_len = write_digest(&mut again, datagram.header.addressing(), &body);
     assert_eq!(&again[..again_len], &bytes[..len]);
 }
 
@@ -164,7 +171,10 @@ fn a_bye_round_trips_to_the_same_bytes() {
     assert_eq!(body.tick, 0x0102_0304);
 
     let mut again = [0u8; MAX_DATAGRAM_BYTES];
-    assert_eq!(write_bye(&mut again, datagram.header, &body), len);
+    assert_eq!(
+        write_bye(&mut again, datagram.header.addressing(), &body),
+        len
+    );
     assert_eq!(&again[..len], &bytes[..len]);
 }
 
@@ -199,10 +209,10 @@ fn an_inputs_run_round_trips_with_every_frame_at_its_own_tick() {
     let mut again = [0u8; MAX_DATAGRAM_BYTES];
     let again_len = write_inputs(
         &mut again,
-        datagram.header,
+        datagram.header.addressing(),
         body.first_tick,
-        body.input_bytes,
         body.count,
+        body.input_bytes,
         body.frames(),
     )
     .expect("what the reader accepted, the writer must be able to write");
@@ -489,38 +499,38 @@ fn a_zero_digest_period_is_refused() {
 #[test]
 fn the_inputs_writer_refuses_every_argument_the_reader_would_reject() {
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
-    let head = header(Kind::Inputs);
+    let head = addressing();
 
     assert_eq!(
-        write_inputs(&mut out, head, 0, 2, 0, &[]),
+        write_inputs(&mut out, head, 0, 0, 2, &[]),
         Err(WriteError::FrameCount {
             saw: 0,
             ceiling: INPUT_REDUNDANCY
         })
     );
     assert_eq!(
-        write_inputs(&mut out, head, 0, 1, INPUT_REDUNDANCY + 1, &[0; 9]),
+        write_inputs(&mut out, head, 0, INPUT_REDUNDANCY + 1, 1, &[0; 9]),
         Err(WriteError::FrameCount {
             saw: INPUT_REDUNDANCY + 1,
             ceiling: INPUT_REDUNDANCY
         })
     );
     assert_eq!(
-        write_inputs(&mut out, head, 0, 0, 1, &[]),
+        write_inputs(&mut out, head, 0, 1, 0, &[]),
         Err(WriteError::InputBytes {
             saw: 0,
             ceiling: MAX_INPUT_BYTES
         })
     );
     assert_eq!(
-        write_inputs(&mut out, head, 0, MAX_INPUT_BYTES + 1, 1, &[0; 17]),
+        write_inputs(&mut out, head, 0, 1, MAX_INPUT_BYTES + 1, &[0; 17]),
         Err(WriteError::InputBytes {
             saw: MAX_INPUT_BYTES + 1,
             ceiling: MAX_INPUT_BYTES
         })
     );
     assert_eq!(
-        write_inputs(&mut out, head, 0, 2, 3, &[0; 5]),
+        write_inputs(&mut out, head, 0, 3, 2, &[0; 5]),
         Err(WriteError::FramesLength {
             saw: 5,
             expected: 6
@@ -528,7 +538,7 @@ fn the_inputs_writer_refuses_every_argument_the_reader_would_reject() {
         "refused rather than truncated: a short write is a second spelling of a shorter fact"
     );
     assert_eq!(
-        write_inputs(&mut out, head, u64::MAX, 1, 2, &[0; 2]),
+        write_inputs(&mut out, head, u64::MAX, 2, 1, &[0; 2]),
         Err(WriteError::TickOverflow {
             first_tick: u64::MAX,
             count: 2
@@ -537,15 +547,112 @@ fn the_inputs_writer_refuses_every_argument_the_reader_would_reject() {
 }
 
 #[test]
+fn the_hello_writer_refuses_every_body_the_reader_would_reject() {
+    // The four ranges read_hello enforces, enforced here too — which is
+    // what makes "a writer cannot mint what the reader would refuse" a
+    // contract rather than an aspiration. Each case is also driven
+    // through `read` to prove the refusal was not merely conservative:
+    // the datagram it declined really would have been declined.
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let head = addressing();
+
+    for count in [0u8, 1, MAX_PEERS + 1] {
+        let body = HelloBody {
+            peer_count: count,
+            ..hello_body()
+        };
+        assert_eq!(
+            write_hello(&mut out, head, &body),
+            Err(WriteError::PeerCount {
+                saw: count,
+                floor: 2,
+                ceiling: MAX_PEERS
+            })
+        );
+    }
+
+    for width in [0u8, MAX_INPUT_BYTES + 1] {
+        let body = HelloBody {
+            input_bytes: width,
+            ..hello_body()
+        };
+        assert_eq!(
+            write_hello(&mut out, head, &body),
+            Err(WriteError::InputBytes {
+                saw: width,
+                ceiling: MAX_INPUT_BYTES
+            })
+        );
+    }
+
+    let past = u8::try_from(INPUT_WINDOW).expect("the window fits a byte today");
+    let body = HelloBody {
+        input_delay: past,
+        ..hello_body()
+    };
+    assert_eq!(
+        write_hello(&mut out, head, &body),
+        Err(WriteError::InputDelay {
+            saw: past,
+            window: INPUT_WINDOW
+        })
+    );
+
+    let body = HelloBody {
+        digest_period: 0,
+        ..hello_body()
+    };
+    assert_eq!(
+        write_hello(&mut out, head, &body),
+        Err(WriteError::DigestPeriodZero)
+    );
+
+    // The boundaries the other way, so the refusals pin a range rather
+    // than only its outside.
+    for body in [
+        HelloBody {
+            peer_count: 2,
+            ..hello_body()
+        },
+        HelloBody {
+            peer_count: MAX_PEERS,
+            ..hello_body()
+        },
+        HelloBody {
+            input_bytes: 1,
+            ..hello_body()
+        },
+        HelloBody {
+            input_bytes: MAX_INPUT_BYTES,
+            ..hello_body()
+        },
+        HelloBody {
+            input_delay: past - 1,
+            ..hello_body()
+        },
+        HelloBody {
+            digest_period: 1,
+            ..hello_body()
+        },
+    ] {
+        let len = write_hello(&mut out, head, &body).expect("a body at its boundary is legal");
+        assert!(
+            read(&out[..len]).is_ok(),
+            "the writer accepted {body:?} and the reader did not"
+        );
+    }
+}
+
+#[test]
 fn the_widest_legal_run_writes_exactly_the_ceiling() {
     let frames = [7u8; (INPUT_REDUNDANCY as usize) * (MAX_INPUT_BYTES as usize)];
     let mut out = [0u8; MAX_DATAGRAM_BYTES];
     let len = write_inputs(
         &mut out,
-        header(Kind::Inputs),
+        addressing(),
         0,
-        MAX_INPUT_BYTES,
         INPUT_REDUNDANCY,
+        MAX_INPUT_BYTES,
         &frames,
     )
     .expect("both ceilings, exactly");
@@ -560,23 +667,175 @@ fn the_widest_legal_run_writes_exactly_the_ceiling() {
 }
 
 #[test]
-fn every_refusal_says_something_a_reader_can_act_on() {
-    // A refusal set whose Display arms are untested is a set that can grow
-    // an arm printing nothing, and nothing would notice.
-    let cases: Vec<WireError> = vec![
-        refusal(&[]),
-        refusal(&[0u8; MAX_DATAGRAM_BYTES + 1]),
-        refusal(&[0u8; HELLO_DATAGRAM_BYTES]),
+fn refusals_display_their_evidence() {
+    // Every arm, not a sample. A refusal set with untested arms is one
+    // that can grow an arm printing nothing, and nothing would notice —
+    // and three of twenty-one is a sample however the comment reads.
+    let wire_errors = vec![
+        WireError::TooShort { len: 15 },
+        WireError::TooLong { len: 157 },
+        WireError::BadMagic { saw: *b"XNWL" },
+        WireError::BadVersion { saw: 2 },
+        WireError::UnknownKind { saw: 9 },
+        WireError::SenderPastCeiling { saw: 8, ceiling: 8 },
+        WireError::SessionZero,
+        WireError::SizeMismatch {
+            kind: Kind::Hello,
+            declared: 56,
+            actual: 57,
+        },
+        WireError::PadNotZero { offset: 52, saw: 1 },
+        WireError::FrameCountZero,
+        WireError::FrameCountPastRedundancy { saw: 9, ceiling: 8 },
+        WireError::InputBytesZero,
+        WireError::InputBytesPastCeiling {
+            saw: 17,
+            ceiling: 16,
+        },
+        WireError::TickOverflow {
+            first_tick: u64::MAX,
+            count: 3,
+        },
+        WireError::PeerCountOutOfRange {
+            saw: 1,
+            floor: 2,
+            ceiling: 8,
+        },
+        WireError::InputDelayPastWindow {
+            saw: 64,
+            window: 64,
+        },
+        WireError::DigestPeriodZero,
     ];
-    for case in cases {
+    let write_errors = vec![
+        WriteError::FrameCount { saw: 9, ceiling: 8 },
+        WriteError::InputBytes {
+            saw: 17,
+            ceiling: 16,
+        },
+        WriteError::FramesLength {
+            saw: 5,
+            expected: 6,
+        },
+        WriteError::TickOverflow {
+            first_tick: u64::MAX,
+            count: 2,
+        },
+        WriteError::PeerCount {
+            saw: 1,
+            floor: 2,
+            ceiling: 8,
+        },
+        WriteError::InputDelay {
+            saw: 64,
+            window: 64,
+        },
+        WriteError::DigestPeriodZero,
+    ];
+
+    // Four refusals name their value in words rather than in digits,
+    // because the value IS zero and "0" would read worse than "zero".
+    // Held to that spelling by name rather than exempted from the rule,
+    // so the rule keeps its teeth for the other nineteen.
+    let spelled_out = |text: &str| assert!(text.contains("zero"), "expected the word: \"{text}\"");
+
+    for case in wire_errors {
         let text = case.to_string();
         assert!(!text.is_empty(), "{case:?} printed nothing");
-        assert!(
-            text.chars().any(|character| character.is_ascii_digit()),
-            "{case:?} printed no number: \"{text}\" — a refusal that names no value teaches a \
-             reader nothing"
-        );
+        match case {
+            WireError::SessionZero
+            | WireError::FrameCountZero
+            | WireError::InputBytesZero
+            | WireError::DigestPeriodZero => spelled_out(&text),
+            _ => assert!(
+                text.chars().any(|character| character.is_ascii_digit()),
+                "{case:?} printed no number: \"{text}\" — a refusal that names no value teaches                  a reader nothing"
+            ),
+        }
     }
+    for case in write_errors {
+        let text = case.to_string();
+        assert!(!text.is_empty(), "{case:?} printed nothing");
+        if matches!(case, WriteError::DigestPeriodZero) {
+            spelled_out(&text);
+        } else {
+            assert!(
+                text.chars().any(|character| character.is_ascii_digit()),
+                "{case:?} printed no number: \"{text}\""
+            );
+        }
+    }
+}
+
+#[test]
+fn every_body_size_is_a_function_of_its_kind() {
+    // The three fixed kinds ignore both counts; only Inputs reads them.
+    assert_eq!(Kind::Hello.body_bytes(0, 0), Some(40));
+    assert_eq!(Kind::Digest.body_bytes(9, 9), Some(24));
+    assert_eq!(Kind::Bye.body_bytes(u8::MAX, u8::MAX), Some(8));
+    assert_eq!(Kind::Inputs.body_bytes(3, 2), Some(18));
+    assert_eq!(
+        Kind::Inputs.body_bytes(u8::MAX, u8::MAX),
+        Some(12 + 255 * 255),
+        "the product is computed in u64, so even the widest pair of bytes fits"
+    );
+}
+
+// ---- the golden: bytes a human typed, from the page a reader reads ----
+
+#[test]
+fn a_hand_built_datagram_writes_back_to_itself() {
+    // Every other assertion in this file is the writer against the
+    // reader, and a writer and a reader that made the SAME mistake are
+    // still exact inverses of each other — the argument the trace codec's
+    // golden already writes down. These bytes were typed from the layout
+    // tables in README.md, not from wire.rs, so they are an independent
+    // referent: a field that moved would have to move on the front page
+    // too before this test agreed with it again.
+    #[rustfmt::skip]
+    let hand_built: [u8; 40] = [
+        // header, 16 bytes
+        b'R', b'N', b'W', b'L',   // magic
+        0x01, 0x00,               // wire version 1, little-endian
+        0x03,                     // kind 3 = Digest
+        0x01,                     // sender: seat 1
+        0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, // session 0x0123456789abcdef
+        // Digest body, 24 bytes
+        0x58, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // tick 600
+        0xcd, 0xab, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // state digest 0xabcd
+        0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // input digest 0x1234
+    ];
+
+    let datagram = read(&hand_built).expect("bytes typed from the documented layout");
+    assert_eq!(datagram.header.kind, Kind::Digest);
+    assert_eq!(datagram.header.sender.index(), 1);
+    assert_eq!(datagram.header.session.get(), SESSION);
+    let Body::Digest(body) = datagram.body else {
+        panic!("the kind byte says Digest")
+    };
+    assert_eq!(
+        (body.tick, body.state_digest, body.input_digest),
+        (600, 0xabcd, 0x1234)
+    );
+
+    // And the inverse: what the reader accepted, the writer reproduces
+    // byte for byte. This is the half a writer-against-reader round trip
+    // cannot give, because both halves would be wrong together.
+    let mut written = [0u8; MAX_DATAGRAM_BYTES];
+    let len = write_digest(&mut written, datagram.header.addressing(), &body);
+    assert_eq!(&written[..len], &hand_built[..]);
+
+    // The fixture agrees with the constants it was not typed from — which
+    // is what makes a disagreement point at the layout rather than at a
+    // typo in the test.
+    assert_eq!(&hand_built[..4], &MAGIC[..]);
+    assert_eq!(len, DIGEST_DATAGRAM_BYTES);
+    assert_eq!(
+        u16::from_le_bytes([hand_built[4], hand_built[5]]),
+        WIRE_VERSION
+    );
+    assert_eq!(hand_built[6], Kind::Digest.code());
+    assert_eq!(HEADER_BYTES, 16);
 }
 
 // ---- sweeps ----


### PR DESCRIPTION
Adds `renew-net`: the wire half of inputs-only multiplayer. A world too
large to replicate as state is nearly free to replicate as "everybody
pressed these buttons", and this is the codec that turns button presses
into bytes without learning what a button means. Four datagrams — the
parameters a peer claims, a run of consecutive per-tick inputs, a pair of
fingerprints, and a departure that names the tick it happened at.

The crate declares itself simulation code, which denies it a dependency
path to the platform crate at any depth and in any dependency kind. That
is deliberate and it is the whole shape of the thing: the socket cannot
live here, so it will live behind a default-off feature elsewhere with no
dependency edge between the halves, and an application holds both. What
that buys is not tidiness — every later step, from an entropy source to a
keyed authentication tag, lands at the socket seam and changes no line of
the code that decides what a tick means. The crate ships with no
dependencies at all, so the promise is structural rather than stated.

**The format admits exactly one byte string for any fact it can carry,
and the reader proves that rather than trusting it.** Length equality
rather than a lower bound, computed in `u64` before a region is sliced;
one accepted version; closed enumerations, because skipping an unknown
word is how a format silently forks; and every reserved byte proven zero.
A test flips every bit of every byte of all four kinds and asserts that no
mutation yields a second spelling of the same datagram. Another cuts each
kind at every length and asserts all of them refuse. A third types a whole
datagram out by hand from the layout tables on the crate's front page and
holds the codec against it — because every other assertion here is the
writer against the reader, and two halves that made the same mistake are
still exact inverses of each other.

**A writer cannot mint what the reader would refuse, and that is enforced
by construction wherever it can be.** The writers take an `Addressing` —
sender and session, no kind — so a datagram whose bytes disagree with the
function that made them cannot be expressed. The session is `NonZeroU64`,
so the reader's one illegal value is unrepresentable in a caller's hand
rather than refused in a branch. What genuinely needs a refusal has one:
`write_hello` returns an error for each of the four parameter ranges the
reader enforces, and `write_inputs` refuses rather than truncating,
because a silently shorter run would be a second spelling of a shorter
fact.

Two root denies beyond the workspace set, and they are load-bearing rather
than stylistic: every byte here can arrive from a hostile peer, and a
release build aborts on panic, so an unchecked index is a remote process
abort and an unchecked add is a remote abort in debug and a wrong answer
in release. Ring depths are powers of two so an index is a mask, since `%`
would trip the second deny where `&` does not.

Loss is answered by redundancy rather than retransmission: a datagram
carries up to eight frames, the newest plus seven repeats, so seven
consecutive losses of one peer's stream cost nothing and no round trip
recovers data that has already expired. Frames are addressed by absolute
tick, never a delta and never a sequence number, so arrival order cannot
reach a stored value.

Ceilings are documented as ceilings, not targets, and the widest datagram
is derived from them rather than chosen — 156 bytes, asserted against both
its own composition and the smallest path this protocol assumes. Both
assertions are compile-time, because a test could only report them after
the build that broke them had already succeeded. The eight-seat roster is
a type decision rather than a tunable: the peer set is one byte because of
it, and a ninth seat is a change to that type.

The crate's front page states what this is not, where a reader will meet
it: no authentication, no confidentiality, no integrity protection, and a
deployment scope of a LAN or an explicit invitation among people who trust
each other. Information cheating is unpreventable in any inputs-only
design, because every peer necessarily holds the whole world; what the
model does give is that state never crosses the wire, so a cheater can lie
to himself and cannot lie to anyone else.

The engine's module table gains this crate and `renew-scene`, which had
been missing since it landed, with the crate count and the
removability-configuration count corrected to match what CI runs.
