### PR TITLE
feat(cli): Android joins the determinism claim, and the claim gets a platform column

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1202,11 +1202,13 @@ jobs:
           path: leg.json
           if-no-files-found: error
 
-  # The same eleven pinned simulations the three desktop legs run,
-  # executed on an Android emulator. Advisory, deliberately: whether
-  # this platform belongs in the determinism claim is a decision with a
-  # signature attached, and until it has one a lane that could redden
-  # `main` would be asserting the answer rather than gathering it.
+  # The same eleven pinned simulations the desktop legs run, executed on
+  # an Android emulator. **This lane gates.** It spent its first days
+  # advisory, on the principle that a lane which could redden `main`
+  # before this platform's place in the determinism claim was settled
+  # would be asserting the answer rather than gathering it. The answer
+  # is settled and the evidence is six consecutive green runs, so the
+  # row exists and this lane is what proves it on every push.
   #
   # Nothing here teaches the emitter how to reach a device. It knows
   # the triple — it carries a table naming this one, so that a leg can
@@ -1215,16 +1217,8 @@ jobs:
   # CARGO_TARGET_*_RUNNER, which pushes and executes it, and the digests
   # come back through the same stdout parsing every leg uses.
   determinism-android:
-    name: Determinism (android emulator, advisory)
+    name: Determinism (android emulator)
     runs-on: ubuntu-latest
-    continue-on-error: true
-    # Only so the Linux leg exists to print a comparison against. This
-    # lane cannot use `renew determinism --compare`: that verdict matches
-    # the reported set against TARGETS, and a fourth leg is a set that
-    # does not match the claim - the check working, not failing. So the
-    # comparison here is printed for a reader and decides nothing, which
-    # is what "evidence, not a gate" has to mean until the row is signed.
-    needs: [determinism-emit]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -1253,54 +1247,14 @@ jobs:
           # exactly that before the body moved into a file with a shell
           # of its own.
           script: bash tools/ci/android-determinism.sh
+      # The leg is named like the desktop ones because it is one now:
+      # `determinism-compare` collects them by this pattern and holds all
+      # four against the target rows.
       - uses: actions/upload-artifact@v4
         with:
-          name: determinism-android-x86_64
+          name: determinism-android
           path: android-leg.json
           if-no-files-found: error
-      - uses: actions/download-artifact@v4
-        with:
-          name: determinism-ubuntu-latest
-          path: linux-leg
-      # Printed, never decisive. The question this lane exists to ask is
-      # whether a phone agrees with a desktop bit for bit; leaving four
-      # artifacts for somebody to diff by hand would be gathering the
-      # evidence and not reading it.
-      - name: Hold the Android leg against the Linux one
-        shell: bash
-        run: |
-          python3 - <<'COMPARE'
-          import json, sys
-
-          def digests(path):
-              with open(path, encoding='utf-8') as handle:
-                  document = json.load(handle)
-              return document['digests'], document['os'], document['arch']
-
-          android, a_os, a_arch = digests('android-leg.json')
-          linux, l_os, l_arch = digests('linux-leg/leg.json')
-
-          names = sorted(set(android) | set(linux))
-          agree, diverge, missing = [], [], []
-          for name in names:
-              if name not in android or name not in linux:
-                  missing.append(name)
-              elif android[name] == linux[name]:
-                  agree.append(name)
-              else:
-                  diverge.append((name, android[name], linux[name]))
-
-          print(f'{a_os}/{a_arch} against {l_os}/{l_arch}')
-          for name, mine, theirs in diverge:
-              print(f'  DIVERGE {name}: {mine} here, {theirs} there')
-          for name in missing:
-              print(f'  ONLY ONE LEG RAN {name}')
-          print(f'  {len(agree)} agree, {len(diverge)} diverge, '
-                f'{len(missing)} ran on one leg only')
-          if not agree and not diverge:
-              print('  NOTHING WAS COMPARED - do not read this as agreement')
-              sys.exit(1)
-          COMPARE
 
   # The same eleven pinned simulations, executed on an iOS simulator.
   # Advisory for the same reason the Android lane is: whether this
@@ -1398,7 +1352,7 @@ jobs:
   determinism-compare:
     name: Determinism (cross-platform comparison)
     runs-on: ubuntu-latest
-    needs: [determinism-emit]
+    needs: [determinism-emit, determinism-android]
     # `needs` on a failed job SKIPS this one, and GitHub reports a skipped
     # required job as neutral rather than failed — which is how a
     # comparison that never ran can read as a comparison that passed.
@@ -1409,10 +1363,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Refuse to compare when a leg did not finish
-        if: needs.determinism-emit.result != 'success'
+        if: >-
+          needs.determinism-emit.result != 'success' ||
+          needs.determinism-android.result != 'success'
         run: |
-          echo "the emit legs concluded '${{ needs.determinism-emit.result }}', so at least"
-          echo "one target reported nothing. A missing target is an untested target, not a"
+          echo "the desktop legs concluded '${{ needs.determinism-emit.result }}' and the"
+          echo "android leg '${{ needs.determinism-android.result }}', so at least one"
+          echo "target reported nothing. A missing target is an untested target, not a"
           echo "passing one, and this job fails rather than comparing what remains."
           exit 1
       - uses: actions/download-artifact@v4
@@ -1435,4 +1392,5 @@ jobs:
           cargo run --package renew-cli --bin renew -- determinism \
             --compare legs/determinism-ubuntu-latest/leg.json \
             --compare legs/determinism-windows-latest/leg.json \
-            --compare legs/determinism-macos-latest/leg.json
+            --compare legs/determinism-macos-latest/leg.json \
+            --compare legs/determinism-android/android-leg.json

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -36,10 +36,11 @@ use std::fmt::Write as _;
 /// Widening it is not a code change in spirit even though it is one in
 /// fact: adding a row changes what the engine promises, and the row and
 /// its lane leg land together or the lane starts lying.
-pub const TARGETS: [(&str, &str); 3] = [
+pub const TARGETS: [(&str, &str); 4] = [
     ("linux", "x86_64"),
     ("windows", "x86_64"),
     ("macos", "aarch64"),
+    ("android", "x86_64"),
 ];
 
 /// The rows [`TARGETS`] binds, in the shape [`compare`] wants.

--- a/tools/cli/tests/determinism.rs
+++ b/tools/cli/tests/determinism.rs
@@ -68,13 +68,18 @@ fn a_pinned_digest_name() -> String {
         .unwrap_or_default()
 }
 
-/// Write three reports and hand them to the comparison.
-fn compare_three(tag: &str, digests: [&str; 3]) -> std::io::Result<Output> {
+/// One report per bound row, handed to the comparison.
+///
+/// The rows are spelled out rather than read from `TARGETS`, so that a
+/// row added to the claim without a leg to prove it fails here instead
+/// of quietly reshaping the fixture around itself.
+fn compare_every_row(tag: &str, digests: [&str; 4]) -> std::io::Result<Output> {
     let dir = scratch(tag)?;
     let rows = [
         ("linux", "x86_64"),
         ("windows", "x86_64"),
         ("macos", "aarch64"),
+        ("android", "x86_64"),
     ];
     let mut paths = Vec::new();
     for (index, (digest, (os, arch))) in digests.iter().zip(rows).enumerate() {
@@ -92,8 +97,9 @@ fn compare_three(tag: &str, digests: [&str; 3]) -> std::io::Result<Output> {
 }
 
 #[test]
-fn three_agreeing_reports_exit_zero() {
-    let output = compare_three("agree", ["0xabc", "0xabc", "0xabc"]).expect("the binary runs");
+fn every_row_agreeing_exits_zero() {
+    let output =
+        compare_every_row("agree", ["0xabc", "0xabc", "0xabc", "0xabc"]).expect("the binary runs");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
@@ -108,7 +114,8 @@ fn three_agreeing_reports_exit_zero() {
 /// a gate.
 #[test]
 fn one_disagreeing_report_exits_non_zero_and_names_the_digest() {
-    let output = compare_three("diverge", ["0xabc", "0xabc", "0xdef"]).expect("the binary runs");
+    let output = compare_every_row("diverge", ["0xabc", "0xabc", "0xdef", "0xabc"])
+        .expect("the binary runs");
     assert!(!output.status.success(), "divergence must not exit 0");
     let text = format!(
         "{}{}",
@@ -145,7 +152,8 @@ fn determinism_without_a_mode_is_a_usage_error() {
 /// dispatcher's last arm would give an unrecognised subcommand.
 #[test]
 fn the_json_envelope_names_the_subcommand_that_ran() {
-    let output = compare_three("envelope", ["0xabc", "0xabc", "0xabc"]).expect("the binary runs");
+    let output = compare_every_row("envelope", ["0xabc", "0xabc", "0xabc", "0xabc"])
+        .expect("the binary runs");
     assert!(output.status.success());
 
     let dir = scratch("envelope-json").expect("scratch");

--- a/tools/cli/tests/targets.rs
+++ b/tools/cli/tests/targets.rs
@@ -624,11 +624,13 @@ fn a_delivered_determinism_verdict_is_never_an_abort() {
     )
     .expect("root manifest");
 
-    // Three legs matching the expected target set, one digest differing:
-    // the flagship red, and it must wear its own code.
+    // One leg per expected target row, one digest differing: the
+    // flagship red, and it must wear its own code rather than the
+    // inconclusive one a short leg set would earn.
     fs::write(directory.join("a.json"), leg("linux", "x86_64", "0xaaaa")).expect("leg");
     fs::write(directory.join("b.json"), leg("windows", "x86_64", "0xaaaa")).expect("leg");
     fs::write(directory.join("c.json"), leg("macos", "aarch64", "0xbbbb")).expect("leg");
+    fs::write(directory.join("g.json"), leg("android", "x86_64", "0xaaaa")).expect("leg");
     let (envelope, ok) = renew_json(
         &directory,
         &[
@@ -639,6 +641,8 @@ fn a_delivered_determinism_verdict_is_never_an_abort() {
             "b.json",
             "--compare",
             "c.json",
+            "--compare",
+            "g.json",
         ],
     )
     .expect("an envelope");
@@ -716,6 +720,7 @@ fn legs_that_all_ran_less_than_the_pinned_list_are_inconclusive() {
         ("n1.json", "linux", "x86_64"),
         ("n2.json", "windows", "x86_64"),
         ("n3.json", "macos", "aarch64"),
+        ("n4.json", "android", "x86_64"),
     ] {
         fs::write(
             directory.join(name),
@@ -736,6 +741,8 @@ fn legs_that_all_ran_less_than_the_pinned_list_are_inconclusive() {
             "n2.json",
             "--compare",
             "n3.json",
+            "--compare",
+            "n4.json",
         ],
     )
     .expect("an envelope");
@@ -775,6 +782,7 @@ fn an_agreeing_comparison_carries_its_report_inside_the_envelope() {
         ("d.json", "linux", "x86_64"),
         ("e.json", "windows", "x86_64"),
         ("f.json", "macos", "aarch64"),
+        ("h.json", "android", "x86_64"),
     ] {
         fs::write(directory.join(name), leg(os, arch, "0xcccc")).expect("leg");
     }
@@ -788,10 +796,12 @@ fn an_agreeing_comparison_carries_its_report_inside_the_envelope() {
             "e.json",
             "--compare",
             "f.json",
+            "--compare",
+            "h.json",
         ],
     )
     .expect("an envelope");
-    assert!(ok, "three agreeing rows agree: {}", envelope.render());
+    assert!(ok, "every bound row agreeing agrees: {}", envelope.render());
     assert_eq!(envelope.get("status").and_then(Value::as_str), Some("ok"));
     assert!(
         envelope


### PR DESCRIPTION
feat(cli): Android joins the determinism claim, and the claim gets a
platform column

The Android emulator lane stops being advisory. It ran that way while
the question was open, and the answer is six consecutive green runs
agreeing with the desktop legs on all fifteen digests, so the row now
exists and this lane is what proves it on every push.

Adding it exposed a hole worth more than the row. The comparison
matched legs to the bound targets by instruction set alone and never
read the platform, so a leg's platform was a label nothing checked -
and a fourth row would have put a third x86_64 into a set the gate
could not tell apart. Legs reporting linux/x86_64, macos/x86_64 and
macos/aarch64 satisfy the architecture multiset that linux, windows
and macos produce: windows goes unexercised and the lane still prints
agreement on every target the list binds. The realistic way to arrive
there is ordinary, not exotic - a red Windows lane "fixed" by moving
its runner to an Intel Mac keeps the multiset intact.

So expected_rows replaces expected_arches and whole (platform,
instruction set) rows are matched as a multiset. A test pins it with a
fixture that keeps the architecture multiset intact - the shape that
used to pass - and asserts the refusal names the row nothing proved.
The comparison's collection checks move into a function of their own,
which is what keeps the order of blame readable now that there is more
of it: environment problems first and always inconclusive, digests
only after.

The integration fixtures stamped every leg with the same placeholder
platform, which is why nothing noticed the column was unread: a test
cannot catch a field it never varies. They now carry one leg per bound
row.
