### PR TITLE
feat(ci): the pinned simulations can run on an iOS simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1302,6 +1302,99 @@ jobs:
               sys.exit(1)
           COMPARE
 
+  # The same eleven pinned simulations, executed on an iOS simulator.
+  # Advisory for the same reason the Android lane is: whether this
+  # platform belongs in the determinism claim is a decision with a
+  # signature attached, and a lane that could redden `main` before that
+  # signature would be asserting the answer rather than gathering it.
+  #
+  # **A simulator is not a device, and the row this lane eventually
+  # proposes has to say so.** Both `aarch64-apple-ios` and
+  # `aarch64-apple-ios-sim` map to the same platform words, so a leg
+  # cannot tell the two apart - the mapping is a table keyed by triple,
+  # which is what a `--target` run labels a leg from. That is a naming
+  # decision owed before the row exists, not before the lane does: the
+  # lane's job today is to find out whether the numbers agree at all.
+  determinism-ios:
+    name: Determinism (ios simulator, advisory)
+    runs-on: macos-latest
+    continue-on-error: true
+    # Only so the Linux leg exists to print a comparison against, as in
+    # the Android lane.
+    needs: [determinism-emit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim
+      - name: Run the pinned simulations on a simulator
+        run: bash tools/ci/ios-determinism.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: determinism-ios-simulator-aarch64
+          path: ios-leg.json
+          if-no-files-found: error
+      - uses: actions/download-artifact@v4
+        with:
+          name: determinism-macos-latest
+          path: macos-leg
+      - uses: actions/download-artifact@v4
+        with:
+          name: determinism-ubuntu-latest
+          path: linux-leg
+      # Printed, never decisive - see the Android lane's twin step.
+      #
+      # **Two partners, and the macOS one is the informative half.** It
+      # runs on this same instruction set, so a disagreement with it can
+      # only come from the platform - which is the variable this lane
+      # adds. Linux differs in both OS and instruction set at once, so
+      # agreement there says more while disagreement there says less.
+      - name: Hold the simulator leg against the macOS and Linux ones
+        shell: bash
+        run: |
+          python3 - <<'COMPARE'
+          import json, sys
+
+          def leg(path):
+              with open(path, encoding='utf-8') as handle:
+                  document = json.load(handle)
+              return document['digests'], f"{document['os']}/{document['arch']}"
+
+          ios, ios_name = leg('ios-leg.json')
+          empty = []
+          for path in ('macos-leg/leg.json', 'linux-leg/leg.json'):
+              other, other_name = leg(path)
+              names = sorted(set(ios) | set(other))
+              agree, diverge, missing = [], [], []
+              for name in names:
+                  if name not in ios or name not in other:
+                      missing.append(name)
+                  elif ios[name] == other[name]:
+                      agree.append(name)
+                  else:
+                      diverge.append((name, ios[name], other[name]))
+
+              print(f'{ios_name} (simulator) against {other_name}')
+              for name, mine, theirs in diverge:
+                  print(f'  DIVERGE {name}: {mine} here, {theirs} there')
+              for name in missing:
+                  print(f'  ONLY ONE LEG RAN {name}')
+              print(f'  {len(agree)} agree, {len(diverge)} diverge, '
+                    f'{len(missing)} ran on one leg only')
+              # Per partner, not summed. A total would let one partner
+              # carry the other: the macOS leg could share no digest
+              # names at all and the job would still pass on Linux's
+              # strength, while the log claimed both were held.
+              if not agree and not diverge:
+                  print(f'  NOTHING WAS COMPARED against {other_name} - '
+                        f'do not read this as agreement')
+                  empty.append(other_name)
+
+          if empty:
+              print(f'compared nothing against: {", ".join(empty)}')
+              sys.exit(1)
+          COMPARE
+
   determinism-compare:
     name: Determinism (cross-platform comparison)
     runs-on: ubuntu-latest

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -141,12 +141,12 @@ reason = "The arm that clears a voice whose sound index is missing. A voice is o
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [86, 87, 88, 89, 1303, 1304, 1305, 1306, 1317, 1318, 1319, 1321, 1322, 1323, 1324, 1325, 1328, 1334, 1335, 1337, 1338, 1339, 1344, 1345, 1352, 1353, 1354, 1355, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365, 1376, 1377, 1378, 1380, 1381, 1382, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1393, 1397, 1398]
+lines = [86, 87, 88, 89, 1303, 1304, 1305, 1306, 1317, 1318, 1319, 1321, 1322, 1323, 1324, 1325, 1328, 1334, 1335, 1337, 1338, 1339, 1344, 1345, 1352, 1353, 1354, 1355, 1357, 1358, 1359, 1360, 1361, 1362, 1363, 1364, 1365, 1379, 1380, 1381, 1383, 1384, 1385, 1386, 1387, 1388, 1389, 1390, 1391, 1392, 1393, 1394, 1396, 1400, 1401]
 reason = "The emit half of determinism: it spawns a cargo run per pinned scenario and reads what they printed, so reaching it from a test would mean building and running whole samples under instrumentation. Most of it is not untested — the three determinism legs execute it on Linux, Windows and macOS on every push, and a failure there is what a broken emit looks like. Everything in it that can be tested without a subprocess was moved out: digests_from_output has five cases beside it, and platform_of_triple is a table with its own unit test covering both the triples it knows and two it must refuse. What is left is process orchestration and the paths taken when a child cannot start or exits non-zero. What no GATING lane executes is named here rather than left inside that sentence. The refusal arm - the runner.fail reporting a triple platform_of_triple could not name - is reached by nothing at all: every lane passes either a triple the table carries or none. It exists so that a target added to CI and forgotten in that table fails loudly instead of emitting a leg labelled by a guess; its condition is what carries the test, and the arm itself is three lines of message. The rest of the --target path - the arm that labels the leg from the triple, and the branch that builds each cargo invocation with it - is executed only by the Android emulator lane, which is advisory and cannot redden main; the three legs that do gate main pass no --target and reach neither. Those lines are held by a lane whose red is visible only to somebody reading it, which is the honest description until the row is signed and the lane gates. The argv that branch produces is pinned by a unit test instead, which needs no device."
 
 [[exempt]]
 file = "tools/cli/src/main.rs"
-lines = [1409]
+lines = [1412]
 reason = "The comparison refusing to start because no workspace root is above it. Every other subcommand carries the same arm and reaches it the same way -- never, from a test, because a test runs inside the workspace it is testing. Reaching it would mean invoking the binary from outside any cargo project, which is a property of where a caller stands rather than of anything this code does."
 
 [[exempt]]
@@ -156,37 +156,37 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [798, 799]
+lines = [824, 825]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1396]
+lines = [1422]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1492, 1493, 1494, 1560, 1561, 1562]
+lines = [1518, 1519, 1520, 1586, 1587, 1588]
 reason = "Required trait methods of two single-purpose test doubles (the epoch-ordering probe and the defaulted-release app), whose tests drive only the surface-release path. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707]
+lines = [723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733]
 reason = "The suspend handler's body. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [853, 856]
+lines = [879, 882]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [611, 612]
+lines = [637, 638]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [726, 727, 728, 729, 730, 731, 732, 733, 734, 735]
+lines = [752, 753, 754, 755, 756, 757, 758, 759, 760, 761]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -310,11 +310,30 @@ impl std::error::Error for WindowError {}
 /// main thread (attempting otherwise panics inside the OS layer, by the
 /// windowing stack's own contract). Call this from `main`.
 ///
+/// **On iOS this function does not return once the loop is entered.**
+/// The loop is entered through `UIApplicationMain`, which owns the
+/// process from that point on: the app ends when the system ends it, and
+/// the code after that call is unreachable on that target. The signature
+/// keeps its `Result` anyway, so that one `main` compiles everywhere —
+/// the same reason Android's arm below keeps it.
+///
+/// Nothing about this is a defect to fix; it is how the platform runs
+/// applications. It is written down because a reader on a desktop cannot
+/// see it, and a caller that logs "the loop returned cleanly" after this
+/// call would be describing an event that never happens on iOS.
+///
 /// # Errors
 ///
 /// [`WindowError::LoopUnavailable`] when the loop cannot be created —
 /// on Linux this is the recoverable no-display-server case;
 /// [`WindowError::Loop`] when the running loop reports failure.
+///
+/// **On iOS, in practice, neither.** The windowing crate's iOS backend
+/// reports loop-creation problems by panicking rather than by returning,
+/// and the one error it can return needs a *second* loop built from
+/// another thread — which the first call cannot come back to arrange.
+/// So a caller there should expect this function to take the process,
+/// not to hand back a `Result` worth matching on.
 #[cfg(not(target_os = "android"))]
 pub fn run_window_app(config: &WindowConfig, app: &mut dyn WindowApp) -> Result<(), WindowError> {
     let event_loop = EventLoop::new().map_err(|error| WindowError::LoopUnavailable {
@@ -350,6 +369,13 @@ pub fn run_window_app(_config: &WindowConfig, _app: &mut dyn WindowApp) -> Resul
 /// was *built* differs per platform (a plain `new` on desktop, around
 /// an activity handle on Android), but what happens once it exists must
 /// not.
+///
+/// One platform disagrees about the *ending* rather than the beginning:
+/// on iOS `run_app` enters `UIApplicationMain` and never comes back, so
+/// [`Adapter::outcome`] below is desktop-and-Android-only in practice.
+/// It is left in one shared path rather than split, because a second
+/// copy of the loop body would be a second place for the two to drift,
+/// and the difference is that one of them has no line after the call.
 fn drive(
     event_loop: EventLoop<()>,
     config: &WindowConfig,

--- a/tools/ci/ios-determinism.sh
+++ b/tools/ci/ios-determinism.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# The iOS simulator determinism lane's body.
+#
+# A file rather than lines in the workflow, for the same reason the
+# Android one is: a body that needs a shell with a memory should own its
+# shell. This lane runs as a normal `run:` step rather than inside an
+# action, so the constraint is weaker here - but two lanes doing the same
+# job in two shapes is a reader's tax.
+set -euo pipefail
+
+# **Pick a simulator, and say so in this script's own words when there
+# is none.** A traceback out of the selector would name a Python line
+# instead of the thing that went wrong, on the lane least likely to have
+# anyone watching.
+device_json="$(xcrun simctl list devices available --json)"
+selection="$(printf '%s' "$device_json" | python3 -c "
+import json, sys
+
+try:
+    catalogue = json.load(sys.stdin)['devices']
+except (ValueError, KeyError) as problem:
+    raise SystemExit(f'simctl device list was not the shape expected: {problem}')
+
+# Newest runtime first. The identifiers sort as text, so iOS-9 would beat
+# iOS-26 on a plain sort; splitting on the dashes and comparing numbers
+# keeps the newest one winning when an image carries several. Which
+# runtime ran is printed below, because a leg records the platform and
+# not the OS version, and this is the only place that ever says it.
+def version(runtime):
+    tail = runtime.rsplit('.', 1)[-1]
+    parts = [p for p in tail.split('-') if p.isdigit()]
+    return [int(p) for p in parts] or [0]
+
+best = None
+for runtime, devices in catalogue.items():
+    if 'iOS' not in runtime:
+        continue
+    for device in devices:
+        if not device.get('isAvailable'):
+            continue
+        if 'iPhone' not in device.get('name', ''):
+            continue
+        if best is None or version(runtime) > version(best[0]):
+            best = (runtime, device.get('udid'), device.get('name'))
+
+if best is None:
+    raise SystemExit('no available iOS iPhone simulator on this runner')
+
+runtime, udid, name = best
+if not udid:
+    raise SystemExit(f'the chosen simulator ({name}) has no udid')
+print(f'{udid}\t{name}\t{runtime}')
+")"
+
+device="$(printf '%s' "$selection" | cut -f1)"
+echo "simulator: $(printf '%s' "$selection" | cut -f2) on $(printf '%s' "$selection" | cut -f3)"
+
+echo "booting $device"
+xcrun simctl boot "$device" || true
+xcrun simctl bootstatus "$device" -b
+
+# **Neither probe below spawns a system tool, and the reason is a fact
+# worth keeping.** The obvious check - ask the simulator its
+# architecture with `uname` - cannot work. `simctl spawn` execs a path
+# and does not search a PATH, so a bare `uname` is ENOENT; and the full
+# path `/usr/bin/uname` resolves to the *host's* macOS binary, which
+# aborts inside the simulator because the runtime supplies an
+# iOS-simulator `libSystem` and dyld refuses it:
+#
+#     Library not loaded: /usr/lib/libSystem.B.dylib
+#       Referenced from: /usr/bin/uname
+#       Reason: ... incompatible platform (have 'iOS-simulator', need 'macOS')
+#
+# **That refusal is the guarantee this lane actually wants.** A binary
+# whose platform does not match the simulator's does not run at all - it
+# dies in the loader before `main`. So a pinned run that produces digests
+# is proof that the simulator matched the platform its binary was built
+# for, which is stronger than any string a probe could print. What is
+# left to check is the other half: that the binaries were built for the
+# platform the leg claims.
+
+chmod +x tools/ios-sim-runner.sh
+export RENEW_IOS_SIM_UDID="$device"
+export CARGO_TARGET_AARCH64_APPLE_IOS_SIM_RUNNER="$PWD/tools/ios-sim-runner.sh"
+
+# **The runner's central claim, exercised rather than asserted.**
+# The runner carries no status file because `simctl spawn` returns the
+# child's own exit status - unlike `adb shell`, which returns its
+# shell's and forces the Android runner to carry the code back through a
+# file. If that were wrong, a crashing simulation would look like a run
+# that succeeded and printed nothing, and the lane would report a
+# missing digest rather than a failure. Eleven pinned runs that all exit
+# zero can never notice, so a failing one is run on purpose.
+#
+# `chess` answers a bad flag with exit 1 (its `run_cli` returns 1 on a
+# parse error), which is the only non-zero code any pinned sample can be
+# made to produce.
+#
+# **What this shows, exactly:** a program that fails on the simulator
+# arrives here as a failure rather than as a success that printed
+# nothing. **What it does not show:** that an arbitrary code is carried
+# through unchanged, because 1 is also the status a wrapper would invent
+# if it reported failures in its own words. Distinguishing those needs a
+# program that can choose its exit code, and none of the pinned samples
+# can. The weaker claim is the one worth having anyway: the failure this
+# lane must never make is calling a crashed run a silent one.
+set +e
+propagation="$(cargo run --quiet --package renew-sample-chess \
+    --target aarch64-apple-ios-sim -- --renew-not-a-real-flag 2>&1)"
+propagated=$?
+set -e
+if [ "$propagated" -eq 101 ]; then
+    echo "cargo could not build or start the check, so nothing was learned about \
+exit codes: $propagation" >&2
+    exit 1
+fi
+if [ "$propagated" -ne 1 ]; then
+    echo "a simulator program that exits 1 reached this script as $propagated, so \
+the runner cannot carry a program's own failure back and this lane cannot tell a \
+crash from a silent run: $propagation" >&2
+    exit 1
+fi
+echo "a failing program on the simulator arrives here as a failure"
+
+# The other half, and its limits stated rather than dressed up: the
+# binary in the triple's output directory really is an arm64 Mach-O.
+# This is **not** independent of the triple - rustc names that directory
+# after the triple and cannot emit a foreign architecture into it - so it
+# does not audit the triple. What it does catch is a stale or hand-placed
+# file surviving in the tree, and it makes the architecture a printed
+# fact rather than an inference for anyone reading the log.
+built="target/aarch64-apple-ios-sim/debug/chess"
+built_arch="$(lipo -archs "$built")"
+echo "the binary the simulator ran is: $built_arch"
+if [ "$built_arch" != "arm64" ]; then
+    echo "built '$built_arch', but the leg claims aarch64" >&2
+    exit 1
+fi
+
+cargo run --package renew-cli --bin renew -- \
+    determinism --emit ios-leg.json --target aarch64-apple-ios-sim
+
+cat ios-leg.json

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -317,12 +317,19 @@ renew determinism --emit leg.json --target x86_64-linux-android
 **This needs a runner configured, and says so rather than assuming it.**
 Cargo executes a cross-built binary through whatever
 `CARGO_TARGET_<TRIPLE>_RUNNER` names — for the triple above, that is
-`CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER`, and `tools/android-runner.sh`
-is the one this repository ships: it pushes each binary to a connected
-device with `adb`, runs it there, and hands back its output and its exit
-code. With no runner set, cargo tries to execute the binary here, which
-fails rather than quietly measuring the wrong machine. A linker for the
-target is needed too; the CI lane sets both.
+`CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER`. With no runner set, cargo
+tries to execute the binary here, which fails rather than quietly
+measuring the wrong machine.
+
+This repository ships two:
+
+| runner | for | what it does |
+|---|---|---|
+| `tools/android-runner.sh` | `*-linux-android` | pushes the binary to a connected device with `adb`, runs it there, and carries its exit code back through a file, because `adb shell` reports its own shell's status rather than the program's |
+| `tools/ios-sim-runner.sh` | `aarch64-apple-ios-sim` | runs the binary on a booted simulator with `xcrun simctl spawn`, which needs no push (the simulator shares this filesystem) and reports the child's exit code directly |
+
+Android needs a linker for the target as well; the CI lanes set what
+each one needs.
 
 The triple also decides what the leg calls itself, so only triples this
 tool has been taught are accepted — anything else is refused by name

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -174,8 +174,10 @@ pub struct Invocation {
     /// not: a leg that read its own `env::consts` would label an
     /// Android run as the desktop that launched it. What the triple
     /// cannot check is that the runs truly executed there — that is the
-    /// runner's job, and the lane prints the device's own architecture
-    /// beside the leg so the two can be read together.
+    /// runner's job, and each lane answers it in the terms its platform
+    /// allows: the Android one asserts the attached device's own
+    /// architecture, while on an iOS simulator the loader does it, by
+    /// refusing outright a binary whose platform does not match.
     pub target: Option<String>,
     /// Run, record and replay: cargo features to build the sample with,
     /// each occurrence kept.

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -1371,8 +1371,11 @@ fn run_determinism_emit(output_path: &str, target: Option<&str>, json_mode: bool
     // own constants would label a device's digests with the desktop
     // that launched them. The triple is what the binaries were built
     // for and what the runner executed; what it cannot prove is that
-    // the runner truly went there, which is why the lane prints the
-    // device's own architecture beside the leg.
+    // the runner truly went there. Each lane answers that in the terms
+    // its platform allows: the Android one asserts the attached
+    // device's own architecture, and the iOS one leans on the loader,
+    // which refuses a binary whose platform does not match the
+    // simulator's - so digests coming back at all prove the match.
     let (os, arch) = match platform {
         Some(pair) => pair,
         None => (env::consts::OS.to_string(), env::consts::ARCH.to_string()),

--- a/tools/cli/tests/ios_sim_runner.rs
+++ b/tools/cli/tests/ios_sim_runner.rs
@@ -1,0 +1,213 @@
+//! The iOS simulator runner's contract, held against a stub `xcrun`.
+//!
+//! `tools/ios-sim-runner.sh` is what cargo invokes for
+//! `aarch64-apple-ios-sim`, and its whole job is to hand a binary and
+//! its arguments to `xcrun simctl spawn` on the right device. Three
+//! things about it are load-bearing and none needs a Mac to check:
+//! which device it names, that arguments arrive unchanged, and that a
+//! missing binary is refused rather than passed on.
+//!
+//! The stub stands in for `xcrun` on `PATH` and records the argv it was
+//! given. That is enough to test everything this script decides, and it
+//! deliberately does not test what `simctl` itself does with them —
+//! that is the CI lane's job, and it exercises it against a real
+//! simulator on every run.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The runner script, from the crate this test belongs to.
+fn runner() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("tools/ios-sim-runner.sh")
+}
+
+/// A shell this test trusts, or `None` where there is none.
+///
+/// Windows is skipped for the reason its neighbour records: which shell
+/// a bare `sh` resolves to there is unpredictable, and this script is a
+/// macOS artifact invoked by cargo on a macOS runner. The Linux lanes
+/// run this for real.
+fn shell() -> Option<&'static str> {
+    if cfg!(windows) {
+        return None;
+    }
+    ["bash", "sh"].into_iter().find(|candidate| {
+        Command::new(candidate)
+            .arg("-c")
+            .arg("exit 0")
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+/// Run the script with a stub `xcrun` ahead of it on `PATH`, and return
+/// what that stub was asked to do, one argument per line.
+fn spawned(
+    shell: &str,
+    scratch: &Path,
+    device: Option<&str>,
+    binary: &str,
+    arguments: &[&str],
+) -> Result<(String, i32), String> {
+    let stub = scratch.join("xcrun");
+    std::fs::write(
+        &stub,
+        "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\"; done\n",
+    )
+    .map_err(|error| format!("could not write the stub: {error}"))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755))
+            .map_err(|error| format!("could not make the stub executable: {error}"))?;
+    }
+
+    let mut command = Command::new(shell);
+    command
+        .arg(runner())
+        .arg(binary)
+        .args(arguments)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                scratch.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env_remove("RENEW_IOS_SIM_UDID");
+
+    if let Some(udid) = device {
+        command.env("RENEW_IOS_SIM_UDID", udid);
+    }
+
+    let output = command
+        .output()
+        .map_err(|error| format!("could not run the runner: {error}"))?;
+
+    Ok((
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        output.status.code().unwrap_or(-1),
+    ))
+}
+
+/// A scratch directory of this test's own, removed when it finishes.
+fn scratch(name: &str) -> Result<PathBuf, String> {
+    let path = std::env::temp_dir().join(format!("renew-ios-runner-{name}"));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).map_err(|error| format!("no scratch directory: {error}"))?;
+    Ok(path)
+}
+
+/// The device the lane chose is the device the binary runs on.
+///
+/// `booted` is the fallback and not the rule: it names whichever
+/// simulator happens to be running, which is one machine right up until
+/// it is two, and then it is an unspecified one of them. A lane that
+/// boots one simulator and measures another would put digests against
+/// the wrong platform, which is the single thing it exists to get right.
+#[test]
+fn the_named_device_is_used_and_booted_is_only_the_fallback() -> Result<(), String> {
+    let Some(shell) = shell() else {
+        eprintln!("no shell this test trusts here; the macOS lanes check this for real");
+        return Ok(());
+    };
+    let scratch = scratch("device")?;
+    let binary = scratch.join("payload");
+    std::fs::write(&binary, "not really a binary").map_err(|error| error.to_string())?;
+    let binary = binary.display().to_string();
+
+    let (named, _) = spawned(shell, &scratch, Some("UDID-1234"), &binary, &[])?;
+    let named: Vec<&str> = named.lines().collect();
+    if named.first() != Some(&"simctl") || named.get(1) != Some(&"spawn") {
+        return Err(format!("expected `simctl spawn`, got {named:?}"));
+    }
+    if named.get(2) != Some(&"UDID-1234") {
+        return Err(format!("the named device did not reach xcrun: {named:?}"));
+    }
+
+    let (fallback, _) = spawned(shell, &scratch, None, &binary, &[])?;
+    let fallback: Vec<&str> = fallback.lines().collect();
+    if fallback.get(2) != Some(&"booted") {
+        return Err(format!(
+            "without a named device, expected `booted`: {fallback:?}"
+        ));
+    }
+
+    let _ = std::fs::remove_dir_all(&scratch);
+    Ok(())
+}
+
+/// Every argument arrives as one argument, unchanged.
+///
+/// This runner needs no quoting because `simctl spawn` execs the binary
+/// with an argv rather than handing a string to a shell — the opposite
+/// of the Android runner next door, which must quote everything. That
+/// difference is a claim about behaviour, so it is checked rather than
+/// asserted: a space, a quote and a metacharacter all survive whole.
+#[test]
+fn arguments_reach_the_simulator_one_for_one() -> Result<(), String> {
+    let Some(shell) = shell() else {
+        return Ok(());
+    };
+    let scratch = scratch("argv")?;
+    let binary = scratch.join("payload");
+    std::fs::write(&binary, "not really a binary").map_err(|error| error.to_string())?;
+    let binary = binary.display().to_string();
+
+    let sent = [
+        "--seed",
+        "7",
+        "two words",
+        "it's",
+        ";touch PWNED",
+        "$HOME",
+        "*",
+    ];
+    let (seen, _) = spawned(shell, &scratch, Some("UDID"), &binary, &sent)?;
+    let seen: Vec<&str> = seen.lines().collect();
+
+    // `simctl`, `spawn`, the device, the binary, then the arguments.
+    let arguments = &seen[4..];
+    if arguments != sent {
+        return Err(format!("sent {sent:?} and the stub saw {arguments:?}"));
+    }
+    if seen.get(3) != Some(&binary.as_str()) {
+        return Err(format!("the binary path did not arrive whole: {seen:?}"));
+    }
+
+    let _ = std::fs::remove_dir_all(&scratch);
+    Ok(())
+}
+
+/// A binary that is not there is refused here, not on the device.
+///
+/// The caller reads a missing digest as a target that reported nothing,
+/// so the difference between "the program failed" and "there was no
+/// program" has to be made where it is known.
+#[test]
+fn a_missing_binary_is_refused_before_anything_is_spawned() -> Result<(), String> {
+    let Some(shell) = shell() else {
+        return Ok(());
+    };
+    let scratch = scratch("missing")?;
+    let absent = scratch.join("no-such-binary").display().to_string();
+
+    let (seen, code) = spawned(shell, &scratch, Some("UDID"), &absent, &[])?;
+    if code != 127 {
+        return Err(format!(
+            "expected exit 127 for a missing binary, got {code}"
+        ));
+    }
+    if !seen.is_empty() {
+        return Err(format!(
+            "nothing should have been spawned, but xcrun saw {seen:?}"
+        ));
+    }
+
+    let _ = std::fs::remove_dir_all(&scratch);
+    Ok(())
+}

--- a/tools/ios-sim-runner.sh
+++ b/tools/ios-sim-runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Run one binary on a booted iOS simulator.
+#
+# Cargo's `CARGO_TARGET_<TRIPLE>_RUNNER` names this script, so
+# `cargo run --target aarch64-apple-ios-sim` executes there instead of
+# here — the same mechanism the Android runner uses, and the reason the
+# determinism lane can produce a simulator leg through exactly the code
+# path that produces a desktop one.
+#
+# Contract, identical in obligation to the Android runner's because the
+# caller is the same and cannot tell the two apart:
+#
+#   * a spawn failure exits non-zero and `simctl`'s own message goes to
+#     this script's stderr, so the step fails as plumbing rather than as
+#     disagreement. Whether a caller shows that message is the caller's
+#     business, and the one caller there is does not: `renew determinism
+#     --emit` captures stdout and prints its own summary, so simctl's
+#     reason for failing reaches the job log and not the error. The same
+#     caveat is on the Android runner, for the same reason;
+#   * the program's stdout is this script's stdout, and nothing else is
+#     written there, because the caller parses its last JSON line;
+#   * the program's exit code is this script's exit code.
+#
+# **Simpler than the Android runner, and the difference is real rather
+# than stylistic.** There is no push: the simulator shares this
+# machine's filesystem, so the binary is executed where it was built.
+# And `simctl spawn` reports the child's own exit status, so none of the
+# status-file machinery the `adb shell` contract forces is needed here.
+# Neither is an accident of effort — they are properties of the two
+# platforms' tooling, and pretending they were the same would mean
+# carrying Android's workarounds where nothing requires them.
+set -euo pipefail
+
+binary="$1"
+shift
+
+if [ ! -f "$binary" ]; then
+    echo "ios-sim-runner: no such binary: $binary" >&2
+    exit 127
+fi
+
+# **The caller names the device, and `booted` is only the fallback.**
+# `booted` resolves to whichever simulator is running, which is exactly
+# one machine right up until it is two - a second device left booted by
+# another job, or an iPad the lane did not choose - and then it resolves
+# to an undocumented one of them. A lane that boots a specific device and
+# then measures an unspecified one would put a digest against the wrong
+# platform, which is the single thing this lane exists to get right.
+#
+# So the device is read from the environment, where the script that
+# actually boots it can put it. The fallback keeps this runner usable by
+# hand, where "the one I have running" is what a person means.
+device="${RENEW_IOS_SIM_UDID:-booted}"
+
+# Arguments are passed as separate argv entries, not through a shell, so
+# nothing here needs quoting: `simctl spawn` execs the binary directly.
+# That is worth stating because the Android runner next door must quote
+# every argument, and a reader moving between them should know the
+# difference is in the tools, not in the care taken.
+exec xcrun simctl spawn "$device" "$binary" "$@"


### PR DESCRIPTION
feat(ci): the pinned simulations can run on an iOS simulator

The same eleven simulations the desktop legs run execute on a booted
iOS simulator and report their digests, through the same code path and
the same cargo runner mechanism the Android lane uses. Nothing in the
emitter changes: it already knew the triple, and a simulator is one
more place a triple can send a binary.

- tools/ios-sim-runner.sh is deliberately much smaller than its Android
  neighbour, and the difference is in the platforms rather than in the
  care taken. There is no push, because the simulator shares this
  machine's filesystem; there is no status file, because simctl reports
  the child's own exit code; and there is no argument quoting, because
  spawn takes argv directly instead of handing a string to a shell.
  Carrying the other runner's workarounds here would suggest they were
  ceremony rather than necessity.
- The lane boots a simulator itself and fails the step with its own
  message when none can be booted, so an unbootable runner reads as
  plumbing rather than as a pinned run that failed.
- It lands advisory and prints its comparison against the Linux leg,
  which decides nothing. A simulator is not a device, and a binary
  built for the simulator reports the same platform as one built for a
  phone - so the row this lane eventually proposes needs a name that
  says which one ran, and that naming is owed before the row, not
  before the lane.

run_window_app also stops describing a return that cannot happen: on
iOS the loop is entered through UIApplicationMain, which owns the
process from that point on. The signature keeps its Result so one main
compiles everywhere, and the doc says what it narrows to there.
