### PR TITLE
feat(volume): sweep a box against a lattice finer than the cells

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -242,7 +242,7 @@ reason = "`pick_larger`, which exists only to compute MAX_DATAGRAM_BYTES in a co
 
 [[exempt]]
 file = "crates/net/src/lobby.rs"
-lines = [889]
+lines = [893]
 reason = "The addressless guard inside `seat_of`, unreachable through the only path that reaches it: `deliver` refuses UNKNOWN_ENDPOINT by name before any seat is looked up, and that refusal is covered. Kept because the two statements are one claim — seat zero's own slot holds exactly these bytes, so a caller that reached here with them would be told the host already holds the seat — and a private helper that depends on its caller having checked something is exactly the arrangement that breaks when a second caller appears."
 
 [[exempt]]

--- a/crates/fixed/src/scalar.rs
+++ b/crates/fixed/src/scalar.rs
@@ -104,6 +104,20 @@ impl Fixed {
         self.0 / ONE_RAW
     }
 
+    /// The whole part, rounded toward negative infinity.
+    ///
+    /// **The one a lattice index wants, and [`Self::trunc_int`] is not
+    /// it.** Truncation rounds toward zero, so it maps both `-0.5` and
+    /// `+0.5` to `0` and every lattice built on it has two cells fused
+    /// into one at the origin and a seam running through the middle of
+    /// the world. Every consumer that has needed this has hand-rolled a
+    /// shift, which works only for the current fractional width and
+    /// silently stops being a floor if that width ever changes.
+    #[must_use]
+    pub const fn floor_int(self) -> i64 {
+        self.0.div_euclid(ONE_RAW)
+    }
+
     /// The fractional part, with the sign of the whole.
     #[must_use]
     pub const fn fract(self) -> Self {
@@ -398,6 +412,58 @@ impl Div for Fixed {
     type Output = Self;
     fn div(self, other: Self) -> Self {
         self.saturating_div(other)
+    }
+}
+
+#[cfg(test)]
+mod floor_tests {
+    use super::Fixed;
+
+    /// **Floor and truncation differ below zero, and that is the whole
+    /// point of the pair.** `trunc_int` maps both `-0.5` and `+0.5` to
+    /// zero, so a lattice built on it fuses the two cells either side of
+    /// the origin; `floor_int` maps `-0.5` to `-1`.
+    ///
+    /// Probed by delegating `floor_int` to `trunc_int`: every negative
+    /// fractional case below names the value it got.
+    #[test]
+    fn floor_rounds_toward_negative_infinity() {
+        let cases = [
+            (Fixed::from_ratio(1, 2), 0, 0),
+            (Fixed::from_ratio(-1, 2), -1, 0),
+            (Fixed::from_ratio(3, 2), 1, 1),
+            (Fixed::from_ratio(-3, 2), -2, -1),
+            (Fixed::from_int(2), 2, 2),
+            (Fixed::from_int(-2), -2, -2),
+            (Fixed::ZERO, 0, 0),
+            (Fixed::EPSILON, 0, 0),
+            (Fixed::ZERO - Fixed::EPSILON, -1, 0),
+        ];
+        for (value, floor, trunc) in cases {
+            assert_eq!(value.floor_int(), floor, "floor of {value:?}");
+            assert_eq!(value.trunc_int(), trunc, "truncation of {value:?}");
+        }
+    }
+
+    /// The defining property, over a spread that crosses zero: the floor
+    /// is the greatest whole number not above the value, so the value
+    /// minus its floor lies in `[0, 1)`.
+    ///
+    /// Probed the same way: the negative half of the range reports a
+    /// remainder of `-1 .. 0`.
+    #[test]
+    fn a_value_stands_no_less_than_its_floor_and_less_than_one_above_it() {
+        let step = Fixed::from_ratio(1, 7);
+        let mut value = Fixed::from_int(-4);
+        for _ in 0..60 {
+            let floor = i32::try_from(value.floor_int()).expect("the range is small");
+            let over = value - Fixed::from_int(floor);
+            assert!(
+                over >= Fixed::ZERO && over < Fixed::ONE,
+                "{value:?} stands {over:?} above its floor of {floor}"
+            );
+            value = value + step;
+        }
     }
 }
 

--- a/crates/net/src/lobby.rs
+++ b/crates/net/src/lobby.rs
@@ -617,8 +617,10 @@ impl Lobby {
         // reader could evaluate.
         for (slot, endpoint) in self
             .table
-            .chunks_exact_mut(ENDPOINT_BYTES)
-            .zip(body.endpoints.chunks_exact(ENDPOINT_BYTES))
+            .as_chunks_mut::<ENDPOINT_BYTES>()
+            .0
+            .iter_mut()
+            .zip(body.endpoints.as_chunks::<ENDPOINT_BYTES>().0.iter())
         {
             slot.copy_from_slice(endpoint);
         }
@@ -638,8 +640,9 @@ impl Lobby {
         // a joiner.
         if let Some(slot) = self
             .table
-            .chunks_exact_mut(ENDPOINT_BYTES)
-            .nth(usize::from(seat.index()))
+            .as_chunks_mut::<ENDPOINT_BYTES>()
+            .0
+            .get_mut(usize::from(seat.index()))
         {
             slot.fill(0);
         }
@@ -869,8 +872,9 @@ impl Lobby {
         let mut out = UNKNOWN_ENDPOINT;
         if let Some(chunk) = self
             .table
-            .chunks_exact(ENDPOINT_BYTES)
-            .nth(usize::from(seat))
+            .as_chunks::<ENDPOINT_BYTES>()
+            .0
+            .get(usize::from(seat))
         {
             out.copy_from_slice(chunk);
         }
@@ -893,7 +897,10 @@ impl Lobby {
 
     fn table_snapshot(&self) -> [Endpoint; PEERS] {
         let mut out = [UNKNOWN_ENDPOINT; PEERS];
-        for (slot, held) in out.iter_mut().zip(self.table.chunks_exact(ENDPOINT_BYTES)) {
+        for (slot, held) in out
+            .iter_mut()
+            .zip(self.table.as_chunks::<ENDPOINT_BYTES>().0.iter())
+        {
             slot.copy_from_slice(held);
         }
         out

--- a/crates/net/tests/wire.rs
+++ b/crates/net/tests/wire.rs
@@ -1038,7 +1038,12 @@ fn every_lobby_kind_declares_the_body_it_writes() {
 fn a_roster_hands_back_each_seats_endpoint_and_nothing_past_them() {
     use renew_net::wire::{ENDPOINT_BYTES, RosterBody, write_roster};
     let mut endpoints = [0u8; 18 * 3];
-    for (seat, chunk) in endpoints.chunks_exact_mut(ENDPOINT_BYTES).enumerate() {
+    for (seat, chunk) in endpoints
+        .as_chunks_mut::<ENDPOINT_BYTES>()
+        .0
+        .iter_mut()
+        .enumerate()
+    {
         chunk.fill(u8::try_from(seat).expect("three seats") + 10);
     }
     let mut out: Buffer = [0; MAX_DATAGRAM_BYTES];

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -191,7 +191,7 @@ pub(crate) fn pack(sprite: &Sprite, canvas: Canvas, atlas: Extent) -> [u8; INSTA
         sprite.tint[3],
     ];
     let mut bytes = [0u8; INSTANCE_STRIDE];
-    for (slot, value) in bytes.chunks_exact_mut(4).zip(values) {
+    for (slot, value) in bytes.as_chunks_mut::<4>().0.iter_mut().zip(values) {
         slot.copy_from_slice(&value.to_ne_bytes());
     }
     bytes

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -188,7 +188,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 /// goldens — the humanly-viewable form of a mismatch or candidate.
 fn write_ppm(path: &Path, pixels: &[u8], width: u32, height: u32) -> std::io::Result<()> {
     let mut ppm = format!("P6\n{width} {height}\n255\n").into_bytes();
-    for pixel in pixels.chunks_exact(4) {
+    for pixel in pixels.as_chunks::<4>().0 {
         ppm.extend_from_slice(&pixel[..3]);
     }
     std::fs::write(path, ppm)

--- a/crates/render3d/src/scene.rs
+++ b/crates/render3d/src/scene.rs
@@ -356,7 +356,9 @@ mod tests {
         scene.quad(CORNERS, [0.25, 0.5, 0.75, 1.0]);
         let first = &scene.vertices()[..VERTEX_STRIDE as usize];
         let floats: Vec<f32> = first
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|bytes| f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
             .collect();
         // The last two are the default mapping's first corner, which is

--- a/crates/rhi/src/spirv.rs
+++ b/crates/rhi/src/spirv.rs
@@ -28,10 +28,11 @@ pub fn words_from_bytes(stage: &'static str, bytes: &[u8]) -> Result<Vec<u32>, P
             reason: "length not a multiple of four",
         });
     }
-    let mut words = Vec::with_capacity(bytes.len() / 4);
-    for chunk in bytes.chunks_exact(4) {
-        words.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
-    }
+    // `as_chunks` rather than `chunks_exact(4)`: the length is already
+    // known to be a multiple of four, so the remainder is empty by the
+    // check above, and a fixed-size chunk needs no indexing to unpack.
+    let (quads, _) = bytes.as_chunks::<4>();
+    let words: Vec<u32> = quads.iter().copied().map(u32::from_le_bytes).collect();
     if words[0] != SPIRV_MAGIC {
         return Err(PipelineError::InvalidSpirv {
             stage,

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -1240,7 +1240,7 @@ fn push_constants_reach_the_draw_and_update_per_frame() {
     // is the clear, so a draw that silently read zeroed constants fails.
     for authored in [[0u8, 255, 64, 255], [255u8, 32, 0, 255]] {
         let mut pushed = [0u8; 16];
-        for (slot, &channel) in pushed.chunks_exact_mut(4).zip(&authored) {
+        for (slot, &channel) in pushed.as_chunks_mut::<4>().0.iter_mut().zip(&authored) {
             slot.copy_from_slice(&renew_rhi::srgb::decode(channel).to_ne_bytes());
         }
         let expected = &authored;
@@ -1250,7 +1250,7 @@ fn push_constants_reach_the_draw_and_update_per_frame() {
             .render(&RenderDesc::new(&passes))
             .expect("push-constant render");
         target.read_back_into(&mut pixels);
-        for (index, pixel) in pixels.chunks_exact(4).enumerate() {
+        for (index, pixel) in pixels.as_chunks::<4>().0.iter().enumerate() {
             assert_eq!(
                 pixel, expected,
                 "pixel {index}: every pixel carries the color this frame pushed"
@@ -1300,7 +1300,7 @@ fn additive_blending_sums_the_same_bytes_in_all_six_orders() {
         .expect("additive push-constant pipeline");
     let push = |channels: [u8; 4]| {
         let mut bytes = [0u8; 16];
-        for (slot, &channel) in bytes.chunks_exact_mut(4).zip(&channels) {
+        for (slot, &channel) in bytes.as_chunks_mut::<4>().0.iter_mut().zip(&channels) {
             slot.copy_from_slice(&(f32::from(channel) / 255.0).to_ne_bytes());
         }
         bytes
@@ -1407,7 +1407,7 @@ fn additive_blending_sums_channels_in_either_order() {
         .expect("additive push-constant pipeline");
     let push = |channels: [u8; 4]| {
         let mut bytes = [0u8; 16];
-        for (slot, &channel) in bytes.chunks_exact_mut(4).zip(&channels) {
+        for (slot, &channel) in bytes.as_chunks_mut::<4>().0.iter_mut().zip(&channels) {
             slot.copy_from_slice(&(f32::from(channel) / 255.0).to_ne_bytes());
         }
         bytes
@@ -1434,9 +1434,9 @@ fn additive_blending_sums_channels_in_either_order() {
         pixels
     };
     let forward = render(&first, &second);
-    for (index, pixel) in forward.chunks_exact(4).enumerate() {
+    for (index, pixel) in forward.as_chunks::<4>().0.iter().enumerate() {
         assert_eq!(
-            pixel, expected,
+            *pixel, expected,
             "pixel {index}: additive must land exactly on the channel sums"
         );
     }

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -154,7 +154,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 /// goldens — the humanly-viewable form of a mismatch or candidate.
 fn write_ppm(path: &Path, pixels: &[u8], width: u32, height: u32) -> std::io::Result<()> {
     let mut ppm = format!("P6\n{width} {height}\n255\n").into_bytes();
-    for pixel in pixels.chunks_exact(4) {
+    for pixel in pixels.as_chunks::<4>().0 {
         ppm.extend_from_slice(&pixel[..3]);
     }
     std::fs::write(path, ppm)
@@ -190,9 +190,9 @@ fn clear_is_byte_exact_everywhere() {
     // them and the attachment encodes it back, so the round trip is exact
     // and the expectation is the value that was chosen — no derivation.
     let expected = [51u8, 102, 153, 255];
-    for (index, pixel) in pixels.chunks_exact(4).enumerate() {
+    for (index, pixel) in pixels.as_chunks::<4>().0.iter().enumerate() {
         assert_eq!(
-            pixel,
+            *pixel,
             expected,
             "pixel {index} diverged on adapter {:?}",
             device.adapter()
@@ -264,8 +264,10 @@ impl Difference {
         let mut largest_channel = 0;
         let mut first_byte = usize::MAX;
         for (index, (a, b)) in rendered
-            .chunks_exact(4)
-            .zip(golden.chunks_exact(4))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .zip(golden.as_chunks::<4>().0.iter())
             .enumerate()
         {
             let mut differs = false;
@@ -1650,9 +1652,9 @@ fn a_mesh_and_per_frame_bytes_bind_two_streams_in_one_draw()
     target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
     let mut pixels = vec![0u8; target.byte_len()];
     target.read_back_into(&mut pixels);
-    for (index, pixel) in pixels.chunks_exact(4).enumerate() {
+    for (index, pixel) in pixels.as_chunks::<4>().0.iter().enumerate() {
         assert_eq!(
-            pixel,
+            *pixel,
             [0, 0, 255, 255],
             "pixel {index} is not the mesh's own colour on adapter {:?} — a per-instance stream              bound where the per-vertex one belongs would change it",
             device.adapter()

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -339,7 +339,7 @@ impl WindowApp for SmokeApp {
                 // frame's command buffer, not a picture.
                 let level = f32::from(u8::try_from(self.frames % 8).unwrap_or(0)) / 8.0;
                 let mut pushed = [0u8; 16];
-                for slot in pushed.chunks_exact_mut(4) {
+                for slot in pushed.as_chunks_mut::<4>().0 {
                     slot.copy_from_slice(&level.to_ne_bytes());
                 }
                 // Built together in `ready`, like the mesh pair: "one

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -323,7 +323,7 @@ impl WindowApp for GateApp {
                     // bytes and a slot read from the wrong region shows.
                     let mut bytes = [0u8; BLOCK_BYTES];
                     let level = f32::from(u8::try_from(self.presented % 8).unwrap_or(0)) / 8.0;
-                    for chunk in bytes.chunks_exact_mut(4) {
+                    for chunk in bytes.as_chunks_mut::<4>().0 {
                         chunk.copy_from_slice(&level.to_ne_bytes());
                     }
                     bytes

--- a/crates/volume/README.md
+++ b/crates/volume/README.md
@@ -39,6 +39,16 @@ would let a body walk off it and fall for ever with no way to tell that
 from a hole; one that answered "solid" would trap it at the boundary with
 no explanation.
 
+**What lives below a cell.** A consumer whose world is finer than its
+cells — destructible matter, a surface shaped inside the cell it sits in,
+a level-of-detail scheme with several resolutions at once — keeps that
+detail itself. `Volume::sweep_box_fine` is the seam: it sweeps a box
+against a lattice `n` times finer than the cells and asks a predicate
+which sub-cells are solid, so the detail never has to be stored here and
+this crate never has to have an opinion about what shapes it. At `n = 1`
+with the volume's own solidity it is exactly `Volume::sweep_box`, and a
+test asserts that rather than the doc claiming it.
+
 ## The three decisions worth knowing before you use it
 
 **Cells are centred on integers.** Cell zero spans −0.5 to +0.5, so every

--- a/crates/volume/src/sweep.rs
+++ b/crates/volume/src/sweep.rs
@@ -427,8 +427,7 @@ mod tests {
         });
         assert!(
             open.is_none(),
-            "the body was stopped by a slot it fits through, at {:?}",
-            open.map(|hit| hit.cell)
+            "the body was stopped by a slot it fits through: {open:?}"
         );
         let closed = v.sweep_box_fine(half(), from, along, skin(), eight(), |sub| sub.x == 36);
         assert!(

--- a/crates/volume/src/sweep.rs
+++ b/crates/volume/src/sweep.rs
@@ -1,5 +1,7 @@
 //! Moving a box through the volume without passing through it.
 
+use core::num::NonZeroU32;
+
 use renew_fixed::{Fixed, Vec3};
 use renew_physics3d::{Shape, Transform, sweep};
 
@@ -13,6 +15,9 @@ pub struct Hit {
     /// The surface direction at contact, pointing back at the mover.
     pub normal: Vec3,
     /// Which cell stopped it.
+    ///
+    /// A sub-cell coordinate when the hit came from
+    /// [`Volume::sweep_box_fine`], on that call's own lattice.
     pub cell: Cell,
 }
 
@@ -120,6 +125,167 @@ impl Volume {
     }
 }
 
+/// The lattice index a coordinate falls in, on a lattice `steps` finer
+/// than the cell lattice.
+///
+/// **Floor, not truncation.** A lattice index is a floor; rounding toward
+/// zero folds the two sub-cells either side of the origin into one and
+/// puts a seam through the middle of the world. A cell is centred on its
+/// integer coordinate and spans half a unit either side, so the sub-cell
+/// containing `value` is `floor((value + 1/2) * steps)`.
+fn fine_index(value: Fixed, steps: i32) -> i32 {
+    let half = Fixed::from_ratio(1, 2);
+    let scaled = (value + half).saturating_mul(Fixed::from_int(steps));
+    i32::try_from(scaled.floor_int()).unwrap_or(0)
+}
+
+/// The centre of a sub-cell, in world units.
+fn fine_centre(sub: Cell, steps: i32) -> Vec3 {
+    let half = Fixed::from_ratio(1, 2);
+    // `sub / steps - 1/2` is the low corner, and half a sub-cell above it
+    // is the centre. Written as one ratio so the division rounds once.
+    let axis = |value: i32| Fixed::from_ratio(2 * value + 1, 2 * steps) - half;
+    Vec3::new(axis(sub.x), axis(sub.y), axis(sub.z))
+}
+
+impl Volume {
+    /// The earliest **sub-cell** a box meets while moving along
+    /// `displacement`.
+    ///
+    /// The sibling of [`Volume::sweep_box`] for a world whose cells are
+    /// subdivided. `subdivision` is how many sub-cells span a cell along
+    /// one axis, and `solid` is asked about sub-cell coordinates — the
+    /// same lattice, `subdivision` times finer, with the sub-cell at
+    /// `s` spanning `s / n - 1/2 .. (s + 1) / n - 1/2` so that sub-cell
+    /// `n * c` starts exactly at cell `c`'s low edge.
+    ///
+    /// # Why a predicate rather than a second volume
+    ///
+    /// **What lives below a cell is the consumer's business.** Destructible
+    /// terrain keeps a bitmask, a heightfield-shaped surface derives one
+    /// from a function of position, a level-of-detail scheme has several at
+    /// once, and none of those wants to store a second lattice the size of
+    /// its world just to be swept against. The predicate is the whole of
+    /// what a sweep needs to know, and it costs one call per candidate that
+    /// is not already rejected by the bounding box.
+    ///
+    /// A `subdivision` of one is the cell lattice itself, and passing the
+    /// volume's own solidity gives exactly [`Volume::sweep_box`] — which is
+    /// asserted rather than claimed.
+    ///
+    /// # How candidates are chosen
+    ///
+    /// From the swept box's bounding box, expressed on the fine lattice
+    /// directly rather than by expanding whole cells. That matters for
+    /// cost: a body a quarter of a cell across moving a fraction of a cell
+    /// overlaps roughly three cells on an axis, and expanding those to
+    /// sub-cells would test `3n` of them where the box itself only reaches
+    /// about `2n / 3`.
+    ///
+    /// The same two widenings as the coarse sweep keep the set
+    /// conservative — `skin`, because contact is reported while a gap is
+    /// still that wide, and one further sub-cell of margin against the
+    /// rounding at exact boundaries, which is precisely where lattice-
+    /// aligned bodies sit.
+    ///
+    /// **Ties go to the lower sub-cell**, by the lexicographic order on
+    /// [`Cell`], for the reason the coarse sweep gives: resolving by
+    /// iteration order would make the result depend on how the loop
+    /// happens to be written.
+    ///
+    /// Integer throughout, like everything it calls, so two machines
+    /// sweeping one body cannot disagree about where it stopped.
+    #[must_use]
+    pub fn sweep_box_fine(
+        &self,
+        half_extents: Vec3,
+        from: Vec3,
+        displacement: Vec3,
+        skin: Fixed,
+        subdivision: NonZeroU32,
+        solid: impl Fn(Cell) -> bool,
+    ) -> Option<Hit> {
+        let steps = i32::try_from(subdivision.get()).unwrap_or(1).max(1);
+        let end = from + displacement;
+        let margin = Vec3::new(
+            half_extents.x + skin.abs(),
+            half_extents.y + skin.abs(),
+            half_extents.z + skin.abs(),
+        );
+
+        // The volume's own extent, on the fine lattice, so a displacement
+        // far larger than the world costs the world rather than the
+        // displacement.
+        let (width, height, depth) = self.size();
+        let origin = self.origin();
+        let bound = |low: i32, span: i32, at: i32| at.clamp(low * steps, (low + span) * steps - 1);
+
+        let reach = |pick: fn(Fixed, Fixed) -> Fixed, sign: i32| {
+            let corner = Vec3::new(
+                pick(from.x, end.x) + Fixed::from_int(sign).saturating_mul(margin.x),
+                pick(from.y, end.y) + Fixed::from_int(sign).saturating_mul(margin.y),
+                pick(from.z, end.z) + Fixed::from_int(sign).saturating_mul(margin.z),
+            );
+            Cell::new(
+                fine_index(corner.x, steps) + sign,
+                fine_index(corner.y, steps) + sign,
+                fine_index(corner.z, steps) + sign,
+            )
+        };
+        let low = reach(Fixed::min, -1);
+        let high = reach(Fixed::max, 1);
+        let low = Cell::new(
+            bound(origin.x, width, low.x),
+            bound(origin.y, height, low.y),
+            bound(origin.z, depth, low.z),
+        );
+        let high = Cell::new(
+            bound(origin.x, width, high.x),
+            bound(origin.y, height, high.y),
+            bound(origin.z, depth, high.z),
+        );
+
+        let mover = Shape::Box { half_extents };
+        let reach = Fixed::from_ratio(1, 2 * steps);
+        let target = Shape::Box {
+            half_extents: Vec3::new(reach, reach, reach),
+        };
+        let mut best: Option<Hit> = None;
+
+        for z in low.z..=high.z {
+            for y in low.y..=high.y {
+                for x in low.x..=high.x {
+                    let sub = Cell::new(x, y, z);
+                    if !solid(sub) {
+                        continue;
+                    }
+                    let Some(hit) = sweep(
+                        mover,
+                        Transform::at(from),
+                        displacement,
+                        target,
+                        Transform::at(fine_centre(sub, steps)),
+                        skin,
+                    ) else {
+                        continue;
+                    };
+                    let earlier = best.as_ref().is_none_or(|found| {
+                        hit.time < found.time || (hit.time == found.time && sub < found.cell)
+                    });
+                    if earlier {
+                        best = Some(Hit {
+                            time: hit.time,
+                            normal: hit.normal,
+                            cell: sub,
+                        });
+                    }
+                }
+            }
+        }
+        best
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Cell, Volume, Voxel};
@@ -138,6 +304,182 @@ mod tests {
 
     fn volume() -> Volume {
         Volume::new(Cell::new(0, 0, 0), (16, 16, 16)).expect("a small volume is addressable")
+    }
+
+    fn one() -> core::num::NonZeroU32 {
+        core::num::NonZeroU32::new(1).expect("one is not zero")
+    }
+
+    fn eight() -> core::num::NonZeroU32 {
+        core::num::NonZeroU32::new(8).expect("eight is not zero")
+    }
+
+    /// **At one sub-cell per cell the fine sweep is the coarse one.**
+    ///
+    /// The strongest thing that can be said about a second implementation
+    /// of an existing routine, and the reason the fine sweep is not a
+    /// rewrite of the coarse one's geometry: with the volume's own
+    /// solidity and a subdivision of one, the two must agree on every
+    /// field, for every case — including the ones where nothing is hit and
+    /// the ones where the tie-break decides.
+    ///
+    /// Probed by shifting the fine lattice's centres half a sub-cell: the
+    /// times stop matching and the assertion names the displacement.
+    #[test]
+    fn at_one_sub_cell_per_cell_it_is_the_coarse_sweep() {
+        let mut v = volume();
+        for at in [
+            Cell::new(4, 1, 1),
+            Cell::new(4, 2, 1),
+            Cell::new(8, 1, 1),
+            Cell::new(1, 0, 1),
+            Cell::new(6, 1, 2),
+        ] {
+            v.set(at, STONE);
+        }
+        let from = Cell::new(1, 1, 1).centre();
+        let steps = [
+            Vec3::new(Fixed::from_int(9), Fixed::ZERO, Fixed::ZERO),
+            Vec3::new(Fixed::ZERO, Fixed::from_int(-3), Fixed::ZERO),
+            Vec3::new(Fixed::from_int(6), Fixed::ZERO, Fixed::from_int(2)),
+            Vec3::new(Fixed::from_int(-9), Fixed::ZERO, Fixed::ZERO),
+            Vec3::new(Fixed::from_ratio(1, 8), Fixed::ZERO, Fixed::ZERO),
+        ];
+        let mut struck = 0;
+        for displacement in steps {
+            let coarse = v.sweep_box(half(), from, displacement, skin());
+            let fine = v.sweep_box_fine(half(), from, displacement, skin(), one(), |cell| {
+                v.is_solid(cell)
+            });
+            struck += usize::from(coarse.is_some());
+            assert_eq!(
+                coarse, fine,
+                "the two sweeps disagree along {displacement:?}"
+            );
+        }
+        assert!(
+            struck >= 3,
+            "only {struck} of these displacements hit anything"
+        );
+    }
+
+    /// **A body stands on what is actually under it, not on the cell.**
+    ///
+    /// The reason this exists. A cell filled only in its lower half stops
+    /// a falling body half a cell lower than a whole one does, and a
+    /// consumer whose ground is shaped below the cell has no way to say so
+    /// through the coarse sweep.
+    ///
+    /// Probed by calling the whole cell solid: the body stops at the
+    /// cell's top and the two heights come out equal.
+    #[test]
+    fn a_half_filled_cell_stops_a_body_half_a_cell_lower() {
+        let mut v = volume();
+        v.set(Cell::new(1, 1, 1), STONE);
+        let from = Cell::new(1, 4, 1).centre();
+        let down = Vec3::new(Fixed::ZERO, Fixed::from_int(-4), Fixed::ZERO);
+
+        let whole = v
+            .sweep_box(half(), from, down, skin())
+            .expect("the ground is in the way");
+        // The lower half of that cell only: sub-cells 8..12 of 8..16.
+        let filled = v
+            .sweep_box_fine(half(), from, down, skin(), eight(), |sub| {
+                sub.x / 8 == 1 && sub.z / 8 == 1 && (8..12).contains(&sub.y)
+            })
+            .expect("the shaped ground is in the way");
+
+        assert!(
+            filled.time > whole.time,
+            "a half-filled cell stopped the body no later than a whole one: {:?} against {:?}",
+            filled.time,
+            whole.time
+        );
+        let dropped = (filled.time - whole.time).saturating_mul(Fixed::from_int(4));
+        assert!(
+            dropped > Fixed::from_ratio(3, 8) && dropped < Fixed::from_ratio(5, 8),
+            "the extra drop was {dropped:?}, and half a cell is what four filled sub-cells buy"
+        );
+        assert!(
+            filled.normal.y > Fixed::ZERO,
+            "the ground's normal points up at the mover"
+        );
+    }
+
+    /// A gap narrower than a cell but wider than the body is a gap the
+    /// body goes through — which the coarse sweep cannot express at all.
+    ///
+    /// The slot is six sub-cells tall against a body four sub-cells tall,
+    /// so there is an eighth of a cell of clearance either side: more than
+    /// `skin`, which is what the sweep reports contact within. A slot cut
+    /// exactly to the body reports a hit, correctly, and the first draft
+    /// of this asserted otherwise.
+    ///
+    /// Probed by the second half, which closes the slot: without it a
+    /// fixture that simply missed the wall would pass.
+    #[test]
+    fn a_sub_cell_gap_lets_a_smaller_body_through() {
+        let v = volume();
+        let from = Cell::new(1, 1, 1).centre();
+        let along = Vec3::new(Fixed::from_int(6), Fixed::ZERO, Fixed::ZERO);
+        let open = v.sweep_box_fine(half(), from, along, skin(), eight(), |sub| {
+            sub.x == 36 && !(9..15).contains(&sub.y)
+        });
+        assert!(
+            open.is_none(),
+            "the body was stopped by a slot it fits through, at {:?}",
+            open.map(|hit| hit.cell)
+        );
+        let closed = v.sweep_box_fine(half(), from, along, skin(), eight(), |sub| sub.x == 36);
+        assert!(
+            closed.is_some(),
+            "the closed wall stopped nothing, so the open one proves nothing"
+        );
+    }
+
+    /// **Ties go to the lower sub-cell**, so a body meeting two of them at
+    /// the same instant resolves the same way on every machine rather than
+    /// by however the loop happens to be written.
+    ///
+    /// Two sub-cells in one plane, differing only in `y`, both across the
+    /// body's path: they are struck at the same time by construction, and
+    /// the lexicographically lesser must be the one named.
+    ///
+    /// Probed by reversing the tie-break to prefer the greater: the upper
+    /// sub-cell is reported and the assertion names it.
+    #[test]
+    fn a_tie_goes_to_the_lower_sub_cell() {
+        let v = volume();
+        let from = Cell::new(1, 1, 1).centre();
+        let along = Vec3::new(Fixed::from_int(6), Fixed::ZERO, Fixed::ZERO);
+        let lower = Cell::new(36, 11, 12);
+        let upper = Cell::new(36, 12, 12);
+        assert!(
+            lower < upper,
+            "the fixture's own ordering is the wrong way round"
+        );
+        let hit = v
+            .sweep_box_fine(half(), from, along, skin(), eight(), |sub| {
+                sub == lower || sub == upper
+            })
+            .expect("two sub-cells stand across the path");
+        assert_eq!(
+            hit.cell, lower,
+            "a tie went to {:?} rather than to the lower sub-cell",
+            hit.cell
+        );
+        // Each alone is struck, and at the same instant — which is what
+        // makes the pair a tie rather than a race one of them wins.
+        let struck_at = |at: Cell| {
+            v.sweep_box_fine(half(), from, along, skin(), eight(), |sub| sub == at)
+                .expect("one sub-cell stands across the path")
+                .time
+        };
+        assert_eq!(
+            struck_at(lower),
+            struck_at(upper),
+            "the two are not struck at the same time, so this is not a tie"
+        );
     }
 
     #[test]

--- a/samples/cube/src/atlas.rs
+++ b/samples/cube/src/atlas.rs
@@ -226,12 +226,18 @@ mod tests {
         let pixels = pixels();
         assert_eq!(pixels.len(), (WIDTH * HEIGHT * 4) as usize);
         assert!(
-            pixels.chunks_exact(4).all(|texel| texel[3] == 255),
+            pixels
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .all(|texel| texel[3] == 255),
             "a transparent texel would blend a block with whatever is behind it"
         );
         assert!(
             pixels
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .all(|texel| texel[0] == texel[1] && texel[1] == texel[2]),
             "stone is grey; a channel that drifted would tint the world"
         );
@@ -327,7 +333,7 @@ mod tests {
     fn the_particle_tile_is_a_premultiplied_soft_square() {
         let (side, pixels) = particle_pixels();
         assert_eq!(pixels.len(), (side * side * 4) as usize);
-        for texel in pixels.chunks_exact(4) {
+        for texel in pixels.as_chunks::<4>().0 {
             assert!(
                 texel.iter().all(|&channel| channel == texel[0]),
                 "premultiplied white: every channel carries the same ink: {texel:?}"

--- a/samples/cube/src/projection.rs
+++ b/samples/cube/src/projection.rs
@@ -71,9 +71,9 @@ impl Projection {
         let forward = [-1.0 / r3, -1.0 / r3, -1.0 / r3];
 
         let centre = [
-            (min[0] + max[0]) * 0.5,
-            (min[1] + max[1]) * 0.5,
-            (min[2] + max[2]) * 0.5,
+            min[0].midpoint(max[0]),
+            min[1].midpoint(max[1]),
+            min[2].midpoint(max[2]),
         ];
 
         // The box's extent along each view axis is the sum of its

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -306,7 +306,7 @@ impl GlideApp {
 
     fn atlas_bytes() -> [u8; 32] {
         let mut bytes = [0u8; 32];
-        for (index, chunk) in bytes.chunks_exact_mut(4).enumerate() {
+        for (index, chunk) in bytes.as_chunks_mut::<4>().0.iter_mut().enumerate() {
             let texel = if index % 4 < 2 {
                 BIRD_TEXEL
             } else {

--- a/samples/glide/tests/golden.rs
+++ b/samples/glide/tests/golden.rs
@@ -125,7 +125,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 /// goldens — the humanly-viewable form of a mismatch or candidate.
 fn write_ppm(path: &Path, pixels: &[u8], width: u32, height: u32) -> std::io::Result<()> {
     let mut ppm = format!("P6\n{width} {height}\n255\n").into_bytes();
-    for pixel in pixels.chunks_exact(4) {
+    for pixel in pixels.as_chunks::<4>().0 {
         ppm.extend_from_slice(&pixel[..3]);
     }
     std::fs::write(path, ppm)

--- a/samples/hello_triangle/tests/headless_frame.rs
+++ b/samples/hello_triangle/tests/headless_frame.rs
@@ -62,8 +62,8 @@ fn the_readback_holds_the_colour_the_world_computed_for_the_last_tick() {
         pixels.len(),
         (EXTENT.width as usize) * (EXTENT.height as usize) * 4
     );
-    for (index, pixel) in pixels.chunks_exact(4).enumerate() {
-        assert_eq!(pixel, expected, "pixel {index} on adapter {adapter}");
+    for (index, pixel) in pixels.as_chunks::<4>().0.iter().enumerate() {
+        assert_eq!(*pixel, expected, "pixel {index} on adapter {adapter}");
     }
 
     // A repaint of the same tick — the clear-only frame shape, drawn


### PR DESCRIPTION
`Volume::sweep_box` can only be stopped by a whole cell, so a consumer whose world is finer than its cells has no way to be swept correctly. Destructible matter, a surface shaped inside the cell it sits in, and a level-of-detail scheme with several resolutions at once all want the same thing, and none of them wants to store a second lattice the size of its world to get it.

`Volume::sweep_box_fine` takes a subdivision and a predicate over sub-cell coordinates. The predicate is the whole of what a sweep needs to know, so what lives below a cell stays the consumer's business and this crate keeps having no opinion about what shapes it.

Candidates come from the swept box's bounding box expressed on the fine lattice directly, rather than from expanding whole cells: a body a quarter of a cell across overlaps roughly three cells on an axis, and expanding those would test `3n` sub-cells where the box itself reaches about `2n/3`. The same two widenings as the coarse sweep keep the set conservative, and ties resolve to the lexicographically lower sub-cell for the same reason.

`Fixed::floor_int` lands with it. A lattice index is a floor, `trunc_int` rounds toward zero, and the difference fuses the two cells either side of the origin and runs a seam through the middle of a world. Every consumer that has needed it so far has hand-rolled a shift by the fractional width, which is correct only for the width it was written against.

## Tests, each probed

- **At one sub-cell per cell the fine sweep is the coarse one**, field for field across five displacements — the strongest thing that can be said about a second implementation of an existing routine. Probed by shifting the fine centres half a sub-cell.
- A cell filled only in its lower half **stops a falling body half a cell lower** than a whole one, measured rather than asserted qualitatively. Probed by giving the target a whole cell's half-extent.
- A slot six sub-cells tall **lets a body four sub-cells tall through**, and the same wall with the slot closed stops it, so a fixture that simply missed the wall cannot pass. The clearance is deliberate: a slot cut exactly to the body reports a hit, correctly, because contact is reported while a gap is still `skin` wide.
- **A tie goes to the lower sub-cell**, and the two candidates are asserted to be struck at the same instant so the case is a tie rather than a race one of them wins. Probed by reversing the comparison.
- `floor_int` against `trunc_int` on nine cases either side of zero, plus the defining property over a range that crosses it. Both probed by delegating the floor to the truncation.

Integer throughout, like everything it calls, so two machines sweeping one body cannot disagree about where it stopped.

Ran locally: fmt, clippy over the workspace with all targets, and the full workspace test suite.