### PR TITLE
feat(sample): the mobile APKs carry the emulator's ABI too

### DIFF
--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -226,7 +226,7 @@ Two commands produce an installable debug APK (the second from
 `android/`):
 
 ```
-cargo ndk -t arm64-v8a -o samples/hello_triangle/android/app/src/main/jniLibs build -p renew-sample-hello-triangle --release
+cargo ndk -t arm64-v8a -t x86_64 -o samples/hello_triangle/android/app/src/main/jniLibs build -p renew-sample-hello-triangle --release
 ./gradlew assembleDebug
 ```
 

--- a/samples/hello_triangle/android/app/build.gradle
+++ b/samples/hello_triangle/android/app/build.gradle
@@ -20,8 +20,12 @@ android {
         versionCode 1
         versionName "0.1.1"
         ndk {
-            // The device ABI. The emulator ABI joins when its lane does.
-            abiFilters "arm64-v8a"
+            // Both, and the second one is why an APK can be exercised at
+            // all without hardware: arm64-v8a is every phone worth
+            // shipping to, and x86_64 is what an emulator runs. The
+            // comment here used to say the emulator ABI would join when
+            // its lane did, and it has.
+            abiFilters "arm64-v8a", "x86_64"
         }
     }
 

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -164,9 +164,15 @@ Two commands produce an installable debug APK (run the second from
 `android/`):
 
 ```
-cargo ndk -t arm64-v8a -o samples/input_echo/android/app/src/main/jniLibs build -p renew-sample-input-echo --release
+cargo ndk -t arm64-v8a -t x86_64 -o samples/input_echo/android/app/src/main/jniLibs build -p renew-sample-input-echo --release
 ./gradlew assembleDebug
 ```
+
+Two ABIs, because an APK with only `arm64-v8a` can be installed on a
+phone and on nothing else. `x86_64` is what an emulator runs, and it is
+what makes the app's lifecycle testable without hardware: install it,
+send it to the background, bring it back, and the surface epochs are
+observable in the log this sample writes.
 
 `cargo-ndk` (pinned 4.1.2) needs `ANDROID_NDK_HOME` pointing at an
 r28+ NDK — r28 aligns segments to the 16 KB pages newer devices

--- a/samples/input_echo/android/app/build.gradle
+++ b/samples/input_echo/android/app/build.gradle
@@ -20,8 +20,12 @@ android {
         versionCode 1
         versionName "0.1.1"
         ndk {
-            // The device ABI. The emulator ABI joins when its lane does.
-            abiFilters "arm64-v8a"
+            // Both, and the second one is why an APK can be exercised at
+            // all without hardware: arm64-v8a is every phone worth
+            // shipping to, and x86_64 is what an emulator runs. The
+            // comment here used to say the emulator ABI would join when
+            // its lane did, and it has.
+            abiFilters "arm64-v8a", "x86_64"
         }
     }
 


### PR DESCRIPTION
feat(sample): the mobile APKs carry the emulator's ABI too

Both sample APKs filtered to arm64-v8a, which installs on a phone and
on nothing else. Adding x86_64 makes them installable on an emulator,
and that is what turns the app lifecycle from something argued into
something observed: the platform genuinely revokes a window when an
app is backgrounded, and no desktop lane can produce that.

Measured on an API 34 x86_64 emulator with input_echo, four cycles of
launch, background and resume in one process: three surface-lost
events against four ready events, the epoch invariant holding on a
real Android runtime rather than in a unit test.

The comment being replaced said the emulator ABI would join when its
lane did. It has.
