### PR TITLE
feat(sample): input_echo becomes a launchable iOS application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,7 +682,13 @@ jobs:
             lint: "true"
           - os: macos-latest
             targets: aarch64-apple-ios,aarch64-apple-ios-sim
-            lint: "false"
+            # Clippy rides along here for the same reason it does on the
+            # Android leg: there is now a module behind
+            # `cfg(target_os = "ios")`, and the canonical lint never
+            # compiles it. Without this, the first `pedantic` finding in
+            # a file only these targets build would land in `main`
+            # unseen.
+            lint: "true"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -1394,6 +1400,32 @@ jobs:
               print(f'compared nothing against: {", ".join(empty)}')
               sys.exit(1)
           COMPARE
+
+  # An iOS application, launched on a simulator and driven through
+  # background and foreground.
+  #
+  # **This is the only lane that can observe what happens to a window
+  # when iOS suspends an app.** The determinism lane runs headless
+  # command-line simulations: they never open a window, so no suspend
+  # event reaches the handler and nothing about it is testable there.
+  # The platform layer revokes the surface on Android alone, on the
+  # argument that iOS keeps it - argued, and until this lane, never
+  # observed.
+  #
+  # Advisory while the observation is new. A lane that gates on a
+  # platform assumption should first establish that the assumption
+  # holds, and this is the run that establishes it.
+  ios-lifecycle:
+    name: iOS app lifecycle (advisory)
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim
+      - name: Background and resume the app, and read its log
+        run: bash tools/ci/ios-lifecycle.sh
 
   determinism-compare:
     name: Determinism (cross-platform comparison)

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -156,37 +156,37 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [824, 825]
+lines = [904, 905]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1422]
+lines = [1502]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1518, 1519, 1520, 1586, 1587, 1588]
-reason = "Required trait methods of two single-purpose test doubles (the epoch-ordering probe and the defaulted-release app), whose tests drive only the surface-release path. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
+lines = [1599, 1600, 1601, 1667, 1668, 1669, 1693, 1694, 1695, 1752, 1753, 1754]
+reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733]
-reason = "The suspend handler's body. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
+lines = [798, 802, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813]
+reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [879, 882]
+lines = [959, 962]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [637, 638]
+lines = [711, 712]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [752, 753, 754, 755, 756, 757, 758, 759, 760, 761]
+lines = [832, 833, 834, 835, 836, 837, 838, 839, 840, 841]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -57,6 +57,19 @@ datagrams — each a thin, explicit seam.
   handle re-export is the one documented exception to the
   no-windowing-library-type rule, because the value exists before any
   engine code runs.
+  **Losing the surface and losing the foreground are different events**,
+  and `WindowApp` has a callback for each: `surface_lost` says the window
+  is being destroyed, while `suspended` and `resumed` say only that
+  nobody is attending to the application. Android sends both when it
+  backgrounds an activity; iOS sends only the second pair, and sends it
+  for every interruption — a call, the app switcher, a notification
+  shade — with the surface still valid throughout. An application that
+  pauses a clock wants the interruption pair; one that holds
+  window-derived resources wants `surface_lost`. `resumed` fires only
+  after a `suspended`, so a launch is not a return, and a platform that
+  repeats itself gets one `suspended` per interruption rather than one
+  per message. All three are defaulted, so an application that does not
+  care writes nothing.
 - `audio` (default-**off** `audio-out` feature) — the default output
   device, a negotiated stream shape, and a fill callback the OS audio
   thread drives. Bring-up is two phases because the shape has to be

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -277,6 +277,38 @@ pub trait WindowApp {
     /// one revoking platform is Android; iOS suspends without revoking
     /// and deliberately does not reach this callback.
     fn surface_lost(&mut self) {}
+
+    /// The application has stopped being the one in front.
+    ///
+    /// **Deliberately not "backgrounded", because the platforms do not
+    /// agree on how much this means.** Android sends it when the
+    /// activity goes to the background. iOS sends it for every
+    /// interruption — an incoming call, the app switcher, a
+    /// notification shade pulled down — and the application may be
+    /// frontmost again a second later without ever having left. What is
+    /// common to both, and all this callback promises, is that nobody
+    /// is attending to it right now.
+    ///
+    /// **Separate from [`surface_lost`](Self::surface_lost), because on
+    /// one platform they are the same event and on another they are
+    /// not.** Android revokes the window when it backgrounds an app, so
+    /// both fire; iOS keeps the surface, so only this one does. An
+    /// application that wants to pause a clock or stop a sound wants
+    /// this callback; one that must release window-derived resources
+    /// wants the other.
+    ///
+    /// Delivered once per interruption: a platform that repeats itself
+    /// — Android emits back-to-back suspends — does not repeat this.
+    fn suspended(&mut self) {}
+
+    /// The application has come back to the foreground.
+    ///
+    /// Fires only after a [`suspended`](Self::suspended), so a launch is
+    /// not a resume — the first time an application is given a window
+    /// it hears [`ready`](Self::ready) and nothing else. On a platform
+    /// that revoked the surface, [`ready`](Self::ready) follows this
+    /// with the new one.
+    fn resumed(&mut self) {}
 }
 
 /// Why the window loop could not run.
@@ -365,6 +397,40 @@ pub fn run_window_app(_config: &WindowConfig, _app: &mut dyn WindowApp) -> Resul
     })
 }
 
+/// Tell an application it has been interrupted, once per interruption.
+///
+/// A free function for the reason [`close_epoch`] is one: the adapter's
+/// handlers take an `ActiveEventLoop`, which no test can build, so any
+/// rule living only on that path is a rule no test can reach. The state
+/// is passed in rather than owned so this is the whole transition and
+/// the caller keeps none of it.
+///
+/// **Idempotent, and that is not symmetry for its own sake.** Android
+/// emits back-to-back suspends — the epoch's own close tolerates a
+/// redundant one for exactly that reason — and an application told
+/// twice would pause a clock twice, or unbalance a refcount it had
+/// taken once. A second suspend without an intervening resume is the
+/// same interruption still in progress, so it is not news.
+fn note_suspend(was_suspended: &mut bool, app: &mut dyn WindowApp) {
+    if !*was_suspended {
+        *was_suspended = true;
+        app.suspended();
+    }
+}
+
+/// Tell an application it is back, if it ever left.
+///
+/// **Only a real return counts as one.** The windowing stack calls its
+/// resume handler once on the way up as well, and an application told
+/// it had "resumed" before it ever ran would have to second-guess the
+/// word. The flag is what makes the callback mean what its name says.
+fn note_resume(was_suspended: &mut bool, app: &mut dyn WindowApp) {
+    if *was_suspended {
+        *was_suspended = false;
+        app.resumed();
+    }
+}
+
 /// The loop's second half, shared by every entry point: how the loop
 /// was *built* differs per platform (a plain `new` on desktop, around
 /// an activity handle on Android), but what happens once it exists must
@@ -387,6 +453,7 @@ fn drive(
         app,
         epoch: SurfaceEpoch::new(),
         failure: None,
+        was_suspended: false,
         commanding: false,
         cursor_wanted: core::cell::Cell::new(false),
     };
@@ -522,6 +589,13 @@ struct Adapter<'a> {
     /// loop so it surfaces through `run_window_app`'s Result instead of
     /// a log line.
     failure: Option<String>,
+    /// Whether the platform has suspended this application since it
+    /// last had the foreground.
+    ///
+    /// The windowing stack calls its resume handler once on the way up
+    /// too, so without this a launch would be reported to the
+    /// application as a return from somewhere it had never been.
+    was_suspended: bool,
     /// Whether a command modifier is currently down.
     ///
     /// **Because a shortcut is not typing.** The windowing library
@@ -701,6 +775,7 @@ impl ApplicationHandler for Adapter<'_> {
         // platform granting a window back, and the poll cadence returns
         // with it. Idempotent on desktop, where nothing ever parked it.
         event_loop.set_control_flow(ControlFlow::Poll);
+        note_resume(&mut self.was_suspended, self.app);
         self.open(&|attributes| {
             event_loop
                 .create_window(attributes)
@@ -721,6 +796,11 @@ impl ApplicationHandler for Adapter<'_> {
     /// rather than an attribute so every target compiles every path —
     /// the branch is decided at compile time either way.
     fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        // Told first, and on every platform that emits a suspend,
+        // because "you have been interrupted" is true everywhere this
+        // fires — what differs is only whether the window survives it.
+        note_suspend(&mut self.was_suspended, self.app);
+
         if cfg!(target_os = "android") {
             self.close_surface();
             // A backgrounded app with no window has nothing to draw
@@ -1450,6 +1530,7 @@ mod tests {
             app,
             epoch: SurfaceEpoch::new(),
             failure: None,
+            was_suspended: false,
             commanding: false,
             cursor_wanted: core::cell::Cell::new(false),
         }
@@ -1594,6 +1675,93 @@ mod tests {
             epoch.close(&mut Holdless),
             "a holdless app passes the release verification unchanged"
         );
+    }
+
+    /// The suspend transition, in every order a platform can produce.
+    ///
+    /// Drives the defaulted callbacks too: an application that
+    /// implements neither is the common case, and a default that
+    /// nothing ever calls is a default nobody has checked.
+    #[test]
+    fn an_application_hears_about_an_interruption_once_and_a_return_only_after_one() {
+        #[derive(Default)]
+        struct Counting {
+            suspends: usize,
+            resumes: usize,
+        }
+        impl WindowApp for Counting {
+            fn ready(&mut self, _window: &WindowRef<'_>) {}
+            fn event(&mut self, _event: WindowEvent) {}
+            fn update(&mut self, _control: &mut LoopControl) {}
+            fn suspended(&mut self) {
+                self.suspends += 1;
+            }
+            fn resumed(&mut self) {
+                self.resumes += 1;
+            }
+        }
+
+        // A resume before anything suspended is the loop starting up,
+        // not an application coming back.
+        let mut flag = false;
+        let mut app = Counting::default();
+        note_resume(&mut flag, &mut app);
+        assert_eq!(
+            (app.suspends, app.resumes),
+            (0, 0),
+            "a launch is not a return"
+        );
+
+        note_suspend(&mut flag, &mut app);
+        assert_eq!((app.suspends, app.resumes), (1, 0));
+
+        // Android emits back-to-back suspends; the second is the same
+        // interruption still in progress.
+        note_suspend(&mut flag, &mut app);
+        assert_eq!(
+            (app.suspends, app.resumes),
+            (1, 0),
+            "a repeated suspend is not news"
+        );
+
+        note_resume(&mut flag, &mut app);
+        assert_eq!((app.suspends, app.resumes), (1, 1));
+
+        // And a second resume is not a second return.
+        note_resume(&mut flag, &mut app);
+        assert_eq!(
+            (app.suspends, app.resumes),
+            (1, 1),
+            "a repeated resume is not news"
+        );
+
+        // The cycle repeats cleanly, which is what a lane counting
+        // three of each depends on.
+        note_suspend(&mut flag, &mut app);
+        note_resume(&mut flag, &mut app);
+        assert_eq!((app.suspends, app.resumes), (2, 2));
+    }
+
+    /// The defaulted pair is a real answer, not an unimplemented one:
+    /// an application with no interest in interruptions must be able to
+    /// ignore them, and this drives the bodies that let it.
+    #[test]
+    fn the_defaulted_interruption_callbacks_do_nothing_and_that_is_allowed() {
+        struct Incurious;
+        impl WindowApp for Incurious {
+            fn ready(&mut self, _window: &WindowRef<'_>) {}
+            fn event(&mut self, _event: WindowEvent) {}
+            fn update(&mut self, _control: &mut LoopControl) {}
+            // suspended and resumed deliberately not implemented.
+        }
+        let mut flag = false;
+        note_suspend(&mut flag, &mut Incurious);
+        assert!(
+            flag,
+            "the transition is recorded even when the app ignores it"
+        );
+        note_resume(&mut flag, &mut Incurious);
+        assert!(!flag, "and cleared on the way back");
     }
 
     /// Opening into a live epoch is a bug in the loop, not a state to

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -174,6 +174,40 @@ what makes the app's lifecycle testable without hardware: install it,
 send it to the background, bring it back, and the surface epochs are
 observable in the log this sample writes.
 
+## iOS
+
+The same shape once more, with a doorway that never returns.
+`src/ios.rs` is entered from `main` on that target and hands straight to
+the event loop, which enters `UIApplicationMain` and owns the process
+from then on. It wraps the same `EchoApp` in the same kind of logging
+adapter, writing to `Documents` inside the app's sandbox — read back
+from the host, since a simulator's filesystem is this machine's.
+
+**No Xcode project, and that is a decision rather than an omission.** An
+iOS application is a directory: an executable plus an `Info.plist`
+naming it. A Rust `[[bin]]` built for `aarch64-apple-ios-sim` is that
+executable, so `tools/ios-app-bundle.sh` assembles the bundle and
+nothing generates or parses a `project.pbxproj`. A *device* build would
+be different — installing on hardware needs signing and provisioning,
+which is where a real project earns its keep — and this sample does not
+do one.
+
+```
+bash tools/ios-app-bundle.sh renew-sample-input-echo input_echo com.renewengine.inputecho target/ios-app
+xcrun simctl install booted target/ios-app/input_echo.app
+xcrun simctl launch booted com.renewengine.inputecho
+```
+
+The log is at `$(xcrun simctl get_app_container booted com.renewengine.inputecho
+data)/Documents/input_echo.log`. Launching another app (Settings, say)
+backgrounds this one, and relaunching brings it back: the log then
+carries `suspended` and `resumed` lines and — unlike Android — no
+`surface lost` between them, because iOS keeps the window across an
+interruption.
+
+Both of these need macOS with Xcode's command-line tools; a simulator
+build needs no signing identity.
+
 `cargo-ndk` (pinned 4.1.2) needs `ANDROID_NDK_HOME` pointing at an
 r28+ NDK — r28 aligns segments to the 16 KB pages newer devices
 require, by default. Gradle needs `JAVA_HOME` and `ANDROID_HOME`; the

--- a/samples/input_echo/src/android.rs
+++ b/samples/input_echo/src/android.rs
@@ -117,4 +117,16 @@ impl WindowApp for Filed {
         self.note("surface lost: epoch closed, awaiting the next ready");
         self.echo.surface_lost();
     }
+
+    /// Android reports both: it backgrounds the app *and* takes the
+    /// window. Logging them separately is what lets the two platforms'
+    /// logs be read side by side — the pair here, only this pair on
+    /// iOS, where the window survives.
+    fn suspended(&mut self) {
+        self.note("suspended: the app is in the background");
+    }
+
+    fn resumed(&mut self) {
+        self.note("resumed: the app is in the foreground again");
+    }
 }

--- a/samples/input_echo/src/ios.rs
+++ b/samples/input_echo/src/ios.rs
@@ -1,0 +1,157 @@
+//! The iOS doorway: the OS enters through `main`, as the desktop does,
+//! and then never comes back.
+//!
+//! Unlike Android there is no separate entry symbol to export — an iOS
+//! application's executable starts at `main` like any other program, and
+//! the difference is what happens next: the event loop enters
+//! `UIApplicationMain`, which owns the process from that point on. So
+//! this doorway is a function `main` hands off to and does not expect a
+//! return from.
+//!
+//! A phone has no terminal anyone watches, so the sample's visible half
+//! moves, exactly as it does on Android: everything the desktop prints,
+//! this doorway appends to a log inside the app's sandbox, read back
+//! from the host with `xcrun simctl get_app_container`. The log is the
+//! sample's report on this platform — ready, every event as its one-line
+//! description, and each surface epoch as it opens or closes.
+
+use std::path::PathBuf;
+
+use renew_platform::window::{
+    LoopControl, WindowApp, WindowConfig, WindowEvent, WindowRef, run_window_app,
+};
+
+use crate::app::{EchoApp, describe};
+use crate::cli::Options;
+
+/// Where an iOS app writes its report.
+///
+/// The sandbox root arrives in `HOME`, and the whole container is read
+/// back from the host with `get_app_container`; `Documents` is simply
+/// where a document goes. A launch without `HOME`
+/// falls back to the temporary directory rather than going mute — the
+/// same rule the diagnostics sink follows.
+///
+/// Returns a path rather than an `Option`, because it always has one:
+/// the Android doorway's equivalent is optional for a real reason (the
+/// activity may genuinely have no data path), and copying its shape
+/// here would be a signature that cannot fail claiming it can.
+fn log_path() -> PathBuf {
+    std::env::var_os("HOME").map_or_else(
+        || std::env::temp_dir().join("input_echo.log"),
+        |home| PathBuf::from(home).join("Documents").join("input_echo.log"),
+    )
+}
+
+/// The application's entry, called by `main` on this platform.
+///
+/// **Does not return.** `run_window_app` enters `UIApplicationMain`, and
+/// the process ends when the system ends it. The outcome line every
+/// other doorway writes at the end has no counterpart here, and saying
+/// so is the point: a reader looking for it should know it is absent by
+/// design rather than missing by accident.
+pub fn ios_main() -> ! {
+    let log = log_path();
+
+    // The panic hook and the diagnostics channel both go to the same
+    // file, before anything can fail.
+    let _ = renew_platform::diag::log_to_file(Some(log.clone()), Some("input_echo: ios start"));
+
+    let options = Options {
+        // A phone session ends when the OS ends it, not on a tick
+        // budget: an app that quit itself after ten seconds would read
+        // as a crash.
+        frames: u64::MAX,
+        ..Options::default()
+    };
+    let mut app = Filed {
+        echo: EchoApp::new(&options),
+        log,
+    };
+    let config = WindowConfig {
+        title: "renew — input echo".to_string(),
+        logical_width: 640.0,
+        logical_height: 360.0,
+        resizable: true,
+    };
+
+    // A failure here is a loop that never started, which is the only
+    // outcome this call can report: everything after a successful start
+    // belongs to `UIApplicationMain`.
+    if let Err(error) = run_window_app(&config, &mut app) {
+        app.note(&format!("loop never started: {error}"));
+    }
+
+    // Reached when the loop refused to start, and in principle if it
+    // ever returned cleanly — which `run_window_app` documents as
+    // impossible on this platform, the loop having entered
+    // `UIApplicationMain`. Either way the process has nothing left to do
+    // and no OS to hand back to, so it exits rather than falling out of
+    // a function the platform expects never to return from.
+    std::process::exit(1)
+}
+
+/// The library's app, with the desktop's console replaced by the log.
+///
+/// A doorway-local wrapper rather than a library change: what varies per
+/// platform is where the words go, never what the sample does. The
+/// Android doorway carries the same shape for the same reason.
+struct Filed {
+    echo: EchoApp,
+    log: PathBuf,
+}
+
+impl Filed {
+    /// One line into the log, best effort: a line that cannot be written
+    /// has nowhere to report that, and must not become the fault it was
+    /// describing.
+    fn note(&self, line: &str) {
+        let _ = renew_platform::fs::append(&self.log, format!("{line}\n").as_bytes());
+    }
+}
+
+impl WindowApp for Filed {
+    fn ready(&mut self, window: &WindowRef<'_>) {
+        let (width, height) = window.physical_size();
+        self.note(&format!(
+            "ready: {width}x{height} at scale {}",
+            window.scale_factor()
+        ));
+        self.echo.ready(window);
+    }
+
+    /// **The line this platform exists to produce.**
+    ///
+    /// Android revokes the window when an app is backgrounded and this
+    /// fires there on every cycle. iOS is believed not to — the surface
+    /// survives a resign-active — so on this platform the expected count
+    /// is zero, and any line here is the finding.
+    fn surface_lost(&mut self) {
+        self.note("surface lost: epoch closed, awaiting the next ready");
+        self.echo.surface_lost();
+    }
+
+    /// **The two lines that make this platform observable.**
+    ///
+    /// iOS suspends an application without taking its window, so
+    /// `surface_lost` never fires here and an absence of it proves
+    /// nothing on its own: a run that was never backgrounded looks
+    /// exactly the same. These say that the suspend happened, which is
+    /// what turns "no surface was lost" from an absence into a finding.
+    fn suspended(&mut self) {
+        self.note("suspended: the app is in the background");
+    }
+
+    fn resumed(&mut self) {
+        self.note("resumed: the app is in the foreground again");
+    }
+
+    fn event(&mut self, event: WindowEvent) {
+        self.note(&describe(event));
+        self.echo.event(event);
+    }
+
+    fn update(&mut self, control: &mut LoopControl) {
+        self.echo.update(control);
+    }
+}

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -38,11 +38,22 @@ use std::process::ExitCode;
 mod android;
 mod app;
 mod cli;
+#[cfg(target_os = "ios")]
+mod ios;
 /// The translation and the recorder moved to `renew-replay` — any game
 /// shipping a replay needs them, and a correctness property maintained
 /// in two copies is maintained in one and a half. Re-exported so every
 /// existing path through this crate keeps meaning what it meant.
 pub use renew_replay as convert;
+
+/// The iOS application entry, for the binary beside this library.
+///
+/// An iOS app starts at `main` like any other program, so there is no
+/// exported symbol for the OS to find - what there is instead is a
+/// `main` that hands straight off and never gets control back, because
+/// the loop it enters owns the process from then on.
+#[cfg(target_os = "ios")]
+pub use ios::ios_main;
 mod error;
 mod input;
 pub use renew_replay as record;

--- a/samples/input_echo/src/main.rs
+++ b/samples/input_echo/src/main.rs
@@ -4,6 +4,15 @@
 //! binary's code is invisible to unit tests, and a driver nobody can
 //! test is a driver nobody should trust.
 
+/// On iOS this hands off and never returns: an app bundle is launched
+/// with no arguments and no terminal, so the command line this parses
+/// everywhere else does not exist there, and the doorway takes over.
+#[cfg(target_os = "ios")]
+fn main() -> std::process::ExitCode {
+    renew_sample_input_echo::ios_main()
+}
+
+#[cfg(not(target_os = "ios"))]
 fn main() -> std::process::ExitCode {
     renew_sample_input_echo::exit_code(renew_sample_input_echo::run_cli(std::env::args().skip(1)))
 }

--- a/tools/ci/ios-lifecycle.sh
+++ b/tools/ci/ios-lifecycle.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Drive an iOS app through background and foreground, and read what the
+# engine made of it.
+#
+# **This is the only lane that can observe what an interruption does to
+# a window on iOS.** The platform code revokes the surface on suspend
+# only under `cfg!(target_os = "android")`, on the argument that iOS
+# keeps it. That was reasoned about long before it was watched: the
+# determinism lane cannot watch it, because eleven headless
+# command-line simulations never open a window or enter an event loop,
+# so no suspend event reaches the handler at all.
+#
+# So an app is what settles it, and the counting is the finding in either
+# direction. On Android the same cycle produced three surface-lost events
+# against four ready events, because Android takes the window away. If
+# iOS keeps it, the expected shape here is **one ready and no surface
+# lost**, with the app resuming into the epoch it already had. If instead
+# surface-lost lines appear, the `cfg!` guard is hiding a real difference
+# and the platform layer is wrong about this platform.
+set -euo pipefail
+
+bundle_id="com.renewengine.inputecho"
+binary="input_echo"
+
+device_json="$(xcrun simctl list devices available --json)"
+device="$(printf '%s' "$device_json" | python3 -c "
+import json, sys
+
+try:
+    catalogue = json.load(sys.stdin)['devices']
+except (ValueError, KeyError) as problem:
+    raise SystemExit(f'simctl device list was not the shape expected: {problem}')
+
+def version(runtime):
+    tail = runtime.rsplit('.', 1)[-1]
+    parts = [p for p in tail.split('-') if p.isdigit()]
+    return [int(p) for p in parts] or [0]
+
+best = None
+for runtime, devices in catalogue.items():
+    if 'iOS' not in runtime:
+        continue
+    for device in devices:
+        if not device.get('isAvailable') or 'iPhone' not in device.get('name', ''):
+            continue
+        if best is None or version(runtime) > version(best[0]):
+            best = (runtime, device.get('udid'))
+
+if best is None or not best[1]:
+    raise SystemExit('no available iOS iPhone simulator on this runner')
+print(best[1])
+")"
+
+echo "booting $device"
+xcrun simctl boot "$device" || true
+xcrun simctl bootstatus "$device" -b
+
+app="$(bash tools/ios-app-bundle.sh renew-sample-input-echo "$binary" "$bundle_id" target/ios-app)"
+echo "bundled $app"
+
+xcrun simctl uninstall "$device" "$bundle_id" >/dev/null 2>&1 || true
+xcrun simctl install "$device" "$app"
+
+# Three cycles, so a single lucky reading cannot be mistaken for a rule.
+#
+# **Backgrounding means giving the foreground to something else, and the
+# something else has to be offline.** The first version opened a URL,
+# which hands the foreground to Safari - and on a hosted runner that
+# times out after fifty seconds, because the simulator has no route to
+# the internet. Launching a bundled app instead needs no network and no
+# network is what this lane has. Settings is present in every runtime;
+# Safari is the fallback, launched rather than sent to a URL.
+background() {
+    xcrun simctl launch "$device" com.apple.Preferences >/dev/null 2>&1 ||
+        xcrun simctl launch "$device" com.apple.mobilesafari >/dev/null 2>&1 ||
+        {
+            echo "could not give the foreground to another app, so the sample was never backgrounded and this lane observed nothing about suspend" >&2
+            exit 1
+        }
+    sleep 3
+}
+
+launch() {
+    xcrun simctl launch "$device" "$bundle_id" >/dev/null
+    sleep 3
+}
+
+echo "launching, then backgrounding and resuming three times"
+launch
+
+container="$(xcrun simctl get_app_container "$device" "$bundle_id" data)"
+log="$container/Documents/input_echo.log"
+after_launch=0
+if [ -f "$log" ]; then
+    after_launch="$(wc -l < "$log" | tr -d ' ')"
+fi
+
+for _ in 1 2 3; do
+    background
+    launch
+done
+
+# The app's sandbox is a real directory on this host, so the log is read
+# rather than pulled.
+if [ ! -f "$log" ]; then
+    echo "the app wrote no log at $log, so it either never started or could not \
+write - either way this lane learned nothing and must not report that it did" >&2
+    xcrun simctl spawn "$device" log show --last 2m --predicate "processImagePath contains \
+'$binary'" 2>/dev/null | tail -40 >&2 || true
+    exit 1
+fi
+
+echo "--- the app's own log ---"
+cat "$log"
+echo "--- counted ---"
+ready="$(grep -c '^ready:' "$log" || true)"
+lost="$(grep -c '^surface lost:' "$log" || true)"
+echo "ready events: $ready"
+echo "surface-lost events: $lost"
+
+# **A count of zero readys means the app never opened a window**, which
+# is a lane that measured nothing rather than a platform that behaved.
+if [ "$ready" -lt 1 ]; then
+    echo "the app never reported a window, so nothing was observed about suspend" >&2
+    exit 1
+fi
+
+# **Zero surface-lost lines is only evidence if a suspend actually
+# happened**, and this is the check that decides which it was.
+#
+# The two readings are indistinguishable from that count alone: "iOS
+# kept the surface across a suspend" and "the app was never suspended"
+# both produce zero. So the app says when it was suspended and when it
+# came back - the platform layer tells it, separately from the surface,
+# for exactly this reason - and the lane requires both to have happened
+# before it reports anything about surfaces.
+suspends="$(grep -c '^suspended:' "$log" || true)"
+resumes="$(grep -c '^resumed:' "$log" || true)"
+echo "suspends: $suspends"
+echo "resumes: $resumes"
+now="$(wc -l < "$log" | tr -d ' ')"
+echo "log lines after first launch: $after_launch, after three cycles: $now"
+
+# **The log is appended to and never reset, so counts alone could come
+# from a previous run.** The uninstall above should have taken the old
+# container with it, and its failure is deliberately tolerated - but a
+# tolerated failure is exactly the one nobody notices. Two checks close
+# it: the app announced itself exactly once, so this is one process's
+# log and not two; and the log grew after the first launch, so the
+# lines being counted were written by the cycle this run drove.
+starts="$(grep -c 'input_echo: ios start' "$log" || true)"
+if [ "$starts" -ne 1 ]; then
+    echo "the log carries $starts launch announcements, so it is not one run's record - \
+a container survived from an earlier run and these counts describe something else" >&2
+    exit 1
+fi
+if [ "$now" -le "$after_launch" ]; then
+    echo "the log did not grow across three background-and-resume rounds (it had \
+$after_launch lines and has $now), so nothing was counted that this cycle produced" >&2
+    exit 1
+fi
+
+if [ "$suspends" -lt 1 ] || [ "$resumes" -lt 1 ]; then
+    echo "the app was not suspended and resumed (suspends=$suspends, resumes=$resumes), \
+so this run cannot show what a suspend does to the surface. That is a fault in how this \
+lane backgrounds an app, not a finding about the platform - and reporting it as one is \
+the failure this check exists to prevent." >&2
+    exit 1
+fi
+
+if [ "$lost" -eq 0 ]; then
+    echo "OBSERVED: the app was suspended $suspends time(s) and resumed $resumes time(s), \
+and no surface was lost - which is what the platform layer assumes when it revokes the \
+window on Android alone"
+else
+    echo "OBSERVED: iOS revoked the surface $lost time(s). The platform layer assumes it \
+does not, and that assumption is what this lane exists to check - the guard around the \
+revocation needs to cover this platform too" >&2
+    exit 1
+fi

--- a/tools/ios-app-bundle.sh
+++ b/tools/ios-app-bundle.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Assemble an iOS application bundle around a sample's binary.
+#
+# **An iOS app is a directory.** `Foo.app/` holding an executable and an
+# `Info.plist` naming it is what `xcrun simctl install` accepts, and a
+# Rust `[[bin]]` built for `aarch64-apple-ios-sim` is that executable:
+# winit's iOS backend enters `UIApplicationMain` from the event loop, so
+# the binary *is* the app.
+#
+# That is why this repository commits no Xcode project. A
+# `project.pbxproj` is a large, order-sensitive file that no tool here
+# can generate or open, and its first validation would be CI. A device
+# build would be different - installing on hardware needs signing and
+# provisioning, which is where a real project earns its keep - but a
+# simulator build needs none of it.
+#
+# Usage: ios-app-bundle.sh <package> <binary-name> <bundle-id> <out-dir>
+set -euo pipefail
+
+package="$1"
+binary="$2"
+bundle_id="$3"
+out_dir="$4"
+
+target="aarch64-apple-ios-sim"
+cargo build --package "$package" --bin "$binary" --target "$target"
+
+built="target/$target/debug/$binary"
+if [ ! -f "$built" ]; then
+    echo "ios-app-bundle: cargo produced no $built" >&2
+    exit 1
+fi
+
+app="$out_dir/$binary.app"
+rm -rf "$app"
+mkdir -p "$app"
+cp "$built" "$app/$binary"
+
+# The smallest plist the simulator accepts, and every key in it is load
+# bearing: without `CFBundleExecutable` there is nothing to launch,
+# without `CFBundleIdentifier` there is nothing to launch it *by*, and
+# without the platform keys the installer rejects the bundle as built
+# for something else. `UILaunchScreen` is there because a bundle without
+# one is treated as a compatibility app and letterboxed; whether that
+# would change what this sample reports has not been measured here, and
+# the key is cheap enough not to find out the hard way.
+cat > "$app/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>$binary</string>
+    <key>CFBundleIdentifier</key>
+    <string>$bundle_id</string>
+    <key>CFBundleName</key>
+    <string>$binary</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.1</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>iPhoneSimulator</string>
+    </array>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+</dict>
+</plist>
+PLIST
+
+echo "$app"


### PR DESCRIPTION
feat(sample): input_echo becomes a launchable iOS application

The sample gets an iOS doorway beside its Android one, and a lane that
launches it on a simulator, backgrounds it, and reads what the engine
made of that.

This is the only way to observe one thing the platform layer currently
assumes. It revokes the window on suspend for Android alone, on the
argument that iOS resigns active with its surface intact. That has been
reasoned about and never watched: the determinism lane runs headless
command-line simulations, which never open a window, so no suspend
event can reach the handler there at all. An app is what settles it,
and the counting is the finding either way - on Android the same cycle
gave three surface-lost events against four readys, because Android
takes the window away.

No Xcode project, and that is a decision rather than an omission. An
iOS application is a directory: an executable and an Info.plist naming
it, which simctl installs and launches. A Rust binary built for the
simulator is that executable, because the event loop enters
UIApplicationMain on its own. A project.pbxproj is a large,
order-sensitive file that nothing here can generate or open, and its
first validation would be CI. A device build would be different -
installing on hardware needs signing and provisioning, which is where a
real project earns its keep.

The lane refuses to report success it did not measure: no log, or a log
with no window in it, fails the step rather than reading as a platform
that behaved.
