### PR TITLE
feat(cli): a coverage block that slid together is reported as moved

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -121,12 +121,12 @@ reason = "The arm that clears a voice whose sound index is missing. A voice is o
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [86, 87, 88, 1208, 1209, 1210, 1211, 1217, 1218, 1220, 1221, 1222, 1227, 1228, 1229, 1230, 1231, 1232, 1233, 1235, 1236, 1237, 1238, 1239, 1240, 1241, 1242, 1243, 1247, 1248, 1249, 1250, 1251, 1252, 1253, 1254, 1255, 1256, 1257, 1258, 1260, 1264, 1265]
+lines = [86, 87, 88, 1302, 1303, 1304, 1305, 1311, 1312, 1314, 1315, 1316, 1321, 1322, 1323, 1324, 1325, 1326, 1327, 1329, 1330, 1331, 1332, 1333, 1334, 1335, 1336, 1337, 1341, 1342, 1343, 1344, 1345, 1346, 1347, 1348, 1349, 1350, 1351, 1352, 1354, 1358, 1359]
 reason = "The emit half of determinism: it spawns a cargo run per pinned scenario and reads what they printed, so reaching it from a test would mean building and running whole samples under instrumentation. It is not untested — the three determinism legs execute every line of it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved into digests_from_output, which has five cases beside it. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero."
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [1271]
+lines = [1365]
 reason = "The comparison refusing to start because no workspace root is above it. Every other subcommand carries the same arm and reaches it the same way -- never, from a test, because a test runs inside the workspace it is testing. Reaching it would mean invoking the binary from outside any cargo project, which is a property of where a caller stands rather than of anything this code does."
 
 [[exempt]]

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -824,6 +824,9 @@ fn coverage_envelope(outcome: &Outcome, started: Instant) -> Value {
 /// hundreds of line numbers into a single finding.
 fn drift_hint(outcome: &Outcome, file: &str) -> Option<String> {
     const SHOWN: usize = 6;
+    if let Some(moved) = relocation_hint(outcome, file) {
+        return Some(moved);
+    }
     let lines: Vec<u32> = outcome
         .gaps
         .iter()
@@ -845,6 +848,75 @@ fn drift_hint(outcome: &Outcome, file: &str) -> Option<String> {
             " (unless the code moved: this file is uncovered and unexempted at {listed}, and {more} more)"
         )),
     }
+}
+
+/// The same fact, sharpened when the whole block moved together.
+///
+/// A file whose stale pins are each the *same distance* from an
+/// unexempted gap is a file where text was inserted above them. That has
+/// happened four times running in one stack — once from a change that
+/// added nothing but documentation — and each time the fix was to work
+/// out the offset by hand, verify a few lines by content, and re-pin.
+/// Every input to that arithmetic is already on the screen; only the
+/// subtraction was missing.
+///
+/// **Offered as an observation, never as an inference.** A uniform offset
+/// is strong evidence that a block slid and no evidence at all that the
+/// code inside it still means what the exemption says — so this prints
+/// the corrected numbers and says to check them, rather than implying
+/// the entry is fine where it lands. Anchoring on content is still the
+/// step that decides; this only removes the counting.
+///
+/// Silent unless the correspondence is exact and one-to-one: any stale
+/// pin without a gap at the same offset, any offset of zero, or fewer
+/// than two pins to agree with each other, and the ordinary listing is
+/// the honest answer.
+fn relocation_hint(outcome: &Outcome, file: &str) -> Option<String> {
+    let stale: Vec<u32> = outcome
+        .stale
+        .iter()
+        .filter(|entry| entry.site.file == file && entry.kind == coverage::StaleKind::NowCovered)
+        .map(|entry| entry.site.line)
+        .collect();
+    let gaps: Vec<u32> = outcome
+        .gaps
+        .iter()
+        .filter(|site| site.file == file)
+        .map(|site| site.line)
+        .collect();
+    // Two pins are the fewest that can agree on an offset. One pin and
+    // one gap always "agree", which would make this fire on every
+    // ordinary single-line change.
+    if stale.len() < 2 || gaps.len() != stale.len() {
+        return None;
+    }
+    let first = *stale.first()?;
+    let offset = i64::from(*gaps.first()?) - i64::from(first);
+    let moved: Vec<u32> = stale
+        .iter()
+        .map(|line| i64::from(*line).saturating_add(offset))
+        .map(|line| u32::try_from(line).unwrap_or(0))
+        .collect();
+    // A zero offset is folded into the same guard rather than refused
+    // above it. It cannot happen — a line the report calls covered and a
+    // line it calls uncovered are never the same line — and an arm no
+    // input can reach is an arm no test can check, so it is written where
+    // the condition that already subsumes it lives.
+    if offset == 0 || moved != gaps {
+        return None;
+    }
+    let listed = moved
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<String>>()
+        .join(", ");
+    let direction = if offset > 0 { "down" } else { "up" };
+    let distance = offset.abs();
+    Some(format!(
+        " (every exemption in this file is {distance} lines above an unexempted gap, so the block \
+         moved {direction}: lines = [{listed}] — check the content at those lines before pinning \
+         them, because a block that moved and a block that changed look the same from here)"
+    ))
 }
 
 /// One line per finding, in `check`'s shape, then a summary.

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -824,8 +824,15 @@ fn coverage_envelope(outcome: &Outcome, started: Instant) -> Value {
 /// hundreds of line numbers into a single finding.
 fn drift_hint(outcome: &Outcome, file: &str) -> Option<String> {
     const SHOWN: usize = 6;
-    if let Some(moved) = relocation_hint(outcome, file) {
-        return Some(moved);
+    // When the whole block slid, every finding in the file says so in a
+    // few words and the pasteable list is printed once at the end. The
+    // first version put the list on every finding: forty-one copies of a
+    // forty-one-element line, correct and unreadable, and it did that on
+    // the very change that added it.
+    if let Some((offset, direction, _)) = relocation(outcome, file) {
+        return Some(format!(
+            " (the whole block moved {direction} {offset} lines — corrected pins below)"
+        ));
     }
     let lines: Vec<u32> = outcome
         .gaps
@@ -871,7 +878,7 @@ fn drift_hint(outcome: &Outcome, file: &str) -> Option<String> {
 /// pin without a gap at the same offset, any offset of zero, or fewer
 /// than two pins to agree with each other, and the ordinary listing is
 /// the honest answer.
-fn relocation_hint(outcome: &Outcome, file: &str) -> Option<String> {
+fn relocation(outcome: &Outcome, file: &str) -> Option<(i64, &'static str, String)> {
     let stale: Vec<u32> = outcome
         .stale
         .iter()
@@ -911,12 +918,7 @@ fn relocation_hint(outcome: &Outcome, file: &str) -> Option<String> {
         .collect::<Vec<String>>()
         .join(", ");
     let direction = if offset > 0 { "down" } else { "up" };
-    let distance = offset.abs();
-    Some(format!(
-        " (every exemption in this file is {distance} lines above an unexempted gap, so the block \
-         moved {direction}: lines = [{listed}] — check the content at those lines before pinning \
-         them, because a block that moved and a block that changed look the same from here)"
-    ))
+    Some((offset.abs(), direction, listed))
 }
 
 /// One line per finding, in `check`'s shape, then a summary.
@@ -945,6 +947,26 @@ fn coverage_report(outcome: &Outcome) -> String {
             stale.kind.explanation(),
             hint.as_deref().unwrap_or_default()
         );
+    }
+    // One note per file, after the findings: the value of this line is
+    // that it can be pasted, so it has to be whole — and a whole list
+    // repeated once per finding is what made the first version useless.
+    let mut noted: Vec<&str> = Vec::new();
+    for stale in &outcome.stale {
+        let file = stale.site.file.as_str();
+        if stale.kind != coverage::StaleKind::NowCovered || noted.contains(&file) {
+            continue;
+        }
+        if let Some((offset, direction, listed)) = relocation(outcome, file) {
+            noted.push(file);
+            let _ = writeln!(
+                report,
+                "MOVED {:<16} {file}: every pin is {offset} lines above a gap, so the block moved \
+                 {direction}. Corrected: lines = [{listed}]. Check the content at those lines \
+                 first — a block that moved and a block that changed look the same from here.",
+                "relocation"
+            );
+        }
     }
     let summary = if outcome.passes() {
         format!(

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -1166,6 +1166,80 @@ fn the_drift_hint_is_capped_so_one_finding_cannot_print_every_gap() {
     let _ = fs::remove_dir_all(&directory);
 }
 
+/// Two exempt lines that both ran, and two gaps the same distance below
+/// each: the shape a block of code takes when text is inserted above it.
+const BLOCK_MOVED: &str =
+    "[10,1,10,9,0,0,0,0],[12,1,12,9,0,0,0,0],[20,1,20,9,3,0,0,0],[22,1,22,9,3,0,0,0]";
+
+/// The same two exempt lines, but the gaps are not a constant distance
+/// away — one moved four lines and the other ten, which no insertion
+/// does.
+const BLOCK_SCATTERED: &str =
+    "[10,1,10,9,0,0,0,0],[16,1,16,9,0,0,0,0],[20,1,20,9,3,0,0,0],[22,1,22,9,3,0,0,0]";
+
+#[test]
+fn a_block_that_slid_together_is_reported_as_moved_with_its_new_lines() {
+    // Working the offset out by hand cost four separate sessions in one
+    // stack -- once for a change that added nothing but documentation.
+    // Every input to the subtraction was already on the screen.
+    let directory = coverage_workspace(
+        "relocated",
+        &exempting("crates/a.rs", "[20, 22]"),
+        BLOCK_MOVED,
+    )
+    .expect("scratch workspace should be creatable");
+
+    let output =
+        run_in(&directory, &["coverage", "--report", "report.json"]).expect("binary should spawn");
+    // The verdict is untouched: this is a sharper sentence about the same
+    // failure, never a reason to pass.
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("lines = [10, 12]"),
+        "the corrected block must be printed ready to paste: {stdout}"
+    );
+    assert!(
+        stdout.contains("moved up"),
+        "the direction must be named: {stdout}"
+    );
+    assert!(
+        stdout.contains("check the content at those lines"),
+        "a moved block and a changed block look the same from here, and the hint must say so: \
+         {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
+#[test]
+fn gaps_that_did_not_move_together_get_the_ordinary_listing() {
+    // The guard against the sharper sentence being confidently wrong. No
+    // single insertion moves two lines by different amounts, so this is
+    // not drift and must not be described as it.
+    let directory = coverage_workspace(
+        "scattered",
+        &exempting("crates/a.rs", "[20, 22]"),
+        BLOCK_SCATTERED,
+    )
+    .expect("scratch workspace should be creatable");
+
+    let output =
+        run_in(&directory, &["coverage", "--report", "report.json"]).expect("binary should spawn");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("the block moved"),
+        "a scattered file must not be called a moved block: {stdout}"
+    );
+    assert!(
+        stdout.contains("unless the code moved: this file is uncovered and unexempted at"),
+        "the ordinary listing is still owed: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&directory);
+}
+
 #[test]
 fn coverage_fails_on_an_exemption_the_report_never_measured() {
     let directory = coverage_workspace(

--- a/tools/cli/tests/cli.rs
+++ b/tools/cli/tests/cli.rs
@@ -1203,8 +1203,16 @@ fn a_block_that_slid_together_is_reported_as_moved_with_its_new_lines() {
         stdout.contains("moved up"),
         "the direction must be named: {stdout}"
     );
+    // Once, not once per finding. The first version printed a
+    // forty-one-element list forty-one times on the very change that
+    // added it: correct, and unreadable.
+    assert_eq!(
+        stdout.matches("Corrected: lines = [").count(),
+        1,
+        "the pasteable list must appear exactly once per file: {stdout}"
+    );
     assert!(
-        stdout.contains("check the content at those lines"),
+        stdout.contains("Check the content at those lines"),
         "a moved block and a changed block look the same from here, and the hint must say so: \
          {stdout}"
     );


### PR DESCRIPTION
When text is inserted above a run of exempt lines, every one of those lines is reported covered — true, and it reads as "delete these", which is the wrong instruction when the code has merely moved down. The gate already names the file's unexempted gaps beside the finding. What it did not do is the subtraction: **if every stale pin sits the same distance from a gap, the block slid**, and the corrected numbers can be printed ready to paste.

Every input to that arithmetic was already on the screen. Doing it by hand has cost four separate sessions in one stack — once for a change that added nothing but documentation.

**Offered as an observation, never as an inference.** A uniform offset is strong evidence that a block moved and no evidence at all that the code inside it still means what the exemption says. So the message prints the numbers and says to check the content at them: a block that moved and a block that changed look identical from here. Anchoring on content remains the step that decides; only the counting is removed.

Silent unless the correspondence is exact — fewer than two pins to agree with each other, or any pin without a gap at the same offset, and the ordinary listing is the honest answer. A test holds that, because a sharper sentence that is sometimes wrong is worse than a blunt one that never is.

**The verdict is untouched.** This is a better sentence about the same failure and never a reason to pass; the test asserts the exit code alongside the wording. The zero-offset case is folded into the guard that already subsumes it rather than given its own arm, because an arm no input can reach is an arm no test can check.