### PR TITLE
feat(platform): the socket seam, and one datagram means one outcome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,6 +594,34 @@ jobs:
   # cannot test on any runner it has, and claiming otherwise by adding a
   # leg that compiles but never opens anything would be the emptier
   # kind of green.
+  networking:
+    name: Networking (the socket seam)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # All three, and Windows is the reason rather than a completeness
+      # habit. A UDP socket there reports a datagram that did not fit as
+      # an error, where the others silently truncate and report the
+      # clamped length; it also surfaces a prior send's ICMP
+      # port-unreachable on a later RECEIVE, which is the ordinary case
+      # at the start of a session. A seam tested only on Linux would
+      # therefore pass while being wrong twice on the platform most of
+      # these runs happen on.
+      #
+      # Nothing here reaches the network: every socket binds loopback on
+      # port zero and asks the kernel which port it got, so two legs can
+      # run at once and neither needs an agreed number.
+      - name: Build, lint, and test the socket seam
+        run: |
+          cargo build -p renew-platform --features net
+          cargo clippy -p renew-platform --features net --all-targets -- -D warnings
+          cargo test -p renew-platform --features net
+
   audio:
     name: Audio (mixer, reader, and the device seam)
     strategy:

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "renew-platform"
-description = "Operating-system seams: monotonic time, whole-file I/O, named threads, the window, and audio output"
+description = "Operating-system seams: monotonic time, whole-file I/O, named threads, the window, audio output, and UDP datagrams"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ readme = "README.md"
 homepage.workspace = true
 
 [package.metadata.renew]
-purpose = "The engine's only doorway to the operating system: clock, filesystem, thread, window, and audio-output seams."
+purpose = "The engine's only doorway to the operating system: clock, filesystem, thread, window, audio-output, and UDP-socket seams."
 maturity = "internal"
 core = true
 extension_points = ["window-app"]
@@ -85,6 +85,14 @@ workspace = true
 name = "window_smoke"
 harness = false
 required-features = ["window"]
+
+# Compiled only where the seam is. A file-level `cfg` would be the
+# obvious spelling and the wrong one: the binary would still be built
+# with the feature off, contain zero tests, and report green — a pass
+# that measured nothing.
+[[test]]
+name = "net_loopback"
+required-features = ["net"]
 
 # Touching a real device: compiled only where the seam is, and written
 # so that a machine with a sound card and a machine without one are

--- a/crates/core/platform/Cargo.toml
+++ b/crates/core/platform/Cargo.toml
@@ -31,6 +31,13 @@ window = ["dep:winit", "dep:raw-window-handle"]
 # diagnostics crate with it, because the stream's error callback is the
 # one place in this crate that reports from a thread it does not own.
 audio-out = ["dep:cpal"]
+# UDP datagrams via the platform's net module. Default-OFF, on the same
+# terms as `audio-out`: a headless harness has a display server more
+# often than it has a port it is allowed to bind, and a build that talks
+# to nobody should compile no socket at all. Unlike `audio-out` it
+# carries no dependency — `std::net` is std — so it resolves no crate and
+# the minimal-core graph is unchanged by its existence.
+net = []
 
 [dependencies]
 # The event vocabulary this crate re-exports as its `event` module.

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -1,8 +1,8 @@
 # renew-platform
 
 The engine's only doorway to the operating system: a monotonic clock,
-whole-file I/O, named threads, the window, and audio output — each a
-thin, explicit seam.
+whole-file I/O, named threads, the window, audio output, and UDP
+datagrams — each a thin, explicit seam.
 
 - `Clock` — a value the caller owns, anchored at `start()`, reporting
   integer nanoseconds (`elapsed_nanos`, saturating at ~584 years). No

--- a/crates/core/platform/src/lib.rs
+++ b/crates/core/platform/src/lib.rs
@@ -57,6 +57,12 @@ pub mod audio;
 #[cfg(feature = "window")]
 pub mod window;
 
+/// UDP datagrams: bind, send, and a non-blocking receive. Behind the
+/// `net` feature, which is off by default — a build that talks to nobody
+/// compiles no socket at all.
+#[cfg(feature = "net")]
+pub mod net;
+
 pub use clock::Clock;
 /// The error-classification vocabulary, re-exported so consumers match
 /// on kinds without importing `std::io` themselves — the doorway stays

--- a/crates/core/platform/src/net.rs
+++ b/crates/core/platform/src/net.rs
@@ -1,0 +1,295 @@
+//! UDP datagrams — the network seam, behind the `net` feature.
+//!
+//! **This module is the only place in the engine that names `std::net`.**
+//! That is a zoning decision rather than a style one: a crate that
+//! promises deterministic simulation is denied a dependency path to this
+//! one, at any depth and in any dependency kind, so the code that decides
+//! what a tick means cannot reach a socket even by accident. What travels
+//! over the wire is decided in a crate that has no way to send it, and
+//! moved across by an application that holds both.
+//!
+//! What that split buys is not tidiness. Every later step of the security
+//! story — an entropy source, a keyed authentication tag, encryption —
+//! lands *here*, and changes no line of the code that runs the game.
+//!
+//! # No threads, and no blocking
+//!
+//! A socket is non-blocking from birth; there is no blocking mode to
+//! reach. It is polled from the loop that already runs, and drains in
+//! microseconds — a handful of small datagrams per tick has nothing for a
+//! thread to overlap, and a receive thread would cost a shared queue, a
+//! sanitizer obligation, and an argument about send/sync, to save nothing
+//! measurable. The audio seam takes the mirror decision for the mirror
+//! reason: there the operating system owns the thread, so this crate
+//! spawns none; here there is no such thread, so this crate polls.
+//!
+//! # Failing recoverably
+//!
+//! A machine with no interface, no permission, or a port already taken
+//! fails with [`NetError::Unavailable`] — the same graceful-skip seam the
+//! audio and window modules offer, so a headless or firewalled run
+//! reports an outcome instead of dying.
+
+use core::fmt;
+use std::io::ErrorKind;
+use std::net::UdpSocket;
+
+/// Re-exported so a consumer can name an address without importing
+/// `std::net` itself. The doorway stays a doorway.
+pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+/// The largest datagram this seam will hand back, in bytes.
+///
+/// A seam-level ceiling, deliberately independent of whatever protocol a
+/// caller speaks: anything larger is refused as oversized rather than
+/// delivered in pieces. Two kilobytes is comfortably above the smallest
+/// maximum transmission unit any path is expected to carry, so a refusal
+/// here means a peer sent something no ordinary route would deliver
+/// whole.
+pub const RECEIVE_CEILING: usize = 2048;
+
+/// The Windows error a UDP receive raises when the datagram did not fit.
+///
+/// Named by number because `ErrorKind` folds it into `Uncategorized`,
+/// which cannot be matched on stably. Winsock calls it WSAEMSGSIZE.
+#[cfg(windows)]
+const WSAEMSGSIZE: i32 = 10040;
+
+/// Why a socket could not be opened or used.
+///
+/// Every variant names the address it was about, the way every
+/// filesystem error here names its path: an error that does not say
+/// *which* endpoint failed is one a caller cannot act on.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum NetError {
+    /// The machine, not the request: no interface, no permission, or the
+    /// port already taken. Recoverable by design — a caller reports it
+    /// and runs offline.
+    Unavailable { addr: SocketAddr, kind: ErrorKind },
+    /// The kernel refused a send for a reason that is not back-pressure.
+    Send { to: SocketAddr, kind: ErrorKind },
+    /// The kernel refused a receive for a reason that is not emptiness.
+    Receive { kind: ErrorKind },
+    /// The datagram was longer than the buffer offered.
+    ///
+    /// **Reported, never silently truncated.** A truncated datagram is a
+    /// different message: a codec handed a prefix would refuse it as
+    /// malformed, blaming the sender for the receiver's small buffer.
+    Oversized { capacity: usize },
+}
+
+impl fmt::Display for NetError {
+    fn fmt(&self, out: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable { addr, kind } => {
+                write!(out, "{addr} is unavailable: {kind:?}")
+            }
+            Self::Send { to, kind } => write!(out, "sending to {to} failed: {kind:?}"),
+            Self::Receive { kind } => write!(out, "receiving failed: {kind:?}"),
+            Self::Oversized { capacity } => write!(
+                out,
+                "a datagram was longer than the {capacity}-byte buffer offered, and a truncated \
+                 datagram is a different message"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for NetError {}
+
+/// Whether the kernel took the bytes.
+///
+/// A non-blocking socket with a full send buffer is a normal condition
+/// and not an error. Nothing is lost by it: a lockstep session re-offers
+/// whatever it still owes on the next pump, which is why this is a
+/// reported outcome a caller can count rather than a failure it must
+/// handle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Sent {
+    Delivered,
+    WouldBlock,
+}
+
+/// A bound UDP socket, owned by whoever bound it.
+///
+/// No ambient state, no background thread, and no queue this crate
+/// manages — the buffers belong to the caller, which is what lets a
+/// consumer keep its whole steady state allocation-free.
+#[derive(Debug)]
+pub struct Socket {
+    inner: UdpSocket,
+}
+
+impl Socket {
+    /// Bind, and switch to non-blocking.
+    ///
+    /// Port zero binds an ephemeral port; [`Socket::local_addr`] reports
+    /// which one, which is how a test gets two sockets without agreeing a
+    /// number in advance.
+    ///
+    /// # Errors
+    ///
+    /// [`NetError::Unavailable`] when the address cannot be bound, or
+    /// when the socket cannot be switched out of blocking mode — the two
+    /// are one outcome for a caller, because a blocking socket is not a
+    /// thing this seam is willing to hand back.
+    pub fn bind(addr: SocketAddr) -> Result<Self, NetError> {
+        let inner = UdpSocket::bind(addr).map_err(|error| NetError::Unavailable {
+            addr,
+            kind: error.kind(),
+        })?;
+        inner
+            .set_nonblocking(true)
+            .map_err(|error| NetError::Unavailable {
+                addr,
+                kind: error.kind(),
+            })?;
+        Ok(Self { inner })
+    }
+
+    /// The address actually bound, which is how an ephemeral port is
+    /// discovered.
+    ///
+    /// # Errors
+    ///
+    /// [`NetError::Unavailable`] if the kernel will not report it.
+    pub fn local_addr(&self) -> Result<SocketAddr, NetError> {
+        self.inner
+            .local_addr()
+            .map_err(|error| NetError::Unavailable {
+                addr: SocketAddr::from(([0, 0, 0, 0], 0)),
+                kind: error.kind(),
+            })
+    }
+
+    /// Send one datagram.
+    ///
+    /// # Errors
+    ///
+    /// [`NetError::Send`] for anything that is not back-pressure;
+    /// back-pressure is [`Sent::WouldBlock`] and not an error.
+    pub fn send_to(&self, bytes: &[u8], to: SocketAddr) -> Result<Sent, NetError> {
+        match self.inner.send_to(bytes, to) {
+            Ok(_) => Ok(Sent::Delivered),
+            Err(error) if error.kind() == ErrorKind::WouldBlock => Ok(Sent::WouldBlock),
+            Err(error) => Err(NetError::Send {
+                to,
+                kind: error.kind(),
+            }),
+        }
+    }
+
+    /// Take one datagram, if one is waiting.
+    ///
+    /// `Ok(None)` means nothing was there. Never blocks, never allocates,
+    /// and never partially fills a buffer.
+    ///
+    /// **Oversized is detected identically on every platform, and it
+    /// takes work to make that true.** The two families disagree: Windows
+    /// raises an error, while Unix silently truncates and reports the
+    /// clamped length, so a naive `len > buffer.len()` check can never
+    /// fire there and would hand back a prefix as though it were whole.
+    /// This reads into a buffer larger than the caller's and compares, so
+    /// truncation is *observed* rather than trusted to be reported.
+    ///
+    /// **Two kinds read as "nothing waiting", and the second is the
+    /// interesting one.** `WouldBlock` is the obvious empty case. On
+    /// Windows a UDP socket also surfaces `ConnectionReset` *on receive*
+    /// to report an ICMP port-unreachable provoked by an earlier *send* —
+    /// to a peer whose process has not started yet, which is the ordinary
+    /// case at the beginning of a session. A receive loop that treated it
+    /// as fatal would die reliably on one platform and never on the
+    /// others, which is the worst shape a bug can have.
+    ///
+    /// # Errors
+    ///
+    /// [`NetError::Oversized`] when the datagram would not fit, and
+    /// [`NetError::Receive`] for any other kind.
+    pub fn recv_from(&self, into: &mut [u8]) -> Result<Option<(usize, SocketAddr)>, NetError> {
+        // One byte of headroom is what makes truncation visible: a
+        // datagram that fills this exactly is one the kernel may have
+        // cut, and is refused rather than guessed at.
+        let mut scratch = [0u8; RECEIVE_CEILING + 1];
+        match self.inner.recv_from(&mut scratch) {
+            Ok((len, from)) => {
+                if len > into.len() || len > RECEIVE_CEILING {
+                    return Err(NetError::Oversized {
+                        capacity: into.len().min(RECEIVE_CEILING),
+                    });
+                }
+                let (Some(source), Some(destination)) = (scratch.get(..len), into.get_mut(..len))
+                else {
+                    return Err(NetError::Oversized {
+                        capacity: into.len(),
+                    });
+                };
+                destination.copy_from_slice(source);
+                Ok(Some((len, from)))
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::WouldBlock | ErrorKind::ConnectionReset
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(error) => {
+                // Windows reports "it did not fit" as an error rather
+                // than by truncating, and folds it into an ErrorKind that
+                // cannot be matched on. The number is the only stable
+                // handle, and mapping it here is what keeps one datagram
+                // one outcome on every platform.
+                #[cfg(windows)]
+                if error.raw_os_error() == Some(WSAEMSGSIZE) {
+                    return Err(NetError::Oversized {
+                        capacity: into.len().min(RECEIVE_CEILING),
+                    });
+                }
+                Err(NetError::Receive { kind: error.kind() })
+            }
+        }
+    }
+}
+
+/// A stable, comparable tag for an address.
+///
+/// **A v4-mapped IPv6 address folds to its v4 form**, and that is the
+/// whole reason this exists rather than every driver keying on
+/// `SocketAddr` directly. The same peer can reach one machine as
+/// `::ffff:1.2.3.4` and another as `1.2.3.4`; a roster keyed on the raw
+/// address would see two peers, hand out two seats, and the resulting
+/// divergence would surface hundreds of ticks later as a desync with no
+/// obvious cause. Canonicalising belongs in the crate that owns the
+/// address type, not in each consumer that keys by one.
+///
+/// The layout is sixteen bytes of address, then the port, big-endian: two
+/// tags compare and sort without anyone deciding a byte order twice.
+#[must_use]
+pub fn peer_tag(addr: SocketAddr) -> [u8; 18] {
+    let mut tag = [0u8; 18];
+    let canonical = match addr.ip() {
+        IpAddr::V4(v4) => IpAddr::V4(v4),
+        // `to_ipv4_mapped` returns Some only for the ::ffff:a.b.c.d form,
+        // which is exactly the case that must fold. A native v6 address
+        // stays a v6 address.
+        IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(IpAddr::V6(v6), IpAddr::V4),
+    };
+    match canonical {
+        IpAddr::V4(v4) => {
+            if let Some(room) = tag.get_mut(..4) {
+                room.copy_from_slice(&v4.octets());
+            }
+        }
+        IpAddr::V6(v6) => {
+            if let Some(room) = tag.get_mut(..16) {
+                room.copy_from_slice(&v6.octets());
+            }
+        }
+    }
+    if let Some(room) = tag.get_mut(16..18) {
+        room.copy_from_slice(&addr.port().to_be_bytes());
+    }
+    tag
+}

--- a/crates/core/platform/src/net.rs
+++ b/crates/core/platform/src/net.rs
@@ -211,43 +211,52 @@ impl Socket {
         // datagram that fills this exactly is one the kernel may have
         // cut, and is refused rather than guessed at.
         let mut scratch = [0u8; RECEIVE_CEILING + 1];
-        match self.inner.recv_from(&mut scratch) {
-            Ok((len, from)) => {
-                if len > into.len() || len > RECEIVE_CEILING {
-                    return Err(NetError::Oversized {
-                        capacity: into.len().min(RECEIVE_CEILING),
-                    });
+        // A loop, not a single attempt, and the difference matters. A
+        // consumed ICMP error is not an empty queue: returning `None` for
+        // one would end the caller's drain early and leave real datagrams
+        // sitting behind it until the next pump. On Windows a peer that
+        // is not listening yet produces one of these per send, so the
+        // rate is set by the network rather than by this machine — a
+        // drain that gave up on each would fall behind exactly when a
+        // session is starting. Only `WouldBlock` means "nothing there".
+        loop {
+            match self.inner.recv_from(&mut scratch) {
+                Ok((len, from)) => {
+                    if len > into.len() || len > RECEIVE_CEILING {
+                        return Err(NetError::Oversized {
+                            capacity: into.len().min(RECEIVE_CEILING),
+                        });
+                    }
+                    let (Some(source), Some(destination)) =
+                        (scratch.get(..len), into.get_mut(..len))
+                    else {
+                        return Err(NetError::Oversized {
+                            capacity: into.len(),
+                        });
+                    };
+                    destination.copy_from_slice(source);
+                    return Ok(Some((len, from)));
                 }
-                let (Some(source), Some(destination)) = (scratch.get(..len), into.get_mut(..len))
-                else {
-                    return Err(NetError::Oversized {
-                        capacity: into.len(),
-                    });
-                };
-                destination.copy_from_slice(source);
-                Ok(Some((len, from)))
-            }
-            Err(error)
-                if matches!(
-                    error.kind(),
-                    ErrorKind::WouldBlock | ErrorKind::ConnectionReset
-                ) =>
-            {
-                Ok(None)
-            }
-            Err(error) => {
-                // Windows reports "it did not fit" as an error rather
-                // than by truncating, and folds it into an ErrorKind that
-                // cannot be matched on. The number is the only stable
-                // handle, and mapping it here is what keeps one datagram
-                // one outcome on every platform.
-                #[cfg(windows)]
-                if error.raw_os_error() == Some(WSAEMSGSIZE) {
-                    return Err(NetError::Oversized {
-                        capacity: into.len().min(RECEIVE_CEILING),
-                    });
+                Err(error) if error.kind() == ErrorKind::WouldBlock => return Ok(None),
+                // Consumed and stepped over. The empty arm is the loop
+                // going round again: an ICMP error is not a datagram and
+                // not an empty queue, so the only correct response is to
+                // ask once more.
+                Err(error) if error.kind() == ErrorKind::ConnectionReset => {}
+                Err(error) => {
+                    // Windows reports "it did not fit" as an error rather
+                    // than by truncating, and folds it into an ErrorKind that
+                    // cannot be matched on. The number is the only stable
+                    // handle, and mapping it here is what keeps one datagram
+                    // one outcome on every platform.
+                    #[cfg(windows)]
+                    if error.raw_os_error() == Some(WSAEMSGSIZE) {
+                        return Err(NetError::Oversized {
+                            capacity: into.len().min(RECEIVE_CEILING),
+                        });
+                    }
+                    return Err(NetError::Receive { kind: error.kind() });
                 }
-                Err(NetError::Receive { kind: error.kind() })
             }
         }
     }
@@ -276,17 +285,21 @@ pub fn peer_tag(addr: SocketAddr) -> [u8; 18] {
         // stays a v6 address.
         IpAddr::V6(v6) => v6.to_ipv4_mapped().map_or(IpAddr::V6(v6), IpAddr::V4),
     };
-    match canonical {
-        IpAddr::V4(v4) => {
-            if let Some(room) = tag.get_mut(..4) {
-                room.copy_from_slice(&v4.octets());
-            }
-        }
-        IpAddr::V6(v6) => {
-            if let Some(room) = tag.get_mut(..16) {
-                room.copy_from_slice(&v6.octets());
-            }
-        }
+    // **Both families fill all sixteen bytes**, and that is the whole of
+    // the correctness argument. Writing a v4 address into the first four
+    // and leaving twelve zero puts the two families in one key space with
+    // no discriminator: `32.1.13.184` and the native `2001:db8::` would
+    // then produce identical tags, so two genuinely different peers would
+    // take one seat — the exact failure this function exists to prevent,
+    // inverted. Re-emitting v4 in its mapped form keeps the two disjoint
+    // by construction, because the fold above has already turned every
+    // mapped v6 into a v4.
+    let address = match canonical {
+        IpAddr::V4(v4) => v4.to_ipv6_mapped().octets(),
+        IpAddr::V6(v6) => v6.octets(),
+    };
+    if let Some(room) = tag.get_mut(..16) {
+        room.copy_from_slice(&address);
     }
     if let Some(room) = tag.get_mut(16..18) {
         room.copy_from_slice(&addr.port().to_be_bytes());

--- a/crates/core/platform/tests/net_loopback.rs
+++ b/crates/core/platform/tests/net_loopback.rs
@@ -1,0 +1,157 @@
+//! The socket seam, over loopback.
+//!
+//! Everything here binds port zero and asks the kernel which port it got,
+//! so two of these can run at once and neither has to agree a number with
+//! anyone. Nothing reaches the network: an unavailable loopback is a
+//! broken machine, not a flaky test.
+
+#![cfg(feature = "net")]
+
+use renew_platform::net::{
+    IpAddr, Ipv4Addr, Ipv6Addr, NetError, Sent, Socket, SocketAddr, peer_tag,
+};
+
+fn loopback() -> SocketAddr {
+    SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
+}
+
+#[test]
+fn a_datagram_crosses_and_names_its_sender() {
+    let listener = Socket::bind(loopback()).expect("loopback must bind");
+    let sender = Socket::bind(loopback()).expect("loopback must bind");
+    let to = listener
+        .local_addr()
+        .expect("a bound socket has an address");
+    let from = sender.local_addr().expect("a bound socket has an address");
+
+    assert_eq!(
+        sender.send_to(b"hello", to).expect("loopback send"),
+        Sent::Delivered
+    );
+
+    // Non-blocking, so the datagram may not have landed on the first
+    // look. Spinning a bounded number of times is the only honest way to
+    // wait without a clock this crate is allowed to read.
+    let mut buffer = [0u8; 64];
+    let mut received = None;
+    for _ in 0..10_000 {
+        if let Some(pair) = listener.recv_from(&mut buffer).expect("a healthy socket") {
+            received = Some(pair);
+            break;
+        }
+    }
+    let (len, source) = received.expect("a datagram sent over loopback must arrive");
+    assert_eq!(buffer.get(..len), Some(&b"hello"[..]));
+    assert_eq!(
+        source.port(),
+        from.port(),
+        "the receiver must be told which endpoint sent it"
+    );
+}
+
+#[test]
+fn an_empty_socket_reports_nothing_rather_than_blocking() {
+    let socket = Socket::bind(loopback()).expect("loopback must bind");
+    let mut buffer = [0u8; 64];
+    // If this seam were blocking, this call would never return and the
+    // test would hang rather than fail — which is why the socket has no
+    // blocking mode to reach in the first place.
+    assert!(
+        socket
+            .recv_from(&mut buffer)
+            .expect("an empty socket is healthy")
+            .is_none(),
+        "an empty non-blocking socket reports nothing waiting"
+    );
+}
+
+#[test]
+fn a_datagram_larger_than_the_buffer_is_reported_not_truncated() {
+    let listener = Socket::bind(loopback()).expect("loopback must bind");
+    let sender = Socket::bind(loopback()).expect("loopback must bind");
+    let to = listener.local_addr().expect("bound");
+
+    let big = [7u8; 400];
+    sender.send_to(&big, to).expect("loopback send");
+
+    let mut small = [0u8; 16];
+    let mut verdict = None;
+    for _ in 0..10_000 {
+        match listener.recv_from(&mut small) {
+            Ok(None) => {}
+            other => {
+                verdict = Some(other);
+                break;
+            }
+        }
+    }
+    // A truncated datagram is a different message, so the seam must
+    // refuse rather than hand back a prefix that a codec would then blame
+    // the sender for.
+    match verdict {
+        Some(Err(NetError::Oversized { capacity })) => assert_eq!(capacity, 16),
+        Some(Ok(Some((len, _)))) => {
+            panic!("a 400-byte datagram was accepted into 16 bytes as {len}")
+        }
+        other => panic!("expected an oversized refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn binding_a_port_already_taken_fails_recoverably() {
+    let held = Socket::bind(loopback()).expect("loopback must bind");
+    let taken = held.local_addr().expect("bound");
+    // Binding the same port again is the ordinary "someone is already
+    // playing" case, and must be a reported outcome rather than a panic.
+    match Socket::bind(taken) {
+        Err(NetError::Unavailable { addr, .. }) => assert_eq!(addr, taken),
+        Ok(_) => panic!("the same port bound twice"),
+        Err(other) => panic!("expected an unavailable refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn every_refusal_says_which_endpoint_it_was_about() {
+    let held = Socket::bind(loopback()).expect("bind");
+    let taken = held.local_addr().expect("bound");
+    let text = Socket::bind(taken)
+        .expect_err("the same port twice")
+        .to_string();
+    assert!(!text.is_empty());
+    assert!(
+        text.contains(&taken.port().to_string()),
+        "a refusal that does not name its endpoint cannot be acted on: \"{text}\""
+    );
+}
+
+// ---- address canonicalisation ----
+
+#[test]
+fn a_v4_mapped_address_folds_to_the_v4_it_names() {
+    let plain = SocketAddr::from((Ipv4Addr::new(1, 2, 3, 4), 9000));
+    let mapped = SocketAddr::new(IpAddr::V6(Ipv4Addr::new(1, 2, 3, 4).to_ipv6_mapped()), 9000);
+    assert_eq!(
+        peer_tag(plain),
+        peer_tag(mapped),
+        "the same peer reaching a roster two ways must be one peer, or it takes two seats"
+    );
+}
+
+#[test]
+fn a_native_v6_address_stays_itself() {
+    let v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9000);
+    let v4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 9000));
+    assert_ne!(
+        peer_tag(v6),
+        peer_tag(v4),
+        "folding must apply to mapped addresses only, not to every v6"
+    );
+}
+
+#[test]
+fn the_port_is_part_of_the_tag_and_is_ordered() {
+    let low = peer_tag(SocketAddr::from((Ipv4Addr::LOCALHOST, 1)));
+    let high = peer_tag(SocketAddr::from((Ipv4Addr::LOCALHOST, 2)));
+    assert_ne!(low, high, "two ports on one host are two peers");
+    assert!(low < high, "big-endian, so tags sort the way ports do");
+}

--- a/crates/core/platform/tests/net_loopback.rs
+++ b/crates/core/platform/tests/net_loopback.rs
@@ -5,10 +5,8 @@
 //! anyone. Nothing reaches the network: an unavailable loopback is a
 //! broken machine, not a flaky test.
 
-#![cfg(feature = "net")]
-
 use renew_platform::net::{
-    IpAddr, Ipv4Addr, Ipv6Addr, NetError, Sent, Socket, SocketAddr, peer_tag,
+    IpAddr, Ipv4Addr, Ipv6Addr, NetError, RECEIVE_CEILING, Sent, Socket, SocketAddr, peer_tag,
 };
 
 fn loopback() -> SocketAddr {
@@ -154,4 +152,94 @@ fn the_port_is_part_of_the_tag_and_is_ordered() {
     let high = peer_tag(SocketAddr::from((Ipv4Addr::LOCALHOST, 2)));
     assert_ne!(low, high, "two ports on one host are two peers");
     assert!(low < high, "big-endian, so tags sort the way ports do");
+}
+
+#[test]
+fn a_v4_peer_and_a_native_v6_peer_are_never_one_tag() {
+    // The regression for a collision the test above was reaching for and
+    // missed. It checked `::1`, which happens not to alias; a native v6
+    // whose low twelve bytes are zero does. With the address written into
+    // only the first four bytes, `32.1.13.184` and `2001:db8::` produced
+    // byte-identical tags — two peers, one seat, and a divergence
+    // hundreds of ticks later with no obvious cause.
+    let v4 = SocketAddr::from((Ipv4Addr::new(32, 1, 13, 184), 9000));
+    let v6 = SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 0)),
+        9000,
+    );
+    assert_ne!(
+        peer_tag(v4),
+        peer_tag(v6),
+        "two peers sharing one tag take one seat, which is the bug this fold exists to prevent"
+    );
+
+    // The same shape with a link-local prefix, because one example of a
+    // family collision is an anecdote.
+    let v4 = SocketAddr::from((Ipv4Addr::new(254, 128, 0, 0), 5000));
+    let v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0)), 5000);
+    assert_ne!(peer_tag(v4), peer_tag(v6));
+}
+
+#[test]
+fn a_v4_tag_is_the_mapped_form_and_fills_the_whole_address_field() {
+    // The docstring promises sixteen bytes of address then the port. It
+    // is only true if v4 is re-emitted mapped, so the layout is pinned
+    // rather than left to be re-derived.
+    let tag = peer_tag(SocketAddr::from((Ipv4Addr::new(1, 2, 3, 4), 0x1234)));
+    assert_eq!(
+        &tag[..10],
+        &[0u8; 10],
+        "the mapped prefix is ten zero bytes"
+    );
+    assert_eq!(&tag[10..12], &[0xff, 0xff], "then the mapped marker");
+    assert_eq!(&tag[12..16], &[1, 2, 3, 4], "then the four octets");
+    assert_eq!(&tag[16..18], &[0x12, 0x34], "then the port, big-endian");
+}
+
+#[test]
+fn a_datagram_past_the_seam_ceiling_is_refused_identically_everywhere() {
+    // The whole stated reason for running this job on three platforms,
+    // and until this test existed it proved neither of the two things it
+    // claimed. Windows raises an error here (WSAEMSGSIZE, folded into an
+    // ErrorKind that cannot be matched on, so the seam maps the number);
+    // Unix truncates into the scratch buffer and the seam observes it by
+    // the byte of headroom. Both must produce one outcome.
+    let listener = Socket::bind(loopback()).expect("loopback must bind");
+    let sender = Socket::bind(loopback()).expect("loopback must bind");
+    let to = listener.local_addr().expect("bound");
+
+    // Past the scratch, not merely past the caller's buffer: this is the
+    // path where the two platforms genuinely diverge.
+    let huge = vec![5u8; RECEIVE_CEILING + 64];
+    match sender.send_to(&huge, to) {
+        Ok(_) => {}
+        // A loopback MTU below the ceiling is a property of the machine,
+        // not a defect here. Skipping is honest; asserting would make
+        // this test about the host's network stack.
+        Err(_) => return,
+    }
+
+    let mut buffer = [0u8; RECEIVE_CEILING];
+    let mut verdict = None;
+    for _ in 0..10_000 {
+        match listener.recv_from(&mut buffer) {
+            Ok(None) => {}
+            other => {
+                verdict = Some(other);
+                break;
+            }
+        }
+    }
+    match verdict {
+        // Refused, which is the outcome under test — or nothing arrived
+        // at all, because the host dropped it below this seam, which is
+        // the host and not this seam being wrong. The two share an arm
+        // because the test's claim is "never silently truncated", and
+        // both satisfy it.
+        Some(Err(NetError::Oversized { .. })) | None => {}
+        Some(Ok(Some((len, _)))) => {
+            panic!("a {}-byte datagram came back as {len} bytes", huge.len())
+        }
+        other => panic!("expected an oversized refusal, got {other:?}"),
+    }
 }


### PR DESCRIPTION
Adds a UDP module behind a default-off `net` feature — the only place in
the engine that names `std::net`, and the last piece a peer-to-peer
session needs to put a byte on a wire. Independent of the lockstep
crates: by design there is no dependency edge between the two halves in
either direction, so this targets `main` directly.

Default-off on the same terms as audio output, and unlike audio it
carries no dependency, so it resolves no crate and the minimal-core graph
is unchanged by its existence.

**No threads and no blocking mode.** A socket is non-blocking from birth
and polled from the loop that already runs. A receive thread would cost a
shared queue, a sanitizer obligation and a send/sync argument to save
nothing measurable. The audio seam takes the mirror decision for the
mirror reason: there the operating system owns the thread, so this crate
spawns none; here there is no such thread, so this crate polls.

**The oversized case is where the platforms disagree, and making them
agree is most of the work.** Windows raises an error when a datagram does
not fit, folded into an `ErrorKind` that cannot be matched on stably.
Unix silently truncates and reports the clamped length, so the obvious
"was it longer than the buffer" check can never fire there and would hand
back a prefix as though it were whole — which a codec would then refuse as
malformed, blaming the sender for the receiver's small buffer. The
receive reads into a buffer with a byte of headroom and compares, so
truncation is observed rather than trusted to be reported.

**A consumed ICMP error is not an empty queue.** `ConnectionReset` on
receive reports a prior send's port-unreachable, which on Windows an
unstarted peer produces once per send. Treating it as "nothing waiting"
would end a caller's drain and leave real datagrams behind it — falling
behind exactly when a session is starting. It is stepped over instead;
only back-pressure ends the call.

**Addresses are canonicalised so that one peer is one tag.** Both families
fill the whole sixteen-byte address field, v4 re-emitted in its mapped
form. Writing v4 into the first four bytes and leaving twelve zero puts
the two families in one key space with no discriminator, and
`32.1.13.184` then collides with the native `2001:db8::` — two peers, one
seat, and a divergence hundreds of ticks later with no obvious cause. The
regression pins both a colliding pair and the byte layout.

Unavailability is recoverable, matching the audio and window seams: no
interface, no permission, or a port already taken is a reported outcome a
caller can run offline from. Every refusal names the endpoint it was
about.

The new job runs all three platforms, and Windows is the reason rather
than a completeness habit — a seam tested only on Linux would pass while
being wrong twice on the platform most of these runs happen on. Nothing
in it reaches the network: every socket binds loopback on port zero and
asks the kernel which port it got, so the legs cannot collide. The test
target is gated by `required-features` rather than a file-level `cfg`,
because the latter builds an empty harness that reports green when the
feature is off.
