### PR TITLE
test: guard that comments cite only material this repository contains

### DIFF
--- a/.github/actions/software-vulkan/action.yml
+++ b/.github/actions/software-vulkan/action.yml
@@ -74,7 +74,10 @@ runs:
           # runs weeks apart. A width that never varied cannot be the
           # variable. What does still vary across the pool is the JIT's
           # target CPU and feature set, which llvmpipe takes from the
-          # host and which no vector-width setting reaches - see
-          # DEBT-0072, which holds the evidence and the open question.
+          # host and which no vector-width setting reaches. That is
+          # still open, and it is tracked nowhere in this repository.
+          # What the difference costs, and why the golden's tolerance
+          # bounds it rather than hides it, is written out above the
+          # comparison in `crates/rhi/tests/golden.rs`.
           echo "LP_NATIVE_VECTOR_WIDTH=256"
         } >> "$GITHUB_ENV"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -197,7 +197,7 @@ reason = "The addressless guard inside `seat_of`, unreachable through the only p
 
 [[exempt]]
 file = "crates/net/src/desync.rs"
-lines = [128, 133, 167]
+lines = [129, 134, 168]
 reason = "The error arms of `write!` inside a Display implementation. A formatter over a String cannot fail, so these propagate an error that never arrives; they exist because Display must be total and `?` is the only honest way to write that. Every one of them sits on a line whose successful path is covered by the JSON tests."
 
 [[exempt]]

--- a/crates/core/platform/src/net.rs
+++ b/crates/core/platform/src/net.rs
@@ -1,8 +1,17 @@
 //! UDP datagrams — the network seam, behind the `net` feature.
 //!
 //! **This module is the only place in the engine that names `std::net`.**
-//! That is a zoning decision rather than a style one: a crate that
-//! promises deterministic simulation is denied a dependency path to this
+//! That is a zoning decision rather than a style one, and it is enforced
+//! rather than merely stated:
+//! `only_the_platform_socket_module_names_the_standard_network_types` in
+//! `tools/cli/tests/workspace_lists.rs` walks every Rust file git lists
+//! and fails on any but this one that names those types in code —
+//! `std::net`, `core::net`, a brace group naming `net` however it is
+//! wrapped, or a rename of the crate root. Comments are exempt, this one
+//! among them.
+//!
+//! The graph rule is the other half: a crate that promises deterministic
+//! simulation is denied a dependency path to this
 //! one, at any depth and in any dependency kind, so the code that decides
 //! what a tick means cannot reach a socket even by accident. What travels
 //! over the wire is decided in a crate that has no way to send it, and

--- a/crates/fixed/src/saturation.rs
+++ b/crates/fixed/src/saturation.rs
@@ -37,8 +37,8 @@ impl Saturations {
 
 /// Read this thread's saturation count.
 ///
-/// The explicit snapshot call `threading.md` requires: the counter is never
-/// read from another thread and never published except through here.
+/// The explicit snapshot call: the counter is never read from another
+/// thread and never published except through here.
 ///
 /// # Example
 ///

--- a/crates/fixed/src/scalar.rs
+++ b/crates/fixed/src/scalar.rs
@@ -84,7 +84,7 @@ impl Fixed {
     /// # Panics
     ///
     /// If `denominator` is zero. A contract violation rather than a runtime
-    /// condition (D5): the arguments are almost always literals, so this
+    /// condition: the arguments are almost always literals, so this
     /// fails at the call site that wrote it, and in a `const` context it
     /// fails at compile time.
     #[must_use]
@@ -172,7 +172,7 @@ impl Fixed {
     ///
     /// # Panics
     ///
-    /// If `other` is zero. Division by zero is a contract violation (D5), and
+    /// If `other` is zero. Division by zero is a contract violation, and
     /// returning a sentinel would put a NaN-shaped value into a type whose
     /// whole contract is that it has none.
     #[must_use]

--- a/crates/fixed/tests/properties.rs
+++ b/crates/fixed/tests/properties.rs
@@ -7,9 +7,9 @@
 //!
 //! The associativity and distributivity properties are stated as **bounds**
 //! rather than as laws, and that is not a weakening of ambition. No rounded
-//! multiply satisfies them exactly, under any rounding rule — the design
-//! note's first draft promised the ring laws and could not have delivered
-//! them. A bound is the true statement.
+//! multiply satisfies them exactly, under any rounding rule. Stating them
+//! as laws would promise something no implementation here can keep; a
+//! bound is the true statement.
 
 use proptest::prelude::*;
 use renew_fixed::{Fixed, saturations};

--- a/crates/net/clippy.toml
+++ b/crates/net/clippy.toml
@@ -12,8 +12,11 @@
 # `std::net` is deliberately NOT banned here, and the omission is the
 # point. A definition-path ban is exactly one wrapper deep, which is the
 # evasion the graph rule exists to close — and the graph rule already
-# forbids this crate every path to the only crate ADR-0025 permits to
-# spell `std::net` at all. A ban here would read as the defence when it
+# forbids this crate every path to the only crate permitted to spell
+# `std::net` at all - a permission that is enforced rather than
+# asserted, by
+# `only_the_platform_socket_module_names_the_standard_network_types` in
+# `tools/cli/tests/workspace_lists.rs`. A ban here would read as the defence when it
 # would be the weaker half of one.
 
 allow-unwrap-in-tests = true
@@ -23,7 +26,7 @@ allow-panic-in-tests = true
 disallowed-methods = [
     { path = "std::time::Instant::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
     { path = "std::time::SystemTime::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
-    { path = "std::thread::spawn", reason = "simulation is single-threaded until an accepted decision record defines a deterministic parallel-scheduling contract, and this crate is not that record" },
+    { path = "std::thread::spawn", reason = "simulation is single-threaded, and stays that way until something defines a deterministic parallel-scheduling contract - a fixed partitioning and a fixed reduction order - which this crate does not" },
     { path = "std::thread::Builder::spawn", reason = "the named-thread spelling of the same act" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem: it takes bytes a caller already holds" },
     { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the seam that can refuse an oversized file, which is not here" },

--- a/crates/net/src/chat.rs
+++ b/crates/net/src/chat.rs
@@ -26,9 +26,9 @@
 //! Best effort, the same shape as the input stream: **redundancy rather
 //! than retransmission.** A message is repeated for a few pumps and then
 //! forgotten, and the receiver drops duplicates. Nothing is acknowledged
-//! and nothing is guaranteed — a message can be lost, and the ADR records
-//! that as accepted. Chat that must not be lost is a different feature
-//! with a different cost.
+//! and nothing is guaranteed — a message can be lost, and that is
+//! accepted. Chat that must not be lost is a different feature with a
+//! different cost.
 
 use core::num::NonZeroU64;
 

--- a/crates/net/src/desync.rs
+++ b/crates/net/src/desync.rs
@@ -98,7 +98,8 @@ impl DesyncReport {
         self.peer_state_digests.iter().any(Option::is_some)
     }
 
-    /// The machine-readable form (D11).
+    /// The machine-readable form, so a caller can parse a desync report
+    /// rather than format one itself.
     #[must_use]
     pub const fn json(&self) -> DesyncReportJson<'_> {
         DesyncReportJson(self)

--- a/crates/net/tests/lobby.rs
+++ b/crates/net/tests/lobby.rs
@@ -984,7 +984,7 @@ fn a_datagram_from_no_address_is_refused() {
 /// The structural claim, from the session's side. A lobby datagram that
 /// reaches a session is a routing defect, and the session says so by name
 /// rather than falling through — which is what makes the wall visible in a
-/// log instead of only in a design note.
+/// log instead of only in prose.
 #[test]
 fn a_session_refuses_all_three_lobby_kinds_by_name() {
     use renew_net::{Delivery, Refusal, Session, SessionParams};

--- a/crates/net/tests/zero_alloc.rs
+++ b/crates/net/tests/zero_alloc.rs
@@ -6,8 +6,9 @@
 //! because a gate that arrives later measures whatever the code has grown
 //! into rather than what it promised.
 //!
-//! **This one is a security control as much as a D7 one.** Every byte the
-//! session absorbs can come from a hostile peer, so a per-datagram
+//! **This one is a security control as much as an allocation-discipline
+//! one.** Every byte the session absorbs can come from a hostile peer,
+//! so a per-datagram
 //! allocation is an allocation an attacker drives. The window therefore
 //! includes refused datagrams — a wrong session id every pump — because
 //! "nothing allocates on the happy path" is not the claim that matters.

--- a/crates/rhi/src/vk/device.rs
+++ b/crates/rhi/src/vk/device.rs
@@ -137,7 +137,7 @@ impl DeviceShared {
 
 impl Drop for DeviceShared {
     fn drop(&mut self) {
-        // Best-effort quiesce; failure is logged, never a panic (D5).
+        // Best-effort quiesce; failure is logged, never a panic.
         // SAFETY: the device handle is live (nothing destroys it before
         // this Drop) and externally synchronized (crate-wide !Send).
         let idle = unsafe { self.device.device_wait_idle() };

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -1030,7 +1030,7 @@ impl Drop for OffscreenTarget {
         // created with these callbacks; the mapping is unmapped before
         // its memory is freed.
         unsafe {
-            // Best-effort quiesce; failure is logged, never a panic (D5)
+            // Best-effort quiesce; failure is logged, never a panic
             // — the diag record is the only observable this path has.
             if let Err(code) = self.shared.device.device_wait_idle() {
                 renew_diag::error!(

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -840,7 +840,7 @@ impl Drop for RenderPipeline {
         // Rc; wait-idle guarantees no submitted work still references
         // the pipeline; handles were created with these callbacks.
         unsafe {
-            // Best-effort quiesce; failure is logged, never a panic (D5)
+            // Best-effort quiesce; failure is logged, never a panic
             // — the diag record is the only observable this path has.
             if let Err(code) = self.shared.device.device_wait_idle() {
                 renew_diag::error!(

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -1437,7 +1437,7 @@ impl Drop for WindowTarget {
         // after the swapchain, the window keep-alive after everything
         // (field drop).
         unsafe {
-            // Best-effort quiesce; failure is logged, never a panic (D5)
+            // Best-effort quiesce; failure is logged, never a panic
             // — the diag record is the only observable this path has.
             if let Err(code) = self.shared.device.device_wait_idle() {
                 renew_diag::error!(

--- a/crates/rhi/src/vk/texture.rs
+++ b/crates/rhi/src/vk/texture.rs
@@ -204,7 +204,7 @@ impl Drop for Partial<'_> {
         if self.fence.is_some() {
             // SAFETY: device live via the spine `Rc`; blocking until
             // every queue is idle. Best-effort quiesce; failure is
-            // logged, never a panic (D5) — the diag record is the only
+            // logged, never a panic — the diag record is the only
             // observable this path has.
             if let Err(code) = unsafe { device.device_wait_idle() } {
                 renew_diag::error!(

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -217,7 +217,7 @@ fn clear_is_byte_exact_everywhere() {
 ///
 /// That was not visible before the working space went linear. The golden
 /// sat unchanged and green for twelve days; the encode is what made a
-/// pre-existing one-unit difference reach the output byte. See DEBT-0072.
+/// pre-existing one-unit difference reach the output byte.
 ///
 /// **What the tolerance still catches, which is why it is not a hole.** A
 /// real rendering change moves geometry, colour or coverage: it moves

--- a/crates/volume/src/volume.rs
+++ b/crates/volume/src/volume.rs
@@ -356,8 +356,8 @@ impl Volume {
     /// write can ever make diverge, reported identical. 41 by 12 by 41 is
     /// the engine's own voxel sample, not a contrived size.
     ///
-    /// Named here rather than silently correct because I3 requires a
-    /// digest to say what it leaves out: it leaves out
+    /// Named here rather than silently correct, because a digest must
+    /// say what it leaves out: it leaves out
     /// [`Volume::generation`], which is bookkeeping and has its own test.
     #[must_use]
     pub fn digest(&self) -> u64 {

--- a/crates/volume/tests/determinism.rs
+++ b/crates/volume/tests/determinism.rs
@@ -1,17 +1,16 @@
 //! The determinism trigger: same inputs, bit-identical digest, every run.
 //!
-//! The manifest declares `simulation = true`, and the engine's constitution
-//! makes that declaration carry an obligation — a simulation system owes a
-//! test that the same inputs produce a bit-identical state hash across
-//! repeated runs. This crate is the storage half of that simulation, so it
-//! owes one.
+//! The manifest declares `simulation = true`, and that declaration carries
+//! an obligation: a simulation system owes a test that the same inputs
+//! produce a bit-identical state hash across repeated runs. This crate is
+//! the storage half of that simulation, so it owes one.
 //!
 //! **The committed constant is a regression guard, not evidence of
 //! cross-platform determinism.** It catches a change to the mixing, the
 //! packing, the fold, or the iteration order on *this* machine. Proving the
 //! stronger claim needs the same input replayed on the other target
-//! platforms and the digests compared against each other, which is work for
-//! the milestone that first has more than one machine to run on.
+//! platforms and the digests compared against each other, which needs more
+//! than one machine to run on.
 
 use renew_volume::{Cell, Volume, Voxel};
 

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -351,39 +351,51 @@ fn the_unsafe_surface_is_exactly_what_is_recorded() {
 /// claim the property and permit the calls that break it.
 /// What a `simulation = true` crate's lint file must forbid.
 ///
-/// **Two of I3's three applicable clauses, and it used to be one.** I3
-/// bans wall-clock reads, unseeded randomness, and iteration-order
-/// dependent state (fast-math has no stable-Rust equivalent). Until
+/// **All three applicable clauses, and it used to be one.** A simulation
+/// crate may not read the wall clock, may not use unseeded randomness,
+/// and may not depend on iteration order (fast-math has no stable-Rust
+/// equivalent). Until
 /// 2026-08-01 this list held only the clocks, so a crate could declare
 /// itself simulation code and iterate a `HashMap` freely — which is
 /// precisely the non-determinism the third clause exists to prevent.
 ///
-/// All four declaring crates already banned the collections when this
-/// grew, so it locks in a convention rather than demanding a change.
-/// **That is the argument for adding it now**: a list that costs nothing
-/// to satisfy today costs a rewrite once a crate forgets.
+/// Every declaring crate already banned the collections when that grew,
+/// so it locked in a convention rather than demanding a change. **That
+/// is the argument for adding an entry the moment it is free**: a list
+/// that costs nothing to satisfy today costs a rewrite once a crate
+/// forgets.
 ///
-/// The randomness clause stays unlisted deliberately — but **the reason
-/// recorded here until 2026-08-01 was wrong, and the correction is worth
-/// keeping.** It said `std` ships no generator, so reaching one means
-/// taking a dependency caught at the `docs/deps/` gate. The premise is
-/// true and the inference is not: what is banned is *unseeded
-/// randomness*, not generators, and `RandomState::new` /
-/// `DefaultHasher::new` are stable Rust's dependency-free road to
-/// operating-system entropy.
+/// **The randomness clause is listed now, and the reason it was not is
+/// worth keeping.** The account recorded here until 2026-08-01 was that
+/// `std` ships no generator, so reaching one means taking a dependency,
+/// which is separately gated. The premise is true and the inference is
+/// not: what is banned is *unseeded randomness*, not generators, and
+/// `RandomState::new` / `DefaultHasher::new` are stable Rust's
+/// dependency-free road to operating-system entropy.
 ///
-/// It stays unlisted because adding it here is **not** the zero-cost
-/// lock-in the collections were. Every declaring crate must already
-/// satisfy every entry, and until 2026-08-01 only `renew-rng` banned
-/// those two types — the other three carried the marker with no
-/// randomness guard at all. That gap is now closed crate-by-crate, which
-/// is the prerequisite for listing it here rather than an alternative to
-/// it. Add it once a fifth crate would not be surprised by it.
+/// It stayed unlisted afterwards for a stated reason: every declaring
+/// crate must already satisfy every entry, and the trigger recorded for
+/// adding it was that a further declaring crate would not be surprised
+/// by it.
+///
+/// **That trigger has fired**, several times over. Every crate declaring itself simulation
+/// code now bans both types, so the entry is the same zero-cost lock-in
+/// the collections were, and it is listed above rather than described
+/// here as pending. A documented trigger that has fired and not been
+/// acted on is worse than no trigger, because the prose keeps reading as
+/// a plan.
+///
+/// No count appears in that sentence on purpose: one manifest quotes the
+/// phrase in a comment while declaring the opposite, so a grep over them
+/// answers a different question than the one being asked. The test reads
+/// the manifests either way.
 const BANNED_IN_SIMULATION: &[&str] = &[
     "std::time::Instant::now",
     "std::time::SystemTime::now",
     "std::collections::HashMap",
     "std::collections::HashSet",
+    "std::hash::RandomState",
+    "std::collections::hash_map::DefaultHasher",
 ];
 
 /// Crates whose manifest sets `simulation = true`, with the text of the
@@ -450,7 +462,7 @@ fn simulation_crates(root: &Path) -> Result<Vec<(String, Vec<String>)>, String> 
 /// This does not prove such a crate is reproducible — no test here
 /// could. It proves the one mechanical guard it relies on is present.
 #[test]
-fn every_simulation_crate_forbids_the_nondeterminism_i3_names() {
+fn every_simulation_crate_forbids_clocks_unordered_collections_and_entropy() {
     let root = workspace_root();
     let crates = simulation_crates(&root).expect("manifests and lint files should be readable");
 
@@ -965,9 +977,9 @@ fn the_readme_counts_what_the_workspace_actually_holds() {
     // The front page states three numbers a reader is invited to trust:
     // how many removability configurations CI runs, which one builds the
     // minimal core, and how many engine crates there are. The first of
-    // those is the row the repository nominates as its evidence for I12,
-    // an INVARIANT — its entire function is to let a session audit the
-    // invariant without reading the workflow.
+    // those is the row the repository nominates as its evidence that
+    // every optional crate can be removed — its entire function is to let
+    // a reader audit that claim without reading the workflow.
     //
     // All three had drifted, and one had drifted twice: a crate landed in
     // #217 without a table row and nothing said so, which is exactly the
@@ -1081,4 +1093,432 @@ fn ordinal(n: usize) -> String {
         28 => "twenty-eighth".to_owned(),
         other => format!("{other}th"),
     }
+}
+
+/// The part of a line to read as prose.
+///
+/// In Rust that is whatever follows the first `//`, because the code
+/// half holds names that look like references and are not — the audio
+/// module spells its PCM formats with a capital I and a bit width.
+/// Everywhere else the whole line is prose: Markdown has no comment
+/// syntax, and a reference inside a configuration value is read by
+/// everyone that value speaks to.
+///
+/// Cuts at the first `//` wherever it appears, including inside a string
+/// literal.
+fn comment_part(line: &str, rust: bool) -> &str {
+    if !rust {
+        // **Outside Rust the whole line is prose.** Markdown has no
+        // comment syntax, and a reference in a `reason = "..."` value is
+        // read by anyone the lint speaks to — one of the references this
+        // guard was written for lived in exactly that position, and
+        // reading only what follows `//` would exclude every Markdown
+        // paragraph and every configuration value in the tree.
+        return line;
+    }
+    line.find("//").and_then(|at| line.get(at..)).unwrap_or("")
+}
+
+/// The half of a line the compiler reads: everything before the first
+/// `//`, with the same string-literal caveat.
+fn code_part(line: &str) -> &str {
+    line.find("//")
+        .and_then(|at| line.get(..at))
+        .unwrap_or(line)
+}
+
+/// Code with its whitespace removed and its raw-identifier marks
+/// dropped.
+///
+/// `r#net` and `net` are the same module to the compiler, so they are
+/// the same module here.
+fn squashed(code: &str) -> String {
+    code.replace("r#", "")
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect()
+}
+
+/// Does `code` name `net` inside a group opened by `opening`?
+///
+/// Walks to the matching brace rather than the first one, so a nested
+/// group does not end the region early, and splits on every brace and
+/// comma so depth stops mattering once the region is right. `netas`
+/// catches `net as n`, whose spacing the caller has removed.
+///
+/// `code` must already be [`squashed`].
+fn names_net_in_group(code: &str, opening: &str) -> bool {
+    for tail in code.split(opening).skip(1) {
+        let mut depth = 1_usize;
+        let mut region = String::new();
+        for character in tail.chars() {
+            match character {
+                '{' => depth = depth.saturating_add(1),
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            region.push(character);
+        }
+        if region
+            .split(['{', '}', ','])
+            .any(|part| part == "net" || part.starts_with("net::") || part.starts_with("netas"))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Every file this repository contains, as `(path, contents)`.
+///
+/// **Asked of git rather than of the filesystem.** A working tree's root
+/// can hold files that are no part of the repository — reading those
+/// makes a scan pass in one checkout and fail in another, and it cannot
+/// tell a file it should never have opened from a fault.
+///
+/// Fails rather than shrinks: a listed file that will not read, and a
+/// listing too small to be the tree, are both reported.
+#[allow(
+    clippy::expect_used,
+    reason = "a guard that cannot enumerate the repository must fail loudly, and the message is the report"
+)]
+fn tracked_files(root: &std::path::Path, extensions: &[&str]) -> Vec<(String, String)> {
+    let listing = std::process::Command::new("git")
+        .args(["ls-files", "-z"])
+        .current_dir(root)
+        .output()
+        .expect("`git ls-files` must run; this guard cannot otherwise tell what the tree holds");
+    assert!(
+        listing.status.success(),
+        "`git ls-files` failed, so this guard does not know what the repository holds"
+    );
+    let text = String::from_utf8_lossy(&listing.stdout);
+
+    let mut found = Vec::new();
+    let mut unreadable = Vec::new();
+    for name in text.split('\0').filter(|entry| !entry.is_empty()) {
+        let path = root.join(name);
+        let wanted = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|extension| {
+                extensions
+                    .iter()
+                    .any(|wanted| wanted.eq_ignore_ascii_case(extension))
+            });
+        if !wanted {
+            continue;
+        }
+        // Paths stay as git prints them, separators and all, so nothing
+        // has to convert and nothing differs by platform.
+        //
+        // A listed file that will not read is reported, not skipped. It
+        // is gone from disk, or not UTF-8, or named in bytes this could
+        // not reproduce — and in every case the scan covered less than
+        // it was asked to, which the caller must hear about.
+        match std::fs::read_to_string(&path) {
+            Ok(source) => found.push((name.to_owned(), source)),
+            Err(error) => unreadable.push(format!("{name}: {error}")),
+        }
+    }
+    assert!(
+        unreadable.is_empty(),
+        "git lists these but they could not be read, so the scan covered less than it claims:\n{}",
+        unreadable.join("\n")
+    );
+    assert!(
+        found.len() > 50,
+        "git listed only {} scannable files, so this guard is looking at nothing",
+        found.len()
+    );
+    found
+}
+
+/// An upper-case `I` followed by one or two digits, standing alone.
+///
+/// That is the shape of a reference naming a numbered rule. It is not
+/// the shape of `Ipv4Addr` or `AXIS_I2`, both of which have an
+/// alphanumeric neighbour, so both are skipped.
+fn numbered_rule_citation(line: &str) -> Option<String> {
+    let bytes = line.as_bytes();
+    for index in 0..bytes.len() {
+        if bytes.get(index) != Some(&b'I') {
+            continue;
+        }
+        let before = index
+            .checked_sub(1)
+            .and_then(|earlier| bytes.get(earlier))
+            .copied();
+        if before.is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_') {
+            continue;
+        }
+        let mut digits = 0;
+        while index
+            .checked_add(1 + digits)
+            .and_then(|at| bytes.get(at))
+            .is_some_and(u8::is_ascii_digit)
+        {
+            digits += 1;
+        }
+        if digits == 0 || digits > 2 {
+            continue;
+        }
+        let after = index
+            .checked_add(1 + digits)
+            .and_then(|at| bytes.get(at))
+            .copied();
+        if after.is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_') {
+            continue;
+        }
+        return index
+            .checked_add(1 + digits)
+            .and_then(|end| line.get(index..end))
+            .map(str::to_owned);
+    }
+    None
+}
+
+/// A parenthesised rule reference: a bracketed letter and number.
+///
+/// The brackets are what separate a reference from a label. This tree
+/// writes bare letter-and-number for its own things — fault scenarios
+/// `D1` through `T18`, the Vulkan format `D32` — and none of them is
+/// ever bracketed, so scanning bare ones would report followable labels
+/// as unfollowable references.
+fn parenthesised_rule_citation(line: &str) -> Option<String> {
+    for (start, _) in line.match_indices('(') {
+        let rest = line.get(start.saturating_add(1)..).unwrap_or("");
+        let mut characters = rest.chars();
+        let Some(letter) = characters.next() else {
+            continue;
+        };
+        if !matches!(letter, 'D' | 'I' | 'T' | 'M') {
+            continue;
+        }
+        let digits: String = characters.take_while(char::is_ascii_digit).collect();
+        if digits.is_empty() {
+            continue;
+        }
+        if rest
+            .chars()
+            .nth(digits.len().saturating_add(1))
+            .is_some_and(|next| next == ')')
+        {
+            return Some(format!("({letter}{digits})"));
+        }
+    }
+    None
+}
+
+/// No source file may cite material this repository does not contain.
+///
+/// **A comment naming a document a reader cannot open is worse than a
+/// comment naming nothing.** It reads as sourced. A reader who goes
+/// looking finds no such file and cannot tell whether the evidence is
+/// missing or they are.
+///
+/// A sweep by eye searches for the notations it already knows and
+/// reports the tree clean when it runs out of them, which is why this is
+/// a test — and why the needle list is the thing to extend when a new
+/// spelling turns up.
+///
+/// **The needles are assembled at run time**, halves joined rather than
+/// written whole, so the file defining them is scanned like every other.
+///
+/// What it does not catch: a reference inside an identifier, since the
+/// rule scanners read only prose; a bare letter-and-number, for the
+/// reason [`parenthesised_rule_citation`] gives; and any phrasing that
+/// avoids the literal needles, including a different case of one.
+#[test]
+fn no_source_cites_material_this_repository_does_not_contain() {
+    let root = workspace_root();
+    let join = |left: &str, right: &str| format!("{left}{right}");
+    let needles = [
+        join("DEBT", "-"),
+        join("A", "DR"),
+        join("mile", "stone"),
+        join("consti", "tution"),
+        join("STATE", ".md"),
+        join("ROADMAP", ".md"),
+        join("CLAUDE", ".md"),
+        join("DEVELOPMENT", ".md"),
+        join("DEBT", ".md"),
+        join("docs", "/"),
+        join("spikes", "/"),
+        join("threading", ".md"),
+        join("targets", ".md"),
+        join("lifecycle", ".md"),
+        join("design ", "note"),
+        join("decision ", "journal"),
+        join("decision ", "record"),
+        join("review ", "pass"),
+    ];
+
+    let files = tracked_files(&root, &["rs", "toml", "yml", "yaml", "md", "txt"]);
+
+    let mut faults = Vec::new();
+    for (shown, source) in &files {
+        let rust = std::path::Path::new(shown)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("rs"));
+
+        // **The prose of a file, joined, before it is read line by
+        // line.** A citation is a phrase and a wrap is a line break, so
+        // a two-word needle straddling one is invisible to a per-line
+        // scan — which is how a live citation of a document sat in this
+        // tree while this guard reported clean. Joined first, then
+        // scanned; the per-line pass below survives only to give a line
+        // number when the phrase happens to fit on one.
+        let flowed = source
+            .lines()
+            .map(|line| comment_part(line, rust))
+            // The marker goes too. Joining `// the design` to
+            // `// note's` with the slashes still on puts `//` between
+            // the two words and the phrase never matches — which is the
+            // shape of the miss this pass exists to close, and it went
+            // wrong that way once before it went right.
+            .map(|prose| prose.trim_start().trim_start_matches(['/', '!', '#', ' ']))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        for needle in &needles {
+            if flowed.contains(needle.as_str()) && !source.contains(needle.as_str()) {
+                faults.push(format!("{shown} names `{needle}` across a line break"));
+            }
+        }
+
+        for (offset, line) in source.lines().enumerate() {
+            let number = offset.saturating_add(1);
+            for needle in &needles {
+                if line.contains(needle.as_str()) {
+                    faults.push(format!("{shown}:{number} names `{needle}`"));
+                }
+            }
+            // Only the comment half of a line. A reference is prose; the
+            // collisions are code — the audio module names its PCM
+            // sample formats with a capital I and a bit width, and a
+            // scanner that reads those as references is a scanner
+            // nobody keeps.
+            let prose = comment_part(line, rust);
+            if let Some(found) = numbered_rule_citation(prose) {
+                faults.push(format!("{shown}:{number} cites the rule `{found}`"));
+            }
+            if let Some(found) = parenthesised_rule_citation(prose) {
+                faults.push(format!("{shown}:{number} cites the rule `{found}`"));
+            }
+        }
+    }
+
+    assert!(
+        faults.is_empty(),
+        "these cite material that is not in this repository, so a reader cannot follow \
+         them. Say the thing itself, or name a file that is actually here:\n{}",
+        faults.join("\n")
+    );
+}
+
+/// Only the platform's socket module may name the standard networking
+/// types.
+///
+/// **A zoning rule that was written down and enforced by nothing.** One
+/// module owns the socket so everything above it stays testable without
+/// one, and so a crate carrying a determinism obligation cannot reach a
+/// wire by accident. Any crate could have added the import with every
+/// gate staying green.
+///
+/// **A lexical check, not a proof, and the difference matters.** It
+/// reads text; Rust has more ways to name a path than text can
+/// enumerate, and each round of use has turned up another. What it
+/// catches is the spellings anyone actually writes: `std::net` and
+/// `core::net`; a brace group naming `net`, nested or not, on one line
+/// or split as the formatter splits a long import; `net as something`;
+/// raw identifiers; and `use std as` / `extern crate std as`, refused
+/// outright because no file here needs a second name for the standard
+/// library.
+///
+/// What it does not catch is unbounded, and these are the known ones: a
+/// crate-root rename spelled `use std::{self as s}`; an import on a line
+/// whose earlier text contains `//` inside a string literal, which the
+/// comment split truncates; and any file whose extension is outside the
+/// scanned set. The graph rule in the structure check is the load-bearing
+/// half — it denies a simulation crate any dependency path here at all —
+/// and this is a speed bump in front of it.
+///
+/// Comments are exempt, since the rule is discussed in them, which also
+/// means a string literal quoting the path is a false positive.
+#[test]
+fn only_the_platform_socket_module_names_the_standard_network_types() {
+    let root = workspace_root();
+    let allowed = "crates/core/platform/src/net.rs";
+
+    let files = tracked_files(&root, &["rs"]);
+    assert!(
+        files.iter().any(|(shown, _)| shown == allowed),
+        "the one module allowed to name them was not walked, so this guards nothing"
+    );
+
+    let direct = [
+        format!("{}{}", "std::", "net"),
+        format!("{}{}", "core::", "net"),
+    ];
+    let groups = [
+        format!("{}{}", "std::", "{"),
+        format!("{}{}", "core::", "{"),
+    ];
+    // Renaming the crate root reaches the socket without either pair
+    // ever appearing: `use std as s` then `s::net::UdpSocket`. Tracking
+    // the alias would mean parsing; refusing the rename costs nothing,
+    // because no file here has a reason to give the standard library a
+    // second name.
+    let renames = [
+        format!("{}{}", "usestd", "as"),
+        format!("{}{}", "usecore", "as"),
+        format!("{}{}", "externcratestd", "as"),
+        format!("{}{}", "externcratecore", "as"),
+    ];
+
+    let mut faults = Vec::new();
+    for (shown, source) in &files {
+        if shown == allowed {
+            continue;
+        }
+
+        // The direct spellings, per line, so the report can point at one.
+        for (offset, line) in source.lines().enumerate() {
+            let code = squashed(code_part(line));
+            let named = direct.iter().any(|needle| code.contains(needle.as_str()))
+                || renames.iter().any(|needle| code.contains(needle.as_str()));
+            if named {
+                faults.push(format!("{shown}:{}", offset.saturating_add(1)));
+            }
+        }
+
+        // **Brace groups against the whole file, not line by line.** The
+        // formatter splits an import list wider than the line limit, so
+        // `use std::{` and `net::UdpSocket` land on different lines and a
+        // per-line scan sees unrelated text. The formatter runs as a
+        // gate, so that is where long imports live. Squashing the file
+        // costs the line number, which is why the direct spellings keep
+        // their own pass above.
+        let code = squashed(&source.lines().map(code_part).collect::<Vec<_>>().join("\n"));
+        let grouped = groups
+            .iter()
+            .any(|opening| names_net_in_group(&code, opening));
+        if grouped {
+            faults.push(format!("{shown} (in a brace group)"));
+        }
+    }
+
+    assert!(
+        faults.is_empty(),
+        "the socket belongs to one module and these reach around it:\n{}",
+        faults.join("\n")
+    );
 }


### PR DESCRIPTION
A comment naming a document a reader cannot open reads as sourced while sourcing nothing. These had accumulated across the tree, some in published rustdoc on `pub` items. Each now carries its own content, and two tests keep it that way.

The citation guard scans what git lists rather than what a directory walk finds, and reads each file's prose joined as well as line by line, because a reference straddling a wrap is invisible to a per-line scan. The zoning guard is a lexical check rather than a proof and says so, with its known gaps listed and the structure check's graph rule named as the load-bearing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQoQg24AkhbdRudSXKogk3