### PR TITLE
fix(cli): a simulator leg says it is a simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1262,13 +1262,13 @@ jobs:
   # signature attached, and a lane that could redden `main` before that
   # signature would be asserting the answer rather than gathering it.
   #
-  # **A simulator is not a device, and the row this lane eventually
-  # proposes has to say so.** Both `aarch64-apple-ios` and
-  # `aarch64-apple-ios-sim` map to the same platform words, so a leg
-  # cannot tell the two apart - the mapping is a table keyed by triple,
-  # which is what a `--target` run labels a leg from. That is a naming
-  # decision owed before the row exists, not before the lane does: the
-  # lane's job today is to find out whether the numbers agree at all.
+  # **A simulator is not a device, and this leg says so in its own
+  # name.** `aarch64-apple-ios-sim` is labelled `ios-simulator`, which
+  # no binary reports about itself - the departure is deliberate,
+  # because the device triple reports `ios` too and one shared name
+  # would let a determinism row promise phones on a simulator's
+  # evidence. What this lane can still not do is speak for a phone, and
+  # the name is what keeps that visible.
   determinism-ios:
     name: Determinism (ios simulator, advisory)
     runs-on: macos-latest
@@ -1328,7 +1328,7 @@ jobs:
                   else:
                       diverge.append((name, ios[name], other[name]))
 
-              print(f'{ios_name} (simulator) against {other_name}')
+              print(f'{ios_name} against {other_name}')
               for name, mine, theirs in diverge:
                   print(f'  DIVERGE {name}: {mine} here, {theirs} there')
               for name in missing:

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -692,6 +692,22 @@ pub fn digests_from_output(
 /// report itself, or the comparison would refuse a leg for spelling
 /// rather than for disagreeing.
 ///
+/// **One row deliberately breaks that rule, and it is the more
+/// important rule that makes it.** A binary built for
+/// `aarch64-apple-ios-sim` reports `ios` from `env::consts`, exactly as
+/// one built for a phone does — so following the spelling would give
+/// the two triples one identity, and a determinism row reading
+/// `ios/aarch64` would promise that phones agree when only simulators
+/// had ever been measured. The simulator is therefore named
+/// `ios-simulator`, which no binary reports, because **the words exist
+/// to say what was proved and a row that overclaims is worse than a row
+/// that is oddly spelled.**
+///
+/// This costs nothing elsewhere: `env::consts` is read only when no
+/// `--target` is given, which happens only on the three desktop rows,
+/// where the spellings still match exactly and a test pins that they
+/// do.
+///
 /// **A table, not a parser, and the difference is the whole point.**
 /// Neither column can be read off a triple by position. `android` lives
 /// in the *environment* field of `x86_64-linux-android`, whose os field
@@ -731,7 +747,7 @@ pub const KNOWN_TARGETS: [(&str, &str, &str); 7] = [
     ("aarch64-linux-android", "android", "aarch64"),
     ("x86_64-linux-android", "android", "x86_64"),
     ("aarch64-apple-ios", "ios", "aarch64"),
-    ("aarch64-apple-ios-sim", "ios", "aarch64"),
+    ("aarch64-apple-ios-sim", "ios-simulator", "aarch64"),
 ];
 
 /// Build one pinned run's cargo command line.
@@ -803,7 +819,7 @@ mod tests {
             ("x86_64-linux-android", "android", "x86_64"),
             ("aarch64-linux-android", "android", "aarch64"),
             ("aarch64-apple-ios", "ios", "aarch64"),
-            ("aarch64-apple-ios-sim", "ios", "aarch64"),
+            ("aarch64-apple-ios-sim", "ios-simulator", "aarch64"),
         ] {
             assert_eq!(platform_of_triple(triple), Some((os, arch)), "{triple}");
         }
@@ -845,12 +861,35 @@ mod tests {
                     .find_map(|line| line.strip_prefix(key))
                     .map(|rest| rest.trim_matches('"'))
             };
-            assert_eq!(value("target_os="), Some(os), "target_os for {triple}");
             assert_eq!(
                 value("target_arch="),
                 Some(arch),
                 "target_arch for {triple}"
             );
+
+            // **The one row that deliberately disagrees with rustc, and
+            // it is checked harder than the others rather than
+            // excused.** The simulator triple reports `ios`, exactly as
+            // the device triple does, so following rustc would give the
+            // two one identity and let a determinism row promise phones
+            // on a simulator's evidence. Both halves are asserted: that
+            // rustc still says `ios` (if that ever changed, the reason
+            // for the exception would have changed with it) and that
+            // this table still says something else.
+            if triple == "aarch64-apple-ios-sim" {
+                assert_eq!(
+                    value("target_os="),
+                    Some("ios"),
+                    "the simulator triple no longer reports `ios`, so the reason this row \
+                     departs from rustc needs re-reading"
+                );
+                assert_eq!(
+                    os, "ios-simulator",
+                    "the simulator must not share a name with the device it stands in for"
+                );
+            } else {
+                assert_eq!(value("target_os="), Some(os), "target_os for {triple}");
+            }
         }
 
         // A triple nobody has stated the answer for gets no answer.


### PR DESCRIPTION
fix(cli): a simulator leg says it is a simulator

Both aarch64-apple-ios and aarch64-apple-ios-sim reported the same
platform, because that is what a binary built for either one says about
itself. It left the two with a single identity, and a determinism row
reading ios/aarch64 would have promised that phones agree when only
simulators had ever been measured.

The simulator triple is now labelled ios-simulator, which no binary
reports. That departs from the table's own rule - its words are the
ones env::consts produces - and the departure is the point: the words
exist to say what was proved, and a row that overclaims is worse than
one that is oddly spelled. It costs nothing where the rule was load
bearing, because env::consts is read only when no target is given, and
that happens only on the three desktop rows, where the spellings still
match and a test pins that they do.

That test now checks the exception harder than the rows it exempts: it
asserts both that rustc still reports ios for the simulator triple - if
that ever changed, the reason for departing would have changed with it
- and that this table still says something else.
