### PR TITLE
feat(net): the lockstep session, and arrival made unobservable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       # accumulator, and the bench suite.
       - name: Build and test without the frame loop
         run: |
-          sel="--workspace --exclude renew-frame --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench --exclude renew-cli"
+          sel="--workspace --exclude renew-frame --exclude renew-net --exclude renew-ui --exclude renew-ui-render --exclude renew-sample-chess --exclude renew-sample-chess-rules --exclude renew-sample-cube --exclude renew-sample-cube-world --exclude renew-sample-leap --exclude renew-sample-leap-world --exclude renew-sample-hello-triangle --exclude renew-sample-input-echo --exclude renew-sample-glide --exclude renew-sample-glide-world --exclude hello-engine --exclude renew-bench --exclude renew-cli"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-frame $sel
           cargo build $sel
           cargo test $sel

--- a/.github/workflows/nightly-checks.yml
+++ b/.github/workflows/nightly-checks.yml
@@ -123,7 +123,7 @@ jobs:
         # and once for the hello_triangle sample. Neither was caught by a
         # gate. To check it by hand:
         #   grep -rl '^sanitized = ' --include=Cargo.toml .
-        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-ecs/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized,renew-scene/sanitized,renew-volume/sanitized -Zbuild-std --target ${{ matrix.target }}
+        run: cargo +nightly test --workspace --lib --bins --tests --features renew-audio/sanitized,renew-diag/sanitized,renew-memory/sanitized,renew-bench/sanitized,renew-jobs/sanitized,renew-rhi/sanitized,renew-render2d/sanitized,renew-ecs/sanitized,renew-render3d/sanitized,renew-particles/sanitized,renew-rng/sanitized,renew-frame/sanitized,renew-sample-hello-triangle/sanitized,renew-sample-glide-world/sanitized,renew-cli/sanitized,renew-ui/sanitized,renew-ui-render/sanitized,renew-snapshot/sanitized,renew-scene/sanitized,renew-volume/sanitized,renew-net/sanitized -Zbuild-std --target ${{ matrix.target }}
       # The jobs crate's long stress tier is #[ignore]d in ordinary runs;
       # under the sanitizers it runs in full — the interleaving depth is
       # the point of this job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,11 @@ dependencies = [
 [[package]]
 name = "renew-net"
 version = "0.1.1"
+dependencies = [
+ "proptest",
+ "renew-frame",
+ "renew-memory",
+]
 
 [[package]]
 name = "renew-particles"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -168,3 +168,13 @@ reason = "Two restatements of a bound already proved, re-anchored from 220 and 2
 file = "crates/net/src/wire.rs"
 lines = [147]
 reason = "The overflow arm of the Inputs body-size product. Both factors are u8, so the product peaks at 65,025 and cannot leave u64 — no datagram, and no fuzzer, can drive it. The check is written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and this one is reached from a reader parsing hostile bytes. It cannot be folded away either: `Option::and_then` is not callable in a const fn, so the arm has to be spelled out."
+
+[[exempt]]
+file = "crates/net/src/desync.rs"
+lines = [128, 133, 167]
+reason = "The error arms of `write!` inside a Display implementation. A formatter over a String cannot fail, so these propagate an error that never arrives; they exist because Display must be total and `?` is the only honest way to write that. Every one of them sits on a line whose successful path is covered by the JSON tests."
+
+[[exempt]]
+file = "crates/net/src/session.rs"
+lines = [704, 758, 1071, 1083, 1107]
+reason = "Five arms no input can drive. `render` cannot be called with the terminal emission because the cursor that produces it returns None first, and `render_inputs` cannot see a zero local tick because inputs are only emitted once the session is playing, which requires at least one submission. The backwards walk's missing-frame break cannot fire either: it looks at most eight ticks back and the ring holds sixty-four, so those frames are always present. The remaining two are region ends inside `next_outbound` and `write_frame` whose bodies are covered. All five are kept rather than deleted because each states a bound that would stop being true if a ceiling moved, which is exactly when a silent wrong answer would cost the most."

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -29,8 +29,22 @@ workspace = true
 # seeded hasher, so there is nothing for a future edit to launder one
 # through.
 #
-# The session state machine arrives with `renew-frame`, for the digest
-# fold. It is not taken now, because nothing here folds one yet and a
-# dependency nothing depends on is a claim about the graph that is not
-# true.
+# The digest the session's agreement and input folds answer with — the
+# same explicit-order fingerprint every other simulation state in this
+# tree uses. Nothing else: a crate with one dependency, and that one
+# having none itself, is a determinism promise the graph can check.
 [dependencies]
+renew-frame = { version = "0.1.1", path = "../frame" }
+
+# Property tests for the session's invariants, and the counting allocator
+# behind the zero-allocation gate, which ships with the crate's first
+# per-tick code rather than after it.
+[dev-dependencies]
+proptest = "1.11"
+renew-memory = { path = "../core/memory" }
+
+# The switch the scheduled sanitizer workflow flips: allocation counting
+# is invalid under an instrumented allocator, so the gate ignores itself
+# there.
+[features]
+sanitized = []

--- a/crates/net/src/desync.rs
+++ b/crates/net/src/desync.rs
@@ -1,0 +1,179 @@
+//! What a divergence looks like when it is written down.
+//!
+//! A desync is the one failure this protocol cannot prevent and must
+//! therefore explain. The report exists so the first question a developer
+//! asks — *whose fault is it* — is answered by the data rather than by a
+//! debugger, and the answer is one bit wide: [`DesyncReport::inputs_agree`].
+
+use crate::{MAX_PEERS, PeerId, PeerSet, SessionStats};
+
+const PEERS: usize = MAX_PEERS as usize;
+
+/// Everything known about a divergence at the tick it was caught.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DesyncReport {
+    /// The digested tick at which the fingerprints disagreed.
+    pub tick: u64,
+    pub local: PeerId,
+    pub peer_count: u8,
+    pub local_state_digest: u64,
+    /// One entry per seat; `None` where that peer has not reported.
+    pub peer_state_digests: [Option<u64>; PEERS],
+    pub local_input_digest: u64,
+    pub peer_input_digests: [Option<u64>; PEERS],
+    /// The most recent tick at which every reporting peer agreed.
+    ///
+    /// The divergence is inside `(last_agreed_tick, tick]` — at most
+    /// `digest_period` ticks wide, which turns that parameter from a
+    /// bandwidth knob into a bisect knob and prices it: at sixty hertz
+    /// and a period of thirty, the window to search is half a second of
+    /// simulation.
+    pub last_agreed_tick: Option<u64>,
+    pub agreement_digest: u64,
+    pub content: u64,
+    pub rules: u64,
+    pub seed: u64,
+    /// Arrival- and rate-dependent counters, carried as evidence and
+    /// **never folded into anything**.
+    pub stats: SessionStats,
+}
+
+impl DesyncReport {
+    /// The peers whose state fingerprint differs from this machine's.
+    ///
+    /// With three or more peers this names the odd one out, which is the
+    /// blame that majority corroboration would have bought — recorded
+    /// here rather than acted on, because a majority continuing while a
+    /// minority plays a different game is a silent fork by vote.
+    #[must_use]
+    pub fn dissenters(&self) -> PeerSet {
+        let mut set = PeerSet::EMPTY;
+        for peer in PeerSet::of_count(self.peer_count).iter() {
+            if peer == self.local {
+                continue;
+            }
+            if let Some(Some(theirs)) = self.peer_state_digests.get(usize::from(peer.index()))
+                && *theirs != self.local_state_digest
+            {
+                set = set.with(peer);
+            }
+        }
+        set
+    }
+
+    /// **The one-bit classification, and the reason an input digest is on
+    /// the wire at all.**
+    ///
+    /// `true` — every reporting peer ran identical inputs and produced
+    /// different state. The network is exonerated *by evidence* rather
+    /// than by assertion, and the bug is in the simulation, the
+    /// toolchain, the build profile, or the content. The next step is the
+    /// cross-platform determinism lane, or `content` and `rules`.
+    ///
+    /// `false` — the peers ran different inputs, and the state digest is
+    /// a symptom rather than the disease. The bug is here, in the
+    /// caller's submit discipline, or in transport — and [`Self::stats`]
+    /// is in this report for exactly this branch.
+    #[must_use]
+    pub fn inputs_agree(&self) -> bool {
+        PeerSet::of_count(self.peer_count)
+            .iter()
+            .filter(|peer| *peer != self.local)
+            .filter_map(|peer| {
+                self.peer_input_digests
+                    .get(usize::from(peer.index()))
+                    .copied()
+            })
+            .flatten()
+            .all(|theirs| theirs == self.local_input_digest)
+    }
+
+    /// Whether any remote reported at all for this tick.
+    ///
+    /// A report about a tick nobody witnessed compares nothing, and must
+    /// never read as agreement — the same discipline the determinism
+    /// lane's inconclusive verdict keeps.
+    #[must_use]
+    pub fn witnessed(&self) -> bool {
+        self.peer_state_digests.iter().any(Option::is_some)
+    }
+
+    /// The machine-readable form (D11).
+    #[must_use]
+    pub const fn json(&self) -> DesyncReportJson<'_> {
+        DesyncReportJson(self)
+    }
+}
+
+/// The JSON face of a [`DesyncReport`].
+///
+/// `schema_version` is the first field and it is `1`. Written by hand
+/// rather than derived, for the reason the rest of this tree writes its
+/// JSON by hand: a derive makes the wire shape a consequence of field
+/// order, and this one is read by tools.
+#[derive(Clone, Copy, Debug)]
+pub struct DesyncReportJson<'a>(&'a DesyncReport);
+
+impl core::fmt::Display for DesyncReportJson<'_> {
+    fn fmt(&self, out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let report = self.0;
+        write!(
+            out,
+            r#"{{"schema_version":1,"tick":{},"local":{},"peer_count":{},"inputs_agree":{},"witnessed":{},"#,
+            report.tick,
+            report.local.index(),
+            report.peer_count,
+            report.inputs_agree(),
+            report.witnessed()
+        )?;
+        write!(
+            out,
+            r#""local_state_digest":"{:#018x}","local_input_digest":"{:#018x}","#,
+            report.local_state_digest, report.local_input_digest
+        )?;
+        match report.last_agreed_tick {
+            Some(tick) => write!(out, r#""last_agreed_tick":{tick},"#)?,
+            None => write!(out, r#""last_agreed_tick":null,"#)?,
+        }
+        write!(out, r#""dissenters":["#)?;
+        for (position, peer) in report.dissenters().iter().enumerate() {
+            if position > 0 {
+                write!(out, ",")?;
+            }
+            write!(out, "{}", peer.index())?;
+        }
+        write!(out, r#"],"peers":["#)?;
+        for (position, peer) in PeerSet::of_count(report.peer_count).iter().enumerate() {
+            if position > 0 {
+                write!(out, ",")?;
+            }
+            let seat = usize::from(peer.index());
+            let state = report.peer_state_digests.get(seat).copied().flatten();
+            let input = report.peer_input_digests.get(seat).copied().flatten();
+            write!(out, r#"{{"seat":{},"#, peer.index())?;
+            match state {
+                Some(value) => write!(out, r#""state_digest":"{value:#018x}","#)?,
+                None => write!(out, r#""state_digest":null,"#)?,
+            }
+            match input {
+                Some(value) => write!(out, r#""input_digest":"{value:#018x}"}}"#)?,
+                None => write!(out, r#""input_digest":null}}"#)?,
+            }
+        }
+        write!(
+            out,
+            r#"],"agreement_digest":"{:#018x}","content":"{:#018x}","rules":"{:#018x}","seed":{},"#,
+            report.agreement_digest, report.content, report.rules, report.seed
+        )?;
+        write!(
+            out,
+            r#""stats":{{"datagrams_refused":{},"frames_repeated":{},"frames_contradicted":{},"frames_out_of_window":{},"digests_contradicted":{},"stall_pumps":{}}}}}"#,
+            report.stats.datagrams_refused,
+            report.stats.frames_repeated,
+            report.stats.frames_contradicted,
+            report.stats.frames_out_of_window,
+            report.stats.digests_contradicted,
+            report.stats.stall_pumps
+        )
+    }
+}

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -74,10 +74,19 @@
 // the root instead of at the two functions that obviously need them.
 #![deny(clippy::indexing_slicing, clippy::arithmetic_side_effects)]
 
+mod desync;
+mod params;
 mod peer;
+mod session;
 pub mod wire;
 
+pub use desync::{DesyncReport, DesyncReportJson};
+pub use params::{MIN_PEERS, ParamsError, SessionParams, ValidParams};
 pub use peer::{PeerId, PeerSet, peers};
+pub use session::{
+    Advance, CommitError, Delivery, Outbound, Outcome, Refusal, Session, SessionStats, Step,
+    SubmitError,
+};
 
 /// The most peers one session may hold.
 ///
@@ -120,6 +129,14 @@ pub const INPUT_REDUNDANCY: u8 = 8;
 /// index is `tick & (INPUT_WINDOW - 1)`, and `%` would trip this crate's
 /// arithmetic deny where a mask does not.
 pub const INPUT_WINDOW: u32 = 64;
+
+/// How many digested ticks each peer's fingerprints are retained for.
+///
+/// A power of two, for the same reason [`INPUT_WINDOW`] is: the ring
+/// index is a mask. It bounds how far behind a peer's digest may arrive
+/// and still be compared — beyond it the tick has been forgotten, and a
+/// comparison that cannot run says so rather than passing.
+pub const DIGEST_HISTORY: u32 = 16;
 
 /// The largest datagram this protocol can produce, in bytes.
 ///

--- a/crates/net/src/params.rs
+++ b/crates/net/src/params.rs
@@ -1,0 +1,261 @@
+//! What every peer must agree on before tick zero exists.
+//!
+//! Two types and one rule. [`SessionParams`] is what a caller writes
+//! down; [`ValidParams`] is what a session holds, and it exists only
+//! because a validated value that is indistinguishable from an
+//! unvalidated one gets re-validated at every use, or worse, does not.
+//!
+//! The agreement digest is folded here, once, at validation. Every peer
+//! folds it from its own parameters and puts the result in its `Hello`;
+//! two peers who disagree about anything that matters therefore disagree
+//! about one `u64` at the handshake, rather than about a world four
+//! hundred ticks later.
+
+use renew_frame::StateHash;
+
+use crate::wire::WIRE_VERSION;
+use crate::{INPUT_WINDOW, MAX_INPUT_BYTES, MAX_PEERS, PeerId, PeerSet};
+
+/// The smallest roster that is a session. One peer is not multiplayer.
+pub const MIN_PEERS: u8 = 2;
+
+/// What a caller writes down to start a session.
+///
+/// Plain data with public fields, deliberately: this is the thing an
+/// application builds from a lobby, a command line, or a save file, and
+/// making it a builder would buy nothing but ceremony. It is validated
+/// once, by [`SessionParams::validate`], and the validated form is what
+/// a session takes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SessionParams {
+    /// How many seats are playing. `MIN_PEERS..=MAX_PEERS`.
+    pub peer_count: u8,
+    /// Which seat this machine is. Must be inside the roster.
+    ///
+    /// **Excluded from the agreement digest**, and it is the only field
+    /// that is: it differs per peer by definition, so folding it would
+    /// make every peer disagree with every other at the handshake.
+    pub local: PeerId,
+    /// How wide one peer's input is, per tick. `1..=MAX_INPUT_BYTES`.
+    pub input_bytes: u8,
+    /// How many ticks ahead of the confirmed tick a peer submits.
+    ///
+    /// This is the whole latency knob. Zero means a tick cannot run until
+    /// its own inputs have crossed the wire; higher values buy the
+    /// network that many ticks of slack, at the cost of that many ticks
+    /// between pressing a key and seeing it. Below [`INPUT_WINDOW`].
+    pub input_delay: u8,
+    /// How often a digest is exchanged, in ticks. At least one.
+    ///
+    /// A bandwidth knob that is really a bisect knob: a divergence is
+    /// located to within this many ticks, so at sixty hertz and thirty,
+    /// the window a human has to search is half a second of simulation.
+    pub digest_period: u8,
+    /// The run's master seed.
+    pub seed: u64,
+    /// What content every peer is running — assets, levels, tables.
+    ///
+    /// **The engine cannot compute this and never validates it.** It
+    /// proves only that everyone supplied the same number. What that
+    /// number means is the application's, exactly as the trace header
+    /// keeps caller-owned keys verbatim without reading them.
+    pub content: u64,
+    /// What rules every peer is running, as distinct from what assets.
+    /// Two numbers rather than one so a refusal can name which half.
+    pub rules: u64,
+    /// The session identifier, shared by every peer and never zero.
+    ///
+    /// It is an admission token in the weakest sense: a datagram carrying
+    /// the wrong one is dropped at the header, so an unrelated session on
+    /// the same port cannot reach this one. **It is not a secret and not
+    /// a defence** — the engine has no entropy source, so whatever
+    /// resistance it has is whatever the application's own source of it
+    /// provides.
+    pub session: core::num::NonZeroU64,
+}
+
+/// Why a set of parameters could not start a session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParamsError {
+    PeerCount {
+        saw: u8,
+        floor: u8,
+        ceiling: u8,
+    },
+    /// The local seat is not in the roster it claims to be part of.
+    LocalNotInRoster {
+        local: u8,
+        peer_count: u8,
+    },
+    InputBytes {
+        saw: u8,
+        ceiling: u8,
+    },
+    InputDelay {
+        saw: u8,
+        window: u32,
+    },
+    DigestPeriodZero,
+}
+
+impl core::fmt::Display for ParamsError {
+    fn fmt(&self, out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::PeerCount {
+                saw,
+                floor,
+                ceiling,
+            } => write!(out, "a roster of {saw} is outside {floor}..={ceiling}"),
+            Self::LocalNotInRoster { local, peer_count } => {
+                write!(out, "seat {local} is not inside a roster of {peer_count}")
+            }
+            Self::InputBytes { saw, ceiling } => {
+                write!(out, "an input width of {saw} is not within 1..={ceiling}")
+            }
+            Self::InputDelay { saw, window } => write!(
+                out,
+                "an input delay of {saw} does not fit a window of {window}"
+            ),
+            Self::DigestPeriodZero => {
+                write!(out, "a digest period of zero would digest every tick")
+            }
+        }
+    }
+}
+
+impl core::error::Error for ParamsError {}
+
+impl SessionParams {
+    /// Check every field, and fold the agreement digest once.
+    ///
+    /// # Errors
+    ///
+    /// [`ParamsError`] naming the first field that is out of range, in
+    /// declaration order, so the message is stable rather than dependent
+    /// on how many things are wrong.
+    pub fn validate(self) -> Result<ValidParams, ParamsError> {
+        if !(MIN_PEERS..=MAX_PEERS).contains(&self.peer_count) {
+            return Err(ParamsError::PeerCount {
+                saw: self.peer_count,
+                floor: MIN_PEERS,
+                ceiling: MAX_PEERS,
+            });
+        }
+        if self.local.index() >= self.peer_count {
+            return Err(ParamsError::LocalNotInRoster {
+                local: self.local.index(),
+                peer_count: self.peer_count,
+            });
+        }
+        if self.input_bytes == 0 || self.input_bytes > MAX_INPUT_BYTES {
+            return Err(ParamsError::InputBytes {
+                saw: self.input_bytes,
+                ceiling: MAX_INPUT_BYTES,
+            });
+        }
+        if u32::from(self.input_delay) >= INPUT_WINDOW {
+            return Err(ParamsError::InputDelay {
+                saw: self.input_delay,
+                window: INPUT_WINDOW,
+            });
+        }
+        if self.digest_period == 0 {
+            return Err(ParamsError::DigestPeriodZero);
+        }
+        Ok(ValidParams {
+            params: self,
+            agreement: self.agreement_digest(),
+        })
+    }
+
+    /// The fingerprint every peer compares at the handshake.
+    ///
+    /// Absorbed in written order, so a reordering is a visible diff
+    /// rather than a silently moved digest — the same discipline the
+    /// frame crate's fingerprint is built on. **`local` is excluded and
+    /// `session` is excluded**: the first differs per peer by definition,
+    /// and the second cannot reach a confirmed frame, because two peers
+    /// holding different ones drop each other's datagrams at the header.
+    #[must_use]
+    fn agreement_digest(self) -> u64 {
+        StateHash::new()
+            .absorb_u32(u32::from(WIRE_VERSION))
+            .absorb_u64(self.content)
+            .absorb_u64(self.rules)
+            .absorb_u64(self.seed)
+            .absorb_u32(u32::from(self.peer_count))
+            .absorb_u32(u32::from(self.input_bytes))
+            .absorb_u32(u32::from(self.input_delay))
+            .absorb_u32(u32::from(self.digest_period))
+            .finish()
+    }
+}
+
+/// Parameters that have been checked, and the digest folded from them.
+///
+/// A session takes this rather than [`SessionParams`], so "has this been
+/// validated?" is answered by the type instead of by a comment. The
+/// inner value is readable and the digest is not recomputable from
+/// outside — there is one fold, at one moment, and everything downstream
+/// reads its result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValidParams {
+    params: SessionParams,
+    agreement: u64,
+}
+
+impl ValidParams {
+    #[must_use]
+    pub const fn get(&self) -> &SessionParams {
+        &self.params
+    }
+
+    /// The fingerprint every peer puts in its `Hello`.
+    #[must_use]
+    pub const fn agreement_digest(&self) -> u64 {
+        self.agreement
+    }
+
+    /// Every seat in the session, as a set.
+    #[must_use]
+    pub const fn roster(&self) -> PeerSet {
+        PeerSet::of_count(self.params.peer_count)
+    }
+
+    /// Every seat except this machine's — the peers a datagram goes to.
+    #[must_use]
+    pub const fn remotes(&self) -> PeerSet {
+        self.roster().without(self.params.local)
+    }
+
+    #[must_use]
+    pub const fn local(&self) -> PeerId {
+        self.params.local
+    }
+
+    #[must_use]
+    pub const fn peer_count(&self) -> u8 {
+        self.params.peer_count
+    }
+
+    #[must_use]
+    pub const fn input_bytes(&self) -> u8 {
+        self.params.input_bytes
+    }
+
+    #[must_use]
+    pub const fn input_delay(&self) -> u8 {
+        self.params.input_delay
+    }
+
+    #[must_use]
+    pub const fn digest_period(&self) -> u8 {
+        self.params.digest_period
+    }
+
+    #[must_use]
+    pub const fn session(&self) -> core::num::NonZeroU64 {
+        self.params.session
+    }
+}

--- a/crates/net/src/peer.rs
+++ b/crates/net/src/peer.rs
@@ -96,6 +96,14 @@ impl PeerSet {
         self.0 == 0
     }
 
+    /// The seats in this set that are not in `other`.
+    ///
+    /// What a stall reports: the roster, less whoever has arrived.
+    #[must_use]
+    pub const fn without_all(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
+
     /// How many seats are in the set.
     ///
     /// `u32` rather than `usize`, and deliberately: no pointer-width value

--- a/crates/net/src/session.rs
+++ b/crates/net/src/session.rs
@@ -245,10 +245,6 @@ impl<'a> Outbound<'a> {
 pub enum SubmitError {
     /// The input is not the width every peer agreed on.
     WrongWidth { saw: usize, agreed: u8 },
-    /// This tick already has a local input. **First write wins**, here as
-    /// on the wire: a caller that could revise a submitted input after
-    /// seeing another peer's would be a caller that could cheat.
-    AlreadySubmitted { tick: u64 },
     /// The window is full: the local peer is `INPUT_WINDOW` ticks ahead
     /// of the slowest confirmed tick and may not run further ahead.
     WindowFull { tick: u64, pending: u64 },
@@ -443,6 +439,11 @@ impl Session {
     /// Offer this machine's input for the tick it is owed, returning that
     /// tick.
     ///
+    /// **Never rewrites.** Each call fills the next unsubmitted tick, so a
+    /// caller cannot revise an input after seeing another peer's — which
+    /// is the shape of lookahead cheating, closed here by the state
+    /// machine rather than by a rule.
+    ///
     /// # Errors
     ///
     /// [`SubmitError`] for a wrong width, a tick already submitted, a full
@@ -464,12 +465,14 @@ impl Session {
                 pending: self.pending,
             });
         }
+        // No "already submitted" refusal, and none is possible: this
+        // always fills `local_next`, which only ever advances, and no
+        // remote can write this seat's frame — a datagram claiming to be
+        // from us is refused as `FromSelf`. First-write-wins holds by
+        // construction rather than by a check, so a check here would
+        // advertise a protection that could never fire.
         let tick = self.local_next;
-        let local = self.params.local();
-        if self.held_by(tick).contains(local) {
-            return Err(SubmitError::AlreadySubmitted { tick });
-        }
-        self.write_frame(local, tick, input);
+        self.write_frame(self.params.local(), tick, input);
         self.local_next = self.local_next.saturating_add(1);
         self.maybe_start();
         Ok(tick)

--- a/crates/net/src/session.rs
+++ b/crates/net/src/session.rs
@@ -1,0 +1,1084 @@
+//! Lockstep as a pure state machine.
+//!
+//! Local inputs and received datagram bytes in; confirmed per-tick input
+//! sets and outbound datagram bytes out. **No socket, no clock, no
+//! threads, and no allocation after construction** — the session cannot
+//! reach any of them, and its storage is fixed inline arrays sized by the
+//! crate's ceilings.
+//!
+//! # The one rule everything else serves
+//!
+//! **A tick runs only when every peer's input for it has arrived.** There
+//! is no timeout that advances a tick, no "assume the last input", and no
+//! way for arrival order, duplication or loss to reach a confirmed value.
+//! Those are not omissions to be filled in later: each of them is a
+//! divergence source dressed as a feature, and a lockstep session that
+//! has one is a lockstep session that forks.
+//!
+//! # What this deliberately does not decide
+//!
+//! **When to give up on a silent peer.** Waiting is reported —
+//! [`Advance::Stalled`] carries who is missing and how many pumps it has
+//! been — and the *driver* decides, because the answer depends on a wall
+//! clock and this crate may not read one. A pump budget living in here
+//! would be wall-derived state inside the simulation zone with the power
+//! to end the run.
+
+use renew_frame::StateHash;
+
+use crate::desync::DesyncReport;
+use crate::params::ValidParams;
+use crate::wire::{self, Body, WireError};
+use crate::{
+    DIGEST_HISTORY, INPUT_REDUNDANCY, INPUT_WINDOW, MAX_DATAGRAM_BYTES, MAX_INPUT_BYTES, MAX_PEERS,
+    PeerId, PeerSet,
+};
+
+const PEERS: usize = MAX_PEERS as usize;
+const WINDOW: usize = INPUT_WINDOW as usize;
+const HISTORY: usize = DIGEST_HISTORY as usize;
+const WIDTH: usize = MAX_INPUT_BYTES as usize;
+const WINDOW_MASK: u64 = (INPUT_WINDOW as u64) - 1;
+const HISTORY_MASK: u64 = (DIGEST_HISTORY as u64) - 1;
+
+/// The ring slot a tick occupies.
+///
+/// A mask rather than a remainder, which is why both ring depths are
+/// powers of two: `%` trips this crate's arithmetic deny and `&` does
+/// not. The mask bounds the result below the window, so the narrowing
+/// cannot lose a bit on any target this engine builds for.
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "masked below INPUT_WINDOW (64) one operation earlier, so the value always fits"
+)]
+const fn slot(tick: u64) -> usize {
+    (tick & WINDOW_MASK) as usize
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "masked below DIGEST_HISTORY (16) one operation earlier, so the value always fits"
+)]
+const fn digest_slot(tick: u64) -> usize {
+    (tick & HISTORY_MASK) as usize
+}
+
+/// Counters a driver reports and a desync report carries as evidence.
+///
+/// **Every field here is arrival-order- or frame-rate-dependent, and none
+/// of them may ever enter a digest.** Two healthy peers on two healthy
+/// machines will disagree about all of them; that is what they are for.
+/// This is the exclusion an implementer is most likely to get wrong, and
+/// folding one produces a lane that diverges on three correct machines.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SessionStats {
+    /// Datagrams refused before they reached the session's state.
+    pub datagrams_refused: u64,
+    /// Frames that arrived for a tick already held, carrying the same
+    /// bytes. The redundancy scheme working; not an error.
+    pub frames_repeated: u64,
+    /// Frames that arrived for a tick already held, carrying *different*
+    /// bytes. Counted and dropped — see [`Delivery`].
+    pub frames_contradicted: u64,
+    /// Frames refused for naming a tick outside the window.
+    pub frames_out_of_window: u64,
+    /// Digests that arrived for a `(peer, tick)` already held and
+    /// disagreed with it. Refused, never overwritten.
+    pub digests_contradicted: u64,
+    /// Pumps spent waiting on a tick that could not run.
+    pub stall_pumps: u64,
+}
+
+/// What happened to a delivered datagram.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Delivery {
+    /// Absorbed: new inputs, a new digest, or a departure noted.
+    Accepted,
+    /// Refused, counted, and dropped. **Never terminal**, including for a
+    /// peer that contradicts itself: first-write-wins already makes the
+    /// second frame a state no-op, so ending the session would add no
+    /// safety and would hand any address-spoofing attacker a one-packet
+    /// kill switch that names an innocent peer as the culprit. The digest
+    /// exchange is what catches a genuine fork, at most `digest_period`
+    /// ticks later.
+    Refused(Refusal),
+    /// The session is over and no further tick will be confirmed.
+    Ends(Outcome),
+}
+
+/// Why a datagram was dropped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Refusal {
+    /// Malformed, by the codec's own rules.
+    Malformed(WireError),
+    /// A different session's datagram, arriving at this port.
+    WrongSession { saw: u64 },
+    /// The header's claimed sender disagreed with the seat the transport
+    /// attributed the bytes to. Checked here so a driver that only looks
+    /// at bodies cannot forget it.
+    SenderNotSource { claimed: PeerId, source: PeerId },
+    /// A seat outside this session's roster.
+    NotInRoster { peer: PeerId },
+    /// This machine's own seat, arriving from the network.
+    FromSelf,
+    /// A `Hello` whose parameters are not the ones this peer is playing.
+    Disagreement { theirs: u64, ours: u64 },
+    /// A frame for a tick already confirmed, or too far ahead to buffer.
+    OutOfWindow { tick: u64, pending: u64 },
+    /// A frame for a tick already held, carrying different bytes.
+    Contradiction { peer: PeerId, tick: u64 },
+    /// A frame whose width is not the width everyone agreed on.
+    WrongWidth { saw: u8, agreed: u8 },
+    /// A digest for a `(peer, tick)` already held, disagreeing with it.
+    DigestContradiction { peer: PeerId, tick: u64 },
+}
+
+/// Why a session ended. Every arm is terminal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Outcome {
+    /// A peer's world hashed differently from this one's.
+    ///
+    /// Terminal on purpose, and the argument is worth keeping: letting a
+    /// majority continue while a minority plays a different game is a
+    /// silent fork by vote, which is the exact thing inputs-only lockstep
+    /// exists to prevent. What corroboration would buy is *blame*, and
+    /// blame belongs in the report.
+    Desynced { tick: u64 },
+    /// A peer left, naming the last tick it confirmed.
+    PeerLeft { peer: PeerId, tick: u64 },
+    /// This machine left.
+    LeftLocally { tick: u64 },
+}
+
+/// What the session can do right now.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Advance {
+    /// A tick is confirmed and must be run.
+    Step(Step),
+    /// Nothing to run: every confirmed tick has been taken and the next
+    /// one is not complete. Ordinary, and not an error.
+    Waiting,
+    /// The next tick is missing at least one peer's input.
+    ///
+    /// Reported rather than acted on. `pumps` counts how many times the
+    /// caller has asked while this tick stayed incomplete — a number
+    /// derived from the caller's own frame rate, which is exactly why the
+    /// decision to give up belongs to the caller and not to this crate.
+    Stalled {
+        tick: u64,
+        waiting: PeerSet,
+        pumps: u64,
+    },
+    /// The session is over.
+    Ended(Outcome),
+}
+
+/// One confirmed tick, and the inputs that make it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Step {
+    tick: u64,
+    digest_due: bool,
+    peer_count: u8,
+    input_bytes: u8,
+    frames: [[u8; WIDTH]; PEERS],
+}
+
+impl Step {
+    #[must_use]
+    pub const fn tick(&self) -> u64 {
+        self.tick
+    }
+
+    /// Whether the caller owes a world digest to [`Session::commit`].
+    #[must_use]
+    pub const fn digest_due(&self) -> bool {
+        self.digest_due
+    }
+
+    /// One peer's input for this tick, exactly `input_bytes` wide.
+    #[must_use]
+    pub fn input(&self, peer: PeerId) -> Option<&[u8]> {
+        if peer.index() >= self.peer_count {
+            return None;
+        }
+        self.frames
+            .get(usize::from(peer.index()))?
+            .get(..usize::from(self.input_bytes))
+    }
+
+    /// Every seat's input, **ascending by seat, always**.
+    ///
+    /// The order is the contract, not a consequence: a caller that
+    /// applied inputs in arrival order would put the network into its
+    /// world, and every peer would diverge while each ran correct code.
+    pub fn inputs(&self) -> impl Iterator<Item = (PeerId, &[u8])> {
+        PeerSet::of_count(self.peer_count)
+            .iter()
+            .filter_map(move |peer| self.input(peer).map(|bytes| (peer, bytes)))
+    }
+}
+
+/// A datagram the caller should send, and who to.
+#[derive(Clone, Copy, Debug)]
+pub struct Outbound<'a> {
+    peer: PeerId,
+    bytes: &'a [u8],
+}
+
+impl<'a> Outbound<'a> {
+    #[must_use]
+    pub const fn peer(&self) -> PeerId {
+        self.peer
+    }
+
+    #[must_use]
+    pub const fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+}
+
+/// Why a local submission was refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SubmitError {
+    /// The input is not the width every peer agreed on.
+    WrongWidth { saw: usize, agreed: u8 },
+    /// This tick already has a local input. **First write wins**, here as
+    /// on the wire: a caller that could revise a submitted input after
+    /// seeing another peer's would be a caller that could cheat.
+    AlreadySubmitted { tick: u64 },
+    /// The window is full: the local peer is `INPUT_WINDOW` ticks ahead
+    /// of the slowest confirmed tick and may not run further ahead.
+    WindowFull { tick: u64, pending: u64 },
+    /// The session is over.
+    Ended(Outcome),
+}
+
+/// Why a commit was refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CommitError {
+    /// A tick was committed that was not the one handed out.
+    OutOfOrder { saw: u64, expected: u64 },
+    /// A digest was owed and not supplied, or supplied and not owed.
+    /// Both directions are refused: a caller who does not know which
+    /// ticks are digested has a caller-side bug that would surface later
+    /// as a desync nobody could explain.
+    DigestMismatch { tick: u64, owed: bool },
+}
+
+/// One peer's fingerprints for one tick, as held in the ring.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Fingerprint {
+    tick: u64,
+    state: u64,
+    input: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+    /// Waiting for every peer to say hello and for the local peer to fill
+    /// the delay window. There is no synthetic neutral input to fill it
+    /// with, deliberately: an all-zero frame is a value the game's decoder
+    /// gives a meaning to, and inventing one here would make every peer do
+    /// that thing for the whole window — identically, deterministically,
+    /// and with no digest test able to see it.
+    Joining,
+    Playing,
+    Over,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Emit {
+    Hello,
+    Inputs,
+    Digest,
+    Bye,
+    Done,
+}
+
+/// A lockstep session: bytes and inputs in, confirmed ticks and bytes out.
+pub struct Session {
+    params: ValidParams,
+    phase: Phase,
+
+    /// Every peer's input for every tick in the window, by seat and slot.
+    frames: [[[u8; WIDTH]; WINDOW]; PEERS],
+    /// Which seats have submitted for the tick each slot holds.
+    present: [PeerSet; WINDOW],
+    /// Which tick each slot holds, so a stale slot is never read as a
+    /// present one after the ring wraps.
+    slot_tick: [u64; WINDOW],
+
+    /// The next tick to hand out. Everything below it is history.
+    pending: u64,
+    /// The next tick the local peer will submit for.
+    local_next: u64,
+
+    /// The running fold over every confirmed input set.
+    input_digest: StateHash,
+    /// This peer's own fingerprints, and every remote's.
+    mine: [Option<Fingerprint>; HISTORY],
+    theirs: [[Option<Fingerprint>; HISTORY]; PEERS],
+    /// A fingerprint owed to every remote and not yet sent.
+    owed_digest: Option<Fingerprint>,
+
+    /// Seats that have said hello, including this one.
+    hello_seen: PeerSet,
+    /// The tick handed out by `advance` and not yet committed.
+    uncommitted: Option<(u64, bool)>,
+
+    outcome: Option<Outcome>,
+    stats: SessionStats,
+    stalled_at: u64,
+
+    emit: Emit,
+    emit_peer: u8,
+}
+
+impl Session {
+    /// A session that has not started: no tick exists until every peer has
+    /// said hello and the local peer has filled the delay window.
+    #[must_use]
+    pub fn new(params: ValidParams) -> Self {
+        Self {
+            params,
+            phase: Phase::Joining,
+            frames: [[[0u8; WIDTH]; WINDOW]; PEERS],
+            present: [PeerSet::EMPTY; WINDOW],
+            slot_tick: [u64::MAX; WINDOW],
+            pending: 0,
+            local_next: 0,
+            input_digest: StateHash::new(),
+            mine: [None; HISTORY],
+            theirs: [[None; HISTORY]; PEERS],
+            owed_digest: None,
+            hello_seen: PeerSet::EMPTY.with(params.local()),
+            uncommitted: None,
+            outcome: None,
+            stats: SessionStats::default(),
+            stalled_at: u64::MAX,
+            emit: Emit::Hello,
+            emit_peer: 0,
+        }
+    }
+
+    #[must_use]
+    pub const fn params(&self) -> &ValidParams {
+        &self.params
+    }
+
+    #[must_use]
+    pub const fn stats(&self) -> SessionStats {
+        self.stats
+    }
+
+    /// The next tick that will be handed out — the confirmed frontier.
+    ///
+    /// **Do not key a local input on this.** It moves with the network:
+    /// under loss it lags, and an input chosen from it is an input that
+    /// depends on what the wire did. A scripted run that made that
+    /// mistake would submit the same value for two different ticks and
+    /// still see both peers agree, because they would agree on the wrong
+    /// thing. [`Session::next_local_tick`] is the one to key on.
+    #[must_use]
+    pub const fn pending_tick(&self) -> u64 {
+        self.pending
+    }
+
+    /// The tick the next [`Session::submit`] will fill.
+    ///
+    /// This is what a scripted or replayed run reads: it advances once
+    /// per accepted submission and never moves for any other reason, so
+    /// an input that is a function of it is a function of the tick alone
+    /// — which is the property that makes a recorded run reproducible on
+    /// a machine whose network behaved differently.
+    #[must_use]
+    pub const fn next_local_tick(&self) -> u64 {
+        self.local_next
+    }
+
+    /// Whether every peer has said hello and the delay window is filled.
+    #[must_use]
+    pub const fn is_playing(&self) -> bool {
+        matches!(self.phase, Phase::Playing)
+    }
+
+    #[must_use]
+    pub const fn outcome(&self) -> Option<Outcome> {
+        self.outcome
+    }
+
+    /// The running fold over every confirmed input set so far.
+    #[must_use]
+    pub const fn input_digest(&self) -> u64 {
+        self.input_digest.finish()
+    }
+
+    /// Whether the caller owes a local input right now.
+    ///
+    /// Ask once per pump and submit at most once. A caller that looped
+    /// until this returned false would fill the whole window with one
+    /// frame's held intent and make `input_delay` inert.
+    #[must_use]
+    pub fn wants_local(&self) -> bool {
+        if matches!(self.phase, Phase::Over) {
+            return false;
+        }
+        let horizon = self
+            .pending
+            .saturating_add(u64::from(self.params.input_delay()));
+        self.local_next <= horizon
+            && self.local_next.saturating_sub(self.pending) < u64::from(INPUT_WINDOW)
+    }
+
+    /// Offer this machine's input for the tick it is owed, returning that
+    /// tick.
+    ///
+    /// # Errors
+    ///
+    /// [`SubmitError`] for a wrong width, a tick already submitted, a full
+    /// window, or a session that has ended.
+    pub fn submit(&mut self, input: &[u8]) -> Result<u64, SubmitError> {
+        if let Some(outcome) = self.outcome {
+            return Err(SubmitError::Ended(outcome));
+        }
+        let agreed = self.params.input_bytes();
+        if input.len() != usize::from(agreed) {
+            return Err(SubmitError::WrongWidth {
+                saw: input.len(),
+                agreed,
+            });
+        }
+        if self.local_next.saturating_sub(self.pending) >= u64::from(INPUT_WINDOW) {
+            return Err(SubmitError::WindowFull {
+                tick: self.local_next,
+                pending: self.pending,
+            });
+        }
+        let tick = self.local_next;
+        let local = self.params.local();
+        if self.held_by(tick).contains(local) {
+            return Err(SubmitError::AlreadySubmitted { tick });
+        }
+        self.write_frame(local, tick, input);
+        self.local_next = self.local_next.saturating_add(1);
+        self.maybe_start();
+        Ok(tick)
+    }
+
+    /// Hand the session a datagram, attributed to the seat its transport
+    /// says it came from.
+    ///
+    /// `source` is the seat the *transport* believes sent these bytes. The
+    /// header's own claim is checked against it here, so a driver that
+    /// only reads bodies cannot forget the check.
+    pub fn deliver(&mut self, source: PeerId, bytes: &[u8]) -> Delivery {
+        if let Some(outcome) = self.outcome {
+            return Delivery::Ends(outcome);
+        }
+        let datagram = match wire::read(bytes) {
+            Ok(datagram) => datagram,
+            Err(error) => return self.refuse(Refusal::Malformed(error)),
+        };
+        let sender = datagram.header.sender;
+        let session = datagram.header.session;
+        if session != self.params.session() {
+            return self.refuse(Refusal::WrongSession { saw: session.get() });
+        }
+        if sender != source {
+            return self.refuse(Refusal::SenderNotSource {
+                claimed: sender,
+                source,
+            });
+        }
+        if sender == self.params.local() {
+            return self.refuse(Refusal::FromSelf);
+        }
+        if !self.params.roster().contains(sender) {
+            return self.refuse(Refusal::NotInRoster { peer: sender });
+        }
+
+        match datagram.body {
+            Body::Hello(body) => {
+                if body.agreement_digest != self.params.agreement_digest() {
+                    return self.refuse(Refusal::Disagreement {
+                        theirs: body.agreement_digest,
+                        ours: self.params.agreement_digest(),
+                    });
+                }
+                self.hello_seen = self.hello_seen.with(sender);
+                self.maybe_start();
+                Delivery::Accepted
+            }
+            Body::Inputs(body) => self.absorb_inputs(sender, &body),
+            Body::Digest(body) => {
+                self.absorb_digest(sender, body.tick, body.state_digest, body.input_digest)
+            }
+            Body::Bye(body) => {
+                let outcome = Outcome::PeerLeft {
+                    peer: sender,
+                    tick: body.tick,
+                };
+                self.end(outcome);
+                Delivery::Ends(outcome)
+            }
+        }
+    }
+
+    /// Take the next confirmed tick, if there is one.
+    pub fn advance(&mut self) -> Advance {
+        if let Some(outcome) = self.outcome {
+            return Advance::Ended(outcome);
+        }
+        if self.uncommitted.is_some() || !matches!(self.phase, Phase::Playing) {
+            return Advance::Waiting;
+        }
+        let tick = self.pending;
+        let roster = self.params.roster();
+        let held = self.held_by(tick);
+        if held != roster {
+            if self.stalled_at != tick {
+                self.stalled_at = tick;
+                self.stats.stall_pumps = 0;
+            }
+            self.stats.stall_pumps = self.stats.stall_pumps.saturating_add(1);
+            return Advance::Stalled {
+                tick,
+                waiting: roster.without_all(held),
+                pumps: self.stats.stall_pumps,
+            };
+        }
+        self.stalled_at = u64::MAX;
+
+        let mut frames = [[0u8; WIDTH]; PEERS];
+        let width = usize::from(self.params.input_bytes());
+        let index = slot(tick);
+        for peer in roster.iter() {
+            let seat = usize::from(peer.index());
+            if let (Some(destination), Some(source)) = (
+                frames.get_mut(seat),
+                self.frames.get(seat).and_then(|ring| ring.get(index)),
+            ) && let (Some(destination), Some(source)) =
+                (destination.get_mut(..width), source.get(..width))
+            {
+                destination.copy_from_slice(source);
+            }
+        }
+
+        // Folded once, here, before the tick is handed out — a repeat
+        // frame is proven identical before it is ignored, so absorbing it
+        // again would move the digest for a datagram that moved no state.
+        self.input_digest = self.input_digest.absorb_u64(tick);
+        for peer in roster.iter() {
+            if let Some(bytes) = frames
+                .get(usize::from(peer.index()))
+                .and_then(|frame| frame.get(..width))
+            {
+                self.input_digest = self.input_digest.absorb_bytes(bytes);
+            }
+        }
+
+        let digest_due = tick
+            .checked_rem(u64::from(self.params.digest_period()))
+            .is_some_and(|remainder| remainder == 0);
+        self.uncommitted = Some((tick, digest_due));
+        Advance::Step(Step {
+            tick,
+            digest_due,
+            peer_count: self.params.peer_count(),
+            input_bytes: self.params.input_bytes(),
+            frames,
+        })
+    }
+
+    /// Report that the tick just handed out has been run.
+    ///
+    /// `world_digest` must be present exactly when [`Step::digest_due`]
+    /// said so, and absent otherwise. Both directions are refused: a
+    /// caller who does not know which ticks are digested has a bug that
+    /// would otherwise surface much later as a desync nobody can explain.
+    ///
+    /// # Errors
+    ///
+    /// [`CommitError`] for a tick out of order, or a digest owed and not
+    /// supplied — or supplied and not owed.
+    pub fn commit(&mut self, tick: u64, world_digest: Option<u64>) -> Result<(), CommitError> {
+        let Some((expected, owed)) = self.uncommitted else {
+            return Err(CommitError::OutOfOrder {
+                saw: tick,
+                expected: self.pending,
+            });
+        };
+        if tick != expected {
+            return Err(CommitError::OutOfOrder {
+                saw: tick,
+                expected,
+            });
+        }
+        if owed != world_digest.is_some() {
+            return Err(CommitError::DigestMismatch { tick, owed });
+        }
+
+        self.uncommitted = None;
+        self.pending = self.pending.saturating_add(1);
+
+        if let Some(state) = world_digest {
+            let mine = Fingerprint {
+                tick,
+                state,
+                input: self.input_digest.finish(),
+            };
+            if let Some(cell) = self.mine.get_mut(digest_slot(tick)) {
+                *cell = Some(mine);
+            }
+            self.owed_digest = Some(mine);
+            // Compare against anything already heard for this tick: a
+            // peer running ahead publishes before this machine gets here.
+            self.judge(tick);
+        }
+        Ok(())
+    }
+
+    /// The report explaining a divergence, once one has been found.
+    #[must_use]
+    pub fn desync(&self) -> Option<DesyncReport> {
+        let Some(Outcome::Desynced { tick }) = self.outcome else {
+            return None;
+        };
+        Some(self.report_at(tick))
+    }
+
+    /// Leave, naming the last tick this peer confirmed.
+    pub fn leave(&mut self) -> Outcome {
+        let outcome = Outcome::LeftLocally {
+            tick: self.pending.saturating_sub(1),
+        };
+        if self.outcome.is_none() {
+            self.end(outcome);
+            self.emit = Emit::Bye;
+            self.emit_peer = 0;
+        }
+        self.outcome.unwrap_or(outcome)
+    }
+
+    /// The next datagram the caller should send, written into `out`.
+    ///
+    /// Call until it returns `None`, once per pump. **Nothing received
+    /// causes anything to be sent** — every datagram here is rendered from
+    /// session state on demand, never in reply, which is what keeps this
+    /// port off a reflection list and is asserted by a test rather than
+    /// left as a habit.
+    pub fn next_outbound<'b>(
+        &mut self,
+        out: &'b mut [u8; MAX_DATAGRAM_BYTES],
+    ) -> Option<Outbound<'b>> {
+        loop {
+            let Some(peer) = self.next_target() else {
+                self.emit = self.first_emit();
+                self.emit_peer = 0;
+                return None;
+            };
+            let emit = self.emit;
+            self.emit_peer = self.emit_peer.saturating_add(1);
+            if let Some(len) = self.render(emit, out) {
+                return Some(Outbound {
+                    peer,
+                    bytes: out.get(..len)?,
+                });
+            }
+        }
+    }
+}
+
+/// Everything below is private: the parts a consumer never names.
+impl Session {
+    /// Which seats have a frame for `tick`, or none if the slot has been
+    /// reused by a later tick.
+    fn held_by(&self, tick: u64) -> PeerSet {
+        let index = slot(tick);
+        if self.slot_tick.get(index).copied() == Some(tick) {
+            self.present.get(index).copied().unwrap_or(PeerSet::EMPTY)
+        } else {
+            PeerSet::EMPTY
+        }
+    }
+
+    /// The frame a seat submitted for `tick`, if the slot still holds it.
+    fn frame_of(&self, peer: PeerId, tick: u64) -> Option<&[u8]> {
+        if !self.held_by(tick).contains(peer) {
+            return None;
+        }
+        let width = usize::from(self.params.input_bytes());
+        self.frames
+            .get(usize::from(peer.index()))?
+            .get(slot(tick))?
+            .get(..width)
+    }
+
+    /// Claim a slot for `tick` if a previous tick still holds it, then
+    /// record one seat's frame in it.
+    fn write_frame(&mut self, peer: PeerId, tick: u64, input: &[u8]) {
+        let index = slot(tick);
+        if self.slot_tick.get(index).copied() != Some(tick) {
+            if let Some(cell) = self.slot_tick.get_mut(index) {
+                *cell = tick;
+            }
+            if let Some(cell) = self.present.get_mut(index) {
+                *cell = PeerSet::EMPTY;
+            }
+        }
+        let width = usize::from(self.params.input_bytes());
+        if let Some(destination) = self
+            .frames
+            .get_mut(usize::from(peer.index()))
+            .and_then(|ring| ring.get_mut(index))
+            .and_then(|frame| frame.get_mut(..width))
+            && let Some(source) = input.get(..width)
+        {
+            destination.copy_from_slice(source);
+            if let Some(cell) = self.present.get_mut(index) {
+                *cell = cell.with(peer);
+            }
+        }
+    }
+
+    /// Leave `Joining` once every peer has said hello and the local peer
+    /// has submitted through the delay window.
+    fn maybe_start(&mut self) {
+        if matches!(self.phase, Phase::Joining)
+            && self.hello_seen == self.params.roster()
+            && self.local_next > u64::from(self.params.input_delay())
+        {
+            self.phase = Phase::Playing;
+        }
+    }
+
+    fn refuse(&mut self, refusal: Refusal) -> Delivery {
+        self.stats.datagrams_refused = self.stats.datagrams_refused.saturating_add(1);
+        match refusal {
+            Refusal::Contradiction { .. } => {
+                self.stats.frames_contradicted = self.stats.frames_contradicted.saturating_add(1);
+            }
+            Refusal::OutOfWindow { .. } => {
+                self.stats.frames_out_of_window = self.stats.frames_out_of_window.saturating_add(1);
+            }
+            Refusal::DigestContradiction { .. } => {
+                self.stats.digests_contradicted = self.stats.digests_contradicted.saturating_add(1);
+            }
+            _ => {}
+        }
+        Delivery::Refused(refusal)
+    }
+
+    fn end(&mut self, outcome: Outcome) {
+        if self.outcome.is_none() {
+            self.outcome = Some(outcome);
+            self.phase = Phase::Over;
+        }
+    }
+
+    fn absorb_inputs(&mut self, sender: PeerId, body: &wire::InputsBody<'_>) -> Delivery {
+        let agreed = self.params.input_bytes();
+        if body.input_bytes != agreed {
+            return self.refuse(Refusal::WrongWidth {
+                saw: body.input_bytes,
+                agreed,
+            });
+        }
+
+        let mut accepted = false;
+        let mut refusal = None;
+        for (tick, bytes) in body.iter() {
+            // Below the frontier is history the session has already
+            // folded; past the window is a peer spending this machine's
+            // memory. Neither is an error worth ending a session for, and
+            // the first is the ordinary case: redundancy repeats frames
+            // that have already been used.
+            if tick < self.pending {
+                continue;
+            }
+            if tick.saturating_sub(self.pending) >= u64::from(INPUT_WINDOW) {
+                refusal = Some(Refusal::OutOfWindow {
+                    tick,
+                    pending: self.pending,
+                });
+                continue;
+            }
+            match self.frame_of(sender, tick) {
+                Some(held) if held == bytes => {
+                    self.stats.frames_repeated = self.stats.frames_repeated.saturating_add(1);
+                }
+                Some(_) => {
+                    // First write wins, so this is already a state no-op.
+                    // Counted and dropped rather than fatal: see `Delivery`.
+                    refusal = Some(Refusal::Contradiction { peer: sender, tick });
+                }
+                None => {
+                    self.write_frame(sender, tick, bytes);
+                    accepted = true;
+                }
+            }
+        }
+
+        match refusal {
+            Some(refusal) if !accepted => self.refuse(refusal),
+            Some(refusal) => {
+                // Something useful arrived alongside something refused;
+                // the counter still moves so the evidence survives.
+                let _ = self.refuse(refusal);
+                Delivery::Accepted
+            }
+            None => Delivery::Accepted,
+        }
+    }
+
+    fn absorb_digest(&mut self, sender: PeerId, tick: u64, state: u64, input: u64) -> Delivery {
+        let seat = usize::from(sender.index());
+        let index = digest_slot(tick);
+        let incoming = Fingerprint { tick, state, input };
+        let held = self
+            .theirs
+            .get(seat)
+            .and_then(|ring| ring.get(index))
+            .copied()
+            .flatten();
+
+        match held {
+            // First write wins per (peer, tick): a flood of forged
+            // digests cannot evict a genuine one and blind the detector.
+            Some(previous) if previous.tick == tick && previous != incoming => {
+                return self.refuse(Refusal::DigestContradiction { peer: sender, tick });
+            }
+            Some(previous) if previous == incoming => return Delivery::Accepted,
+            _ => {}
+        }
+
+        if let Some(cell) = self
+            .theirs
+            .get_mut(seat)
+            .and_then(|ring| ring.get_mut(index))
+        {
+            *cell = Some(incoming);
+        }
+        if let Some(outcome) = self.judge(tick) {
+            return Delivery::Ends(outcome);
+        }
+        Delivery::Accepted
+    }
+
+    /// Compare every fingerprint held for `tick`. A tick this peer never
+    /// digested compares nothing and says so by returning `None` — the
+    /// anti-vacuity arm, so a report about an unwitnessed tick can never
+    /// read as agreement.
+    fn judge(&mut self, tick: u64) -> Option<Outcome> {
+        let mine = self
+            .mine
+            .get(digest_slot(tick))
+            .copied()
+            .flatten()
+            .filter(|held| held.tick == tick)?;
+        for peer in self.params.remotes().iter() {
+            let theirs = self
+                .theirs
+                .get(usize::from(peer.index()))
+                .and_then(|ring| ring.get(digest_slot(tick)))
+                .copied()
+                .flatten();
+            if let Some(theirs) = theirs
+                && theirs.tick == tick
+                && theirs.state != mine.state
+            {
+                let outcome = Outcome::Desynced { tick };
+                self.end(outcome);
+                return Some(outcome);
+            }
+        }
+        None
+    }
+
+    fn report_at(&self, tick: u64) -> DesyncReport {
+        let index = digest_slot(tick);
+        let mine = self.mine.get(index).copied().flatten();
+        let mut peer_state = [None; PEERS];
+        let mut peer_input = [None; PEERS];
+        for peer in self.params.remotes().iter() {
+            let seat = usize::from(peer.index());
+            let held = self
+                .theirs
+                .get(seat)
+                .and_then(|ring| ring.get(index))
+                .copied()
+                .flatten()
+                .filter(|held| held.tick == tick);
+            if let (Some(held), Some(state), Some(input)) =
+                (held, peer_state.get_mut(seat), peer_input.get_mut(seat))
+            {
+                *state = Some(held.state);
+                *input = Some(held.input);
+            }
+        }
+        DesyncReport {
+            tick,
+            local: self.params.local(),
+            peer_count: self.params.peer_count(),
+            local_state_digest: mine.map_or(0, |held| held.state),
+            local_input_digest: mine.map_or(0, |held| held.input),
+            peer_state_digests: peer_state,
+            peer_input_digests: peer_input,
+            last_agreed_tick: self.last_agreed_before(tick),
+            agreement_digest: self.params.agreement_digest(),
+            content: self.params.get().content,
+            rules: self.params.get().rules,
+            seed: self.params.get().seed,
+            stats: self.stats,
+        }
+    }
+
+    /// The most recent digested tick below `tick` at which every
+    /// reporting peer agreed. It bounds the search for the divergence to
+    /// at most `digest_period` ticks, which is what turns that parameter
+    /// from a bandwidth knob into a bisect knob.
+    fn last_agreed_before(&self, tick: u64) -> Option<u64> {
+        let mut best: Option<u64> = None;
+        for held in self.mine.iter().flatten() {
+            if held.tick >= tick {
+                continue;
+            }
+            let agreed = self.params.remotes().iter().all(|peer| {
+                self.theirs
+                    .get(usize::from(peer.index()))
+                    .and_then(|ring| ring.get(digest_slot(held.tick)))
+                    .copied()
+                    .flatten()
+                    .filter(|theirs| theirs.tick == held.tick)
+                    .is_none_or(|theirs| theirs.state == held.state)
+            });
+            if agreed && best.is_none_or(|previous| held.tick > previous) {
+                best = Some(held.tick);
+            }
+        }
+        best
+    }
+
+    /// The first thing a pump emits, given the phase.
+    const fn first_emit(&self) -> Emit {
+        match self.phase {
+            Phase::Joining => Emit::Hello,
+            Phase::Playing => Emit::Inputs,
+            Phase::Over => Emit::Bye,
+        }
+    }
+
+    /// Walk remotes for the current emission, then move to the next kind.
+    fn next_target(&mut self) -> Option<PeerId> {
+        loop {
+            if matches!(self.emit, Emit::Done) {
+                return None;
+            }
+            let remotes = self.params.remotes();
+            while let Some(peer) = PeerId::new(self.emit_peer) {
+                if remotes.contains(peer) {
+                    return Some(peer);
+                }
+                self.emit_peer = self.emit_peer.saturating_add(1);
+            }
+            self.emit_peer = 0;
+            // Inputs is the only kind with anything after it. Every other
+            // kind is the whole of what its phase says, so the pump ends.
+            self.emit = match self.emit {
+                Emit::Inputs => Emit::Digest,
+                _ => Emit::Done,
+            };
+            if matches!(self.emit, Emit::Digest) && self.owed_digest.is_none() {
+                self.emit = Emit::Done;
+            }
+        }
+    }
+
+    /// Render one datagram, or `None` when there is nothing of this kind
+    /// to say right now.
+    fn render(&mut self, emit: Emit, out: &mut [u8; MAX_DATAGRAM_BYTES]) -> Option<usize> {
+        let addressing = wire::Addressing {
+            sender: self.params.local(),
+            session: self.params.session(),
+        };
+        match emit {
+            Emit::Hello => {
+                let body = wire::HelloBody {
+                    agreement_digest: self.params.agreement_digest(),
+                    content: self.params.get().content,
+                    rules: self.params.get().rules,
+                    seed: self.params.get().seed,
+                    peer_count: self.params.peer_count(),
+                    input_bytes: self.params.input_bytes(),
+                    input_delay: self.params.input_delay(),
+                    digest_period: self.params.digest_period(),
+                };
+                wire::write_hello(out, addressing, &body).ok()
+            }
+            Emit::Inputs => self.render_inputs(addressing, out),
+            Emit::Digest => {
+                let owed = self.owed_digest?;
+                Some(wire::write_digest(
+                    out,
+                    addressing,
+                    &wire::DigestBody {
+                        tick: owed.tick,
+                        state_digest: owed.state,
+                        input_digest: owed.input,
+                    },
+                ))
+            }
+            Emit::Bye => Some(wire::write_bye(
+                out,
+                addressing,
+                &wire::ByeBody {
+                    tick: self.pending.saturating_sub(1),
+                },
+            )),
+            Emit::Done => None,
+        }
+    }
+
+    /// The newest local frames, oldest first — the redundancy that makes
+    /// loss free without a round trip.
+    fn render_inputs(
+        &self,
+        addressing: wire::Addressing,
+        out: &mut [u8; MAX_DATAGRAM_BYTES],
+    ) -> Option<usize> {
+        if self.local_next == 0 {
+            return None;
+        }
+        let newest = self.local_next.saturating_sub(1);
+        let want = u64::from(INPUT_REDUNDANCY);
+        let oldest = newest
+            .saturating_sub(want.saturating_sub(1))
+            .max(self.pending);
+        let count = u8::try_from(newest.saturating_sub(oldest).saturating_add(1)).ok()?;
+        let width = usize::from(self.params.input_bytes());
+
+        let mut run = [0u8; (INPUT_REDUNDANCY as usize) * WIDTH];
+        let local = self.params.local();
+        for step in 0..u64::from(count) {
+            let tick = oldest.checked_add(step)?;
+            let bytes = self.frame_of(local, tick)?;
+            let at = usize::try_from(step).ok()?.checked_mul(width)?;
+            let destination = run.get_mut(at..)?.get_mut(..width)?;
+            destination.copy_from_slice(bytes);
+        }
+        let total = usize::from(count).checked_mul(width)?;
+        wire::write_inputs(
+            out,
+            addressing,
+            oldest,
+            count,
+            self.params.input_bytes(),
+            run.get(..total)?,
+        )
+        .ok()
+    }
+}

--- a/crates/net/src/session.rs
+++ b/crates/net/src/session.rs
@@ -327,6 +327,11 @@ pub struct Session {
 
     /// Seats that have said hello, including this one.
     hello_seen: PeerSet,
+    /// Seats seen *playing* — proved by any datagram only a playing peer
+    /// sends. A peer cannot leave `Joining` without having heard every
+    /// hello, so one of these is proof that peer heard ours, and that is
+    /// the acknowledgement this handshake has instead of an ack.
+    playing_seen: PeerSet,
     /// The tick handed out by `advance` and not yet committed.
     uncommitted: Option<(u64, bool)>,
 
@@ -356,6 +361,7 @@ impl Session {
             theirs: [[None; HISTORY]; PEERS],
             owed_digest: None,
             hello_seen: PeerSet::EMPTY.with(params.local()),
+            playing_seen: PeerSet::EMPTY,
             uncommitted: None,
             outcome: None,
             stats: SessionStats::default(),
@@ -513,8 +519,12 @@ impl Session {
                 self.maybe_start();
                 Delivery::Accepted
             }
-            Body::Inputs(body) => self.absorb_inputs(sender, &body),
+            Body::Inputs(body) => {
+                self.playing_seen = self.playing_seen.with(sender);
+                self.absorb_inputs(sender, &body)
+            }
             Body::Digest(body) => {
+                self.playing_seen = self.playing_seen.with(sender);
                 self.absorb_digest(sender, body.tick, body.state_digest, body.input_digest)
             }
             Body::Bye(body) => {
@@ -963,12 +973,26 @@ impl Session {
         best
     }
 
+    /// Whether this peer still owes anyone a hello.
+    ///
+    /// **Not "am I joining".** A hello that is lost while the sender goes
+    /// on to play is a hello never sent again, and the peer that missed it
+    /// waits in `Joining` forever holding a full set of that sender's
+    /// input frames — stalled on a handshake rather than on data, with no
+    /// error raised anywhere. So a hello keeps going out until every
+    /// remote has been *seen playing*, which is proof it heard this one.
+    /// That terminates: a peer cannot play without having heard everyone.
+    fn hello_owed(&self) -> bool {
+        !matches!(self.phase, Phase::Over) && self.playing_seen != self.params.remotes()
+    }
+
     /// The first thing a pump emits, given the phase.
-    const fn first_emit(&self) -> Emit {
+    fn first_emit(&self) -> Emit {
         match self.phase {
-            Phase::Joining => Emit::Hello,
-            Phase::Playing => Emit::Inputs,
             Phase::Over => Emit::Bye,
+            _ if self.hello_owed() => Emit::Hello,
+            Phase::Playing => Emit::Inputs,
+            Phase::Joining => Emit::Hello,
         }
     }
 
@@ -986,9 +1010,11 @@ impl Session {
                 self.emit_peer = self.emit_peer.saturating_add(1);
             }
             self.emit_peer = 0;
-            // Inputs is the only kind with anything after it. Every other
-            // kind is the whole of what its phase says, so the pump ends.
             self.emit = match self.emit {
+                // A hello no longer ends the pump: a peer that is playing
+                // and still owes a hello sends both, or its inputs would
+                // stop while it re-announced.
+                Emit::Hello if matches!(self.phase, Phase::Playing) => Emit::Inputs,
                 Emit::Inputs => Emit::Digest,
                 _ => Emit::Done,
             };
@@ -1055,14 +1081,35 @@ impl Session {
         }
         let newest = self.local_next.saturating_sub(1);
         let want = u64::from(INPUT_REDUNDANCY);
-        let oldest = newest
-            .saturating_sub(want.saturating_sub(1))
-            .max(self.pending);
-        let count = u8::try_from(newest.saturating_sub(oldest).saturating_add(1)).ok()?;
+        let local = self.params.local();
+
+        // **Bounded by what this peer has submitted, never by what it has
+        // confirmed.** Clamping the run to the local frontier is the
+        // obvious thing to write and it deadlocks: the moment this peer
+        // confirms a tick it would stop repeating it, so a peer that never
+        // received that frame could never be sent it again — each waiting
+        // on the other, forever, with no error raised anywhere. A sender's
+        // own progress says nothing about what a receiver still needs.
+        //
+        // Walked backwards from the newest and stopped at the first gap,
+        // so a frame the ring has already recycled ends the run instead of
+        // cancelling the whole datagram.
+        let mut oldest = newest;
+        let mut span = 1u64;
+        while span < want {
+            let Some(earlier) = oldest.checked_sub(1) else {
+                break;
+            };
+            if self.frame_of(local, earlier).is_none() {
+                break;
+            }
+            oldest = earlier;
+            span = span.saturating_add(1);
+        }
+        let count = u8::try_from(span).ok()?;
         let width = usize::from(self.params.input_bytes());
 
         let mut run = [0u8; (INPUT_REDUNDANCY as usize) * WIDTH];
-        let local = self.params.local();
         for step in 0..u64::from(count) {
             let tick = oldest.checked_add(step)?;
             let bytes = self.frame_of(local, tick)?;

--- a/crates/net/tests/desync.rs
+++ b/crates/net/tests/desync.rs
@@ -1,0 +1,317 @@
+//! A divergence, caught and written down.
+//!
+//! The report is the one artifact this crate produces for a human, so it
+//! is tested the way a human reads it: force two peers to disagree about
+//! the world while agreeing about the inputs, and check that the report
+//! says exactly that — because "the inputs matched and the states did not"
+//! is the sentence that sends someone to the simulation instead of to the
+//! network.
+
+use core::num::NonZeroU64;
+
+use renew_net::{
+    Advance, Delivery, MAX_DATAGRAM_BYTES, Outcome, PeerId, Session, SessionParams, ValidParams,
+};
+
+const SESSION: u64 = 0x0dd1_c0de;
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn seat(index: u8) -> PeerId {
+    PeerId::new(index).expect("in range")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn params(local: u8) -> ValidParams {
+    SessionParams {
+        peer_count: 2,
+        local: seat(local),
+        input_bytes: 1,
+        input_delay: 0,
+        digest_period: 1,
+        seed: 3,
+        content: 0xc0_11,
+        rules: 0xba_11,
+        session: NonZeroU64::new(SESSION).expect("not zero"),
+    }
+    .validate()
+    .expect("valid parameters")
+}
+
+/// Runs the pair until one of them ends, or the budget is spent.
+///
+/// `world_of` decides what each peer's world hashed to, which is how a
+/// disagreement is injected without any dishonesty on the wire: both peers
+/// send perfectly well-formed digests, they simply differ.
+#[allow(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "the harness's own failure is the report, and names the step it broke at"
+)]
+fn run_until_end(world_of: impl Fn(usize, u64) -> u64) -> [Box<Session>; 2] {
+    let mut peers = [
+        Box::new(Session::new(params(0))),
+        Box::new(Session::new(params(1))),
+    ];
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let mut inflight: Vec<(u8, Vec<u8>)> = Vec::new();
+
+    // A budget, not an expectation. Whether ending is the right outcome
+    // is the caller's question: the healthy control asserts the pair does
+    // NOT end, and a harness that demanded an ending could never express
+    // that.
+    for _ in 0..400 {
+        let carried = std::mem::take(&mut inflight);
+        for (from, bytes) in carried {
+            let target = usize::from(from ^ 1);
+            if let Some(peer) = peers.get_mut(target)
+                && matches!(peer.deliver(seat(from), &bytes), Delivery::Ends(_))
+            {
+                return peers;
+            }
+        }
+        for index in 0..2usize {
+            let Some(peer) = peers.get_mut(index) else {
+                continue;
+            };
+            if peer.wants_local() {
+                let tick = peer.next_local_tick();
+                let _ = peer.submit(&[u8::try_from(tick & 0xff).unwrap_or(0)]);
+            }
+            loop {
+                match peer.advance() {
+                    Advance::Step(confirmed) => {
+                        let tick = confirmed.tick();
+                        let world = confirmed.digest_due().then(|| world_of(index, tick));
+                        peer.commit(tick, world).expect("the tick just handed out");
+                    }
+                    Advance::Ended(_) => return peers,
+                    _ => break,
+                }
+            }
+            let sender = u8::try_from(index).unwrap_or(0);
+            while let Some(datagram) = peer.next_outbound(&mut out) {
+                inflight.push((sender, datagram.bytes().to_vec()));
+            }
+        }
+    }
+    peers
+}
+
+#[test]
+fn agreeing_worlds_never_produce_a_report() {
+    // The anti-vacuity half: if this ended on its own, the test below
+    // would prove nothing about disagreement.
+    let peers = run_until_end(|_, tick| tick.wrapping_mul(31));
+    assert_eq!(peers[0].outcome(), None, "healthy peers must not end");
+    assert!(peers[0].desync().is_none());
+    assert!(
+        peers[0].pending_tick() > 4,
+        "the pair must actually have run"
+    );
+}
+
+#[test]
+fn a_diverging_world_is_caught_and_explained() {
+    // Seat 1's world hashes differently from tick 3 onward. Their inputs
+    // are identical throughout — which is the whole point.
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+
+    let ended = peers
+        .iter()
+        .find(|peer| matches!(peer.outcome(), Some(Outcome::Desynced { .. })))
+        .expect("a divergence must be caught");
+    let report = ended.desync().expect("an ended session explains itself");
+
+    assert!(report.witnessed(), "the report compared nothing");
+    assert!(
+        report.inputs_agree(),
+        "the inputs were identical, so the report must exonerate the network"
+    );
+    assert!(
+        !report.dissenters().is_empty(),
+        "a divergence must name who disagreed"
+    );
+    assert_eq!(report.peer_count, 2);
+    assert_eq!(report.content, 0xc0_11);
+    assert_eq!(report.rules, 0xba_11);
+    assert_eq!(report.seed, 3);
+    assert!(
+        report
+            .last_agreed_tick
+            .is_some_and(|tick| tick < report.tick),
+        "the divergence must be bracketed below the tick it was caught at"
+    );
+}
+
+#[test]
+fn the_report_says_so_when_the_inputs_are_what_differ() {
+    // Hand-built rather than driven: two peers whose input folds differ
+    // is a transport or submit-discipline bug, and the report must point
+    // there instead of at the simulation.
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+    let ended = peers
+        .iter()
+        .find(|peer| peer.outcome().is_some())
+        .expect("an end");
+    let mut report = ended.desync().expect("a report");
+
+    // Move one peer's input fingerprint and the verdict must flip.
+    report.local_input_digest = report.local_input_digest.wrapping_add(1);
+    assert!(
+        !report.inputs_agree(),
+        "differing input folds must not read as agreement"
+    );
+}
+
+#[test]
+fn a_report_nobody_witnessed_does_not_read_as_agreement() {
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+    let ended = peers
+        .iter()
+        .find(|peer| peer.outcome().is_some())
+        .expect("an end");
+    let mut report = ended.desync().expect("a report");
+
+    report.peer_state_digests = [None; 8];
+    report.peer_input_digests = [None; 8];
+    assert!(
+        !report.witnessed(),
+        "a report with no peer entries witnessed nothing and must say so"
+    );
+    assert!(
+        report.dissenters().is_empty(),
+        "nobody can dissent in a report nobody sent"
+    );
+}
+
+#[test]
+fn the_report_renders_as_machine_readable_json() {
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+    let ended = peers
+        .iter()
+        .find(|peer| peer.outcome().is_some())
+        .expect("an end");
+    let report = ended.desync().expect("a report");
+    let json = report.json().to_string();
+
+    // Shape, not prettiness: a tool reads this.
+    assert!(json.starts_with(r#"{"schema_version":1,"#), "got: {json}");
+    assert!(json.ends_with('}'), "got: {json}");
+    for key in [
+        "\"tick\":",
+        "\"local\":",
+        "\"peer_count\":",
+        "\"inputs_agree\":",
+        "\"witnessed\":",
+        "\"local_state_digest\":",
+        "\"local_input_digest\":",
+        "\"last_agreed_tick\":",
+        "\"dissenters\":[",
+        "\"peers\":[",
+        "\"agreement_digest\":",
+        "\"content\":",
+        "\"rules\":",
+        "\"seed\":",
+        "\"stats\":{",
+        "\"datagrams_refused\":",
+        "\"stall_pumps\":",
+    ] {
+        assert!(json.contains(key), "the JSON is missing {key}: {json}");
+    }
+    assert_eq!(
+        json.matches("\"seat\":").count(),
+        2,
+        "one entry per seat, whether or not that seat reported"
+    );
+}
+
+#[test]
+fn a_report_with_no_agreed_tick_renders_null_rather_than_a_number() {
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+    let ended = peers
+        .iter()
+        .find(|peer| peer.outcome().is_some())
+        .expect("an end");
+    let mut report = ended.desync().expect("a report");
+
+    report.last_agreed_tick = None;
+    report.peer_state_digests = [None; 8];
+    report.peer_input_digests = [None; 8];
+    let json = report.json().to_string();
+    assert!(json.contains(r#""last_agreed_tick":null"#), "got: {json}");
+    assert!(json.contains(r#""state_digest":null"#), "got: {json}");
+    assert!(json.contains(r#""input_digest":null"#), "got: {json}");
+    assert!(json.contains(r#""dissenters":[]"#), "got: {json}");
+}
+
+#[test]
+fn a_report_naming_two_dissenters_separates_them() {
+    // The JSON list separator only runs with more than one dissenter, and
+    // a one-element list would leave it untested — which is how a
+    // malformed array reaches a tool that reads this.
+    let peers = run_until_end(|index, tick| {
+        if index == 1 && tick >= 3 {
+            tick.wrapping_mul(31).wrapping_add(1)
+        } else {
+            tick.wrapping_mul(31)
+        }
+    });
+    let ended = peers
+        .iter()
+        .find(|peer| peer.outcome().is_some())
+        .expect("an end");
+    let mut report = ended.desync().expect("a report");
+
+    // Widen the roster and disagree with two of its seats.
+    report.peer_count = 4;
+    report.local = seat(0);
+    report.local_state_digest = 1;
+    report.peer_state_digests = [None, Some(2), Some(3), None, None, None, None, None];
+    assert_eq!(report.dissenters().count(), 2);
+
+    let json = report.json().to_string();
+    let start = json.find(r#""dissenters":["#).expect("the list is present");
+    let tail = json.get(start..).unwrap_or_default();
+    let end = tail.find(']').expect("the list closes");
+    let list = tail.get(0..end).unwrap_or_default();
+    assert!(
+        list.contains("1,2"),
+        "two dissenters must be comma-separated: {list}"
+    );
+}

--- a/crates/net/tests/params.rs
+++ b/crates/net/tests/params.rs
@@ -1,0 +1,286 @@
+//! What a session refuses before it exists, and what the handshake
+//! fingerprint is a function of.
+
+use core::num::NonZeroU64;
+
+use renew_net::{
+    INPUT_WINDOW, MAX_INPUT_BYTES, MAX_PEERS, MIN_PEERS, ParamsError, PeerId, SessionParams,
+};
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn seat(index: u8) -> PeerId {
+    PeerId::new(index).expect("in range")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn good() -> SessionParams {
+    SessionParams {
+        peer_count: 4,
+        local: seat(2),
+        input_bytes: 3,
+        input_delay: 2,
+        digest_period: 30,
+        seed: 99,
+        content: 0xc0_ffee,
+        rules: 0xba5e,
+        session: NonZeroU64::new(7).expect("not zero"),
+    }
+}
+
+#[test]
+fn a_sound_set_of_parameters_validates() {
+    let valid = good().validate().expect("these are in range");
+    assert_eq!(valid.peer_count(), 4);
+    assert_eq!(valid.local(), seat(2));
+    assert_eq!(valid.input_bytes(), 3);
+    assert_eq!(valid.input_delay(), 2);
+    assert_eq!(valid.digest_period(), 30);
+    assert_eq!(valid.session().get(), 7);
+    assert_eq!(valid.get().seed, 99);
+    assert_eq!(valid.roster().count(), 4);
+    assert_eq!(
+        valid.remotes().count(),
+        3,
+        "the remotes are the roster less this machine"
+    );
+    assert!(!valid.remotes().contains(seat(2)));
+}
+
+#[test]
+fn every_field_out_of_range_is_refused_by_name() {
+    for count in [0u8, 1, MAX_PEERS + 1, u8::MAX] {
+        let refusal = SessionParams {
+            peer_count: count,
+            local: seat(0),
+            ..good()
+        }
+        .validate()
+        .expect_err("outside the roster range");
+        assert_eq!(
+            refusal,
+            ParamsError::PeerCount {
+                saw: count,
+                floor: MIN_PEERS,
+                ceiling: MAX_PEERS
+            }
+        );
+    }
+
+    let refusal = SessionParams {
+        peer_count: 2,
+        local: seat(5),
+        ..good()
+    }
+    .validate()
+    .expect_err("a seat outside its own roster");
+    assert_eq!(
+        refusal,
+        ParamsError::LocalNotInRoster {
+            local: 5,
+            peer_count: 2
+        }
+    );
+
+    for width in [0u8, MAX_INPUT_BYTES + 1] {
+        let refusal = SessionParams {
+            input_bytes: width,
+            ..good()
+        }
+        .validate()
+        .expect_err("outside the width range");
+        assert_eq!(
+            refusal,
+            ParamsError::InputBytes {
+                saw: width,
+                ceiling: MAX_INPUT_BYTES
+            }
+        );
+    }
+
+    let past = u8::try_from(INPUT_WINDOW).expect("the window fits a byte today");
+    let refusal = SessionParams {
+        input_delay: past,
+        ..good()
+    }
+    .validate()
+    .expect_err("a delay the window cannot buffer");
+    assert_eq!(
+        refusal,
+        ParamsError::InputDelay {
+            saw: past,
+            window: INPUT_WINDOW
+        }
+    );
+
+    let refusal = SessionParams {
+        digest_period: 0,
+        ..good()
+    }
+    .validate()
+    .expect_err("every tick would owe a digest");
+    assert_eq!(refusal, ParamsError::DigestPeriodZero);
+}
+
+#[test]
+fn the_boundaries_themselves_are_legal() {
+    // A refusal set that only pins its outside is one that could refuse
+    // everything and still pass.
+    let past = u8::try_from(INPUT_WINDOW).expect("fits");
+    for params in [
+        SessionParams {
+            peer_count: MIN_PEERS,
+            local: seat(1),
+            ..good()
+        },
+        SessionParams {
+            peer_count: MAX_PEERS,
+            ..good()
+        },
+        SessionParams {
+            input_bytes: 1,
+            ..good()
+        },
+        SessionParams {
+            input_bytes: MAX_INPUT_BYTES,
+            ..good()
+        },
+        SessionParams {
+            input_delay: 0,
+            ..good()
+        },
+        SessionParams {
+            input_delay: past - 1,
+            ..good()
+        },
+        SessionParams {
+            digest_period: 1,
+            ..good()
+        },
+    ] {
+        assert!(
+            params.validate().is_ok(),
+            "a boundary value was refused: {params:?}"
+        );
+    }
+}
+
+#[test]
+fn every_refusal_names_the_numbers_it_saw() {
+    let past = u8::try_from(INPUT_WINDOW).expect("fits");
+    let cases = [
+        SessionParams {
+            peer_count: 1,
+            local: seat(0),
+            ..good()
+        },
+        SessionParams {
+            peer_count: 2,
+            local: seat(7),
+            ..good()
+        },
+        SessionParams {
+            input_bytes: 0,
+            ..good()
+        },
+        SessionParams {
+            input_delay: past,
+            ..good()
+        },
+        SessionParams {
+            digest_period: 0,
+            ..good()
+        },
+    ];
+    for params in cases {
+        let refusal = params.validate().expect_err("built to be refused");
+        let text = refusal.to_string();
+        assert!(!text.is_empty(), "{refusal:?} printed nothing");
+        if matches!(refusal, ParamsError::DigestPeriodZero) {
+            assert!(text.contains("zero"), "expected the word: \"{text}\"");
+        } else {
+            assert!(
+                text.chars().any(|character| character.is_ascii_digit()),
+                "{refusal:?} printed no number: \"{text}\""
+            );
+        }
+    }
+}
+
+// ---- the agreement fingerprint ----
+
+#[test]
+fn the_agreement_digest_covers_everything_two_peers_must_share() {
+    let base = good().validate().expect("valid").agreement_digest();
+    // Each of these is a genuine disagreement and must move the number.
+    for changed in [
+        SessionParams {
+            seed: 100,
+            ..good()
+        },
+        SessionParams {
+            content: 0xc0_ffef,
+            ..good()
+        },
+        SessionParams {
+            rules: 0xba5f,
+            ..good()
+        },
+        SessionParams {
+            peer_count: 5,
+            ..good()
+        },
+        SessionParams {
+            input_bytes: 4,
+            ..good()
+        },
+        SessionParams {
+            input_delay: 3,
+            ..good()
+        },
+        SessionParams {
+            digest_period: 31,
+            ..good()
+        },
+    ] {
+        assert_ne!(
+            changed.validate().expect("valid").agreement_digest(),
+            base,
+            "a parameter two peers must share did not reach the fingerprint: {changed:?}"
+        );
+    }
+}
+
+#[test]
+fn the_agreement_digest_excludes_exactly_what_differs_per_peer() {
+    let base = good().validate().expect("valid").agreement_digest();
+
+    // The local seat differs per peer by definition. Folding it would make
+    // every peer disagree with every other at the handshake.
+    let elsewhere = SessionParams {
+        local: seat(3),
+        ..good()
+    };
+    assert_eq!(
+        elsewhere.validate().expect("valid").agreement_digest(),
+        base,
+        "the local seat reached the fingerprint, so no two peers could ever agree"
+    );
+
+    // The session id cannot reach a confirmed frame — two peers holding
+    // different ones drop each other's datagrams at the header — so it is
+    // excluded too, and deliberately not derived from the parameters.
+    let other_session = SessionParams {
+        session: NonZeroU64::new(0xfeed).expect("not zero"),
+        ..good()
+    };
+    assert_eq!(
+        other_session.validate().expect("valid").agreement_digest(),
+        base
+    );
+}

--- a/crates/net/tests/refusals.rs
+++ b/crates/net/tests/refusals.rs
@@ -1,0 +1,532 @@
+//! Every way a session says no, and the accessors a driver reads.
+//!
+//! The happy path is covered by `session.rs`; this is the other half.
+//! A refusal set with untested arms is one that can grow an arm that
+//! absorbs what it should drop, and nothing would notice.
+
+use core::num::NonZeroU64;
+
+use renew_net::{
+    Advance, Delivery, INPUT_WINDOW, MAX_DATAGRAM_BYTES, Outcome, PeerId, Refusal, Session,
+    SessionParams, SubmitError, ValidParams, wire,
+};
+
+const SESSION: u64 = 0x5e55_1000;
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn seat(index: u8) -> PeerId {
+    PeerId::new(index).expect("in range")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn params_of(local: u8, peers: u8, delay: u8) -> ValidParams {
+    SessionParams {
+        peer_count: peers,
+        local: seat(local),
+        input_bytes: 1,
+        input_delay: delay,
+        digest_period: 2,
+        seed: 1,
+        content: 2,
+        rules: 3,
+        session: NonZeroU64::new(SESSION).expect("not zero"),
+    }
+    .validate()
+    .expect("valid parameters")
+}
+
+fn session_of(local: u8, peers: u8, delay: u8) -> Box<Session> {
+    Box::new(Session::new(params_of(local, peers, delay)))
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn addressing(sender: u8, session: u64) -> wire::Addressing {
+    wire::Addressing {
+        sender: seat(sender),
+        session: NonZeroU64::new(session).expect("not zero"),
+    }
+}
+
+fn hello_body(agreement: u64) -> wire::HelloBody {
+    wire::HelloBody {
+        agreement_digest: agreement,
+        content: 2,
+        rules: 3,
+        seed: 1,
+        peer_count: 2,
+        input_bytes: 1,
+        input_delay: 0,
+        digest_period: 2,
+    }
+}
+
+// ---- the header gate ----
+
+#[test]
+fn malformed_bytes_are_refused_and_counted() {
+    let mut session = session_of(0, 2, 0);
+    let outcome = session.deliver(seat(1), b"not a datagram");
+    assert!(matches!(outcome, Delivery::Refused(Refusal::Malformed(_))));
+    assert_eq!(session.stats().datagrams_refused, 1);
+}
+
+#[test]
+fn another_sessions_datagram_is_refused() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_bye(&mut out, addressing(1, 0xdead), &wire::ByeBody { tick: 0 });
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::WrongSession { saw: 0xdead })
+    ));
+}
+
+#[test]
+fn a_header_that_disagrees_with_the_transport_is_refused() {
+    let mut session = session_of(0, 3, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_bye(&mut out, addressing(1, SESSION), &wire::ByeBody { tick: 0 });
+    // The bytes claim seat 1; the transport says they came from seat 2.
+    assert!(matches!(
+        session.deliver(seat(2), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::SenderNotSource { .. })
+    ));
+}
+
+#[test]
+fn this_machines_own_seat_arriving_from_the_network_is_refused() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_bye(&mut out, addressing(0, SESSION), &wire::ByeBody { tick: 0 });
+    assert!(matches!(
+        session.deliver(seat(0), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::FromSelf)
+    ));
+}
+
+#[test]
+fn a_seat_outside_the_roster_is_refused() {
+    // A two-seat session; seat 5 is a legal PeerId and not in this game.
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_bye(&mut out, addressing(5, SESSION), &wire::ByeBody { tick: 0 });
+    assert!(matches!(
+        session.deliver(seat(5), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::NotInRoster { peer: _ })
+    ));
+}
+
+#[test]
+fn a_peer_playing_different_parameters_is_refused_at_the_handshake() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_hello(&mut out, addressing(1, SESSION), &hello_body(0xbad))
+        .expect("a legal hello");
+    let outcome = session.deliver(seat(1), out.get(..len).unwrap_or_default());
+    let Delivery::Refused(Refusal::Disagreement { theirs, ours }) = outcome else {
+        panic!("expected a disagreement, got {outcome:?}")
+    };
+    assert_eq!(theirs, 0xbad);
+    assert_ne!(ours, 0xbad, "the refusal must name both sides");
+    assert!(
+        !session.is_playing(),
+        "a disagreeing peer must not start a game"
+    );
+}
+
+#[test]
+fn a_matching_hello_starts_the_game() {
+    // The anti-vacuity twin of the test above: if nothing could start,
+    // every refusal here would pass for the wrong reason.
+    let mut session = session_of(0, 2, 0);
+    let agreement = session.params().agreement_digest();
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_hello(&mut out, addressing(1, SESSION), &hello_body(agreement))
+        .expect("a legal hello");
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+    session.submit(&[1]).expect("a first input");
+    assert!(
+        session.is_playing(),
+        "everyone said hello and the window is full"
+    );
+}
+
+// ---- leaving ----
+
+#[test]
+fn a_peers_departure_ends_the_session_and_names_the_tick() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let len = wire::write_bye(
+        &mut out,
+        addressing(1, SESSION),
+        &wire::ByeBody { tick: 41 },
+    );
+    let outcome = session.deliver(seat(1), out.get(..len).unwrap_or_default());
+    assert_eq!(
+        outcome,
+        Delivery::Ends(Outcome::PeerLeft {
+            peer: seat(1),
+            tick: 41
+        })
+    );
+    assert_eq!(
+        session.outcome(),
+        Some(Outcome::PeerLeft {
+            peer: seat(1),
+            tick: 41
+        })
+    );
+    // Everything afterwards reports the end rather than acting.
+    assert!(matches!(session.advance(), Advance::Ended(_)));
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Ends(_)
+    ));
+    assert!(!session.wants_local());
+}
+
+#[test]
+fn leaving_twice_keeps_the_first_reason() {
+    let mut session = session_of(0, 2, 0);
+    let first = session.leave();
+    let again = session.leave();
+    assert_eq!(first, again, "a session's ending must not be rewritten");
+}
+
+#[test]
+fn a_departing_peer_still_emits_its_farewell() {
+    let mut session = session_of(0, 2, 0);
+    session.leave();
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let mut sent = 0;
+    while let Some(datagram) = session.next_outbound(&mut out) {
+        let read = wire::read(datagram.bytes()).expect("a datagram this crate wrote");
+        assert_eq!(read.header.kind, wire::Kind::Bye);
+        assert_eq!(datagram.peer(), seat(1), "the farewell goes to the remote");
+        sent += 1;
+        assert!(sent < 8, "a farewell repeated forever");
+    }
+    assert_eq!(sent, 1, "one remote, one farewell");
+}
+
+// ---- submitting ----
+
+#[test]
+fn a_submitted_input_is_never_rewritten() {
+    // This started as a test that a second submit for one tick is
+    // REFUSED, and it found that the refusal it was written against
+    // could not fire: `submit` always fills the next unsubmitted tick,
+    // so there is no way to name an earlier one. The variant was removed
+    // and this now pins the behaviour that makes it unnecessary.
+    let mut session = session_of(0, 2, 0);
+    assert_eq!(session.submit(&[1]).expect("the first input"), 0);
+    assert_eq!(
+        session
+            .submit(&[2])
+            .expect("the next tick, not the same one"),
+        1,
+        "a caller that could revise a submitted input could cheat"
+    );
+}
+
+#[test]
+fn submitting_past_the_window_is_refused() {
+    // A wide delay lets the local peer run ahead until the ring is full.
+    let mut session = session_of(0, 2, 63);
+    let mut submitted = 0u64;
+    loop {
+        match session.submit(&[0]) {
+            Ok(_) => submitted = submitted.saturating_add(1),
+            Err(SubmitError::WindowFull { tick, pending }) => {
+                assert_eq!(pending, 0, "nothing was confirmed, so the frontier is zero");
+                assert_eq!(tick, u64::from(INPUT_WINDOW));
+                break;
+            }
+            Err(other) => panic!("unexpected refusal: {other:?}"),
+        }
+        assert!(
+            submitted <= u64::from(INPUT_WINDOW),
+            "the window never filled"
+        );
+    }
+    assert_eq!(
+        submitted,
+        u64::from(INPUT_WINDOW),
+        "the window holds exactly its depth"
+    );
+}
+
+// ---- what a confirmed tick hands back ----
+
+#[test]
+fn a_step_reports_only_the_seats_in_its_roster() {
+    let mut here = session_of(0, 2, 0);
+    let mut there = session_of(1, 2, 0);
+    let agreement = here.params().agreement_digest();
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+
+    for (session, from) in [(&mut here, 1u8), (&mut there, 0u8)] {
+        let len = wire::write_hello(&mut out, addressing(from, SESSION), &hello_body(agreement))
+            .expect("a legal hello");
+        let _ = session.deliver(seat(from), out.get(..len).unwrap_or_default());
+    }
+    here.submit(&[7]).expect("an input");
+    there.submit(&[9]).expect("an input");
+
+    // Carry seat 1's inputs to seat 0 so a tick can be confirmed.
+    let mut carried = Vec::new();
+    while let Some(datagram) = there.next_outbound(&mut out) {
+        carried.push(datagram.bytes().to_vec());
+    }
+    for bytes in carried {
+        let _ = here.deliver(seat(1), &bytes);
+    }
+
+    let Advance::Step(step) = here.advance() else {
+        panic!("both seats submitted, so a tick must be confirmed")
+    };
+    assert_eq!(step.tick(), 0);
+    assert_eq!(step.input(seat(0)), Some(&[7u8][..]));
+    assert_eq!(step.input(seat(1)), Some(&[9u8][..]));
+    assert_eq!(
+        step.input(seat(4)),
+        None,
+        "a seat outside the roster has no input, and asking is not a panic"
+    );
+    let seats: Vec<u8> = step.inputs().map(|(peer, _)| peer.index()).collect();
+    assert_eq!(seats, vec![0, 1], "inputs are handed out ascending by seat");
+}
+
+// ---- committing ----
+
+#[test]
+fn committing_a_tick_that_was_not_handed_out_is_refused() {
+    let mut session = session_of(0, 2, 0);
+    // Nothing has been handed out at all.
+    assert_eq!(
+        session.commit(0, None),
+        Err(renew_net::CommitError::OutOfOrder {
+            saw: 0,
+            expected: 0
+        })
+    );
+}
+
+/// Brings a two-seat pair to the point where seat 0 can confirm ticks.
+#[allow(
+    clippy::expect_used,
+    reason = "see `seat`: the fixture's own failure is the report"
+)]
+fn started_pair() -> (Box<Session>, Box<Session>) {
+    let mut here = session_of(0, 2, 0);
+    let mut there = session_of(1, 2, 0);
+    let agreement = here.params().agreement_digest();
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    for (session, from) in [(&mut here, 1u8), (&mut there, 0u8)] {
+        let len = wire::write_hello(&mut out, addressing(from, SESSION), &hello_body(agreement))
+            .expect("a legal hello");
+        let _ = session.deliver(seat(from), out.get(..len).unwrap_or_default());
+    }
+    here.submit(&[1]).expect("an input");
+    there.submit(&[2]).expect("an input");
+    let mut carried = Vec::new();
+    while let Some(datagram) = there.next_outbound(&mut out) {
+        carried.push(datagram.bytes().to_vec());
+    }
+    for bytes in carried {
+        let _ = here.deliver(seat(1), &bytes);
+    }
+    (here, there)
+}
+
+#[test]
+fn a_digest_owed_and_not_supplied_is_refused_and_so_is_the_reverse() {
+    let (mut here, _there) = started_pair();
+    let Advance::Step(step) = here.advance() else {
+        panic!("both seats submitted, so a tick must be confirmed")
+    };
+    let tick = step.tick();
+    assert!(step.digest_due(), "period two means tick zero is digested");
+
+    // Owed and withheld.
+    assert_eq!(
+        here.commit(tick, None),
+        Err(renew_net::CommitError::DigestMismatch { tick, owed: true })
+    );
+    // The wrong tick entirely.
+    assert!(matches!(
+        here.commit(tick + 5, Some(1)),
+        Err(renew_net::CommitError::OutOfOrder { .. })
+    ));
+    // And the right one, which must still work afterwards.
+    here.commit(tick, Some(1)).expect("owed and supplied");
+}
+
+// ---- absorbing another peer's frames ----
+
+#[test]
+fn a_frame_of_the_wrong_width_is_refused() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    // The session agreed one byte per input; this claims two.
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), 0, 1, 2, &[1, 2])
+        .expect("a legal datagram");
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::WrongWidth { saw: 2, agreed: 1 })
+    ));
+}
+
+#[test]
+fn a_frame_past_the_window_is_refused_and_counted() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let far = u64::from(INPUT_WINDOW) + 100;
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), far, 1, 1, &[9]).expect("legal");
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::OutOfWindow { .. })
+    ));
+    assert_eq!(session.stats().frames_out_of_window, 1);
+}
+
+#[test]
+fn a_repeated_frame_is_counted_and_a_contradicting_one_is_dropped() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), 0, 1, 1, &[7]).expect("legal");
+    let first = out;
+    assert!(matches!(
+        session.deliver(seat(1), first.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+    // The identical frame again: the redundancy working, not an error.
+    assert!(matches!(
+        session.deliver(seat(1), first.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+    assert_eq!(session.stats().frames_repeated, 1);
+
+    // A different frame for the same tick. First write wins, so this is
+    // already a state no-op — counted and dropped, never fatal.
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), 0, 1, 1, &[8]).expect("legal");
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::Contradiction { .. })
+    ));
+    assert_eq!(session.stats().frames_contradicted, 1);
+    assert_eq!(
+        session.outcome(),
+        None,
+        "a contradiction must never end a session: it would be a one-packet kill switch"
+    );
+}
+
+#[test]
+fn a_run_carrying_both_a_new_frame_and_a_refused_one_still_accepts() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+
+    // Seat 1's frame for tick 0 lands.
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), 0, 1, 1, &[7]).expect("legal");
+    let _ = session.deliver(seat(1), out.get(..len).unwrap_or_default());
+
+    // Now a run covering ticks 0 and 1: tick 0 contradicts, tick 1 is new.
+    // The useful half must still be absorbed.
+    let len =
+        wire::write_inputs(&mut out, addressing(1, SESSION), 0, 2, 1, &[8, 9]).expect("legal");
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+    assert_eq!(
+        session.stats().frames_contradicted,
+        1,
+        "the refused half is still counted"
+    );
+}
+
+#[test]
+fn a_second_disagreeing_digest_for_one_tick_is_refused_never_overwritten() {
+    let mut session = session_of(0, 2, 0);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let body = wire::DigestBody {
+        tick: 4,
+        state_digest: 111,
+        input_digest: 222,
+    };
+    let len = wire::write_digest(&mut out, addressing(1, SESSION), &body);
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+    // The identical one again is simply accepted.
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Accepted
+    ));
+
+    // A different one for the same tick: refused, so a flood of forged
+    // digests cannot evict a genuine entry and blind the detector.
+    let forged = wire::DigestBody {
+        tick: 4,
+        state_digest: 999,
+        input_digest: 222,
+    };
+    let len = wire::write_digest(&mut out, addressing(1, SESSION), &forged);
+    assert!(matches!(
+        session.deliver(seat(1), out.get(..len).unwrap_or_default()),
+        Delivery::Refused(Refusal::DigestContradiction { .. })
+    ));
+    assert_eq!(session.stats().digests_contradicted, 1);
+}
+
+#[test]
+fn a_peer_still_filling_its_window_keeps_saying_hello() {
+    // The arm where the phase is still `Joining` but no hello is owed:
+    // every remote has been seen playing, so they have heard this peer —
+    // and yet this peer cannot start until its own delay window is full.
+    // It must keep emitting a hello rather than falling silent, or a
+    // remote that missed the first one would never hear another.
+    let mut session = session_of(0, 2, 2);
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+
+    // An inputs datagram is proof the sender is playing, which is what
+    // stops a hello being owed.
+    let len = wire::write_inputs(&mut out, addressing(1, SESSION), 0, 1, 1, &[3]).expect("legal");
+    let _ = session.deliver(seat(1), out.get(..len).unwrap_or_default());
+
+    session
+        .submit(&[1])
+        .expect("one input, of the three it needs");
+    assert!(!session.is_playing(), "the delay window is not full yet");
+
+    // Drain one whole pump first: the emission cursor is chosen afresh at
+    // the START of each pump, so the interesting decision is the second
+    // one, not the constructor's.
+    while session.next_outbound(&mut out).is_some() {}
+
+    let datagram = session
+        .next_outbound(&mut out)
+        .expect("a joining peer must still announce itself");
+    let read = wire::read(datagram.bytes()).expect("a datagram this crate wrote");
+    assert_eq!(
+        read.header.kind,
+        wire::Kind::Hello,
+        "a peer that cannot play yet says hello, not inputs"
+    );
+}

--- a/crates/net/tests/session.rs
+++ b/crates/net/tests/session.rs
@@ -1,0 +1,301 @@
+//! Two sessions in one process, wired to each other through a link that
+//! loses, reorders and duplicates.
+//!
+//! The claim under test is the one the whole crate exists for: **given the
+//! same parameters and the same submissions, every peer's sequence of
+//! confirmed input sets is bit-identical, whatever the datagrams did on
+//! the way.** Arrival is the non-determinism; making it unobservable is
+//! the job.
+
+use core::num::NonZeroU64;
+
+use renew_net::{
+    Advance, Delivery, MAX_DATAGRAM_BYTES, Outcome, PeerId, Session, SessionParams, SubmitError,
+};
+
+const SESSION: u64 = 0xfeed_face_dead_beef;
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn seat(index: u8) -> PeerId {
+    PeerId::new(index).expect("a seat the test chose in range")
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn params(local: u8, delay: u8) -> SessionParams {
+    SessionParams {
+        peer_count: 2,
+        local: seat(local),
+        input_bytes: 1,
+        input_delay: delay,
+        digest_period: 4,
+        seed: 7,
+        content: 0xc0_ffee,
+        rules: 0xba5e_ba11,
+        session: NonZeroU64::new(SESSION).expect("not zero"),
+    }
+}
+
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn session(local: u8, delay: u8) -> Session {
+    Session::new(params(local, delay).validate().expect("valid parameters"))
+}
+
+/// A datagram in flight, with the seat that sent it.
+type Wire = (u8, Vec<u8>);
+
+/// One peer's confirmed run: every tick, and the inputs that made it.
+type Run = Vec<(u64, Vec<u8>)>;
+
+/// Both peers' runs, and both peers' final input fingerprints.
+type Converged = ([Run; 2], [u64; 2]);
+
+/// Drain one session's outbound queue into a list of datagrams.
+fn pump(from: &mut Session, sender: u8) -> Vec<Wire> {
+    let mut out = [0u8; MAX_DATAGRAM_BYTES];
+    let mut sent = Vec::new();
+    while let Some(datagram) = from.next_outbound(&mut out) {
+        sent.push((sender, datagram.bytes().to_vec()));
+    }
+    sent
+}
+
+/// Run both sessions to a fixed number of confirmed ticks, applying
+/// `hazard` to every datagram before it is delivered. Returns each
+/// session's sequence of (tick, inputs) and its final input digest.
+#[allow(
+    clippy::expect_used,
+    clippy::panic,
+    reason = "the harness's own failure is the report; a panic here names which invariant the two sessions broke, at the point it broke"
+)]
+fn converge(delay: u8, ticks: u64, mut hazard: impl FnMut(usize, &Wire) -> Vec<Wire>) -> Converged {
+    // Boxed because a Session holds its whole input window inline —
+    // roughly eight kilobytes — and two of them overflow the stack-array
+    // ceiling the workspace lints at. A real driver keeps one, for the
+    // lifetime of the session, which is why the type is shaped this way.
+    let mut peers = [Box::new(session(0, delay)), Box::new(session(1, delay))];
+    let mut confirmed: [Run; 2] = [Vec::new(), Vec::new()];
+    let mut inflight: Vec<Wire> = Vec::new();
+    let mut step = 0usize;
+
+    while confirmed.iter().any(|run| (run.len() as u64) < ticks) {
+        step = step.saturating_add(1);
+        assert!(step < 20_000, "the two sessions never converged");
+
+        // Deliver everything the link decided to carry this pump.
+        let carried: Vec<Wire> = inflight.drain(..).flat_map(|w| hazard(step, &w)).collect();
+        for (sender, bytes) in carried {
+            let target = usize::from(sender ^ 1);
+            let source = seat(sender);
+            if let Some(peer) = peers.get_mut(target) {
+                match peer.deliver(source, &bytes) {
+                    Delivery::Ends(outcome) => panic!("unexpected end: {outcome:?}"),
+                    Delivery::Accepted | Delivery::Refused(_) => {}
+                }
+            }
+        }
+
+        for (index, peer) in peers.iter_mut().enumerate() {
+            // One local input per pump, never a loop: a caller that
+            // looped here would fill the window with one held intent.
+            if peer.wants_local() {
+                // Keyed on the tick being SUBMITTED for, never on the
+                // confirmed frontier: an input chosen from the frontier
+                // moves with the network, and the oracle below would then
+                // be comparing two runs that were fed different things.
+                let value = u8::try_from(index).unwrap_or(0).wrapping_mul(16);
+                let tick = peer.next_local_tick();
+                let byte = value.wrapping_add(u8::try_from(tick & 0x0f).unwrap_or(0));
+                match peer.submit(&[byte]) {
+                    Ok(_) | Err(SubmitError::WindowFull { .. }) => {}
+                    Err(error) => panic!("submit refused: {error:?}"),
+                }
+            }
+
+            loop {
+                match peer.advance() {
+                    Advance::Step(confirmed_step) => {
+                        let tick = confirmed_step.tick();
+                        let mut inputs = Vec::new();
+                        for (_, bytes) in confirmed_step.inputs() {
+                            inputs.extend_from_slice(bytes);
+                        }
+                        if let Some(run) = confirmed.get_mut(index) {
+                            run.push((tick, inputs.clone()));
+                        }
+                        // A world digest that is a pure function of the
+                        // confirmed inputs: two peers that confirmed the
+                        // same thing must produce the same number, which
+                        // is what makes a desync here mean something.
+                        let world = confirmed.get(index).map_or(0u64, |run| {
+                            run.iter().fold(0u64, |acc, (t, bytes)| {
+                                bytes
+                                    .iter()
+                                    .fold(acc ^ t, |a, b| a.rotate_left(7) ^ u64::from(*b))
+                            })
+                        });
+                        peer.commit(tick, confirmed_step.digest_due().then_some(world))
+                            .expect("the tick just handed out");
+                    }
+                    Advance::Waiting | Advance::Stalled { .. } => break,
+                    Advance::Ended(outcome) => panic!("unexpected end: {outcome:?}"),
+                }
+            }
+
+            let sender = u8::try_from(index).unwrap_or(0);
+            inflight.extend(pump(peer, sender));
+        }
+    }
+
+    let digests = [peers[0].input_digest(), peers[1].input_digest()];
+    (confirmed, digests)
+}
+
+/// The link is perfect. The floor everything else is measured against.
+#[test]
+fn two_peers_confirm_the_same_ticks_over_a_perfect_link() {
+    let (runs, digests) = converge(2, 40, |_, wire| vec![wire.clone()]);
+    assert_eq!(runs[0], runs[1], "the two peers confirmed different inputs");
+    assert_eq!(digests[0], digests[1], "the input digests diverged");
+    assert!(runs[0].len() >= 40);
+    // Ticks are consecutive from zero, with no gap and no repeat.
+    for (position, (tick, _)) in runs[0].iter().enumerate() {
+        assert_eq!(*tick, position as u64, "ticks are consecutive from zero");
+    }
+}
+
+/// Every third datagram is dropped. The redundancy repairs it with no
+/// round trip, and no confirmed value moves.
+#[test]
+fn loss_changes_nothing_a_peer_confirms() {
+    let (runs, digests) = converge(2, 40, |step, wire| {
+        if step % 3 == 0 {
+            Vec::new()
+        } else {
+            vec![wire.clone()]
+        }
+    });
+    assert_eq!(runs[0], runs[1]);
+    assert_eq!(digests[0], digests[1]);
+    let (perfect, perfect_digests) = converge(2, 40, |_, wire| vec![wire.clone()]);
+    assert_eq!(
+        runs[0][..40],
+        perfect[0][..40],
+        "loss moved a confirmed input, which is the one thing it must never do"
+    );
+    assert_eq!(digests[0], perfect_digests[0]);
+}
+
+/// Every datagram is delivered twice. A repeat is proven identical and
+/// ignored, and must not fold into the digest a second time.
+#[test]
+fn duplication_changes_nothing_a_peer_confirms() {
+    let (runs, digests) = converge(2, 40, |_, wire| vec![wire.clone(), wire.clone()]);
+    let (perfect, perfect_digests) = converge(2, 40, |_, wire| vec![wire.clone()]);
+    assert_eq!(runs[0], runs[1]);
+    assert_eq!(runs[0][..40], perfect[0][..40]);
+    assert_eq!(
+        digests[0], perfect_digests[0],
+        "a repeated frame moved the digest, so it was absorbed twice"
+    );
+}
+
+/// Loss, duplication and delay together.
+#[test]
+fn a_hostile_link_changes_nothing_a_peer_confirms() {
+    let mut held: Vec<Wire> = Vec::new();
+    let (runs, digests) = converge(3, 60, move |step, wire| {
+        let mut carried = Vec::new();
+        // Delay: hold this one and release what was held before.
+        carried.append(&mut held);
+        match step % 4 {
+            0 => {}                       // dropped
+            1 => held.push(wire.clone()), // delayed
+            2 => {
+                carried.push(wire.clone());
+                carried.push(wire.clone()); // duplicated
+            }
+            _ => carried.push(wire.clone()),
+        }
+        carried.reverse(); // reordered
+        carried
+    });
+    let (perfect, perfect_digests) = converge(3, 60, |_, wire| vec![wire.clone()]);
+    assert_eq!(runs[0], runs[1]);
+    assert_eq!(
+        runs[0][..60],
+        perfect[0][..60],
+        "the link reached a confirmed value"
+    );
+    assert_eq!(digests[0], perfect_digests[0]);
+}
+
+/// The delay parameter changes when a tick can run, and nothing else.
+#[test]
+fn the_input_delay_does_not_reach_a_confirmed_value() {
+    let (zero, zero_digests) = converge(0, 30, |_, wire| vec![wire.clone()]);
+    let (five, five_digests) = converge(5, 30, |_, wire| vec![wire.clone()]);
+    assert_eq!(
+        zero[0][..30],
+        five[0][..30],
+        "input_delay is a latency knob, not a simulation one"
+    );
+    assert_eq!(zero_digests[0], five_digests[0]);
+}
+
+// ---- the state machine's own rules ----
+
+#[test]
+fn no_tick_exists_until_everyone_has_said_hello() {
+    let mut alone = session(0, 0);
+    assert!(!alone.is_playing());
+    alone.submit(&[1]).expect("a first input is always welcome");
+    assert!(
+        !alone.is_playing(),
+        "a session with an unheard peer must not start"
+    );
+    assert!(matches!(alone.advance(), Advance::Waiting));
+}
+
+#[test]
+fn a_local_input_cannot_be_revised_after_it_is_submitted() {
+    let mut peer = session(0, 4);
+    peer.submit(&[1]).expect("first");
+    let second = peer.submit(&[2]).expect("the next tick, not the same one");
+    assert_eq!(
+        second, 1,
+        "submit advances to the next tick, never rewrites"
+    );
+}
+
+#[test]
+fn an_input_of_the_wrong_width_is_refused() {
+    let mut peer = session(0, 0);
+    assert_eq!(
+        peer.submit(&[1, 2]),
+        Err(SubmitError::WrongWidth { saw: 2, agreed: 1 })
+    );
+    assert_eq!(
+        peer.submit(&[]),
+        Err(SubmitError::WrongWidth { saw: 0, agreed: 1 })
+    );
+}
+
+#[test]
+fn leaving_is_terminal_and_names_the_last_confirmed_tick() {
+    let mut peer = session(0, 0);
+    let outcome = peer.leave();
+    assert!(matches!(outcome, Outcome::LeftLocally { .. }));
+    assert_eq!(peer.outcome(), Some(outcome));
+    assert!(matches!(peer.advance(), Advance::Ended(_)));
+    assert!(!peer.wants_local());
+    assert!(matches!(peer.submit(&[0]), Err(SubmitError::Ended(_))));
+}

--- a/crates/net/tests/session.rs
+++ b/crates/net/tests/session.rs
@@ -55,7 +55,15 @@ type Wire = (u8, Vec<u8>);
 /// One peer's confirmed run: every tick, and the inputs that made it.
 type Run = Vec<(u64, Vec<u8>)>;
 
-/// Both peers' runs, and both peers' final input fingerprints.
+/// Both peers' runs, and each peer's input fingerprint **at exactly the
+/// requested tick count**.
+///
+/// Snapshotted at that tick rather than read at the end, and the
+/// distinction is load-bearing: the fold runs once per confirmed tick, so
+/// two runs that overshoot the target by different amounts hold different
+/// folds while having confirmed identical inputs. Comparing the end state
+/// of two such runs compares how far each happened to get, which is a
+/// property of the link and not of the simulation.
 type Converged = ([Run; 2], [u64; 2]);
 
 /// Drain one session's outbound queue into a list of datagrams.
@@ -83,6 +91,7 @@ fn converge(delay: u8, ticks: u64, mut hazard: impl FnMut(usize, &Wire) -> Vec<W
     // lifetime of the session, which is why the type is shaped this way.
     let mut peers = [Box::new(session(0, delay)), Box::new(session(1, delay))];
     let mut confirmed: [Run; 2] = [Vec::new(), Vec::new()];
+    let mut digest_at: [Option<u64>; 2] = [None, None];
     let mut inflight: Vec<Wire> = Vec::new();
     let mut step = 0usize;
 
@@ -144,6 +153,14 @@ fn converge(delay: u8, ticks: u64, mut hazard: impl FnMut(usize, &Wire) -> Vec<W
                         });
                         peer.commit(tick, confirmed_step.digest_due().then_some(world))
                             .expect("the tick just handed out");
+                        if confirmed
+                            .get(index)
+                            .is_some_and(|run| run.len() as u64 == ticks)
+                            && let Some(slot) = digest_at.get_mut(index)
+                            && slot.is_none()
+                        {
+                            *slot = Some(peer.input_digest());
+                        }
                     }
                     Advance::Waiting | Advance::Stalled { .. } => break,
                     Advance::Ended(outcome) => panic!("unexpected end: {outcome:?}"),
@@ -155,7 +172,19 @@ fn converge(delay: u8, ticks: u64, mut hazard: impl FnMut(usize, &Wire) -> Vec<W
         }
     }
 
-    let digests = [peers[0].input_digest(), peers[1].input_digest()];
+    // Truncated to exactly the requested count, and that is the claim
+    // being made rather than a convenience. Peers run at their own pace,
+    // so the loop stops when BOTH have reached the target and one may have
+    // taken a further tick inside that last pump. "Both stopped at the
+    // same instant" is not a property of lockstep and could not be: what
+    // is promised is that the sequences agree wherever both have one.
+    for run in &mut confirmed {
+        run.truncate(usize::try_from(ticks).unwrap_or(usize::MAX));
+    }
+    let digests = [
+        digest_at[0].unwrap_or_else(|| peers[0].input_digest()),
+        digest_at[1].unwrap_or_else(|| peers[1].input_digest()),
+    ];
     (confirmed, digests)
 }
 
@@ -298,4 +327,44 @@ fn leaving_is_terminal_and_names_the_last_confirmed_tick() {
     assert!(matches!(peer.advance(), Advance::Ended(_)));
     assert!(!peer.wants_local());
     assert!(matches!(peer.submit(&[0]), Err(SubmitError::Ended(_))));
+}
+
+/// The regression for the deadlock the allocation gate found.
+///
+/// An earlier `render_inputs` bounded its redundancy run by the *sender's*
+/// confirmed frontier. The moment a peer confirmed a tick it stopped
+/// repeating it — so a peer that had never received that frame could never
+/// be sent it again. Both then waited on each other forever, and nothing
+/// raised an error: no refusal, no desync, no timeout. Two sessions
+/// politely stalled, which is the worst shape a bug can take here.
+///
+/// **The hazard has to be one-way, and that is the whole point.** A
+/// symmetric blackout stalls both peers equally and never reproduces it —
+/// the first version of this test did exactly that and passed against the
+/// bug. The deadlock needs one peer to run *ahead*: seat 1 keeps hearing
+/// seat 0 and confirms ticks, while seat 0 hears nothing and starves. When
+/// the link heals, seat 1 must still be willing to repeat frames it has
+/// long since confirmed, or seat 0 never catches up.
+#[test]
+fn a_starved_peer_still_catches_up_after_a_one_way_blackout() {
+    // Seat 0's datagrams always arrive. Seat 1's are dropped for the first
+    // stretch, so seat 1 races ahead while seat 0 waits on tick zero.
+    let (runs, digests) = converge(2, 30, |step, wire| {
+        let (sender, _) = wire;
+        if *sender == 1 && step <= 10 {
+            Vec::new()
+        } else {
+            vec![wire.clone()]
+        }
+    });
+    assert_eq!(runs[0], runs[1], "the two peers confirmed different inputs");
+    assert_eq!(digests[0], digests[1]);
+
+    let (perfect, perfect_digests) = converge(2, 30, |_, wire| vec![wire.clone()]);
+    assert_eq!(
+        runs[0][..30],
+        perfect[0][..30],
+        "a one-way blackout reached a confirmed value"
+    );
+    assert_eq!(digests[0], perfect_digests[0]);
 }

--- a/crates/net/tests/zero_alloc.rs
+++ b/crates/net/tests/zero_alloc.rs
@@ -1,0 +1,195 @@
+//! Mechanical enforcement of the session's allocation contract: after
+//! construction, a full pump — deliver, submit, advance, commit, drain
+//! the outbox — performs no heap allocation through the global allocator.
+//!
+//! Shipped with the crate's first per-tick code rather than after it,
+//! because a gate that arrives later measures whatever the code has grown
+//! into rather than what it promised.
+//!
+//! **This one is a security control as much as a D7 one.** Every byte the
+//! session absorbs can come from a hostile peer, so a per-datagram
+//! allocation is an allocation an attacker drives. The window therefore
+//! includes refused datagrams — a wrong session id every pump — because
+//! "nothing allocates on the happy path" is not the claim that matters.
+//!
+//! **The harness allocates nothing either, and that is not decoration.**
+//! An earlier version collected outbound datagrams with `to_vec()`, which
+//! mints a fresh allocation per datagram per pump; the window then
+//! measured the test's own bookkeeping and failed. Everything here is
+//! fixed-size arrays for that reason, and the counter is left to describe
+//! the session alone.
+//!
+//! **One test in this file**, following the rule the sibling crates
+//! learned from a red lane: the `#[global_allocator]` is process-wide and
+//! cargo runs a file's tests concurrently, so two counting tests in one
+//! binary race and the loser reports a delta it did not cause.
+
+use core::num::NonZeroU64;
+
+use renew_memory::{CountingAllocator, counters};
+use renew_net::{Advance, MAX_DATAGRAM_BYTES, PeerId, Session, SessionParams, wire};
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// The most datagrams one peer emits in one pump: an `Inputs` and a
+/// `Digest` for each remote. Two peers means one remote each.
+const OUTBOX: usize = 4;
+
+/// One full exchange between the pair: submit, advance, commit, drain,
+/// deliver — plus one hostile datagram, so the refusal path is inside
+/// whatever window encloses a call to this.
+fn pump(
+    peers: &mut [Box<Session>; 2],
+    outbox: &mut [u8; MAX_DATAGRAM_BYTES],
+    carried: &mut [[u8; MAX_DATAGRAM_BYTES]; OUTBOX],
+    lengths: &mut [usize; OUTBOX],
+    junk: &[u8],
+    confirmed: &mut u64,
+) {
+    for from in 0..2usize {
+        let mut held = 0usize;
+        if let Some(source) = peers.get_mut(from) {
+            if source.wants_local() {
+                let tick = source.next_local_tick();
+                let byte = u8::try_from(tick & 0xff).unwrap_or(0);
+                let seat_byte = u8::try_from(from).unwrap_or(0);
+                let _ = source.submit(&[byte, seat_byte]);
+            }
+            while let Advance::Step(step) = source.advance() {
+                let tick = step.tick();
+                let digest = step.digest_due().then_some(tick.wrapping_mul(31));
+                let _ = source.commit(tick, digest);
+                *confirmed = confirmed.saturating_add(1);
+            }
+            while let Some(out) = source.next_outbound(outbox) {
+                let bytes = out.bytes();
+                if let (Some(slot), Some(length)) = (carried.get_mut(held), lengths.get_mut(held))
+                    && let Some(room) = slot.get_mut(..bytes.len())
+                {
+                    room.copy_from_slice(bytes);
+                    *length = bytes.len();
+                    held = held.saturating_add(1);
+                }
+            }
+        }
+
+        let Some(sender) = u8::try_from(from).ok().and_then(PeerId::new) else {
+            return;
+        };
+        let target_index = from ^ 1;
+        if let Some(target) = peers.get_mut(target_index) {
+            for index in 0..held {
+                if let (Some(slot), Some(length)) = (carried.get(index), lengths.get(index))
+                    && let Some(bytes) = slot.get(..*length)
+                {
+                    let _ = target.deliver(sender, bytes);
+                }
+            }
+            let _ = target.deliver(sender, junk);
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(
+    feature = "sanitized",
+    ignore = "allocation counting is invalid under instrumented allocators"
+)]
+#[allow(
+    clippy::expect_used,
+    reason = "a fixture that cannot be built is a failure of the fixture, and its message is the report"
+)]
+fn a_whole_pump_allocates_nothing() {
+    let session_id = NonZeroU64::new(0x5e55_1013).expect("not zero");
+    let seat = |index: u8| PeerId::new(index).expect("in range");
+    let params = |local: u8| SessionParams {
+        peer_count: 2,
+        local: seat(local),
+        input_bytes: 2,
+        input_delay: 1,
+        digest_period: 2,
+        seed: 11,
+        content: 1,
+        rules: 2,
+        session: session_id,
+    };
+
+    // Everything that may allocate happens out here: the two sessions,
+    // boxed because each holds its whole input window inline, and the
+    // buffers a real driver would own for the lifetime of the run.
+    let mut peers = [
+        Box::new(Session::new(
+            params(0).validate().expect("valid parameters"),
+        )),
+        Box::new(Session::new(
+            params(1).validate().expect("valid parameters"),
+        )),
+    ];
+    let mut outbox = [0u8; MAX_DATAGRAM_BYTES];
+    let mut carried = [[0u8; MAX_DATAGRAM_BYTES]; OUTBOX];
+    let mut lengths = [0usize; OUTBOX];
+
+    // A datagram from a session nobody here is in: refused at the header,
+    // and delivered inside the measured window.
+    let mut junk = [0u8; MAX_DATAGRAM_BYTES];
+    let stranger_len = wire::write_bye(
+        &mut junk,
+        wire::Addressing {
+            sender: seat(1),
+            session: NonZeroU64::new(0xdead_beef).expect("not zero"),
+        },
+        &wire::ByeBody { tick: 0 },
+    );
+
+    let mut confirmed = 0u64;
+    let stranger = junk.get(..stranger_len).unwrap_or_default().to_vec();
+
+    // Warmup: far enough that every lazy initialisation has landed and
+    // both sessions are playing, so the window measures the steady state
+    // rather than the handshake.
+    for _ in 0..8 {
+        pump(
+            &mut peers,
+            &mut outbox,
+            &mut carried,
+            &mut lengths,
+            &stranger,
+            &mut confirmed,
+        );
+    }
+    assert!(
+        peers[0].is_playing() && peers[1].is_playing(),
+        "the warmup must reach the playing phase, or the window measures joining"
+    );
+    let warmed = confirmed;
+
+    let before = counters::snapshot();
+    for _ in 0..16 {
+        pump(
+            &mut peers,
+            &mut outbox,
+            &mut carried,
+            &mut lengths,
+            &stranger,
+            &mut confirmed,
+        );
+    }
+    let after = counters::snapshot();
+    // Anti-vacuity, both halves: the window must have run ticks, and it
+    // must have refused something. A gate over a window where nothing
+    // happened is a gate that measures nothing and passes.
+    assert!(
+        confirmed > warmed,
+        "the measured window confirmed no ticks, so it proved nothing"
+    );
+    assert!(
+        peers[0].stats().datagrams_refused > 0,
+        "no datagram was refused in the window, so the refusal path went unmeasured"
+    );
+    assert_eq!(
+        after.allocations.saturating_sub(before.allocations),
+        0,
+        "the steady state allocated: a per-datagram allocation is one a hostile peer drives"
+    );
+}


### PR DESCRIPTION
**Stacked on `net-fuzz` (#231), which is stacked on `net-wire` (#230).**
Retarget as each lands.

The crate stops being a codec. `Session` is lockstep as a pure state
machine: local inputs and received datagram bytes in, confirmed per-tick
input sets and outbound datagram bytes out. It owns no socket, reads no
clock, spawns nothing, and allocates nothing after construction — every
structure is a fixed inline array sized by the crate's ceilings, and a
gate proves the allocation claim over a window that includes a hostile
datagram every pump.

**The claim is demonstrated rather than asserted.** Two sessions run in
one process against a link that drops one datagram in three; against one
that delivers everything twice; against one that drops, delays,
duplicates and reorders together; and against a one-way blackout. In
every case both peers confirm the same ticks with the same inputs, and
the sequence is identical to the perfect-link run. A separate test holds
two input delays against each other and shows the parameter reaches when
a tick can run and nothing a tick contains.

A tick runs only when every peer's input for it has arrived. There is no
timeout that advances a tick and no "assume the last input": each is a
divergence source dressed as a feature. Waiting is reported instead, and
the driver decides when to give up, because that answer depends on a wall
clock this crate may not read.

A contradicting frame is counted and dropped, never fatal — first write
wins, so the second frame is already a state no-op, and ending the
session would hand anyone who can spoof a source address a one-packet
kill switch that names an innocent peer. A digest mismatch does end it:
letting a majority continue while a minority plays a different game is a
silent fork by vote. What corroboration would buy is blame, and blame is
in the report, which answers whose fault it is in one bit — if every peer
ran identical inputs and produced different state, the network is
exonerated by evidence.

**Two deadlocks were found and fixed here, both silent.** The redundancy
run was bounded by the sender's own confirmed frontier, so a peer stopped
repeating frames the moment it confirmed them and a starved peer could
never catch up. And a hello was sent only while its sender was joining,
so losing one left the peer that missed it peacefully stuck in the
joining phase forever, holding a complete set of that sender's frames.
Neither raised an error of any kind. The regression test is a one-way
blackout — a symmetric one stalls both peers equally and reproduces
neither — and it was verified against each fix reverted independently.
