### PR TITLE
feat(platform): the cursor grab can change between events

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -136,27 +136,27 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [501, 502]
+lines = [555, 556]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [954]
+lines = [1046]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [535, 538]
+lines = [589, 592]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [351, 352]
+lines = [398, 399]
 reason = "Delivering the characters an OS key event committed. Unreachable for the same root cause as 535 and 538 - the loop can only have a body to run when the arm above yields text, and that needs an unconstructible KeyEvent. Exactly two lines, and the narrowness is measured rather than asserted: the guard on 349 and the block's close on 353 are both entered by every dispatched event and are covered by a_modifier_change_is_remembered_until_the_next_one, which is why 353 was removed from this entry after the gate reported it covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [429, 430, 431, 432, 433, 434, 435, 436, 437, 438]
+lines = [483, 484, 485, 486, 487, 488, 489, 490, 491, 492]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -141,7 +141,7 @@ reason = "The scale-factor and keyboard arms of the winit event translation. Nei
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1046]
+lines = [1096]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -963,6 +963,53 @@ mod tests {
         assert!(control.exit && control.redraw);
     }
 
+    /// **A request between events is remembered, and silence changes
+    /// nothing.** Remembering is the whole mechanism: the loop reapplies
+    /// the last request when focus returns, so an app that asked once
+    /// keeps mouse look across an alt-tab. An iteration that asks nothing
+    /// must therefore leave the memory alone rather than write a default
+    /// into it — otherwise every quiet frame would revoke the grab.
+    ///
+    /// The grab itself is not asserted here and cannot be: there is no
+    /// window under a unit test, and confinement is a request the desktop
+    /// may refuse anyway.
+    #[test]
+    fn a_cursor_request_between_events_is_remembered() {
+        let config = WindowConfig::default();
+
+        let mut asking = Recorder {
+            ask_cursor: Some(true),
+            ..Recorder::default()
+        };
+        let mut adapter = new_adapter(&config, &mut asking);
+        assert!(!adapter.cursor_wanted.get(), "the loop starts holding none");
+        assert!(!adapter.tick());
+        assert!(
+            adapter.cursor_wanted.get(),
+            "the request must outlive the iteration that made it"
+        );
+
+        // A release is a request too, and reaches the same memory.
+        let mut releasing = Recorder {
+            ask_cursor: Some(false),
+            ..Recorder::default()
+        };
+        let mut adapter = new_adapter(&config, &mut releasing);
+        adapter.cursor_wanted.set(true);
+        assert!(!adapter.tick());
+        assert!(!adapter.cursor_wanted.get(), "a release must be applied");
+
+        // And silence is not a release.
+        let mut quiet = Recorder::default();
+        let mut adapter = new_adapter(&config, &mut quiet);
+        adapter.cursor_wanted.set(true);
+        assert!(!adapter.tick());
+        assert!(
+            adapter.cursor_wanted.get(),
+            "an iteration that asked nothing must not revoke the grab"
+        );
+    }
+
     /// The accessors report the fields the loop reads, and a silent
     /// iteration is distinguishable from one that asked for something.
     ///
@@ -1035,6 +1082,9 @@ mod tests {
         updates: u32,
         ask_redraw: bool,
         ask_exit: bool,
+        /// What to ask of the cursor, if anything. `None` asks nothing,
+        /// which is the case that must leave the grab alone.
+        ask_cursor: Option<bool>,
     }
 
     impl WindowApp for Recorder {
@@ -1056,6 +1106,9 @@ mod tests {
             }
             if self.ask_exit {
                 control.exit();
+            }
+            if let Some(held) = self.ask_cursor {
+                control.hold_cursor(held);
             }
         }
     }

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -55,6 +55,9 @@ pub use crate::event::{EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, s
 pub struct LoopControl {
     exit: bool,
     redraw: bool,
+    /// A change of mind about the cursor, if the app had one this
+    /// iteration. `None` leaves the grab as it is.
+    cursor: Option<bool>,
 }
 
 impl LoopControl {
@@ -67,6 +70,22 @@ impl LoopControl {
     /// [`WindowEvent::RedrawRequested`]).
     pub fn request_redraw(&mut self) {
         self.redraw = true;
+    }
+
+    /// Hold the cursor for mouse look, or release it.
+    ///
+    /// **Between events, not only at bring-up.** An application with a
+    /// menu has to release the cursor to be clicked and take it back to
+    /// be played, and it learns which it wants long after the window
+    /// opened. Asking once at bring-up leaves it holding an invisible
+    /// pointer over its own buttons.
+    ///
+    /// Idempotent, and the loop still owns the lifecycle: focus loss
+    /// releases the grab whatever was asked here, and focus return
+    /// reapplies the last request. Refusal is ordinary — cursor
+    /// confinement is one of the places the desktops differ.
+    pub fn hold_cursor(&mut self, held: bool) {
+        self.cursor = Some(held);
     }
 }
 
@@ -373,6 +392,13 @@ impl Adapter<'_> {
         }
         let mut control = LoopControl::default();
         self.app.update(&mut control);
+        if let Some(held) = control.cursor {
+            self.cursor_wanted.set(held);
+            // The answer is the same one bring-up gets and means the
+            // same thing: a desktop that refuses confinement plays on
+            // without mouse look, which is not a failure to report.
+            let _refused = self.apply_cursor_grab(held);
+        }
         if control.redraw
             && let Some(window) = &self.window
         {

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -51,6 +51,15 @@ impl Default for WindowConfig {
 pub use crate::event::{EVERY_EVENT_SHAPE, KeyCode, PointerButton, WindowEvent, shape_index};
 
 /// What the app tells the loop each iteration.
+///
+/// **Readable as well as writable, and the read side is not for the
+/// loop.** The loop owns this type and could reach the fields directly.
+/// The accessors exist for a driver standing where the OS loop normally
+/// stands — a test, a replay, a headless run — which otherwise cannot
+/// see what the application asked for. Requests that nothing can observe
+/// are requests a caller can delete without any test noticing, because
+/// what a test can reach instead is the application's own copy of the
+/// state, which it set itself.
 #[derive(Debug, Default)]
 pub struct LoopControl {
     exit: bool,
@@ -86,6 +95,25 @@ impl LoopControl {
     /// confinement is one of the places the desktops differ.
     pub fn hold_cursor(&mut self, held: bool) {
         self.cursor = Some(held);
+    }
+
+    /// Whether [`exit`](Self::exit) was called this iteration.
+    #[must_use]
+    pub fn exiting(&self) -> bool {
+        self.exit
+    }
+
+    /// Whether [`request_redraw`](Self::request_redraw) was called this
+    /// iteration.
+    #[must_use]
+    pub fn redraw_requested(&self) -> bool {
+        self.redraw
+    }
+
+    /// What the app asked of the cursor this iteration, if anything.
+    #[must_use]
+    pub fn cursor_request(&self) -> Option<bool> {
+        self.cursor
     }
 }
 
@@ -933,6 +961,44 @@ mod tests {
         control.exit();
         control.request_redraw();
         assert!(control.exit && control.redraw);
+    }
+
+    /// The accessors report the fields the loop reads, and a silent
+    /// iteration is distinguishable from one that asked for something.
+    ///
+    /// **The cursor is three-valued and the other two are not.** Saying
+    /// nothing about the cursor leaves the grab alone, which is a
+    /// different instruction from asking for it to be released — so a
+    /// reader that collapsed `None` into `false` would turn every quiet
+    /// iteration into a release request.
+    #[test]
+    fn loop_control_reports_what_was_asked() {
+        let quiet = LoopControl::default();
+        assert!(!quiet.exiting());
+        assert!(!quiet.redraw_requested());
+        assert_eq!(
+            quiet.cursor_request(),
+            None,
+            "saying nothing about the cursor is not asking for it to be released"
+        );
+
+        let mut asked = LoopControl::default();
+        asked.exit();
+        asked.request_redraw();
+        asked.hold_cursor(true);
+        assert!(asked.exiting());
+        assert!(asked.redraw_requested());
+        assert_eq!(asked.cursor_request(), Some(true));
+
+        // A release is a request, and the last one in the iteration wins.
+        let mut released = LoopControl::default();
+        released.hold_cursor(true);
+        released.hold_cursor(false);
+        assert_eq!(released.cursor_request(), Some(false));
+        assert!(
+            !released.exiting(),
+            "a cursor request must not be read as an exit"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two changes to the window seam, both about an application that outlives its own bring-up.

**The grab can change.** An application could ask for the cursor once, at bring-up, and never again. One with a menu needs the opposite: release it to be clicked, take it back to be played, and it learns which it wants long after the window opened. Asking once leaves it holding an invisible pointer over its own buttons. `LoopControl::hold_cursor` is how it says so between events, and the loop still owns the lifecycle — focus loss releases the grab whatever was asked, focus return reapplies the last request.

**And the loop reports what it was asked.** `LoopControl` was write-only: three requests into private fields the loop reads directly. A driver standing where the OS loop stands could observe none of them, so a test could only reach the application's own copy of the state — which it set itself, meaning the request to the loop could be deleted with every test still green. `exiting`, `redraw_requested` and `cursor_request` close that. The cursor one is deliberately three-valued: saying nothing leaves the grab alone, which is not the same instruction as asking for release.