### PR TITLE
docs(net): submit says which tick it filled, after the input had to exist

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -182,7 +182,7 @@ reason = "The same narrowing on both sides of the channel. On the send side the 
 
 [[exempt]]
 file = "crates/net/src/session.rs"
-lines = [729, 783, 1096, 1108, 1132]
+lines = [748, 802, 1115, 1127, 1151]
 reason = "Five arms no input can drive. `render` cannot be called with the terminal emission because the cursor that produces it returns None first, and `render_inputs` cannot see a zero local tick because inputs are only emitted once the session is playing, which requires at least one submission. The backwards walk's missing-frame break cannot fire either: it looks at most eight ticks back and the ring holds sixty-four, so those frames are always present. The remaining two are region ends inside `next_outbound` and `write_frame` whose bodies are covered. All five are kept rather than deleted because each states a bound that would stop being true if a ceiling moved, which is exactly when a silent wrong answer would cost the most."
 
 [[exempt]]

--- a/crates/net/src/session.rs
+++ b/crates/net/src/session.rs
@@ -453,6 +453,25 @@ impl Session {
     /// is the shape of lookahead cheating, closed here by the state
     /// machine rather than by a rule.
     ///
+    /// # The tick is ahead of the world, and an input derived from the wrong one diverges
+    ///
+    /// Submissions run ahead of the confirmed frontier by the agreed
+    /// input delay, so **the tick filled here is not the tick the
+    /// simulation has reached.** A caller whose input depends on the tick
+    /// at all — a recorded trace, a bot, a test fixture, anything
+    /// scripted — must derive it from [`Session::next_local_tick`], which
+    /// says which tick the next call will fill *before* the input has to
+    /// exist. This function returns the number afterwards, which is
+    /// useful for a log and useless for that decision.
+    ///
+    /// Getting it wrong reads the caller's own loop rate instead: how
+    /// many times it spun before a tick was ready is wall-clock, so the
+    /// same seed produces a different run every time. **And no
+    /// peer-to-peer check catches it**, because peers exchange the inputs
+    /// they actually sent rather than recomputing them — every machine
+    /// agrees, and all of them agree on a different game than the last
+    /// run did. Only repeating one seed and comparing finds it.
+    ///
     /// # Errors
     ///
     /// [`SubmitError`] for a wrong width, a tick already submitted, a full


### PR DESCRIPTION
A submission runs ahead of the confirmed frontier by the agreed input delay, so the tick `Session::submit` returns is **not** the tick the simulation has reached — and it returns it *after* the caller has committed to an input. Anything scripted, replayed, or generated has to read `next_local_tick` first, which says the same number while the decision is still open.

Deriving an input from how far the simulation has got reads the caller's own loop rate instead, so the same seed produces a different run every time.

The failure is worth spelling out because of how it hides: **peers exchange the inputs they actually sent rather than recomputing them, so every machine agrees with every other** — and all of them agree on a different game than the last run did. No amount of cross-peer checking can see it. Only repeating one seed and comparing the results does.

`next_local_tick` already documented the useful half. The warning belongs on `submit` too, because that is where a caller is standing when the mistake is available to make. Documentation only.