### PR TITLE
fix: the coverage pins catch up with the cutout renderer

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -81,8 +81,18 @@ reason = "The unreachable arm behind the sample-before-write refusal: the assert
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [652, 653]
+lines = [745, 746]
 reason = "The depthless-adapter arm of the shadow map's refusal, which translates the rendering crate's DepthUnsupported into this crate's own variant rather than reporting it as a texture failure. Unreachable wherever a depth format exists, which is every measuring lane's adapter: the format is chosen at device bring-up from a void query no fault layer can mutate, and the layer's quirk list carries no depthless-adapter quirk either. The sibling arm (any other creation failure) is driven by the R10 fault scenario."
+
+[[exempt]]
+file = "crates/render3d/src/gpu.rs"
+lines = [483]
+reason = "The creation-failure propagation on the cutout pipeline's bring-up. Never taken where creation succeeds, which is every measuring lane's adapter: provoking it needs a device refusing a pipeline the sibling paths already build, and the fault layer's quirk list carries no such refusal."
+
+[[exempt]]
+file = "crates/render3d/src/gpu.rs"
+lines = [507, 508, 509]
+reason = "A Debug impl writing the renderer's constant name. Calling it needs a live renderer, which needs a device, and a device-bound test that exists to print a constant string would be coverage without a claim; the impl exists so an error context can name the renderer."
 
 [[exempt]]
 file = "crates/rhi/src/vk/render_image.rs"


### PR DESCRIPTION
The cutout-texture change moved code in `render3d/gpu.rs` without re-pointing the coverage manifest, leaving the Coverage gate on `main` failing in both directions: the shadow-map refusal's pins landed on doc comments (reported stale) while the arm itself reads as an unexempted gap, plus two genuinely new unreachable-on-the-lane sites from the same change.

Manifest-only fix: the refusal's entry re-anchored to the arm's new position (reason unchanged — it still describes exactly what is there), and entries with reasons for the cutout pipeline's creation-failure propagation and the renderer's constant-name Debug impl. Every anchored line was read at its number before being named.