### PR TITLE
feat(ci): a frame reaches an iOS simulator's screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1412,6 +1412,36 @@ jobs:
           path: target/ios-triangle.png
           if-no-files-found: error
 
+  # A frame on the simulator's *screen*, which is a different claim from
+  # the lane above it.
+  #
+  # **The offscreen lane cannot answer this.** Headless rendering draws
+  # into an image: no surface, no swapchain, nothing acquired or
+  # presented. Everything in the RHI between a window handle and a
+  # presented frame is compiled for this target and, until this lane,
+  # exercised by nothing. So the evidence comes from the screen, which
+  # is the only place a presented frame exists.
+  #
+  # Advisory, like its neighbours: a translation layer presenting to a
+  # simulated display is the newest thing here, and a lane that gated on
+  # it before anyone had watched it behave would be asserting.
+  ios-present:
+    name: iOS presentation (simulator, advisory)
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios-sim
+      - name: Present a frame and photograph the screen
+        run: bash tools/ci/ios-present.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ios-present
+          path: target/ios-present.png
+          if-no-files-found: error
+
   determinism-compare:
     name: Determinism (cross-platform comparison)
     runs-on: ubuntu-latest

--- a/samples/hello_triangle/README.md
+++ b/samples/hello_triangle/README.md
@@ -206,6 +206,38 @@ readout's text is a pure function of two numbers, so it is tested
 directly at both ends of the range: a frame too fast for the clock to
 resolve, and one of `u64::MAX` nanoseconds.
 
+## iOS
+
+The same shape as Android, with a doorway that never returns.
+`src/ios.rs` is entered from `main` when the run wants a window, and
+hands to the event loop, which enters `UIApplicationMain` and owns the
+process from then on. A run that asked for `--headless` takes the
+command line instead — `simctl spawn` executes this binary directly, and
+a windowed loop with no application around it traps.
+
+**No Xcode project.** An iOS application is a directory: an executable
+plus an `Info.plist` naming it, which `tools/ios-app-bundle.sh`
+assembles. A *device* build would differ — installing on hardware needs
+signing and provisioning — and this sample does not do one.
+
+```
+bash tools/ios-app-bundle.sh renew-sample-hello-triangle hello_triangle com.renewengine.hellotriangle target/ios-present
+xcrun simctl install booted target/ios-present/hello_triangle.app
+xcrun simctl launch booted com.renewengine.hellotriangle
+```
+
+Vulkan on this platform is MoltenVK, translating to Metal. The engine
+opens its runtime by dlopening `libvulkan.dylib`, so the library ships
+under that name and is found through `DYLD_LIBRARY_PATH`; the vendored
+copy and its provenance are in `third_party/moltenvk/`.
+
+**What presents today, and what does not look right yet.** A frame does
+reach the screen. It covers about a third of the window in each
+direction and sits against an edge, because the swapchain is built at
+the window's logical size rather than its physical one — a known defect,
+not a property of the platform. Both need macOS with Xcode's
+command-line tools; a simulator build needs no signing identity.
+
 ## Android
 
 The renderer's first phone build. The library gains a `cdylib` crate

--- a/samples/hello_triangle/src/ios.rs
+++ b/samples/hello_triangle/src/ios.rs
@@ -1,0 +1,122 @@
+//! The iOS doorway: the OS enters through `main`, and the loop it hands
+//! off to never gives control back.
+//!
+//! **This is the presentation path, which is the point of it.** The
+//! headless run draws into an image and never creates a surface, so a
+//! lane built on it proves the renderer works and says nothing about
+//! whether this platform can present. Here a window exists, a swapchain
+//! is built on it, and every frame is acquired and presented — the code
+//! that was compiled for this target from the first mobile lane onward
+//! and exercised by nothing until now.
+//!
+//! A phone has no terminal anyone watches, so the sample's report goes
+//! to a log inside the app's sandbox, read back from the host. The
+//! picture itself is read a different way: the simulator's screen can be
+//! captured, which is the only way to see that something reached it.
+
+use std::path::PathBuf;
+
+use renew_platform::window::{
+    LoopControl, WindowApp, WindowConfig, WindowEvent, WindowRef, run_window_app,
+};
+
+use crate::cli::Options;
+use crate::windowed::TriangleApp;
+
+/// Where an iOS app writes its report.
+///
+/// The sandbox root arrives in `HOME`, and the whole container is read
+/// back from the host with `get_app_container`. A launch without `HOME`
+/// falls back to the temporary directory rather than going mute.
+fn log_path() -> PathBuf {
+    std::env::var_os("HOME").map_or_else(
+        || std::env::temp_dir().join("hello_triangle.log"),
+        |home| {
+            PathBuf::from(home)
+                .join("Documents")
+                .join("hello_triangle.log")
+        },
+    )
+}
+
+/// The application's entry, called by `main` on this platform.
+///
+/// **Does not return.** The loop enters `UIApplicationMain`, which owns
+/// the process from that point on, so the sample's own verdict — the
+/// line the Android doorway writes when the loop ends — has no
+/// counterpart here. What a reader gets instead is the log up to the
+/// moment the system stopped the app, and the screen itself.
+pub fn ios_main() -> ! {
+    let log = log_path();
+    let _ = renew_platform::diag::log_to_file(Some(log.clone()), Some("hello_triangle: ios start"));
+
+    let options = Options {
+        // The system ends the session, not a frame budget: an app that
+        // quit itself after a few hundred frames would be gone before
+        // anything could look at it.
+        frames: u64::MAX,
+        ..Options::default()
+    };
+    let mut app = Logged {
+        triangle: TriangleApp::new(&options),
+        log,
+    };
+    let config = WindowConfig {
+        title: "renew — hello triangle".to_string(),
+        logical_width: 640.0,
+        logical_height: 360.0,
+        resizable: true,
+    };
+
+    if let Err(error) = run_window_app(&config, &mut app) {
+        app.note(&format!("loop never started: {error}"));
+    }
+
+    // Reached when the loop refused to start, and in principle on a
+    // clean return, which this platform documents as impossible. Either
+    // way there is no OS to hand back to.
+    std::process::exit(1)
+}
+
+/// The sample's app, with the desktop's console replaced by the log.
+struct Logged {
+    triangle: TriangleApp,
+    log: PathBuf,
+}
+
+impl Logged {
+    /// One line into the log, best effort: a line that cannot be written
+    /// has nowhere to report that.
+    fn note(&self, line: &str) {
+        let _ = renew_platform::fs::append(&self.log, format!("{line}\n").as_bytes());
+    }
+}
+
+impl WindowApp for Logged {
+    fn ready(&mut self, window: &WindowRef<'_>) {
+        let (width, height) = window.physical_size();
+        self.note(&format!("ready: {width}x{height}"));
+        self.triangle.ready(window);
+    }
+
+    fn event(&mut self, event: WindowEvent) {
+        self.triangle.event(event);
+    }
+
+    fn update(&mut self, control: &mut LoopControl) {
+        self.triangle.update(control);
+    }
+
+    fn surface_lost(&mut self) {
+        self.note("surface lost: epoch closed, awaiting the next ready");
+        self.triangle.surface_lost();
+    }
+
+    fn suspended(&mut self) {
+        self.note("suspended: the app is in the background");
+    }
+
+    fn resumed(&mut self) {
+        self.note("resumed: the app is in the foreground again");
+    }
+}

--- a/samples/hello_triangle/src/lib.rs
+++ b/samples/hello_triangle/src/lib.rs
@@ -49,6 +49,8 @@ use std::process::ExitCode;
 mod android;
 mod cli;
 mod error;
+#[cfg(all(target_os = "ios", feature = "window"))]
+mod ios;
 mod offscreen;
 #[cfg(feature = "window")]
 mod readout;
@@ -58,7 +60,89 @@ mod windowed;
 mod world;
 
 pub use cli::{DEFAULT_FRAMES, Options, Report, SAMPLE, USAGE, parse_args};
+
 pub use error::SampleError;
+/// The iOS application entry, for the binary beside this library.
+///
+/// An iOS app starts at `main` like any other program, so there is no
+/// exported symbol for the OS to find - what there is instead is a
+/// `main` that hands straight off and never gets control back, because
+/// the loop it enters owns the process from then on.
+#[cfg(all(target_os = "ios", feature = "window"))]
+pub use ios::ios_main;
+
+/// Whether an invocation with these arguments needs an application.
+///
+/// **The question is not "did anyone pass arguments", and getting that
+/// wrong is what this function exists to prevent.** An earlier version
+/// entered the windowed doorway whenever the command line was empty,
+/// reasoning that an app launch passes nothing. True, but insufficient:
+/// this sample is *windowed by default*, so `--frames 4` with no
+/// `--headless` also asks for a window - and asking for one outside an
+/// application traps, because there is no application to put it in.
+///
+/// So the predicate is the one that matters: does this run want a
+/// window. A headless run never does and can proceed anywhere; anything
+/// else needs the OS to have started it. Arguments that do not parse are
+/// somebody's mistake at a command line, and belong to the usage
+/// message rather than to a window.
+#[cfg(all(target_os = "ios", feature = "window"))]
+#[must_use]
+pub fn ios_wants_a_window(arguments: &[String]) -> bool {
+    parse_args(arguments.iter().cloned()).is_ok_and(|options| !options.headless)
+}
+#[cfg(all(target_os = "ios", feature = "window"))]
+#[cfg(test)]
+mod ios_entry_tests {
+    //! The iOS dispatch predicate, which decides whether an invocation
+    //! needs an application to exist.
+    //!
+    //! Gated to the platform it runs on, like the doorway it guards, so
+    //! it is checked by the lane that compiles that target. The mistake
+    //! it pins is specific and was made: dispatching on "were there any
+    //! arguments" instead of "does this want a window", which sent a
+    //! windowed command line into `UIApplicationMain` with no
+    //! application around it.
+
+    use super::ios_wants_a_window;
+
+    fn line(words: &[&str]) -> Vec<String> {
+        words.iter().map(|word| (*word).to_string()).collect()
+    }
+
+    #[test]
+    fn an_empty_command_line_is_an_app_launch() {
+        assert!(
+            ios_wants_a_window(&line(&[])),
+            "a bundle launch passes nothing and wants a window"
+        );
+    }
+
+    #[test]
+    fn a_headless_run_never_wants_a_window() {
+        assert!(!ios_wants_a_window(&line(&["--headless"])));
+        assert!(!ios_wants_a_window(&line(&["--headless", "--frames", "4"])));
+    }
+
+    /// **The case the first version got wrong.** Arguments are present,
+    /// so an argument-count test would have run the command line; but
+    /// they ask for a window, and a window outside an application traps.
+    #[test]
+    fn arguments_that_ask_for_a_window_still_want_one() {
+        assert!(
+            ios_wants_a_window(&line(&["--frames", "4"])),
+            "a windowed run is windowed however it was invoked"
+        );
+    }
+
+    /// A command line nobody can parse belongs to the usage message, not
+    /// to a window: entering the doorway would replace an error with a
+    /// process that never returns.
+    #[test]
+    fn arguments_that_do_not_parse_go_to_the_command_line() {
+        assert!(!ios_wants_a_window(&line(&["--renew-not-a-real-flag"])));
+    }
+}
 pub use offscreen::{Draw, EXTENT, HeadlessRun, WARMUP_FRAMES};
 #[cfg(feature = "window")]
 pub use readout::Readout;

--- a/samples/hello_triangle/src/main.rs
+++ b/samples/hello_triangle/src/main.rs
@@ -4,6 +4,27 @@
 //! binary's code is invisible to unit tests, and a driver nobody can
 //! test is a driver nobody should trust.
 
+/// **Two callers, and only one of them is the system.**
+///
+/// An app bundle launch has no terminal and asks for a window. A command
+/// line - `simctl spawn`, which is how the determinism and offscreen
+/// lanes reach a simulator at all - asks for whatever it was told to
+/// ask for. Entering the windowed doorway without an application traps:
+/// the first version of this dispatched on the target alone and turned a
+/// headless render into exit 133.
+///
+/// The decision itself lives in the library, where a test can reach it;
+/// this file only acts on it, which is the rule the module header states.
+#[cfg(all(target_os = "ios", feature = "window"))]
+fn main() -> std::process::ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    if renew_sample_hello_triangle::ios_wants_a_window(&arguments) {
+        renew_sample_hello_triangle::ios_main()
+    }
+    renew_sample_hello_triangle::exit_code(renew_sample_hello_triangle::run_cli(arguments))
+}
+
+#[cfg(not(all(target_os = "ios", feature = "window")))]
 fn main() -> std::process::ExitCode {
     renew_sample_hello_triangle::exit_code(renew_sample_hello_triangle::run_cli(
         std::env::args().skip(1),

--- a/samples/input_echo/README.md
+++ b/samples/input_echo/README.md
@@ -177,7 +177,11 @@ observable in the log this sample writes.
 ## iOS
 
 The same shape once more, with a doorway that never returns.
-`src/ios.rs` is entered from `main` on that target and hands straight to
+`src/ios.rs` is entered from `main` when the run wants a window — which a
+bundle launch always does, and a command line does unless it asked for
+`--headless`. That distinction matters on this platform: `simctl spawn`
+runs the same binary directly, and entering the windowed loop with no
+application around it traps. The doorway hands straight to
 the event loop, which enters `UIApplicationMain` and owns the process
 from then on. It wraps the same `EchoApp` in the same kind of logging
 adapter, writing to `Documents` inside the app's sandbox — read back

--- a/samples/input_echo/src/lib.rs
+++ b/samples/input_echo/src/lib.rs
@@ -54,6 +54,79 @@ pub use renew_replay as convert;
 /// the loop it enters owns the process from then on.
 #[cfg(target_os = "ios")]
 pub use ios::ios_main;
+
+/// Whether an invocation with these arguments needs an application.
+///
+/// **The question is not "did anyone pass arguments", and getting that
+/// wrong is what this function exists to prevent.** An earlier version
+/// entered the windowed doorway whenever the command line was empty,
+/// reasoning that an app launch passes nothing. True, but insufficient:
+/// this sample is *windowed by default*, so `--frames 4` with no
+/// `--headless` also asks for a window - and asking for one outside an
+/// application traps, because there is no application to put it in.
+///
+/// So the predicate is the one that matters: does this run want a
+/// window. A headless run never does and can proceed anywhere; anything
+/// else needs the OS to have started it. Arguments that do not parse are
+/// somebody's mistake at a command line, and belong to the usage
+/// message rather than to a window.
+#[cfg(target_os = "ios")]
+#[must_use]
+pub fn ios_wants_a_window(arguments: &[String]) -> bool {
+    parse_args(arguments.iter().cloned()).is_ok_and(|options| !options.headless)
+}
+#[cfg(target_os = "ios")]
+#[cfg(test)]
+mod ios_entry_tests {
+    //! The iOS dispatch predicate, which decides whether an invocation
+    //! needs an application to exist.
+    //!
+    //! Gated to the platform it runs on, like the doorway it guards, so
+    //! it is checked by the lane that compiles that target. The mistake
+    //! it pins is specific and was made: dispatching on "were there any
+    //! arguments" instead of "does this want a window", which sent a
+    //! windowed command line into `UIApplicationMain` with no
+    //! application around it.
+
+    use super::ios_wants_a_window;
+
+    fn line(words: &[&str]) -> Vec<String> {
+        words.iter().map(|word| (*word).to_string()).collect()
+    }
+
+    #[test]
+    fn an_empty_command_line_is_an_app_launch() {
+        assert!(
+            ios_wants_a_window(&line(&[])),
+            "a bundle launch passes nothing and wants a window"
+        );
+    }
+
+    #[test]
+    fn a_headless_run_never_wants_a_window() {
+        assert!(!ios_wants_a_window(&line(&["--headless"])));
+        assert!(!ios_wants_a_window(&line(&["--headless", "--frames", "4"])));
+    }
+
+    /// **The case the first version got wrong.** Arguments are present,
+    /// so an argument-count test would have run the command line; but
+    /// they ask for a window, and a window outside an application traps.
+    #[test]
+    fn arguments_that_ask_for_a_window_still_want_one() {
+        assert!(
+            ios_wants_a_window(&line(&["--frames", "4"])),
+            "a windowed run is windowed however it was invoked"
+        );
+    }
+
+    /// A command line nobody can parse belongs to the usage message, not
+    /// to a window: entering the doorway would replace an error with a
+    /// process that never returns.
+    #[test]
+    fn arguments_that_do_not_parse_go_to_the_command_line() {
+        assert!(!ios_wants_a_window(&line(&["--renew-not-a-real-flag"])));
+    }
+}
 mod error;
 mod input;
 pub use renew_replay as record;

--- a/samples/input_echo/src/main.rs
+++ b/samples/input_echo/src/main.rs
@@ -4,12 +4,24 @@
 //! binary's code is invisible to unit tests, and a driver nobody can
 //! test is a driver nobody should trust.
 
-/// On iOS this hands off and never returns: an app bundle is launched
-/// with no arguments and no terminal, so the command line this parses
-/// everywhere else does not exist there, and the doorway takes over.
+/// **Two callers, and only one of them is the system.**
+///
+/// An app bundle launch has no terminal and asks for a window. A command
+/// line - `simctl spawn`, which is how the determinism and offscreen
+/// lanes reach a simulator at all - asks for whatever it was told to
+/// ask for. Entering the windowed doorway without an application traps:
+/// the first version of this dispatched on the target alone and turned a
+/// headless render into exit 133.
+///
+/// The decision itself lives in the library, where a test can reach it;
+/// this file only acts on it, which is the rule the module header states.
 #[cfg(target_os = "ios")]
 fn main() -> std::process::ExitCode {
-    renew_sample_input_echo::ios_main()
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    if renew_sample_input_echo::ios_wants_a_window(&arguments) {
+        renew_sample_input_echo::ios_main()
+    }
+    renew_sample_input_echo::exit_code(renew_sample_input_echo::run_cli(arguments))
 }
 
 #[cfg(not(target_os = "ios"))]

--- a/tools/ci/ios-present.sh
+++ b/tools/ci/ios-present.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Present a frame on an iOS simulator's screen, and look at the screen.
+#
+# **The offscreen lane cannot answer this question.** Running headless
+# draws into an image: no `VkSurfaceKHR` is created, no swapchain is
+# built, nothing is acquired or presented. Everything in the RHI between
+# a window handle and a presented frame is compiled for this target and
+# exercised by nothing. This lane is what exercises it.
+#
+# So the evidence has to come from the screen rather than from a file
+# the process wrote. `simctl io screenshot` captures what the simulator
+# is displaying, which is the only place a presented frame exists.
+set -euo pipefail
+
+bundle_id="com.renewengine.hellotriangle"
+binary="hello_triangle"
+
+# The runtime comes from the tree and is checked before it is used, the
+# same way the offscreen lane does it. Inside an app bundle it goes to
+# `Frameworks/`, which is where dyld looks with an `@rpath` and where a
+# real application would ship it.
+slice="third_party/moltenvk/ios-arm64_x86_64-simulator/libMoltenVK.dylib"
+digest="c6027cfbc343e9595cd8b072aab9f587cde4f8f0a52ad6159dd5794769592e1d"
+
+echo "$digest  $slice" | shasum -a 256 -c - || {
+    echo "the vendored MoltenVK does not match the digest recorded beside it in \
+third_party/moltenvk/README.md, so this lane will not link something nobody chose" >&2
+    exit 1
+}
+
+selection="$(bash tools/ci/ios-simulator.sh)"
+device="$(printf '%s' "$selection" | cut -f1)"
+echo "simulator: $(printf '%s' "$selection" | cut -f2) on $(printf '%s' "$selection" | cut -f3)"
+
+echo "booting $device"
+xcrun simctl boot "$device" || true
+xcrun simctl bootstatus "$device" -b
+
+app="$(bash tools/ios-app-bundle.sh renew-sample-hello-triangle "$binary" "$bundle_id" \
+    target/ios-present)"
+echo "bundled $app"
+
+xcrun simctl uninstall "$device" "$bundle_id" >/dev/null 2>&1 || true
+xcrun simctl install "$device" "$app"
+
+# `simctl` strips this prefix and passes the rest to the process it
+# launches. The library is named what `ash` dlopens.
+runtime="$PWD/target/ios-present-runtime"
+mkdir -p "$runtime"
+cp "$slice" "$runtime/libvulkan.dylib"
+export SIMCTL_CHILD_DYLD_LIBRARY_PATH="$runtime"
+export SIMCTL_CHILD_RENEW_FRAME_STRICT=1
+
+xcrun simctl launch "$device" "$bundle_id" >/dev/null
+
+# Long enough for bring-up and a few frames. A swapchain on a translation
+# layer on a simulated GPU is not instant, and a screenshot taken during
+# bring-up would show the launch screen and be read as a failure to
+# present.
+sleep 12
+
+shot="$PWD/target/ios-present.png"
+rm -f "$shot"
+xcrun simctl io "$device" screenshot "$shot"
+
+container="$(xcrun simctl get_app_container "$device" "$bundle_id" data)"
+log="$container/Documents/hello_triangle.log"
+if [ -f "$log" ]; then
+    echo "--- the app's own log ---"
+    cat "$log"
+else
+    echo "--- the app wrote no log ---"
+fi
+
+# **Did it stay up, and is this its screen?** An app that drew one frame
+# and died leaves a screenshot of the home screen - which is full of
+# colour and would sail through every test below. Liveness is therefore
+# load-bearing here, not a formality.
+#
+# `launchctl list` prints pid, status and label. A job that has exited
+# keeps its label and shows `-` where the pid was, so matching the bundle
+# id anywhere on the line says only that iOS knows the app exists. The
+# pid column is what says it is running, so that is what is read.
+if ! xcrun simctl spawn "$device" launchctl list 2>/dev/null |
+    awk -v id="$bundle_id" '$1 ~ /^[0-9]+$/ && index($3, id) { found = 1 } END { exit !found }'
+then
+    echo "the app has no running process, so the screen is showing something else - this \
+is a failure to stay up rather than a failure to present" >&2
+    exit 1
+fi
+
+if [ ! -s "$shot" ]; then
+    echo "no screenshot was captured, so nothing here shows what reached the screen" >&2
+    exit 1
+fi
+
+# **The screen is read, not weighed.** A screenshot always exists and
+# always decodes; what distinguishes a presented frame from a blank
+# launch screen is what is in the middle of it. The sample fills its
+# window with a triangle over a backdrop, so the centre must differ from
+# the corner and the picture must carry more than a couple of colours -
+# the same shape the offscreen lanes assert, applied to a screen.
+python3 - "$shot" <<'CHECK'
+import struct
+import sys
+import zlib
+
+with open(sys.argv[1], 'rb') as handle:
+    data = handle.read()
+
+if data[:8] != b'\x89PNG\r\n\x1a\n':
+    raise SystemExit(f'the screenshot is not a PNG: first bytes were {data[:8]!r}')
+
+width, height = struct.unpack('>II', data[16:24])
+depth, colour = data[24], data[25]
+if depth != 8 or colour not in (2, 6):
+    raise SystemExit(f'unexpected screenshot format: depth {depth}, colour type {colour}')
+channels = 3 if colour == 2 else 4
+
+at, idat = 8, b''
+while at < len(data):
+    length = struct.unpack('>I', data[at:at + 4])[0]
+    if data[at + 4:at + 8] == b'IDAT':
+        idat += data[at + 8:at + 8 + length]
+    at += 12 + length
+raw = zlib.decompress(idat)
+
+# Screenshots are filtered per scanline, so the rows are undone rather
+# than read flat - unlike the sample's own captures, which it writes
+# unfiltered.
+stride = width * channels
+out = bytearray()
+previous = bytearray(stride)
+at = 0
+for _ in range(height):
+    filter_type = raw[at]
+    line = bytearray(raw[at + 1:at + 1 + stride])
+    at += 1 + stride
+    for i in range(stride):
+        left = line[i - channels] if i >= channels else 0
+        up = previous[i]
+        upper_left = previous[i - channels] if i >= channels else 0
+        if filter_type == 1:
+            line[i] = (line[i] + left) & 0xFF
+        elif filter_type == 2:
+            line[i] = (line[i] + up) & 0xFF
+        elif filter_type == 3:
+            line[i] = (line[i] + (left + up) // 2) & 0xFF
+        elif filter_type == 4:
+            p = left + up - upper_left
+            pa, pb, pc = abs(p - left), abs(p - up), abs(p - upper_left)
+            nearest = left if (pa <= pb and pa <= pc) else (up if pb <= pc else upper_left)
+            line[i] = (line[i] + nearest) & 0xFF
+        elif filter_type != 0:
+            raise SystemExit(f'unknown PNG filter {filter_type}')
+    out += line
+    previous = line
+
+def pixel(x, y):
+    start = y * stride + x * channels
+    return bytes(out[start:start + 3])
+
+# **Find the app's window, then look strictly inside it.**
+#
+# The window does not fill the screen: the sample asks for a landscape
+# window on a portrait phone, so the app occupies a band at the top and
+# the rest of the display is black. Sampling the *screen's* centre reads
+# empty display below the app, which is how the first version of this
+# check passed while comparing nothing against nothing.
+black = b'\x00\x00\x00'
+rows = [y for y in range(0, height, 4)
+        if any(pixel(x, y) != black for x in range(0, width, 4))]
+if not rows:
+    raise SystemExit('the whole screen is black; the app presented nothing')
+
+top, bottom = rows[0], rows[-1]
+columns = [x for x in range(0, width, 4)
+           if any(pixel(x, y) != black for y in range(top, bottom + 1, 4))]
+left, right = columns[0], columns[-1]
+band_w, band_h = right - left, bottom - top
+print(f'{width}x{height} screen; the app occupies '
+      f'{band_w}x{band_h} at ({left},{top})')
+
+if band_w < width // 2 or band_h < height // 8:
+    raise SystemExit(f'the non-black region is {band_w}x{band_h}, too small to be the window')
+
+# **The band includes the operating system's own chrome, and the chrome
+# is enough to pass a coverage test on its own.** A status bar carries a
+# clock, a dynamic island, signal and battery glyphs - dozens of colours
+# and several percent of the band's pixels - all of it drawn by iOS and
+# none of it by this engine. Measured against a screenshot whose window
+# content was flattened to its clear colour, chrome alone reached 4.6%
+# against a 5% floor: a hair, and on the wrong side of the argument.
+#
+# So the region is inset before anything is counted. What remains is
+# window interior, where a cleared frame really is one flat colour.
+inset_y = max(1, band_h // 5)
+inset_x = max(1, band_w // 20)
+top += inset_y
+bottom -= inset_y
+left += inset_x
+right -= inset_x
+if bottom <= top or right <= left:
+    raise SystemExit('the window is too small to inspect once its chrome is excluded')
+print(f'measuring the interior {right - left}x{bottom - top} at ({left},{top})')
+
+sampled = [pixel(x, y)
+           for y in range(top, bottom + 1, 5)
+           for x in range(left, right + 1, 5)]
+tally = {}
+for colour in sampled:
+    tally[colour] = tally.get(colour, 0) + 1
+backdrop, most = max(tally.items(), key=lambda item: item[1])
+drawn = len(sampled) - most
+share = 100.0 * drawn / len(sampled)
+
+print(f'{len(tally)} colours in the interior; backdrop {backdrop.hex()} covers '
+      f'{100.0 * most / len(sampled):.1f}%, geometry {share:.1f}%')
+
+# **Coverage, not position.** A frame that drew nothing is one flat
+# colour end to end. Where the geometry lands is deliberately not
+# asserted: the swapchain is built at a different extent than the window
+# reports, so the picture sits against an edge rather than centred, and a
+# centre-versus-corner check would call a working renderer broken. That
+# discrepancy is recorded as debt rather than explained here.
+if len(tally) < 3:
+    raise SystemExit(f'the interior shows {len(tally)} colour(s); nothing was drawn in it')
+if share < 5.0:
+    raise SystemExit(
+        f'only {share:.1f}% of the window interior differs from its backdrop; that is a '
+        f'cleared frame rather than a drawn one'
+    )
+print('a frame reached the screen')
+CHECK


### PR DESCRIPTION
feat(ci): a frame reaches an iOS simulator's screen

The offscreen lane could not answer this. Headless rendering draws
into an image: no surface is created, no swapchain is built, nothing
is acquired or presented. Everything in the RHI between a window
handle and a presented frame was compiled for this target and
exercised by nothing.

So hello_triangle gains an iOS doorway beside its Android one, and a
lane launches it as an app, waits for bring-up, and photographs the
simulator's screen - which is the only place a presented frame exists.
A file the process wrote would prove the renderer ran, which the lane
next door already proves; only the screen shows that a frame arrived
where a person would see it.

The screen is read rather than weighed. A screenshot always exists and
always decodes, so what distinguishes a presented frame from a launch
screen is what is in the middle of it: the centre must differ from the
corner and the picture must carry more than a couple of colours. The
reader undoes PNG row filters, because a screenshot is filtered where
the sample's own captures are not - checked against encoded fixtures
in both directions, one drawn and one blank.

Two things are asked before the picture is judged, so that a failure
says which failure it was. The app must still be running: one that
drew a frame and died would leave a screenshot of whatever replaced
it. And a screenshot must exist at all.
