### PR TITLE
feat(platform): an address tag decodes back to an address

### DIFF
--- a/crates/core/platform/src/net.rs
+++ b/crates/core/platform/src/net.rs
@@ -275,6 +275,14 @@ impl Socket {
 ///
 /// The layout is sixteen bytes of address, then the port, big-endian: two
 /// tags compare and sort without anyone deciding a byte order twice.
+///
+/// **This is an encoding, not a hash.** [`peer_addr`] reverses it, which
+/// is what lets a tag travel somewhere that may not name an address and
+/// come back somewhere that must send to one — a roster of peers, for
+/// instance, carried by a crate forbidden from knowing what an address
+/// is. Nothing is lost but the distinction between a v4 address and its
+/// v4-mapped spelling, which is the distinction this function exists to
+/// erase.
 #[must_use]
 pub fn peer_tag(addr: SocketAddr) -> [u8; 18] {
     let mut tag = [0u8; 18];
@@ -305,4 +313,46 @@ pub fn peer_tag(addr: SocketAddr) -> [u8; 18] {
         room.copy_from_slice(&addr.port().to_be_bytes());
     }
     tag
+}
+
+/// The address a tag names: the inverse of [`peer_tag`].
+///
+/// **A tag has to be routable again or it is only half a value.** The
+/// tag exists so an endpoint can cross a boundary that may not name a
+/// `SocketAddr` — a peer roster, a save file, a wire format written by a
+/// crate denied any path to this one. Every one of those hands the bytes
+/// back to something that must then *send* to them, and without this
+/// function that last step is impossible: the roster arrives, and there
+/// is nowhere to put a datagram.
+///
+/// **A v4-mapped tag comes back as a v4 address, not as the mapped v6
+/// spelling it was stored in.** That is deliberate and it is load-bearing
+/// rather than cosmetic: a socket bound to a v4 address refuses a send to
+/// `::ffff:a.b.c.d` on several platforms, so returning the literal
+/// sixteen bytes would produce an address that compares equal to the
+/// right one and cannot be sent to. Unfolding here means the pair reads
+/// as an encoding in one direction and a canonicalisation in the other:
+///
+/// - `peer_tag(peer_addr(t)) == t` for every tag, exactly.
+/// - `peer_addr(peer_tag(a)) == a` for every address already canonical,
+///   and equal to its v4 form for one written as v4-mapped v6 — which is
+///   the same folding [`peer_tag`] does, observed from the other side.
+///
+/// Both properties are held by tests rather than by this paragraph.
+#[must_use]
+pub fn peer_addr(tag: [u8; 18]) -> SocketAddr {
+    let mut address = [0u8; 16];
+    if let Some(bytes) = tag.get(..16) {
+        address.copy_from_slice(bytes);
+    }
+    let mut port = [0u8; 2];
+    if let Some(bytes) = tag.get(16..18) {
+        port.copy_from_slice(bytes);
+    }
+    let v6 = Ipv6Addr::from(address);
+    // The same fold `peer_tag` applies on the way in, so a round trip
+    // through the pair is idempotent rather than alternating between two
+    // spellings of one peer.
+    let ip = v6.to_ipv4_mapped().map_or(IpAddr::V6(v6), IpAddr::V4);
+    SocketAddr::new(ip, u16::from_be_bytes(port))
 }

--- a/crates/core/platform/tests/net_loopback.rs
+++ b/crates/core/platform/tests/net_loopback.rs
@@ -6,7 +6,8 @@
 //! broken machine, not a flaky test.
 
 use renew_platform::net::{
-    IpAddr, Ipv4Addr, Ipv6Addr, NetError, RECEIVE_CEILING, Sent, Socket, SocketAddr, peer_tag,
+    IpAddr, Ipv4Addr, Ipv6Addr, NetError, RECEIVE_CEILING, Sent, Socket, SocketAddr, peer_addr,
+    peer_tag,
 };
 
 fn loopback() -> SocketAddr {
@@ -242,4 +243,98 @@ fn a_datagram_past_the_seam_ceiling_is_refused_identically_everywhere() {
         }
         other => panic!("expected an oversized refusal, got {other:?}"),
     }
+}
+
+// ---- a tag is an encoding, so it has to come back ----
+
+#[test]
+fn a_tag_round_trips_to_an_address_that_can_be_sent_to() {
+    // The property the whole pair exists for: an endpoint crosses a
+    // boundary that may not name a `SocketAddr` — a peer roster, a save,
+    // a wire format written by a crate denied any path to this one — and
+    // arrives somewhere that must put a datagram on it. Without this
+    // direction the tag is only half a value.
+    let listener = Socket::bind(loopback()).expect("loopback must bind");
+    let sender = Socket::bind(loopback()).expect("loopback must bind");
+    let to = listener.local_addr().expect("bound");
+
+    // Out through the tag and back, exactly as a roster would carry it.
+    let carried = peer_tag(to);
+    let recovered = peer_addr(carried);
+
+    assert_eq!(
+        sender.send_to(b"routed", recovered).expect("loopback send"),
+        Sent::Delivered,
+        "an address recovered from a tag must be an address that sends"
+    );
+    let mut buffer = [0u8; 64];
+    let mut got = None;
+    for _ in 0..10_000 {
+        if let Some(pair) = listener.recv_from(&mut buffer).expect("healthy") {
+            got = Some(pair);
+            break;
+        }
+    }
+    let (len, _) = got.expect("a datagram sent to a recovered address must arrive");
+    assert_eq!(buffer.get(..len), Some(&b"routed"[..]));
+}
+
+#[test]
+fn every_tag_encodes_the_address_it_decodes_to() {
+    // `peer_tag(peer_addr(t)) == t`, exactly, for every tag — including
+    // ones no address in this test ever produced, because a tag arriving
+    // off a wire was not necessarily written here.
+    let mut tag = [0u8; 18];
+    for (index, byte) in tag.iter_mut().enumerate() {
+        *byte = u8::try_from(index)
+            .unwrap_or(0)
+            .wrapping_mul(37)
+            .wrapping_add(11);
+    }
+    assert_eq!(
+        peer_tag(peer_addr(tag)),
+        tag,
+        "a decoded tag re-encoded to something else"
+    );
+
+    // And the v4-mapped shape, which is the one the fold touches.
+    let mut mapped = [0u8; 18];
+    mapped[10] = 0xff;
+    mapped[11] = 0xff;
+    mapped[12..16].copy_from_slice(&[203, 0, 113, 9]);
+    mapped[16..18].copy_from_slice(&7777u16.to_be_bytes());
+    assert_eq!(peer_tag(peer_addr(mapped)), mapped);
+}
+
+#[test]
+fn a_mapped_tag_decodes_to_the_v4_address_a_v4_socket_will_accept() {
+    // Returning the literal sixteen bytes would give `::ffff:a.b.c.d`,
+    // which compares equal to the right peer and which a v4-bound socket
+    // refuses to send to on several platforms — an address that looks
+    // correct everywhere except where it is used.
+    let v4 = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 9), 7777));
+    assert_eq!(peer_addr(peer_tag(v4)), v4);
+
+    let written_as_mapped = SocketAddr::new(
+        IpAddr::V6(Ipv4Addr::new(203, 0, 113, 9).to_ipv6_mapped()),
+        7777,
+    );
+    assert_eq!(
+        peer_addr(peer_tag(written_as_mapped)),
+        v4,
+        "the two spellings of one peer must decode to the one the socket accepts"
+    );
+}
+
+#[test]
+fn a_native_v6_tag_stays_v6() {
+    let v6 = SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 0x1234)),
+        443,
+    );
+    assert_eq!(
+        peer_addr(peer_tag(v6)),
+        v6,
+        "folding must not reach a native v6"
+    );
 }


### PR DESCRIPTION
`peer_tag` turns an endpoint into eighteen canonical bytes so it can cross a boundary that may not name a `SocketAddr` — a peer roster, a save file, a wire format written by a crate denied any path to this one. Every one of those hands the bytes back to something that must then **send** to them, and there was no way to do it: the roster arrives, and there is nowhere to put a datagram. A tag that cannot be routed again is half a value.

`peer_addr` is the inverse, and the pair now reads as an encoding rather than a one-way key.

**A v4-mapped tag comes back as a v4 address rather than the mapped v6 spelling it was stored in.** That is load-bearing rather than cosmetic: a socket bound to a v4 address refuses a send to `::ffff:a.b.c.d` on several platforms, so returning the literal sixteen bytes would give an address that compares equal to the right peer and cannot be sent to — correct everywhere except where it is used. Unfolding here makes the pair an encoding in one direction and a canonicalisation in the other, and both halves are held by tests: a decoded tag re-encodes to itself exactly, including for tags no address in the suite produced, and an already-canonical address survives the round trip unchanged.

The test that matters most compares no addresses. It carries a bound socket's address out through a tag, brings it back, and sends a datagram to the result over loopback. Reverting the fold fails it — which is the evidence that the unfolding is about routing and not about equality.

Additive only; nothing existing changes shape.