### PR TITLE
feat(ci): the Android app is packaged and cycled on an emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Run tests
         run: cargo run --package renew-cli --bin renew -- test
+      # **The Android lifecycle counting, checked where no device is.**
+      # The emulator lane exercises that script's success path and none
+      # of its refusals, so a guard could rot into decoration and the
+      # lane would stay green while checking nothing — which is exactly
+      # what happened to its first version. These cases replay canned
+      # device output through it, needing no emulator and no Android
+      # toolchain, so they gate here rather than on the advisory lane
+      # they protect. One platform is enough: the script under test is
+      # the same bytes everywhere, and this checks its logic, not the
+      # shell it happens to run in.
+      - name: The lifecycle counting refuses what it should
+        if: matrix.os == 'ubuntu-latest'
+        run: bash tools/tests/android-lifecycle-cases.sh
 
   build:
     name: Build (dev)
@@ -1268,14 +1281,18 @@ jobs:
   # by no CI job at all: gradle wiring, the JNI library path and the
   # manifest were verified only when somebody ran gradle at a desk, so a
   # break in any of them would have reached `main` and waited there for
-  # whoever next tried to install the sample. And the Android lifecycle
+  # whoever next tried to install the sample. It guards them for the
+  # emulator's ABI only, so a break specific to `arm64-v8a` — the one
+  # every real phone runs — still gets past; building both to close
+  # that would double the compile for a packaging check, and the desk
+  # tool builds whatever ABI is plugged in. And the Android lifecycle
   # — that backgrounding revokes the surface and returning grants a new
   # one — was asserted by a desk tool and by no automation.
   #
   # It draws nothing, which is why it can run here at all: surface
   # epochs are a windowing property, and the emulator's Vulkan 1.2
-  # ceiling that keeps the rendering lane off this platform (DEBT-0085)
-  # does not reach them.
+  # ceiling — which is what keeps the rendering lane off this platform,
+  # since the renderer requires 1.3 — does not reach them.
   #
   # Advisory, for the reason the determinism lane was advisory before it
   # earned its signature: this boots a virtual machine on a shared
@@ -1291,8 +1308,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-linux-android
+      # Pinned, and to the version the desk recipe names. This is the
+      # tool that decides how the shared object is linked and aligned,
+      # on the one lane whose subject is packaging — floating it would
+      # let a release change what CI builds while a developer's machine
+      # stayed put, which is the difference this lane exists to catch.
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
+        run: cargo install cargo-ndk --version 4.1.2 --locked
       # The emulator's ABI only. `abiFilters` names both, and gradle
       # packages whichever shared objects it finds — so building the arm
       # one would add minutes and ship a library this run cannot load.
@@ -1308,7 +1330,7 @@ jobs:
       # of proceeding with an empty path.
       - name: Build the sample for the emulator's ABI
         run: |
-          export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:?the runner image provided no NDK}"
+          export ANDROID_NDK_HOME="${ANDROID_NDK_HOME:-${ANDROID_NDK_LATEST_HOME:?the runner image provided no NDK}}"
           cargo ndk -t x86_64 -o samples/input_echo/android/app/src/main/jniLibs             build -p renew-sample-input-echo --release
       - name: Package the APK
         run: samples/input_echo/android/gradlew -p samples/input_echo/android assembleDebug
@@ -1327,6 +1349,14 @@ jobs:
           # One line, because the action runs this input one line per
           # `sh -c`.
           script: bash tools/ci/android-lifecycle.sh
+      # The emulator is destroyed when the action finishes, so the log
+      # the app wrote leaves with it unless it is kept here.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-lifecycle-log
+          path: android-lifecycle.log
+          if-no-files-found: ignore
 
   # The same eleven pinned simulations, executed on an iOS simulator.
   # Advisory for the same reason the Android lane is: whether this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1262,6 +1262,63 @@ jobs:
           path: android-leg.json
           if-no-files-found: error
 
+  # The Android app, installed on an emulator, backgrounded and resumed.
+  #
+  # **This lane guards two things nothing else did.** The APK was built
+  # by no CI job at all: gradle wiring, the JNI library path and the
+  # manifest were verified only when somebody ran gradle at a desk, so a
+  # break in any of them would have reached `main` and waited there for
+  # whoever next tried to install the sample. And the Android lifecycle
+  # — that backgrounding revokes the surface and returning grants a new
+  # one — was asserted by a desk tool and by no automation.
+  #
+  # It draws nothing, which is why it can run here at all: surface
+  # epochs are a windowing property, and the emulator's Vulkan 1.2
+  # ceiling that keeps the rendering lane off this platform (DEBT-0085)
+  # does not reach them.
+  #
+  # Advisory, for the reason the determinism lane was advisory before it
+  # earned its signature: this boots a virtual machine on a shared
+  # runner, which is the flakiest thing available to it, and a lane that
+  # could redden `main` on a boot timeout before anyone has watched it
+  # behave would be asserting rather than finding out.
+  android-lifecycle:
+    name: Android app lifecycle (emulator, advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-linux-android
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+      # The emulator's ABI only. `abiFilters` names both, and gradle
+      # packages whichever shared objects it finds — so building the arm
+      # one would add minutes and ship a library this run cannot load.
+      - name: Build the sample for the emulator's ABI
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_LATEST_HOME }}
+        run: |
+          cargo ndk -t x86_64 -o samples/input_echo/android/app/src/main/jniLibs             build -p renew-sample-input-echo --release
+      - name: Package the APK
+        run: samples/input_echo/android/gradlew -p samples/input_echo/android assembleDebug
+      - name: Allow the runner to use KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"'             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Background and resume the app, and read its log
+        uses: reactivecircus/android-emulator-runner@v2.34.0
+        with:
+          api-level: 34
+          arch: x86_64
+          target: default
+          emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim -gpu swiftshader_indirect
+          # One line, because the action runs this input one line per
+          # `sh -c`.
+          script: bash tools/ci/android-lifecycle.sh
+
   # The same eleven pinned simulations, executed on an iOS simulator.
   # Advisory for the same reason the Android lane is: whether this
   # platform belongs in the determinism claim is a decision with a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1296,10 +1296,19 @@ jobs:
       # The emulator's ABI only. `abiFilters` names both, and gradle
       # packages whichever shared objects it finds — so building the arm
       # one would add minutes and ship a library this run cannot load.
+      # **The NDK path is read in the shell, not in an expression.**
+      # `${{ env.X }}` sees only variables the workflow itself declared;
+      # the runner image's own variables are not in that context, so an
+      # `env:` block written that way sets the variable to the empty
+      # string. That is worse than omitting it: cargo-ndk falls back to
+      # `ANDROID_NDK_ROOT` when nothing is set, and an empty
+      # `ANDROID_NDK_HOME` overrides the fallback with nothing. The
+      # first run of this lane died exactly there. Read in the shell it
+      # resolves, and `:?` makes a runner without an NDK say so instead
+      # of proceeding with an empty path.
       - name: Build the sample for the emulator's ABI
-        env:
-          ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_LATEST_HOME }}
         run: |
+          export ANDROID_NDK_HOME="${ANDROID_NDK_LATEST_HOME:?the runner image provided no NDK}"
           cargo ndk -t x86_64 -o samples/input_echo/android/app/src/main/jniLibs             build -p renew-sample-input-echo --release
       - name: Package the APK
         run: samples/input_echo/android/gradlew -p samples/input_echo/android assembleDebug

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 .DS_Store
 
 # Cargo.lock is committed: this workspace builds binaries.
+
+# The log the Android lifecycle run pulls off the device. It is kept as
+# a file so CI can upload it after the emulator is destroyed, and it is
+# a record of one run rather than anything the tree should carry.
+/android-lifecycle.log

--- a/tools/android-device-evidence.sh
+++ b/tools/android-device-evidence.sh
@@ -8,8 +8,9 @@
 # is, which is a developer's desk and never CI. A recipe that has to be
 # retyped from a document is a recipe that gets typed differently each
 # time, and evidence that differs between runs is not evidence. So the
-# cycle, the counting and the verdict live here, and the person with the
-# phone runs one command.
+# whole thing is one command: this script finds the machine and builds
+# the APK, and hands both to `android-lifecycle-core.sh`, which is the
+# same cycling and counting the CI emulator lane runs.
 #
 # It works against an emulator too, and that is deliberate: a tool whose
 # first execution is on the hardware it was written for is a tool nobody
@@ -17,8 +18,6 @@
 # device run and an emulator run say which they were.
 set -euo pipefail
 
-cycles="${CYCLES:-3}"
-package="com.renewengine.inputecho"
 sample="renew-sample-input-echo"
 
 command -v adb >/dev/null || {
@@ -55,6 +54,16 @@ if [ -z "$ANDROID_NDK_HOME" ]; then
     exit 1
 fi
 
+# Gradle needs the SDK as much as cargo needs the NDK, and it reports
+# its absence as a build failure two minutes into the run rather than as
+# a missing variable at the start. Checking both here keeps the two
+# preconditions in one place, where the message can name them.
+export ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+if [ -z "$ANDROID_HOME" ]; then
+    echo "ANDROID_HOME is unset; gradle cannot find the SDK" >&2
+    exit 1
+fi
+
 jni="samples/input_echo/android/app/src/main/jniLibs"
 cargo ndk -t "$abi" -o "$jni" build -p "$sample" --release
 
@@ -65,72 +74,7 @@ apk="samples/input_echo/android/app/build/outputs/apk/debug/app-debug.apk"
     exit 1
 }
 
-# A fresh install every time: the app appends to its log, so a container
-# left from an earlier run would have this run counting somebody else's
-# lines.
-adb -s "$serial" uninstall "$package" >/dev/null 2>&1 || true
-adb -s "$serial" install -r "$apk" >/dev/null
-echo "installed $(basename "$apk")"
-
-launch() {
-    adb -s "$serial" shell monkey -p "$package" -c android.intent.category.LAUNCHER 1 \
-        >/dev/null 2>&1
-    sleep 4
-}
-
-echo "launching, then backgrounding and resuming $cycles time(s)"
-launch
-pid="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
-[ -n "$pid" ] || {
-    echo "the app did not start, so there is nothing to observe" >&2
-    exit 1
-}
-
-for _ in $(seq "$cycles"); do
-    adb -s "$serial" shell input keyevent KEYCODE_HOME
-    sleep 3
-    launch
-done
-
-after="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
-
-log="$(adb -s "$serial" shell run-as "$package" cat files/input_echo.log 2>/dev/null || true)"
-if [ -z "$log" ]; then
-    echo "the app wrote no readable log. On a device this usually means the build is not"
-    echo "debuggable, since \`run-as\` only works for a debuggable package." >&2
-    exit 1
-fi
-
-echo "--- the app's own log ---"
-printf '%s\n' "$log"
-echo "--- counted ---"
-ready="$(printf '%s\n' "$log" | grep -c '^ready:' || true)"
-lost="$(printf '%s\n' "$log" | grep -c '^surface lost:' || true)"
-starts="$(printf '%s\n' "$log" | grep -c 'android start' || true)"
-echo "ready: $ready   surface-lost: $lost   launch announcements: $starts"
-echo "process: $pid at first launch, $after at the end"
-
-# **What the counts have to show before this is evidence of anything.**
-# Android revokes the window when it backgrounds an activity, so a real
-# cycle leaves one surface-lost per background and one ready per
-# foreground. Zero of either means the cycle did not happen - a phone
-# that never backgrounded the app, or an app that never came back - and
-# reporting that as a passing lifecycle would be reporting the absence of
-# a test as the result of one.
-if [ "$starts" -ne 1 ]; then
-    echo "the log carries $starts launch announcements, so it is not one run's record" >&2
-    exit 1
-fi
-if [ "$ready" -lt $((cycles + 1)) ] || [ "$lost" -lt "$cycles" ]; then
-    echo "expected at least $((cycles + 1)) ready and $cycles surface-lost for $cycles \
-cycle(s); the app was not backgrounded and resumed as this run assumed" >&2
-    exit 1
-fi
-if [ "$pid" != "$after" ]; then
-    echo "NOTE: the process id changed ($pid -> $after), so the OS restarted the app rather"
-    echo "than backgrounding it. The epochs above are still real, but they span processes."
-fi
-
-echo
-echo "OBSERVED on this $kind: $ready surface epochs opened and $lost closed across"
-echo "$cycles background/resume cycle(s), in $([ "$pid" = "$after" ] && echo "one process" || echo "more than one process")."
+# The cycling, the counting and the verdict are the same on a phone as
+# on an emulator, so they live in one file that both callers use rather
+# than in two that drift.
+exec bash "$(dirname "$0")/android-lifecycle-core.sh" "$serial" "$apk"

--- a/tools/android-device-evidence.sh
+++ b/tools/android-device-evidence.sh
@@ -55,12 +55,18 @@ if [ -z "$ANDROID_NDK_HOME" ]; then
 fi
 
 # Gradle needs the SDK as much as cargo needs the NDK, and it reports
-# its absence as a build failure two minutes into the run rather than as
-# a missing variable at the start. Checking both here keeps the two
-# preconditions in one place, where the message can name them.
+# its absence as a build failure two minutes in rather than as a missing
+# variable at the start.
+#
+# **Not a hard requirement on the variable, though.** Android Studio
+# writes the path into `local.properties`, which this project ignores as
+# machine-local configuration precisely so that setup works — and a
+# check that demanded the variable would reject the standard install
+# while gradle sat there able to find the SDK perfectly well. So this
+# refuses only when neither route exists.
 export ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
-if [ -z "$ANDROID_HOME" ]; then
-    echo "ANDROID_HOME is unset; gradle cannot find the SDK" >&2
+if [ -z "$ANDROID_HOME" ] && [ ! -f samples/input_echo/android/local.properties ]; then
+    echo "no SDK: ANDROID_HOME is unset and there is no local.properties for gradle to read it from" >&2
     exit 1
 fi
 
@@ -77,4 +83,4 @@ apk="samples/input_echo/android/app/build/outputs/apk/debug/app-debug.apk"
 # The cycling, the counting and the verdict are the same on a phone as
 # on an emulator, so they live in one file that both callers use rather
 # than in two that drift.
-exec bash "$(dirname "$0")/android-lifecycle-core.sh" "$serial" "$apk"
+exec bash "$(dirname "$0")/android-lifecycle-core.sh" "$serial" "$apk" "$kind"

--- a/tools/android-lifecycle-core.sh
+++ b/tools/android-lifecycle-core.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Background and resume an installed Android sample, then read what the
+# engine made of that.
+#
+# Usage: android-lifecycle-core.sh <serial> <apk>   (CYCLES=3 by default)
+#
+# **Why this is its own file.** Two callers need exactly this: the desk
+# tool that runs against a phone, and the CI lane that runs against an
+# emulator. They differ in how they get a machine and how they get an
+# APK, and in nothing else — so the cycling, the counting and the
+# verdict live here once. Two copies of a check are two checks that drift
+# apart, and the one that drifts quiet is the one still being trusted.
+set -euo pipefail
+
+serial="${1:?usage: android-lifecycle-core.sh <serial> <apk>}"
+apk="${2:?usage: android-lifecycle-core.sh <serial> <apk>}"
+cycles="${CYCLES:-3}"
+package="com.renewengine.inputecho"
+
+[ -s "$apk" ] || {
+    echo "no APK at $apk" >&2
+    exit 1
+}
+
+# A fresh install every time: the app appends to its log, so a container
+# left from an earlier run would have this run counting somebody else's
+# lines.
+adb -s "$serial" uninstall "$package" >/dev/null 2>&1 || true
+adb -s "$serial" install -r "$apk" >/dev/null
+echo "installed $(basename "$apk")"
+
+launch() {
+    adb -s "$serial" shell monkey -p "$package" -c android.intent.category.LAUNCHER 1 \
+        >/dev/null 2>&1
+    sleep 4
+}
+
+echo "launching, then backgrounding and resuming $cycles time(s)"
+launch
+pid="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
+[ -n "$pid" ] || {
+    echo "the app did not start, so there is nothing to observe" >&2
+    exit 1
+}
+
+for _ in $(seq "$cycles"); do
+    adb -s "$serial" shell input keyevent KEYCODE_HOME
+    sleep 3
+    launch
+done
+
+after="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
+
+log="$(adb -s "$serial" shell run-as "$package" cat files/input_echo.log 2>/dev/null || true)"
+if [ -z "$log" ]; then
+    echo "the app wrote no readable log. This usually means the build is not debuggable," >&2
+    echo "since \`run-as\` only works for a debuggable package." >&2
+    exit 1
+fi
+
+echo "--- the app's own log ---"
+printf '%s\n' "$log"
+echo "--- counted ---"
+ready="$(printf '%s\n' "$log" | grep -c '^ready:' || true)"
+lost="$(printf '%s\n' "$log" | grep -c '^surface lost:' || true)"
+starts="$(printf '%s\n' "$log" | grep -c 'android start' || true)"
+echo "ready: $ready   surface-lost: $lost   launch announcements: $starts"
+echo "process: $pid at first launch, $after at the end"
+
+# **What the counts have to show before this is evidence of anything.**
+# Android revokes the window when it backgrounds an activity, so a real
+# cycle leaves one surface-lost per background and one ready per
+# foreground. Zero of either means the cycle did not happen — a machine
+# that never backgrounded the app, or an app that never came back — and
+# reporting that as a passing lifecycle would be reporting the absence of
+# a test as the result of one.
+if [ "$starts" -ne 1 ]; then
+    echo "the log carries $starts launch announcements, so it is not one run's record" >&2
+    exit 1
+fi
+if [ "$ready" -lt $((cycles + 1)) ] || [ "$lost" -lt "$cycles" ]; then
+    echo "expected at least $((cycles + 1)) ready and $cycles surface-lost for $cycles \
+cycle(s); the app was not backgrounded and resumed as this run assumed" >&2
+    exit 1
+fi
+if [ "$pid" != "$after" ]; then
+    echo "NOTE: the process id changed ($pid -> $after), so the OS restarted the app rather"
+    echo "than backgrounding it. The epochs above are still real, but they span processes."
+fi
+
+echo
+echo "$ready surface epochs opened and $lost closed across $cycles background/resume"
+echo "cycle(s), in $([ "$pid" = "$after" ] && echo "one process" || echo "more than one process")."

--- a/tools/android-lifecycle-core.sh
+++ b/tools/android-lifecycle-core.sh
@@ -2,18 +2,22 @@
 # Background and resume an installed Android sample, then read what the
 # engine made of that.
 #
-# Usage: android-lifecycle-core.sh <serial> <apk>   (CYCLES=3 by default)
+# Usage: android-lifecycle-core.sh <serial> <apk> <kind>  (CYCLES=3)
+#   kind: "device" or "emulator" — it appears in the verdict, because a
+#   count means different things depending on what produced it.
 #
 # **Why this is its own file.** Two callers need exactly this: the desk
 # tool that runs against a phone, and the CI lane that runs against an
 # emulator. They differ in how they get a machine and how they get an
 # APK, and in nothing else — so the cycling, the counting and the
-# verdict live here once. Two copies of a check are two checks that drift
-# apart, and the one that drifts quiet is the one still being trusted.
+# verdict live here once. Two copies of a check are two checks that
+# drift apart, and the one that drifts quiet is the one still being
+# trusted.
 set -euo pipefail
 
-serial="${1:?usage: android-lifecycle-core.sh <serial> <apk>}"
-apk="${2:?usage: android-lifecycle-core.sh <serial> <apk>}"
+serial="${1:?usage: android-lifecycle-core.sh <serial> <apk> <kind>}"
+apk="${2:?usage: android-lifecycle-core.sh <serial> <apk> <kind>}"
+kind="${3:?usage: android-lifecycle-core.sh <serial> <apk> <kind>}"
 cycles="${CYCLES:-3}"
 package="com.renewengine.inputecho"
 
@@ -35,9 +39,19 @@ launch() {
     sleep 4
 }
 
+# **`|| true` on every process read, deliberately.** `pidof` exits 1 when
+# it finds nothing, and under `pipefail` that status propagates through
+# the pipe and out of the assignment, where `set -e` kills the script
+# with no message at all. The two "the app is gone" messages below exist
+# to be read; without this they were unreachable code, and the script's
+# way of reporting a dead app was to exit silently.
+process_id() {
+    adb -s "$serial" shell pidof "$package" 2>/dev/null | tr -d '\r' || true
+}
+
 echo "launching, then backgrounding and resuming $cycles time(s)"
 launch
-pid="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
+pid="$(process_id)"
 [ -n "$pid" ] || {
     echo "the app did not start, so there is nothing to observe" >&2
     exit 1
@@ -49,7 +63,7 @@ for _ in $(seq "$cycles"); do
     launch
 done
 
-after="$(adb -s "$serial" shell pidof "$package" | tr -d '\r')"
+after="$(process_id)"
 
 log="$(adb -s "$serial" shell run-as "$package" cat files/input_echo.log 2>/dev/null || true)"
 if [ -z "$log" ]; then
@@ -58,29 +72,67 @@ if [ -z "$log" ]; then
     exit 1
 fi
 
+# Kept where a later reader can open it: this device is about to be
+# destroyed, and an observation nobody can re-read is thin evidence.
+printf '%s\n' "$log" > android-lifecycle.log
+
 echo "--- the app's own log ---"
 printf '%s\n' "$log"
 echo "--- counted ---"
-ready="$(printf '%s\n' "$log" | grep -c '^ready:' || true)"
-lost="$(printf '%s\n' "$log" | grep -c '^surface lost:' || true)"
-starts="$(printf '%s\n' "$log" | grep -c 'android start' || true)"
-echo "ready: $ready   surface-lost: $lost   launch announcements: $starts"
-echo "process: $pid at first launch, $after at the end"
 
-# **What the counts have to show before this is evidence of anything.**
-# Android revokes the window when it backgrounds an activity, so a real
-# cycle leaves one surface-lost per background and one ready per
-# foreground. Zero of either means the cycle did not happen — a machine
-# that never backgrounded the app, or an app that never came back — and
-# reporting that as a passing lifecycle would be reporting the absence of
-# a test as the result of one.
+# **Defaulted to zero, because an empty count silently disables the
+# guard below it.** `grep -c` prints nothing and exits 2 on a read
+# error, `|| true` swallows the status, and `[ "" -lt 3 ]` then errors
+# with status 2 — which bash treats as a false condition, so the `if`
+# does not fire and the script walks on to its success message.
+count() {
+    local n
+    n="$(printf '%s\n' "$log" | grep -c "$1" || true)"
+    printf '%s' "${n:-0}"
+}
+ready="$(count '^ready:')"
+lost="$(count '^surface lost:')"
+suspends="$(count '^suspended:')"
+resumes="$(count '^resumed:')"
+starts="$(count 'android start')"
+echo "ready: $ready   surface-lost: $lost   suspended: $suspends   resumed: $resumes"
+echo "launch announcements: $starts"
+echo "process: $pid at first launch, ${after:-<gone>} at the end"
+
+# **The counts have to show the cycle, not merely add up.** Surface
+# epochs alone cannot: `input keyevent KEYCODE_HOME` exits 0 whether or
+# not anything went to the background, so a run where nothing was ever
+# backgrounded — a dialog swallowing the keyevent, a window that never
+# took focus — can still accumulate epochs from an unrelated churn and
+# satisfy a count. The claim being made here is causal (backgrounding
+# revokes the surface, returning grants a new one), so the suspend and
+# the resume are what have to be counted, and the surfaces are read
+# against them. The app logs them separately for exactly this reason,
+# and the iOS lane has required both since it was written.
 if [ "$starts" -ne 1 ]; then
     echo "the log carries $starts launch announcements, so it is not one run's record" >&2
     exit 1
 fi
-if [ "$ready" -lt $((cycles + 1)) ] || [ "$lost" -lt "$cycles" ]; then
-    echo "expected at least $((cycles + 1)) ready and $cycles surface-lost for $cycles \
-cycle(s); the app was not backgrounded and resumed as this run assumed" >&2
+if [ "$suspends" -ne "$cycles" ] || [ "$resumes" -ne "$cycles" ]; then
+    echo "expected $cycles suspends and $cycles resumes; the app was not backgrounded and \
+resumed as this run assumed, so the surface counts below describe something else" >&2
+    exit 1
+fi
+# **Exact, not a floor.** A missing epoch is a lifecycle the engine
+# failed to observe; a surplus one is an app thrashing its surface
+# across a transition. Both are findings, and `>=` reports the second as
+# success. Every run recorded here — emulator and CI alike — has
+# produced exactly one closed epoch per background and one opened per
+# foreground, so the model is not a guess.
+if [ "$ready" -ne $((cycles + 1)) ] || [ "$lost" -ne "$cycles" ]; then
+    echo "expected exactly $((cycles + 1)) ready and $cycles surface-lost for $cycles \
+cycle(s); the app was backgrounded $suspends time(s), so the surface count is the \
+surprise here, not the lifecycle" >&2
+    exit 1
+fi
+if [ -z "$after" ]; then
+    echo "the app is not running at the end of the run, so it did not survive the last \
+cycle" >&2
     exit 1
 fi
 if [ "$pid" != "$after" ]; then
@@ -89,5 +141,5 @@ if [ "$pid" != "$after" ]; then
 fi
 
 echo
-echo "$ready surface epochs opened and $lost closed across $cycles background/resume"
-echo "cycle(s), in $([ "$pid" = "$after" ] && echo "one process" || echo "more than one process")."
+echo "OBSERVED on this $kind: $ready surface epochs opened and $lost closed across"
+echo "$cycles background/resume cycle(s), in $([ "$pid" = "$after" ] && echo "one process" || echo "more than one process")."

--- a/tools/ci/android-lifecycle.sh
+++ b/tools/ci/android-lifecycle.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# The Android emulator lifecycle lane's body.
+#
+# **A file, not lines in the workflow.** The emulator action runs its
+# `script:` input one line per `sh -c`: variables do not survive between
+# lines, `set -eu` applies to nothing after itself, and any multi-line
+# construct is a syntax error at the first line break. The determinism
+# lane lost two CI runs learning that; this one inherits the lesson
+# rather than repeating it.
+set -euo pipefail
+
+# **Asserted, not printed.** The APK this lane installs carries an
+# x86_64 shared object and nothing else, so an emulator of another
+# architecture would install it and then fail to load the library — a
+# failure that reads as a broken app rather than a mismatched machine.
+# Saying which it is here costs one line and saves the next reader an
+# afternoon.
+device_arch="$(adb shell uname -m | tr -d '\r')"
+echo "emulator reports: $device_arch"
+if [ "$device_arch" != "x86_64" ]; then
+    echo "the emulator is '$device_arch'; this lane built an x86_64 library" >&2
+    exit 1
+fi
+
+serial="$(adb devices | awk '$2 == "device" { print $1; exit }')"
+[ -n "$serial" ] || {
+    echo "the emulator action reported ready, but no authorised device is attached" >&2
+    exit 1
+}
+
+# **Two cycles, not the desk tool's three.** Each is seven seconds of
+# sleeping, and the property under test — that backgrounding revokes the
+# surface and returning grants a new one — is not more true at three
+# than at two. What a third would buy is a longer lane on a runner that
+# has already booted a virtual machine to get here.
+CYCLES=2 exec bash tools/android-lifecycle-core.sh "$serial" \
+    samples/input_echo/android/app/build/outputs/apk/debug/app-debug.apk

--- a/tools/ci/android-lifecycle.sh
+++ b/tools/ci/android-lifecycle.sh
@@ -9,24 +9,26 @@
 # rather than repeating it.
 set -euo pipefail
 
-# **Asserted, not printed.** The APK this lane installs carries an
-# x86_64 shared object and nothing else, so an emulator of another
-# architecture would install it and then fail to load the library — a
-# failure that reads as a broken app rather than a mismatched machine.
-# Saying which it is here costs one line and saves the next reader an
-# afternoon.
-device_arch="$(adb shell uname -m | tr -d '\r')"
-echo "emulator reports: $device_arch"
-if [ "$device_arch" != "x86_64" ]; then
-    echo "the emulator is '$device_arch'; this lane built an x86_64 library" >&2
-    exit 1
-fi
-
 serial="$(adb devices | awk '$2 == "device" { print $1; exit }')"
 [ -n "$serial" ] || {
     echo "the emulator action reported ready, but no authorised device is attached" >&2
     exit 1
 }
+
+# **The ABI, read with `getprop`, not the kernel arch from `uname`.** The
+# APK this lane installs carries an x86_64 shared object and nothing
+# else, and what decides whether that library loads is the ABI: a 64-bit
+# kernel running a 32-bit system image reports `x86_64` from `uname -m`
+# while its ABI is `x86`, so the weaker probe passes and the app then
+# fails to start for a reason nothing here explains. The desk tool has
+# always asked the right question; asking a different one in CI is how
+# the two drift.
+device_abi="$(adb -s "$serial" shell getprop ro.product.cpu.abi | tr -d '\r')"
+echo "emulator reports ABI: $device_abi"
+if [ "$device_abi" != "x86_64" ]; then
+    echo "the emulator's ABI is '$device_abi'; this lane built an x86_64 library" >&2
+    exit 1
+fi
 
 # **Two cycles, not the desk tool's three.** Each is seven seconds of
 # sleeping, and the property under test — that backgrounding revokes the
@@ -34,4 +36,4 @@ serial="$(adb devices | awk '$2 == "device" { print $1; exit }')"
 # than at two. What a third would buy is a longer lane on a runner that
 # has already booted a virtual machine to get here.
 CYCLES=2 exec bash tools/android-lifecycle-core.sh "$serial" \
-    samples/input_echo/android/app/build/outputs/apk/debug/app-debug.apk
+    samples/input_echo/android/app/build/outputs/apk/debug/app-debug.apk emulator

--- a/tools/tests/android-lifecycle-cases.sh
+++ b/tools/tests/android-lifecycle-cases.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Drive `android-lifecycle-core.sh` through the runs a real emulator will
+# not produce on demand, and check that it reports each one correctly.
+#
+# **Why this exists.** The core's job is to refuse — the whole value of
+# the lifecycle lane is that a run which did not happen is reported as a
+# failure rather than a pass. That property is invisible on a green
+# emulator: every honest run exercises the success path and none of the
+# refusals, so the guards can rot into decoration and the lane stays
+# green while checking nothing.
+#
+# It is not hypothetical. The first version of the core counted surface
+# epochs and nothing else, and the `no background` case below — a log
+# with three surfaces, two closures and not one suspend — passed it,
+# printing "2 background/resume cycle(s)" about a run that was never
+# backgrounded at all. `adb shell input keyevent KEYCODE_HOME` exits 0
+# whether or not anything went to the background, so nothing upstream
+# would have caught it either.
+#
+# No device, no emulator, no toolchain: a stand-in `adb` replays canned
+# output, so this runs anywhere in about a minute.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin"
+echo "apk" > "$work/fake.apk"
+
+cat > "$work/bin/adb" <<'FAKE'
+#!/usr/bin/env bash
+# Answers the four things the core asks a device, from the scenario in
+# the environment. Everything else succeeds silently, as adb does.
+case "$*" in
+    *pidof*)
+        seen=0
+        [ -f "$FAKE_STATE" ] && seen="$(cat "$FAKE_STATE")"
+        echo $((seen + 1)) > "$FAKE_STATE"
+        # The first read is the launch, later ones are the end of the
+        # run - which is where a crashed app has to be distinguishable.
+        if [ "$seen" -eq 0 ]; then
+            printf '%s\r\n' "$FAKE_PID_START"
+        elif [ -n "$FAKE_PID_END" ]; then
+            printf '%s\r\n' "$FAKE_PID_END"
+        fi
+        exit 0
+        ;;
+    *run-as*) cat "$FAKE_LOG"; exit 0 ;;
+    *) exit 0 ;;
+esac
+FAKE
+chmod +x "$work/bin/adb"
+export PATH="$work/bin:$PATH"
+
+# Two clean cycles: one launch, and a suspend/close/resume/open quartet
+# per background. This is what the emulator lane actually prints.
+cat > "$work/honest.log" <<'LOG'
+INFO diagnostics: input_echo: android start
+ready: 320x640 at scale 1
+focus false
+suspended: the app is in the background
+surface lost: epoch closed, awaiting the next ready
+resumed: the app is in the foreground again
+ready: 320x640 at scale 1
+focus false
+suspended: the app is in the background
+surface lost: epoch closed, awaiting the next ready
+resumed: the app is in the foreground again
+ready: 320x640 at scale 1
+LOG
+
+# The surfaces churned, but the app was never backgrounded: the keyevent
+# went to a dialog, or to a window that never took focus. The epoch
+# counts are identical to the honest run, which is the point.
+grep -v '^suspended:\|^resumed:' "$work/honest.log" > "$work/no-background.log"
+
+# The app was backgrounded twice and produced a third epoch anyway -
+# a surface thrashed across a transition. A floor would call this a pass.
+cp "$work/honest.log" "$work/surplus.log"
+cat >> "$work/surplus.log" <<'LOG'
+surface lost: epoch closed, awaiting the next ready
+ready: 320x640 at scale 1
+LOG
+
+# Two launch announcements: a container left over from an earlier run,
+# so the log is two runs' lines with one run's story read out of them.
+cat "$work/honest.log" "$work/honest.log" > "$work/two-runs.log"
+
+: > "$work/empty.log"
+
+failures=0
+check() {
+    local name="$1" want="$2" log="$3" pid_end="$4" expect="$5"
+    rm -f "$work/state"
+    local out rc
+    set +e
+    out="$(FAKE_STATE="$work/state" FAKE_LOG="$log" FAKE_PID_START=4242 \
+        FAKE_PID_END="$pid_end" CYCLES=2 \
+        bash "$root/tools/android-lifecycle-core.sh" fake-serial "$work/fake.apk" emulator 2>&1)"
+    rc=$?
+    set -e
+
+    if { [ "$want" = "pass" ] && [ "$rc" -ne 0 ]; } ||
+        { [ "$want" = "fail" ] && [ "$rc" -eq 0 ]; }; then
+        echo "FAIL  $name: wanted it to $want, it exited $rc"
+        printf '%s\n' "$out" | sed 's/^/        /'
+        failures=$((failures + 1))
+        return
+    fi
+    # A refusal for the wrong reason is not the check working; it is a
+    # second bug wearing the first one's exit code.
+    if ! printf '%s' "$out" | grep -q "$expect"; then
+        echo "FAIL  $name: exited $rc as wanted, but did not say why"
+        echo "        expected to find: $expect"
+        printf '%s\n' "$out" | sed 's/^/        /'
+        failures=$((failures + 1))
+        return
+    fi
+    echo "ok    $name"
+}
+
+check "a clean two-cycle run is reported"     pass "$work/honest.log"       4242 "OBSERVED on this emulator: 3 surface epochs"
+check "surfaces without a background refuse"  fail "$work/no-background.log" 4242 "expected 2 suspends and 2 resumes"
+check "a surplus epoch refuses"               fail "$work/surplus.log"      4242 "expected exactly 3 ready"
+check "two runs in one log refuse"            fail "$work/two-runs.log"     4242 "launch announcements, so it is not one run"
+check "an app gone at the end refuses"        fail "$work/honest.log"       ""   "did not survive the last cycle"
+check "an unreadable log refuses"             fail "$work/empty.log"        4242 "wrote no readable log"
+
+if [ "$failures" -ne 0 ]; then
+    echo
+    echo "$failures case(s) wrong: the lifecycle lane cannot be trusted to refuse" >&2
+    exit 1
+fi
+echo
+echo "all six cases behaved: the core reports a real run and refuses five ways of not being one"


### PR DESCRIPTION
feat(ci): the Android app is packaged and cycled on an emulator

Two things were guarded by nothing. The APK was built by no CI job at
all - gradle wiring, the JNI library path and the manifest were checked
only when somebody ran gradle at a desk, so a break in any of them would
have reached the default branch and waited there for whoever next tried
to install the sample. And the Android lifecycle, the property that
backgrounding revokes the surface and returning grants a new one, was
asserted by a desk tool and by no automation, on the one platform where
the OS takes the window away rather than leaving it alone.

The lane draws nothing, which is why it can exist: surface epochs are a
windowing property, and the emulator's Vulkan ceiling that keeps the
rendering lane off this platform does not reach them.

The cycling and the counting now live in one file that both callers run,
rather than in a desk copy and a CI copy. Two copies of a check are two
checks that drift apart, and the one that drifts quiet is the one still
being trusted. Verified against a local emulator after the move: three
surface epochs opened and two closed across two cycles, in one process -
the same counts the code produced before it was split.

Advisory to begin with, for the reason the determinism lane was advisory
before it earned its signature: this boots a virtual machine on a shared
runner, and a lane that could redden the default branch on a boot
timeout before anyone has watched it behave would be asserting rather
than finding out.
