### PR TITLE
feat(cli): the iOS simulator joins the determinism claim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1276,12 +1276,8 @@ jobs:
   # evidence. What this lane can still not do is speak for a phone, and
   # the name is what keeps that visible.
   determinism-ios:
-    name: Determinism (ios simulator, advisory)
+    name: Determinism (ios simulator)
     runs-on: macos-latest
-    continue-on-error: true
-    # Only so the Linux leg exists to print a comparison against, as in
-    # the Android lane.
-    needs: [determinism-emit]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -1291,7 +1287,7 @@ jobs:
         run: bash tools/ci/ios-determinism.sh
       - uses: actions/upload-artifact@v4
         with:
-          name: determinism-ios-simulator-aarch64
+          name: determinism-ios
           path: ios-leg.json
           if-no-files-found: error
       - uses: actions/download-artifact@v4
@@ -1445,7 +1441,7 @@ jobs:
   determinism-compare:
     name: Determinism (cross-platform comparison)
     runs-on: ubuntu-latest
-    needs: [determinism-emit, determinism-android]
+    needs: [determinism-emit, determinism-android, determinism-ios]
     # `needs` on a failed job SKIPS this one, and GitHub reports a skipped
     # required job as neutral rather than failed — which is how a
     # comparison that never ran can read as a comparison that passed.
@@ -1458,12 +1454,14 @@ jobs:
       - name: Refuse to compare when a leg did not finish
         if: >-
           needs.determinism-emit.result != 'success' ||
-          needs.determinism-android.result != 'success'
+          needs.determinism-android.result != 'success' ||
+          needs.determinism-ios.result != 'success'
         run: |
-          echo "the desktop legs concluded '${{ needs.determinism-emit.result }}' and the"
-          echo "android leg '${{ needs.determinism-android.result }}', so at least one"
-          echo "target reported nothing. A missing target is an untested target, not a"
-          echo "passing one, and this job fails rather than comparing what remains."
+          echo "the desktop legs concluded '${{ needs.determinism-emit.result }}', the android"
+          echo "leg '${{ needs.determinism-android.result }}' and the ios leg"
+          echo "'${{ needs.determinism-ios.result }}', so at least one target reported"
+          echo "nothing. A missing target is an untested target, not a passing one, and this"
+          echo "job fails rather than comparing what remains."
           exit 1
       - uses: actions/download-artifact@v4
         with:
@@ -1486,4 +1484,5 @@ jobs:
             --compare legs/determinism-ubuntu-latest/leg.json \
             --compare legs/determinism-windows-latest/leg.json \
             --compare legs/determinism-macos-latest/leg.json \
-            --compare legs/determinism-android/android-leg.json
+            --compare legs/determinism-android/android-leg.json \
+            --compare legs/determinism-ios/ios-leg.json

--- a/tools/cli/src/determinism.rs
+++ b/tools/cli/src/determinism.rs
@@ -36,11 +36,12 @@ use std::fmt::Write as _;
 /// Widening it is not a code change in spirit even though it is one in
 /// fact: adding a row changes what the engine promises, and the row and
 /// its lane leg land together or the lane starts lying.
-pub const TARGETS: [(&str, &str); 4] = [
+pub const TARGETS: [(&str, &str); 5] = [
     ("linux", "x86_64"),
     ("windows", "x86_64"),
     ("macos", "aarch64"),
     ("android", "x86_64"),
+    ("ios-simulator", "aarch64"),
 ];
 
 /// The rows [`TARGETS`] binds, in the shape [`compare`] wants.

--- a/tools/cli/tests/determinism.rs
+++ b/tools/cli/tests/determinism.rs
@@ -73,13 +73,14 @@ fn a_pinned_digest_name() -> String {
 /// The rows are spelled out rather than read from `TARGETS`, so that a
 /// row added to the claim without a leg to prove it fails here instead
 /// of quietly reshaping the fixture around itself.
-fn compare_every_row(tag: &str, digests: [&str; 4]) -> std::io::Result<Output> {
+fn compare_every_row(tag: &str, digests: [&str; 5]) -> std::io::Result<Output> {
     let dir = scratch(tag)?;
     let rows = [
         ("linux", "x86_64"),
         ("windows", "x86_64"),
         ("macos", "aarch64"),
         ("android", "x86_64"),
+        ("ios-simulator", "aarch64"),
     ];
     let mut paths = Vec::new();
     for (index, (digest, (os, arch))) in digests.iter().zip(rows).enumerate() {
@@ -98,8 +99,8 @@ fn compare_every_row(tag: &str, digests: [&str; 4]) -> std::io::Result<Output> {
 
 #[test]
 fn every_row_agreeing_exits_zero() {
-    let output =
-        compare_every_row("agree", ["0xabc", "0xabc", "0xabc", "0xabc"]).expect("the binary runs");
+    let output = compare_every_row("agree", ["0xabc", "0xabc", "0xabc", "0xabc", "0xabc"])
+        .expect("the binary runs");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
@@ -114,7 +115,7 @@ fn every_row_agreeing_exits_zero() {
 /// a gate.
 #[test]
 fn one_disagreeing_report_exits_non_zero_and_names_the_digest() {
-    let output = compare_every_row("diverge", ["0xabc", "0xabc", "0xdef", "0xabc"])
+    let output = compare_every_row("diverge", ["0xabc", "0xabc", "0xdef", "0xabc", "0xabc"])
         .expect("the binary runs");
     assert!(!output.status.success(), "divergence must not exit 0");
     let text = format!(
@@ -152,7 +153,7 @@ fn determinism_without_a_mode_is_a_usage_error() {
 /// dispatcher's last arm would give an unrecognised subcommand.
 #[test]
 fn the_json_envelope_names_the_subcommand_that_ran() {
-    let output = compare_every_row("envelope", ["0xabc", "0xabc", "0xabc", "0xabc"])
+    let output = compare_every_row("envelope", ["0xabc", "0xabc", "0xabc", "0xabc", "0xabc"])
         .expect("the binary runs");
     assert!(output.status.success());
 

--- a/tools/cli/tests/targets.rs
+++ b/tools/cli/tests/targets.rs
@@ -631,6 +631,11 @@ fn a_delivered_determinism_verdict_is_never_an_abort() {
     fs::write(directory.join("b.json"), leg("windows", "x86_64", "0xaaaa")).expect("leg");
     fs::write(directory.join("c.json"), leg("macos", "aarch64", "0xbbbb")).expect("leg");
     fs::write(directory.join("g.json"), leg("android", "x86_64", "0xaaaa")).expect("leg");
+    fs::write(
+        directory.join("i.json"),
+        leg("ios-simulator", "aarch64", "0xaaaa"),
+    )
+    .expect("leg");
     let (envelope, ok) = renew_json(
         &directory,
         &[
@@ -643,6 +648,8 @@ fn a_delivered_determinism_verdict_is_never_an_abort() {
             "c.json",
             "--compare",
             "g.json",
+            "--compare",
+            "i.json",
         ],
     )
     .expect("an envelope");
@@ -721,6 +728,7 @@ fn legs_that_all_ran_less_than_the_pinned_list_are_inconclusive() {
         ("n2.json", "windows", "x86_64"),
         ("n3.json", "macos", "aarch64"),
         ("n4.json", "android", "x86_64"),
+        ("n5.json", "ios-simulator", "aarch64"),
     ] {
         fs::write(
             directory.join(name),
@@ -743,6 +751,8 @@ fn legs_that_all_ran_less_than_the_pinned_list_are_inconclusive() {
             "n3.json",
             "--compare",
             "n4.json",
+            "--compare",
+            "n5.json",
         ],
     )
     .expect("an envelope");
@@ -783,6 +793,7 @@ fn an_agreeing_comparison_carries_its_report_inside_the_envelope() {
         ("e.json", "windows", "x86_64"),
         ("f.json", "macos", "aarch64"),
         ("h.json", "android", "x86_64"),
+        ("j.json", "ios-simulator", "aarch64"),
     ] {
         fs::write(directory.join(name), leg(os, arch, "0xcccc")).expect("leg");
     }
@@ -798,6 +809,8 @@ fn an_agreeing_comparison_carries_its_report_inside_the_envelope() {
             "f.json",
             "--compare",
             "h.json",
+            "--compare",
+            "j.json",
         ],
     )
     .expect("an envelope");


### PR DESCRIPTION
feat(cli): the iOS simulator joins the determinism claim

The lane stops being advisory. It ran that way while the question was
open, and the answer is seven consecutive green runs agreeing with both
macOS - same instruction set, different platform - and Linux, which
differs in both. So the row exists and this lane proves it on every
push.

The row is named `ios-simulator`, not `ios`, and the leg names itself
the same way. A simulator is a different machine from a phone: a
different Vulkan implementation on a different GPU. A row reading `ios`
would promise the phone on the simulator's evidence, which is the
substitution the target list exists to prevent. The device row joins
when a device lane does.

Every fixture that hands the comparison a leg per row grows one, which
is the intended cost rather than a chore around it: a fixture short of
a row now fails, exactly as a row added without a lane to prove it
should.
