### PR TITLE
fix(net): a duplicate is not a refusal, so a healthy channel counts none

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -177,7 +177,7 @@ reason = "The narrowing conversion on a chat message's length in the writer, gua
 
 [[exempt]]
 file = "crates/net/src/chat.rs"
-lines = [244, 245, 246, 247, 324, 325, 326, 327]
+lines = [249, 250, 251, 252, 339, 340, 341, 342]
 reason = "The same narrowing on both sides of the channel. On the send side the caller's slice is measured against MAX_CHAT_BYTES immediately above; on the receive side the reader has already refused anything longer. Both are unreachable while that ceiling stays under 256, and both are written fallible for the reason above: a silently wrapped length is a reader pointed at the wrong bytes."
 
 [[exempt]]

--- a/crates/net/src/chat.rs
+++ b/crates/net/src/chat.rs
@@ -89,7 +89,12 @@ pub struct ChatStats {
     pub duplicates: u64,
     /// Messages dropped because the inbox was full and nobody drained it.
     pub inbox_overflowed: u64,
-    /// Datagrams refused.
+    /// Datagrams refused, **not counting duplicates**.
+    ///
+    /// Zero on a healthy channel however much traffic crosses it, which
+    /// is what makes it worth reading: a rising count is a peer sending
+    /// something this one will not take, never the redundancy working.
+    /// Repeats live in [`ChatStats::duplicates`].
     pub refused: u64,
 }
 
@@ -279,7 +284,17 @@ impl ChatChannel {
     /// whole reason it lives out here.
     pub fn deliver(&mut self, source: PeerId, bytes: &[u8]) -> Result<(), ChatRefusal> {
         let refusal = self.absorb(source, bytes);
-        if refusal.is_err() {
+        // **A duplicate is not counted here.** It is a refusal in the
+        // return type, because nothing was delivered, and it is the
+        // protocol behaving rather than misbehaving: a message is
+        // repeated a fixed number of times and never acknowledged, so
+        // every message that arrives at all arrives several times over.
+        // Folding those into `refused` gave that counter a healthy value
+        // of five per message, which makes it useless for the one
+        // question it is asked — is something wrong? They are in
+        // [`ChatStats::duplicates`], which is where a reader looking for
+        // the redundancy working will look.
+        if matches!(refusal, Err(refused) if !matches!(refused, ChatRefusal::AlreadySeen { .. })) {
             self.stats.refused = self.stats.refused.saturating_add(1);
         }
         refusal

--- a/crates/net/tests/chat.rs
+++ b/crates/net/tests/chat.rs
@@ -4,8 +4,8 @@
 use core::num::NonZeroU64;
 
 use renew_net::{
-    Advance, CHAT_INBOX, CHAT_OUTBOX, ChatChannel, ChatRefusal, Delivery, MAX_DATAGRAM_BYTES,
-    PeerId, Refusal, Session, SessionParams, ValidParams, wire,
+    Advance, CHAT_INBOX, CHAT_OUTBOX, CHAT_REPEATS, ChatChannel, ChatRefusal, Delivery,
+    MAX_DATAGRAM_BYTES, PeerId, Refusal, Session, SessionParams, ValidParams, wire,
 };
 
 const SESSION: u64 = 0x0bad_c0de_0bad_c0de;
@@ -428,4 +428,53 @@ fn a_message_from_this_machine_arriving_from_the_network_is_refused() {
         there.deliver(seat(1), out.get(..len).unwrap_or_default()),
         Err(ChatRefusal::NotAPeer { .. })
     ));
+}
+
+#[test]
+fn a_healthy_channel_reports_no_refusals_however_many_repeats_arrive() {
+    // **The counter exists to answer one question — is something wrong —
+    // and it can only answer it if the healthy value is zero.** A message
+    // is repeated a fixed number of times and never acknowledged, so
+    // every message that arrives at all arrives several times over.
+    // Counting those as refusals gave the counter a healthy value of five
+    // per message, and two separate consumers downstream then read a
+    // clean run as a peer refusing nearly everything it heard.
+    let mut sender = ChatChannel::new(&params(0));
+    let mut receiver = ChatChannel::new(&params(1));
+    sender.send(b"hello").expect("a short message");
+
+    let from = PeerId::new(0).expect("seat zero");
+    let mut buffer = [0u8; MAX_DATAGRAM_BYTES];
+    let mut carried = 0usize;
+    // Every repeat the sender offers, delivered — which is what a link
+    // with no loss does, and the case the counter has to survive.
+    for _ in 0..CHAT_REPEATS {
+        while let Some(out) = sender.next_outbound(&mut buffer) {
+            let _ = receiver.deliver(from, out.bytes());
+            carried += 1;
+        }
+    }
+    assert!(carried > 1, "the redundancy must have actually repeated");
+
+    let stats = receiver.stats();
+    assert_eq!(stats.received, 1, "one message, however many datagrams");
+    assert!(
+        stats.duplicates > 0,
+        "the repeats must be counted somewhere"
+    );
+    assert_eq!(
+        stats.refused, 0,
+        "a channel that lost nothing and refused nothing must say so: {stats:?}"
+    );
+
+    // And the counter still moves for something genuinely wrong, or the
+    // fix above would have been to delete it.
+    let mut nonsense = [0u8; MAX_DATAGRAM_BYTES];
+    nonsense[0] = 0xff;
+    let _ = receiver.deliver(from, &nonsense[..32]);
+    assert_eq!(
+        receiver.stats().refused,
+        1,
+        "malformed bytes are still a refusal"
+    );
 }


### PR DESCRIPTION
A chat message is repeated a fixed number of times and never acknowledged, so every message that arrives at all arrives several times over. Those repeats were counted in **both** `duplicates` and `refused`, giving `refused` a healthy value of five per message.

**A counter whose healthy value is nonzero cannot answer the question it is asked.** `refused` is what a caller reads to tell "nothing is reaching me" from "the peer will not take what I send". Two separate consumers of this crate read a clean two-player run as a peer refusing nearly everything it heard, and one of them was a step away from reporting a perfect handshake as a version mismatch. Both had to work around the number locally; both should have been able to trust it.

Duplicates now count only in `duplicates`, where a reader looking for the redundancy working already looks. `refused` still moves for malformed bytes, a wrong session, a stranger, or an oversized message — the test asserts that as well, because otherwise the right fix would have been to delete the counter rather than narrow it.

The return type is unchanged: a duplicate is still an error, since nothing was delivered. What changed is what gets tallied as trouble.