### PR TITLE
feat(rhi): narrow vertex attribute formats

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -126,7 +126,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1288, 1289, 1290]
+lines = [1320, 1321, 1322]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/crates/render2d/src/gpu.rs
+++ b/crates/render2d/src/gpu.rs
@@ -307,9 +307,10 @@ mod tests {
     /// exhaustiveness tripwire is kept and every arm is exercised.
     fn packed_width(attribute: VertexAttribute) -> usize {
         match attribute {
-            VertexAttribute::Vec2 => 8,
+            VertexAttribute::Vec2 | VertexAttribute::Uint32x2 => 8,
             VertexAttribute::Vec3 => 12,
             VertexAttribute::Vec4 => 16,
+            VertexAttribute::Uint32 | VertexAttribute::Unorm8x4 => 4,
         }
     }
 
@@ -318,6 +319,9 @@ mod tests {
         assert_eq!(packed_width(VertexAttribute::Vec2), 8);
         assert_eq!(packed_width(VertexAttribute::Vec3), 12);
         assert_eq!(packed_width(VertexAttribute::Vec4), 16);
+        assert_eq!(packed_width(VertexAttribute::Uint32), 4);
+        assert_eq!(packed_width(VertexAttribute::Uint32x2), 8);
+        assert_eq!(packed_width(VertexAttribute::Unorm8x4), 4);
     }
 
     #[test]

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -1416,9 +1416,10 @@ mod tests {
     /// not use unexecuted.
     fn attribute_width(attribute: VertexAttribute) -> u32 {
         match attribute {
-            VertexAttribute::Vec2 => 8,
+            VertexAttribute::Vec2 | VertexAttribute::Uint32x2 => 8,
             VertexAttribute::Vec3 => 12,
             VertexAttribute::Vec4 => 16,
+            VertexAttribute::Uint32 | VertexAttribute::Unorm8x4 => 4,
         }
     }
 
@@ -1427,5 +1428,8 @@ mod tests {
         assert_eq!(attribute_width(VertexAttribute::Vec2), 8);
         assert_eq!(attribute_width(VertexAttribute::Vec3), 12);
         assert_eq!(attribute_width(VertexAttribute::Vec4), 16);
+        assert_eq!(attribute_width(VertexAttribute::Uint32), 4);
+        assert_eq!(attribute_width(VertexAttribute::Uint32x2), 8);
+        assert_eq!(attribute_width(VertexAttribute::Unorm8x4), 4);
     }
 }

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -155,14 +155,43 @@ pub enum VertexAttribute {
     Vec3,
     /// Four 32-bit floats.
     Vec4,
+    /// One 32-bit unsigned integer, delivered to the shader as a `uint`.
+    ///
+    /// **A correctness fix rather than a saving, and the distinction is
+    /// worth stating because the workaround looks fine.** Without an
+    /// integer format the only way to carry an integer field per vertex
+    /// is to store it in a float attribute and recover it with
+    /// `floatBitsToUint`. For a small integer that bit pattern has a zero
+    /// exponent field — it is a denormal — and both the Vulkan spec and
+    /// real drivers permit flushing denormals to zero in vertex input
+    /// conversion. A software rasteriser very likely passes it and a
+    /// discrete part very likely does not, which is precisely the class
+    /// of defect a golden on one software lane cannot see.
+    ///
+    /// The other workaround, storing the integer as an exactly
+    /// representable float *value* below 2^24 and reading it with
+    /// `uint(attr)`, is sound but caps a packed record at 24 exact bits —
+    /// so four 8-bit fields do not fit, and any such packing has to be
+    /// 4x6 bits or split across components.
+    Uint32,
+    /// Two 32-bit unsigned integers, as a `uvec2`.
+    Uint32x2,
+    /// Four bytes, each normalised to `0.0..=1.0` and delivered as a
+    /// `vec4`.
+    ///
+    /// The compact way to carry a colour, a normal or four small
+    /// fractions per vertex: sixteen bytes of `Vec4` for four values that
+    /// never needed more than eight bits each.
+    Unorm8x4,
 }
 
 impl VertexAttribute {
     pub(crate) fn byte_len(self) -> u32 {
         match self {
-            Self::Vec2 => 8,
+            Self::Vec2 | Self::Uint32x2 => 8,
             Self::Vec3 => 12,
             Self::Vec4 => 16,
+            Self::Uint32 | Self::Unorm8x4 => 4,
         }
     }
 
@@ -171,6 +200,9 @@ impl VertexAttribute {
             Self::Vec2 => vk::Format::R32G32_SFLOAT,
             Self::Vec3 => vk::Format::R32G32B32_SFLOAT,
             Self::Vec4 => vk::Format::R32G32B32A32_SFLOAT,
+            Self::Uint32 => vk::Format::R32_UINT,
+            Self::Uint32x2 => vk::Format::R32G32_UINT,
+            Self::Unorm8x4 => vk::Format::R8G8B8A8_UNORM,
         }
     }
 }
@@ -1669,21 +1701,70 @@ mod tests {
         assert_eq!(desc.address, AddressMode::ClampToEdge);
     }
 
-    /// Every attribute's size and Vulkan spelling, all three arms. Here
-    /// rather than in the device suite for the reason the filter test
-    /// above states: that suite skips wherever the validation layer is
-    /// absent, which is most machines.
+    /// Every attribute's size and Vulkan spelling, every arm. Here rather
+    /// than in the device suite for the reason the filter test above
+    /// states: that suite skips wherever the validation layer is absent,
+    /// which is most machines.
+    ///
+    /// **Exhaustive by construction.** The expectation is a `match`, so a
+    /// seventh format is a compile error in this test before it can be a
+    /// wrong stride in a vertex buffer — which is a silent failure that
+    /// reads the wrong bytes and draws a plausible wrong picture.
     #[test]
     fn every_vertex_attribute_maps_to_its_vulkan_spelling() {
-        assert_eq!(VertexAttribute::Vec2.byte_len(), 8);
-        assert_eq!(VertexAttribute::Vec3.byte_len(), 12);
-        assert_eq!(VertexAttribute::Vec4.byte_len(), 16);
-        assert_eq!(VertexAttribute::Vec2.format(), vk::Format::R32G32_SFLOAT);
-        assert_eq!(VertexAttribute::Vec3.format(), vk::Format::R32G32B32_SFLOAT);
-        assert_eq!(
-            VertexAttribute::Vec4.format(),
-            vk::Format::R32G32B32A32_SFLOAT
-        );
+        const EVERY: [VertexAttribute; 6] = [
+            VertexAttribute::Vec2,
+            VertexAttribute::Vec3,
+            VertexAttribute::Vec4,
+            VertexAttribute::Uint32,
+            VertexAttribute::Uint32x2,
+            VertexAttribute::Unorm8x4,
+        ];
+        fn expected(attribute: VertexAttribute) -> (u32, vk::Format) {
+            match attribute {
+                VertexAttribute::Vec2 => (8, vk::Format::R32G32_SFLOAT),
+                VertexAttribute::Vec3 => (12, vk::Format::R32G32B32_SFLOAT),
+                VertexAttribute::Vec4 => (16, vk::Format::R32G32B32A32_SFLOAT),
+                VertexAttribute::Uint32 => (4, vk::Format::R32_UINT),
+                VertexAttribute::Uint32x2 => (8, vk::Format::R32G32_UINT),
+                VertexAttribute::Unorm8x4 => (4, vk::Format::R8G8B8A8_UNORM),
+            }
+        }
+        for attribute in EVERY {
+            let (bytes, format) = expected(attribute);
+            assert_eq!(attribute.byte_len(), bytes, "{attribute:?} byte length");
+            assert_eq!(attribute.format(), format, "{attribute:?} Vulkan format");
+        }
+    }
+
+    /// **No two attributes share a Vulkan format**, which the table above
+    /// cannot catch on its own: it restates the implementation, so a
+    /// copy-paste that gave `Uint32x2` the single-component spelling
+    /// would be wrong in both places and agree with itself.
+    ///
+    /// Injectivity is the property that does not restate anything. Two
+    /// formats colliding means one attribute reads the other's component
+    /// count, which is a stride the pipeline accepts and a buffer the
+    /// shader misreads.
+    #[test]
+    fn no_two_vertex_attributes_share_a_vulkan_format() {
+        const EVERY: [VertexAttribute; 6] = [
+            VertexAttribute::Vec2,
+            VertexAttribute::Vec3,
+            VertexAttribute::Vec4,
+            VertexAttribute::Uint32,
+            VertexAttribute::Uint32x2,
+            VertexAttribute::Unorm8x4,
+        ];
+        for (index, one) in EVERY.iter().enumerate() {
+            for other in EVERY.iter().skip(index + 1) {
+                assert_ne!(
+                    one.format(),
+                    other.format(),
+                    "{one:?} and {other:?} claim the same Vulkan format"
+                );
+            }
+        }
     }
 
     /// **The two streams share one location space, and this is where

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -10,7 +10,7 @@ use renew_rhi::{
     AddressMode, Attachment, Binding, BindingDesc, BindingSource, BufferUsage, ClearValue, Color,
     DepthState, Device, DeviceDesc, DeviceError, Extent, Filter, FrameData, Item, ItemList, LoadOp,
     MeshDesc, Pass, PipelineDesc, PipelineError, RenderDesc, Sampler, SamplerDesc, Shaders,
-    StoreOp, TargetFormat, Texture, Validation, builtin,
+    StoreOp, TargetFormat, Texture, Validation, VertexAttribute, builtin,
 };
 
 /// The one color attachment these frames render into: cleared, stored.
@@ -157,6 +157,66 @@ fn bring_up_reports_an_adapter_and_stays_clean() {
 // the lane exists to prove the rendering path, so an adapter that
 // refuses both formats must redden it rather than silently narrowing
 // what the lane proves. Elsewhere, no-format is a reportable fact.
+/// **A real driver accepts the narrow attribute formats.** The unit test
+/// beside the enum pins the Vulkan spelling and that the mapping is
+/// injective; neither can tell you whether an adapter will build a
+/// pipeline out of them. This can, and it is the cheapest form of that
+/// question: a pipeline is created and nothing is drawn, so no shader has
+/// to declare the locations — supplying an attribute the shader ignores
+/// is legal, and what is under test is the format and the stride
+/// arithmetic rather than the values arriving.
+///
+/// **What this deliberately does not prove** is the reason the formats
+/// exist. `Uint32` is here because packing an integer into an SFLOAT
+/// attribute and recovering it with `floatBitsToUint` yields a denormal
+/// for small integers, which a driver may flush to zero — and only a
+/// shader that reads the value can show that. That proof arrives with the
+/// first consumer; a format with nothing reading it cannot be proven
+/// correct by construction, and saying so is better than a test that
+/// looks like it did.
+///
+/// **The first probe written for this came back green and is worth
+/// recording.** Giving `Unorm8x4` a sixteen-byte length changes nothing
+/// here: offsets are the running sum of the same lengths, so an inflated
+/// one makes the stride bigger and leaves everything consistent —
+/// validation has no view of what the buffer actually holds at pipeline
+/// creation. What this test can see is whether a format is a legal vertex
+/// format at all, so that is what it claims and that is what it is probed
+/// with.
+///
+/// Probed by spelling `Uint32` as `D32_SFLOAT`: validation reports that a
+/// depth format has no defined size for alignment and does not carry
+/// `VERTEX_BUFFER_BIT`.
+#[test]
+fn a_driver_builds_a_pipeline_from_the_narrow_attribute_formats() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    // The mesh layout the builtin vertex stage declares, followed by the
+    // three narrow formats it does not — extra attributes are supplied
+    // and ignored, which is what makes this need no new shader.
+    let layout = [
+        VertexAttribute::Vec3,
+        VertexAttribute::Vec4,
+        VertexAttribute::Vec2,
+        VertexAttribute::Uint32,
+        VertexAttribute::Uint32x2,
+        VertexAttribute::Unorm8x4,
+    ];
+    let pipeline = device.create_pipeline(&PipelineDesc::mesh(
+        builtin::MESH,
+        TargetFormat::Rgba8Srgb,
+        &layout,
+    ));
+    assert!(
+        pipeline.is_ok(),
+        "an adapter refused a pipeline declaring the narrow formats: {:?}",
+        pipeline.err()
+    );
+    drop(pipeline);
+    assert_no_validation_errors(&device);
+}
+
 #[test]
 fn the_adapter_reports_its_depth_format() {
     let Some(device) = required_device().expect("device bring-up") else {


### PR DESCRIPTION
`VertexAttribute` offered `Vec2`, `Vec3` and `Vec4` of `f32` and nothing else, so an integer field per vertex had to be stored in a float attribute and recovered with `floatBitsToUint`. For a small integer that bit pattern has a zero exponent field — it is a denormal — and both the spec and real drivers permit flushing denormals to zero during vertex input conversion. A software rasteriser very likely passes it and a discrete part very likely does not, which is exactly the class of defect a golden on one software lane cannot see. **This is a correctness fix, not a saving.**

Adds `Uint32` (`R32_UINT`), `Uint32x2` (`R32G32_UINT`) and `Unorm8x4` (`R8G8B8A8_UNORM`).

The enum's own doc says growing it should be a compile error at every in-tree match rather than a silent wildcard arm — and it was. Both `render2d` and `render3d` failed to build until their width helpers listed the new arms.

### Three tests, at three distances from the hardware

1. **The spelling table, exhaustive by construction.** The expectation is a `match`, so a seventh format is a compile error in the test before it can be a wrong stride in a buffer.
2. **No two attributes share a Vulkan format.** The table above restates the implementation; injectivity restates nothing, and it is what catches a copy-paste giving `Uint32x2` the single-component spelling — wrong in two places and agreeing with itself.
3. **A real driver builds a pipeline declaring all three.** No new shader needed: supplying an attribute the shader ignores is legal, and what is under test is the format and the stride arithmetic.

### The probe that came back green

Worth recording. Inflating `Unorm8x4` to sixteen bytes changes nothing in test 3 — offsets are the running sum of the same lengths, so the stride grows and everything stays consistent; validation has no view of what a buffer holds at pipeline creation. The test was claimed down to what it can actually see — whether a format is a legal vertex format — and probed with that instead: spelling `Uint32` as `D32_SFLOAT` makes validation report both that a depth format has no defined size for alignment and that it lacks `VERTEX_BUFFER_BIT`.

**What this deliberately does not prove** is the denormal argument itself, which needs a shader that reads the value. That arrives with the first consumer. A format with nothing reading it cannot be proven correct by construction, and saying so beats a test that looks like it did.

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` all green on a real adapter with validation active, exit codes read directly.