### PR TITLE
feat(png): read a PNG, not only write one

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -269,3 +269,13 @@ reason = "The slot lookup in `edit_focused`, refused a line after `field_slot` r
 file = "crates/ui/src/field.rs"
 lines = [124, 133, 139, 145, 240, 243]
 reason = "The bounds arms of the two loops that move bytes inside a field, and the width check above them. Every one is refused by arithmetic the lines before it already did: a field is 64 bytes and a scalar is at most 4, so the `checked_add` cannot leave `usize`; the insert guard refuses anything past the ceiling before either loop runs, so every index the loops build is inside the array; and `remove` only ever walks the region between two cursor positions, both of which are `<= len`. They are written as refusals rather than indexing because the crate bans unchecked indexing outright — a widget tree takes its bytes from a driver, and an unchecked index there is a panic somebody else can cause. Kept rather than restructured: the two arms that were merely untested rather than unreachable — the forward character walk and backspace at position zero — were found by this same measurement and now have tests, which is the line between the two kinds."
+
+[[exempt]]
+file = "crates/png/src/inflate.rs"
+lines = [391]
+reason = "The fallthrough arm of the code-length symbol match, which a nineteen-entry table cannot reach: `Huffman::new` is built from exactly nineteen lengths, so every symbol it can hand back is 0..=18 and the arms above cover all of them. Kept because the match is on a `u16` and the compiler requires an arm — deleting it is not an option, and returning something other than a refusal there would be a decoder that trusted a value it had not checked."
+
+[[exempt]]
+file = "crates/png/src/colours.rs"
+lines = [90]
+reason = "A test's own failure message: the panic inside `read`'s error closure runs only when a fixture fails to decode, which is exactly when the suite is red. A test that could cover it would be a test asserting its own helper is broken."

--- a/crates/png/Cargo.toml
+++ b/crates/png/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "renew-png"
-description = "PNG encoding with no dependencies: RGBA pixels to the bytes of a file"
+description = "PNG with no dependencies, both ways: RGBA pixels to the bytes of a file and back"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-keywords = ["png", "encoding", "image", "gamedev", "no-std"]
-categories = ["multimedia::images", "encoding"]
+keywords = ["png", "encoding", "decoding", "image", "gamedev"]
+categories = ["multimedia::images", "encoding", "parser-implementations"]
 readme = "README.md"
 homepage.workspace = true
 
 [package.metadata.renew]
-purpose = "PNG encoding with no dependencies: RGBA pixels in, the bytes of a file out. It never touches the filesystem."
+purpose = "PNG with no dependencies, both ways: RGBA pixels in and the bytes of a file out, or a file in and pixels out. It never touches the filesystem."
 maturity = "bootstrap"
 core = false
 extension_points = []

--- a/crates/png/README.md
+++ b/crates/png/README.md
@@ -1,9 +1,9 @@
 # renew-png
 
-PNG encoding with no dependencies: RGBA pixels in, the bytes of a file
-out. It never touches the filesystem — writing the file is the caller's
-business, which is what keeps the encoder a pure function and testable
-without one.
+PNG with no dependencies, both ways: RGBA pixels in and the bytes of a
+file out, or a file in and RGBA pixels out. It never touches the
+filesystem — reading and writing the file are the caller's business, which
+is what keeps both halves pure functions and testable without one.
 
 ## What it is for
 
@@ -14,14 +14,32 @@ stream, and deflate's *fixed* Huffman tables are published constants, so
 the whole encoder is four chunks, two checksums and a small
 back-reference search.
 
+## Reading is the wider half
+
+The encoder writes one shape of file — 8-bit RGBA, fixed Huffman, no
+filtering — because that is all a picture of geometry needs. The decoder
+has no such freedom: it reads what other tools wrote. So it carries
+dynamic Huffman, all five scanline filters, palettes with `tRNS`,
+greyscale, and 16-bit samples reduced to eight.
+
+It refuses two things by name rather than mis-reading them: **interlaced**
+images, which are a different image layout rather than a different pixel
+format, and **bit depths below eight**, which want a bit-unpacker nothing
+has asked for. Both are additions here when something needs them, not a
+second decoder.
+
+Every chunk's CRC is checked, every declared length is validated against
+the bytes actually present, and the decompressor takes a ceiling — a
+sixty-byte header can otherwise ask for sixty-four gigabytes.
+
 ## The charter, so this does not become a junk drawer
 
 **The PNG format, in memory, and nothing else.**
 
-The one direction it may grow is a **decoder for the same format** —
-which `renew-asset` names as a missing piece — because encoding and
-decoding one format are one body of knowledge, and splitting them puts
-the same specification in two crates.
+The decoder this once named as its one permitted direction of growth —
+because encoding and decoding one format are one body of knowledge, and
+splitting them puts the same specification in two crates — has landed.
+That direction is now closed: the charter below is the whole of it.
 
 Explicitly out of scope:
 

--- a/crates/png/src/colours.rs
+++ b/crates/png/src/colours.rs
@@ -1,0 +1,548 @@
+//! Every colour type read, and every refusal refused.
+//!
+//! **A decoder tested only against what this crate writes is tested
+//! against one file shape.** The encoder emits 8-bit RGBA, unfiltered,
+//! fixed Huffman — so a round trip proves the truecolour-with-alpha path
+//! and nothing else. Greyscale, truecolour, palette and greyscale-with-
+//! alpha were all unverified when they were written, which is the same
+//! hole the scanline filters were in and was found the same way: a probe
+//! that broke one of them stayed green.
+//!
+//! The fixtures here are built by hand, in a **stored** deflate block, so
+//! what is under test is the pixel layout rather than the Huffman coding
+//! — which the round trip and the real-file test already cover from both
+//! directions.
+
+#[cfg(test)]
+mod tests {
+    use crate::decode::{DecodeError, Image, decode};
+
+    /// Wrap bytes as a PNG chunk: length, type, body, checksum.
+    fn chunk(id: [u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&u32::try_from(body.len()).unwrap_or(0).to_be_bytes());
+        out.extend_from_slice(&id);
+        out.extend_from_slice(body);
+        out.extend_from_slice(&crate::checksum(id, body).to_be_bytes());
+        out
+    }
+
+    /// A zlib stream holding `raw` in one stored block.
+    fn stored(raw: &[u8]) -> Vec<u8> {
+        let mut out = vec![0x78, 0x01, 0b0000_0001];
+        let length = u16::try_from(raw.len()).expect("a small fixture");
+        out.extend_from_slice(&length.to_le_bytes());
+        out.extend_from_slice(&(!length).to_le_bytes());
+        out.extend_from_slice(raw);
+        out.extend_from_slice(&crate::adler32(raw).to_be_bytes());
+        out
+    }
+
+    /// How a fixture is shaped.
+    #[derive(Clone)]
+    struct Shape {
+        width: u32,
+        height: u32,
+        depth: u8,
+        colour: u8,
+        /// Samples, already in the file's own layout, without filter
+        /// bytes — those are added here, all zero.
+        samples: Vec<u8>,
+        palette: Vec<u8>,
+        alpha: Vec<u8>,
+    }
+
+    /// A whole PNG from a shape.
+    fn file(shape: &Shape) -> Vec<u8> {
+        let channels = match shape.colour {
+            0 | 3 => 1,
+            2 => 3,
+            4 => 2,
+            _ => 4,
+        };
+        let stride = shape.width as usize * channels * usize::from(shape.depth) / 8;
+        let mut raw = Vec::new();
+        for line in 0..shape.height as usize {
+            raw.push(0);
+            raw.extend_from_slice(&shape.samples[line * stride..(line + 1) * stride]);
+        }
+
+        let mut header = Vec::new();
+        header.extend_from_slice(&shape.width.to_be_bytes());
+        header.extend_from_slice(&shape.height.to_be_bytes());
+        header.extend_from_slice(&[shape.depth, shape.colour, 0, 0, 0]);
+
+        let mut out = crate::SIGNATURE.to_vec();
+        out.extend_from_slice(&chunk(*b"IHDR", &header));
+        if !shape.palette.is_empty() {
+            out.extend_from_slice(&chunk(*b"PLTE", &shape.palette));
+        }
+        if !shape.alpha.is_empty() {
+            out.extend_from_slice(&chunk(*b"tRNS", &shape.alpha));
+        }
+        out.extend_from_slice(&chunk(*b"IDAT", &stored(&raw)));
+        out.extend_from_slice(&chunk(*b"IEND", &[]));
+        out
+    }
+
+    fn read(shape: &Shape) -> Image {
+        decode(&file(shape)).unwrap_or_else(|error| {
+            panic!(
+                "colour {} at depth {} did not decode: {error:?}",
+                shape.colour, shape.depth
+            )
+        })
+    }
+
+    /// **Greyscale becomes grey, on every channel, and opaque.**
+    ///
+    /// Probed by copying only the red channel: green and blue come out
+    /// zero and the pixels compare unequal.
+    #[test]
+    fn greyscale_expands_to_grey() {
+        let shape = Shape {
+            width: 3,
+            height: 2,
+            depth: 8,
+            colour: 0,
+            samples: vec![0, 40, 255, 90, 130, 200],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        let image = read(&shape);
+        let want: Vec<u8> = shape
+            .samples
+            .iter()
+            .flat_map(|grey| [*grey, *grey, *grey, 255])
+            .collect();
+        assert_eq!(image.pixels, want, "greyscale did not expand evenly");
+    }
+
+    /// A greyscale image's `tRNS` names one shade as fully clear — and
+    /// **the value sits in the low byte of a sixteen-bit pair**, which is
+    /// the mistake that makes transparency work only on the images that
+    /// do not need it.
+    ///
+    /// Probed by reading index zero instead: nothing comes out clear.
+    #[test]
+    fn a_greyscale_transparent_shade_is_read_from_the_low_byte() {
+        let shape = Shape {
+            width: 3,
+            height: 1,
+            depth: 8,
+            colour: 0,
+            samples: vec![10, 20, 30],
+            palette: Vec::new(),
+            // Sixteen bits, big-endian: the value 20.
+            alpha: vec![0, 20],
+        };
+        let image = read(&shape);
+        let alphas: Vec<u8> = image
+            .pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|p| p[3])
+            .collect();
+        assert_eq!(
+            alphas,
+            vec![255, 0, 255],
+            "the named shade is not the one that came out clear"
+        );
+    }
+
+    /// Truecolour keeps its channels and comes out opaque.
+    #[test]
+    fn truecolour_keeps_its_channels() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 2,
+            samples: vec![10, 20, 30, 200, 100, 50],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        assert_eq!(
+            read(&shape).pixels,
+            vec![10, 20, 30, 255, 200, 100, 50, 255],
+            "truecolour changed its channels"
+        );
+    }
+
+    /// A truecolour `tRNS` names one colour as clear, read from the low
+    /// byte of each pair for the same reason greyscale's is.
+    #[test]
+    fn a_truecolour_transparent_colour_is_named_exactly() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 2,
+            samples: vec![10, 20, 30, 200, 100, 50],
+            palette: Vec::new(),
+            alpha: vec![0, 200, 0, 100, 0, 50],
+        };
+        let image = read(&shape);
+        assert_eq!(
+            image.pixels[3], 255,
+            "a colour that was not named came out clear"
+        );
+        assert_eq!(
+            image.pixels[7], 0,
+            "the named colour did not come out clear"
+        );
+    }
+
+    /// **A palette image is its palette**, and its `tRNS` is one alpha per
+    /// entry rather than a value to compare against.
+    ///
+    /// Probed by indexing the palette with the pixel's position instead of
+    /// its value: every pixel comes out the first entry.
+    #[test]
+    fn a_palette_image_reads_its_entries() {
+        let shape = Shape {
+            width: 4,
+            height: 1,
+            depth: 8,
+            colour: 3,
+            samples: vec![2, 0, 1, 2],
+            palette: vec![255, 0, 0, 0, 255, 0, 0, 0, 255],
+            alpha: vec![255, 128],
+        };
+        assert_eq!(
+            read(&shape).pixels,
+            vec![
+                0, 0, 255, 255, // entry 2, no tRNS entry, so opaque
+                255, 0, 0, 255, // entry 0, alpha 255
+                0, 255, 0, 128, // entry 1, alpha 128
+                0, 0, 255, 255,
+            ],
+            "the palette was not read entry by entry"
+        );
+    }
+
+    /// An index past the palette's end is a refusal, not a wrap: a file
+    /// that names an entry it did not supply is corrupt, and reading
+    /// entry zero instead would hand back a picture that looks plausible.
+    #[test]
+    fn a_palette_index_past_the_end_is_refused() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 3,
+            samples: vec![0, 7],
+            palette: vec![255, 0, 0],
+            alpha: Vec::new(),
+        };
+        assert_eq!(
+            decode(&file(&shape)),
+            Err(DecodeError::BadPalette {
+                entries: 1,
+                index: 7
+            })
+        );
+    }
+
+    /// Greyscale with alpha carries its own opacity per pixel.
+    #[test]
+    fn greyscale_with_alpha_keeps_both() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 4,
+            samples: vec![90, 10, 200, 255],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        assert_eq!(
+            read(&shape).pixels,
+            vec![90, 90, 90, 10, 200, 200, 200, 255],
+            "greyscale with alpha lost one of its halves"
+        );
+    }
+
+    /// **Sixteen-bit samples are taken by their high byte.** The low byte
+    /// is a precision this decoder's output cannot carry, and averaging
+    /// the pair would invent a value neither of them holds.
+    ///
+    /// Probed by taking the low byte instead: every channel comes out the
+    /// second of its pair.
+    #[test]
+    fn sixteen_bit_samples_keep_their_high_byte() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 16,
+            colour: 2,
+            // Big-endian pairs: (0x1234, 0x5678, 0x9abc) then all 0xff00.
+            samples: vec![
+                0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00,
+            ],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        assert_eq!(
+            read(&shape).pixels,
+            vec![0x12, 0x56, 0x9a, 255, 0xff, 0xff, 0xff, 255],
+            "a sixteen-bit sample did not come back as its high byte"
+        );
+    }
+
+    /// Every header field the format constrains is checked, and each is
+    /// refused by its own name rather than by a shared "bad file".
+    #[test]
+    fn every_impossible_header_field_is_named() {
+        let good = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 6,
+            samples: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        // The header body begins after the signature and the chunk's
+        // length and type; its checksum follows the thirteen bytes.
+        let at = crate::SIGNATURE.len() + 8;
+        let bend = |byte: usize, value: u8| -> Vec<u8> {
+            let mut out = file(&good);
+            out[at + byte] = value;
+            let body = out[at..at + 13].to_vec();
+            let fixed = crate::checksum(*b"IHDR", &body);
+            out[at + 13..at + 17].copy_from_slice(&fixed.to_be_bytes());
+            out
+        };
+
+        assert_eq!(
+            decode(&bend(9, 9)),
+            Err(DecodeError::BadColourType { colour: 9 }),
+            "a colour type the format does not define was accepted"
+        );
+        assert_eq!(
+            decode(&bend(8, 4)),
+            Err(DecodeError::UnsupportedDepth {
+                depth: 4,
+                colour: 6
+            }),
+            "a sub-byte depth was accepted"
+        );
+        assert_eq!(
+            decode(&bend(12, 1)),
+            Err(DecodeError::Interlaced),
+            "an interlaced image was accepted"
+        );
+        assert_eq!(
+            decode(&bend(10, 1)),
+            Err(DecodeError::BadMethod {
+                compression: 1,
+                filter: 0
+            }),
+            "a compression method the format does not define was accepted"
+        );
+        assert_eq!(
+            decode(&bend(11, 1)),
+            Err(DecodeError::BadMethod {
+                compression: 0,
+                filter: 1
+            }),
+            "a filter method the format does not define was accepted"
+        );
+    }
+
+    /// **A chunk this decoder has no use for is stepped over**, not
+    /// refused: the format is built on that, and a file carrying a text
+    /// note or a gamma value is an ordinary file rather than a damaged
+    /// one.
+    #[test]
+    fn a_chunk_it_does_not_know_is_stepped_over() {
+        let shape = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 6,
+            samples: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        let plain = file(&shape);
+        // A `tEXt` chunk between the header and the data.
+        let at = crate::SIGNATURE.len() + 25;
+        let mut out = plain[..at].to_vec();
+        out.extend_from_slice(&chunk(*b"tEXt", b"Comment\0made up"));
+        out.extend_from_slice(&plain[at..]);
+        assert_eq!(
+            decode(&out),
+            decode(&plain),
+            "an unknown chunk changed what the file decoded to"
+        );
+    }
+
+    /// A header chunk shorter than the thirteen bytes the format fixes is
+    /// refused rather than read out of whatever follows it.
+    #[test]
+    fn a_header_shorter_than_the_format_allows_is_refused() {
+        let mut out = crate::SIGNATURE.to_vec();
+        out.extend_from_slice(&chunk(*b"IHDR", &[0, 0, 0, 2, 0, 0, 0, 1]));
+        out.extend_from_slice(&chunk(*b"IEND", &[]));
+        assert_eq!(decode(&out), Err(DecodeError::BadHeader));
+    }
+
+    /// Image data too short to hold even a zlib header is refused there
+    /// rather than at the first byte of a stream that does not exist.
+    #[test]
+    fn image_data_too_short_for_a_zlib_header_is_refused() {
+        let mut header = Vec::new();
+        header.extend_from_slice(&2u32.to_be_bytes());
+        header.extend_from_slice(&1u32.to_be_bytes());
+        header.extend_from_slice(&[8, 6, 0, 0, 0]);
+        let mut out = crate::SIGNATURE.to_vec();
+        out.extend_from_slice(&chunk(*b"IHDR", &header));
+        out.extend_from_slice(&chunk(*b"IDAT", &[0x78]));
+        out.extend_from_slice(&chunk(*b"IEND", &[]));
+        assert_eq!(
+            decode(&out),
+            Err(DecodeError::BadZlibHeader { header: [0, 0] })
+        );
+    }
+
+    /// A file with no image data in it is refused rather than decoded to
+    /// an empty picture.
+    #[test]
+    fn a_file_with_no_image_data_is_refused() {
+        let mut header = Vec::new();
+        header.extend_from_slice(&2u32.to_be_bytes());
+        header.extend_from_slice(&1u32.to_be_bytes());
+        header.extend_from_slice(&[8, 6, 0, 0, 0]);
+        let mut out = crate::SIGNATURE.to_vec();
+        out.extend_from_slice(&chunk(*b"IHDR", &header));
+        out.extend_from_slice(&chunk(*b"IEND", &[]));
+        assert_eq!(decode(&out), Err(DecodeError::NoImageData));
+    }
+
+    /// A file with no header is refused, however well-formed the rest of
+    /// it is.
+    #[test]
+    fn a_file_with_no_header_is_refused() {
+        let mut out = crate::SIGNATURE.to_vec();
+        out.extend_from_slice(&chunk(*b"IDAT", &stored(&[0, 1, 2, 3])));
+        out.extend_from_slice(&chunk(*b"IEND", &[]));
+        assert_eq!(decode(&out), Err(DecodeError::BadHeader));
+    }
+
+    /// The zlib wrapper's own checks are made rather than skipped over:
+    /// a method that is not deflate, a preset dictionary PNG forbids, and
+    /// the header pair's divisibility.
+    #[test]
+    fn a_malformed_zlib_header_is_refused() {
+        let good = Shape {
+            width: 2,
+            height: 1,
+            depth: 8,
+            colour: 6,
+            samples: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        // The IDAT body starts after the signature, IHDR (25 bytes) and
+        // its own length and type.
+        let at = crate::SIGNATURE.len() + 25 + 8;
+        let bend = |byte: usize, value: u8| -> Vec<u8> {
+            let mut out = file(&good);
+            out[at + byte] = value;
+            // The chunk's own checksum is not fixed up: this asks about
+            // the zlib header, so the CRC must not be what refuses it.
+            let length =
+                u32::from_be_bytes([out[at - 8], out[at - 7], out[at - 6], out[at - 5]]) as usize;
+            let body = out[at..at + length].to_vec();
+            let fixed = crate::checksum(*b"IDAT", &body);
+            out[at + length..at + length + 4].copy_from_slice(&fixed.to_be_bytes());
+            out
+        };
+        for (byte, value) in [(0, 0x79u8), (1, 0x21), (1, 0x02)] {
+            let mut header = [0x78, 0x01];
+            header[byte] = value;
+            assert_eq!(
+                decode(&bend(byte, value)),
+                Err(DecodeError::BadZlibHeader { header }),
+                "byte {byte} set to {value:#04x} was accepted as a zlib header"
+            );
+        }
+    }
+
+    /// A stream that decompresses to the wrong number of bytes is refused
+    /// rather than padded or cropped — a row short is a picture with a
+    /// stripe of nothing at the bottom.
+    #[test]
+    fn image_data_of_the_wrong_length_is_refused() {
+        let mut shape = Shape {
+            width: 2,
+            height: 2,
+            depth: 8,
+            colour: 6,
+            samples: vec![0; 2 * 2 * 4],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        // Claim three rows and supply two.
+        let short = file(&shape);
+        shape.height = 3;
+        let mut out = short;
+        let at = crate::SIGNATURE.len() + 8;
+        out[at + 4..at + 8].copy_from_slice(&3u32.to_be_bytes());
+        let body = out[at..at + 13].to_vec();
+        let fixed = crate::checksum(*b"IHDR", &body);
+        out[at + 13..at + 17].copy_from_slice(&fixed.to_be_bytes());
+        // Named exactly: two rows of nine bytes supplied against three
+        // required. A looser pattern would pass on a decoder that had
+        // refused for some other reason entirely.
+        assert_eq!(
+            decode(&out),
+            Err(DecodeError::BadImageLength {
+                expected: 27,
+                found: 18
+            }),
+            "a stream two rows long was accepted for a three-row image"
+        );
+    }
+
+    /// A scanline filter the format does not define is refused, and the
+    /// error names the row — because a file with one bad row is a file
+    /// somebody will want to find the row in.
+    #[test]
+    fn a_filter_the_format_does_not_define_is_refused() {
+        let shape = Shape {
+            width: 2,
+            height: 2,
+            depth: 8,
+            colour: 6,
+            samples: vec![7; 2 * 2 * 4],
+            palette: Vec::new(),
+            alpha: Vec::new(),
+        };
+        let mut out = file(&shape);
+        // The second row's filter byte, inside the stored block: past the
+        // signature, IHDR, the IDAT header, the zlib header, the stored
+        // block header, one filter byte and one row.
+        let stride = 2 * 4;
+        let at = crate::SIGNATURE.len() + 25 + 8 + 2 + 5 + (1 + stride);
+        out[at] = 9;
+        let length = u32::from_be_bytes([
+            out[crate::SIGNATURE.len() + 25],
+            out[crate::SIGNATURE.len() + 26],
+            out[crate::SIGNATURE.len() + 27],
+            out[crate::SIGNATURE.len() + 28],
+        ]) as usize;
+        let body_at = crate::SIGNATURE.len() + 25 + 8;
+        let body = out[body_at..body_at + length].to_vec();
+        let fixed = crate::checksum(*b"IDAT", &body);
+        out[body_at + length..body_at + length + 4].copy_from_slice(&fixed.to_be_bytes());
+        assert_eq!(
+            decode(&out),
+            Err(DecodeError::BadFilter { filter: 9, row: 1 }),
+            "a filter byte of nine was accepted"
+        );
+    }
+}

--- a/crates/png/src/decode.rs
+++ b/crates/png/src/decode.rs
@@ -762,6 +762,31 @@ mod filters {
         file
     }
 
+    /// **The Paeth predictor's third answer.**
+    ///
+    /// Paeth takes whichever of the three neighbours is nearest their
+    /// linear estimate, and the up-left corner winning is the rarest of
+    /// the three — the generated fixture above never produced it, so that
+    /// branch was unexercised while every filter looked covered. These
+    /// values make it win outright: left 10, up 200, corner 100 gives an
+    /// estimate of 110, which is a hundred from the left, ninety from the
+    /// up, and ten from the corner.
+    ///
+    /// Probed by returning `up` where the corner is chosen: the second
+    /// row comes back wrong.
+    #[test]
+    fn the_paeth_predictor_can_choose_the_corner() {
+        let width = 2u32;
+        let mut pixels = vec![100u8, 100, 100, 255, 200, 200, 200, 255];
+        pixels.extend_from_slice(&[10, 10, 10, 255, 77, 88, 99, 255]);
+        let file = built(width, &pixels, &[0, 4]);
+        let image = decode(&file).expect("the fixture decodes");
+        assert_eq!(
+            image.pixels, pixels,
+            "the corner-predicted row came back wrong"
+        );
+    }
+
     /// **Every scanline filter, undone.**
     ///
     /// The encoder in this crate writes filter zero and nothing else, and
@@ -793,16 +818,16 @@ mod filters {
                 .unwrap_or_else(|error| panic!("{filters:?} did not decode: {error:?}"));
             assert_eq!(image.width, width);
             assert_eq!(image.height, 5);
-            for (row, (got, want)) in image
+            for (row, ((got, want), filter)) in image
                 .pixels
                 .chunks(width as usize * 4)
                 .zip(pixels.chunks(width as usize * 4))
+                .zip(&filters)
                 .enumerate()
             {
                 assert_eq!(
                     got, want,
-                    "row {row} under filter {} came back different",
-                    filters[row]
+                    "row {row} under filter {filter} came back different"
                 );
             }
         }

--- a/crates/png/src/decode.rs
+++ b/crates/png/src/decode.rs
@@ -1,0 +1,810 @@
+//! A PNG decoder, to the encoder's dimensions.
+//!
+//! # Why this exists
+//!
+//! A crate that writes pictures and cannot read one leaves every consumer
+//! that ships art to find its own way in. That is the gap: this crate has
+//! encoded since its first commit so a person could look at what the
+//! renderer drew, and the moment anything wants to *load* an image —
+//! sprites, tiles, a font atlas, a heightfield — it has nowhere to go.
+//!
+//! Written rather than depended on for the reason the encoder gives: the
+//! two halves of a format should not disagree about what the format is,
+//! and the tables, the bit order and the chunk layout are already here.
+//!
+//! # What it reads
+//!
+//! Every non-interlaced 8- and 16-bit PNG: greyscale, greyscale with
+//! alpha, truecolour, truecolour with alpha, and palette — with `tRNS`
+//! honoured for the three types that can carry it. Output is always 8-bit
+//! RGBA, because a consumer that wanted to branch on colour type would be
+//! doing the decoder's job.
+//!
+//! **Not** interlaced images, and not bit depths below eight. Both are
+//! refused by name rather than mis-read. Adam7 is a different image layout
+//! rather than a different pixel format, and sub-byte depths want a
+//! bit-unpacker that nothing has asked for; when something does, they are
+//! additions here rather than a second decoder.
+//!
+//! # Refusals
+//!
+//! Every chunk's CRC is checked, every length is validated against the
+//! bytes actually present, and every field is checked against the values
+//! the specification allows. A file from disk or from the network is
+//! hostile input, and this reads it as such: nothing is trusted because it
+//! is written down.
+
+use crate::inflate::{InflateError, inflate};
+
+/// A decoded image: 8-bit RGBA, row-major, top row first.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Image {
+    /// Pixels across.
+    pub width: u32,
+    /// Pixels down.
+    pub height: u32,
+    /// `width * height * 4` bytes, red, green, blue then alpha.
+    pub pixels: Vec<u8>,
+}
+
+/// Why an image could not be decoded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecodeError {
+    /// The first eight bytes are not PNG's signature. Usually a file that
+    /// is not a PNG at all, which is worth saying differently from a PNG
+    /// that is damaged.
+    NotAPng,
+    /// A chunk's declared length runs past the end of the file.
+    ChunkOverruns {
+        /// The four bytes of the chunk's type.
+        id: [u8; 4],
+        /// Where the chunk began.
+        at: usize,
+        /// The length it declared.
+        declared: usize,
+        /// How many bytes were actually left.
+        available: usize,
+    },
+    /// A chunk's checksum does not match its contents.
+    BadChecksum {
+        /// The four bytes of the chunk's type.
+        id: [u8; 4],
+        /// What the file claimed.
+        declared: u32,
+        /// What the bytes actually hash to.
+        found: u32,
+    },
+    /// No `IHDR`, or one that is not thirteen bytes.
+    BadHeader,
+    /// A width or a height of zero, which PNG does not allow.
+    ZeroExtent {
+        /// The width the header declared.
+        width: u32,
+        /// The height the header declared.
+        height: u32,
+    },
+    /// A colour type the format does not define.
+    BadColourType {
+        /// The value the header carried.
+        colour: u8,
+    },
+    /// A bit depth this decoder does not read. Eight and sixteen are
+    /// read; one, two and four are legal PNG and refused here.
+    UnsupportedDepth {
+        /// The depth the header declared.
+        depth: u8,
+        /// The colour type it went with.
+        colour: u8,
+    },
+    /// An interlaced image. Legal PNG, and a different image layout
+    /// rather than a different pixel format.
+    Interlaced,
+    /// A compression or filter method the format does not define — both
+    /// have exactly one legal value.
+    BadMethod {
+        /// The compression method byte.
+        compression: u8,
+        /// The filter method byte.
+        filter: u8,
+    },
+    /// A palette image with no `PLTE`, or an index past the palette's end.
+    BadPalette {
+        /// How many entries the palette held.
+        entries: usize,
+        /// The index that was asked for.
+        index: usize,
+    },
+    /// No `IDAT` chunks at all.
+    NoImageData,
+    /// The file ended without an `IEND` chunk.
+    ///
+    /// **Which is how a truncation is caught.** Image data is written
+    /// before the terminator, so a file cut short after its last `IDAT`
+    /// holds a complete-looking image and would otherwise decode without
+    /// complaint — a half-downloaded sprite that looks like a whole one.
+    MissingEnd,
+    /// The zlib wrapper around the image data is malformed.
+    BadZlibHeader {
+        /// The two bytes that were read.
+        header: [u8; 2],
+    },
+    /// The image data could not be decompressed.
+    Deflate {
+        /// Why not.
+        cause: InflateError,
+    },
+    /// The decompressed data is not a whole number of filtered rows.
+    BadImageLength {
+        /// What the header's shape requires.
+        expected: usize,
+        /// What arrived.
+        found: usize,
+    },
+    /// A scanline filter byte the format does not define.
+    BadFilter {
+        /// The value that was read.
+        filter: u8,
+        /// Which row carried it.
+        row: usize,
+    },
+    /// The image is larger than this machine can address.
+    TooLarge {
+        /// The width the header declared.
+        width: u32,
+        /// The height the header declared.
+        height: u32,
+    },
+}
+
+/// The largest image this decoder will expand into memory, in bytes.
+///
+/// **A ceiling rather than trust.** A header is four bytes of width and
+/// four of height, so a file of sixty bytes can ask for sixty-four
+/// gigabytes; without a limit the refusal is an allocation failure rather
+/// than an answer. Two hundred and fifty-six megabytes is far past any
+/// texture a game loads and far short of anything that hurts.
+const CEILING: usize = 256 << 20;
+
+/// Read a PNG.
+///
+/// # Errors
+///
+/// Every way a file can fail to be a readable PNG, by name — see
+/// [`DecodeError`].
+pub fn decode(bytes: &[u8]) -> Result<Image, DecodeError> {
+    if bytes.len() < crate::SIGNATURE.len() || bytes[..crate::SIGNATURE.len()] != crate::SIGNATURE {
+        return Err(DecodeError::NotAPng);
+    }
+
+    let mut header: Option<Header> = None;
+    let mut palette: Vec<[u8; 3]> = Vec::new();
+    let mut alpha: Vec<u8> = Vec::new();
+    let mut data: Vec<u8> = Vec::new();
+    let mut ended = false;
+
+    let mut at = crate::SIGNATURE.len();
+    while at + 8 <= bytes.len() {
+        let declared =
+            u32::from_be_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]) as usize;
+        let id = [bytes[at + 4], bytes[at + 5], bytes[at + 6], bytes[at + 7]];
+        let body_at = at + 8;
+        let available = bytes.len().saturating_sub(body_at);
+        // The four checksum bytes must be there too.
+        if declared.saturating_add(4) > available {
+            return Err(DecodeError::ChunkOverruns {
+                id,
+                at,
+                declared,
+                available,
+            });
+        }
+        let body = &bytes[body_at..body_at + declared];
+        let stated = u32::from_be_bytes([
+            bytes[body_at + declared],
+            bytes[body_at + declared + 1],
+            bytes[body_at + declared + 2],
+            bytes[body_at + declared + 3],
+        ]);
+        let found = crate::checksum(id, body);
+        if stated != found {
+            return Err(DecodeError::BadChecksum {
+                id,
+                declared: stated,
+                found,
+            });
+        }
+
+        match &id {
+            b"IHDR" => header = Some(read_header(body)?),
+            b"PLTE" => {
+                palette = body.as_chunks::<3>().0.to_vec();
+            }
+            b"tRNS" => alpha = body.to_vec(),
+            b"IDAT" => data.extend_from_slice(body),
+            b"IEND" => {
+                ended = true;
+                break;
+            }
+            _ => {}
+        }
+        at = body_at + declared + 4;
+    }
+
+    let header = header.ok_or(DecodeError::BadHeader)?;
+    if !ended {
+        return Err(DecodeError::MissingEnd);
+    }
+    if data.is_empty() {
+        return Err(DecodeError::NoImageData);
+    }
+    let raw = decompress(&data, &header)?;
+    let samples = unfilter(raw, &header)?;
+    expand(&samples, &header, &palette, &alpha)
+}
+
+/// What `IHDR` said.
+#[derive(Clone, Copy, Debug)]
+struct Header {
+    width: u32,
+    height: u32,
+    depth: u8,
+    colour: u8,
+}
+
+impl Header {
+    /// How many samples each pixel carries.
+    const fn channels(self) -> usize {
+        match self.colour {
+            0 | 3 => 1,
+            2 => 3,
+            4 => 2,
+            _ => 4,
+        }
+    }
+
+    /// How many bytes each pixel occupies in the filtered stream.
+    const fn stride(self) -> usize {
+        self.channels() * (self.depth as usize / 8)
+    }
+
+    /// How many bytes each row occupies, without its filter byte.
+    const fn row(self) -> usize {
+        self.width as usize * self.stride()
+    }
+}
+
+fn read_header(body: &[u8]) -> Result<Header, DecodeError> {
+    let Some(body) = body.get(..13) else {
+        return Err(DecodeError::BadHeader);
+    };
+    let width = u32::from_be_bytes([body[0], body[1], body[2], body[3]]);
+    let height = u32::from_be_bytes([body[4], body[5], body[6], body[7]]);
+    let (depth, colour, compression, filter, interlace) =
+        (body[8], body[9], body[10], body[11], body[12]);
+    if width == 0 || height == 0 {
+        return Err(DecodeError::ZeroExtent { width, height });
+    }
+    if !matches!(colour, 0 | 2 | 3 | 4 | 6) {
+        return Err(DecodeError::BadColourType { colour });
+    }
+    if compression != 0 || filter != 0 {
+        return Err(DecodeError::BadMethod {
+            compression,
+            filter,
+        });
+    }
+    if interlace != 0 {
+        return Err(DecodeError::Interlaced);
+    }
+    // Sixteen-bit palette entries do not exist; everything else may be
+    // eight or sixteen here.
+    if !matches!(depth, 8 | 16) || (colour == 3 && depth != 8) {
+        return Err(DecodeError::UnsupportedDepth { depth, colour });
+    }
+    let header = Header {
+        width,
+        height,
+        depth,
+        colour,
+    };
+    // The filtered stream is one byte per row plus the row itself, and it
+    // has to fit in a `usize` before anything is allocated for it.
+    header
+        .row()
+        .checked_add(1)
+        .and_then(|row| row.checked_mul(height as usize))
+        .filter(|total| *total <= CEILING)
+        .ok_or(DecodeError::TooLarge { width, height })?;
+    Ok(header)
+}
+
+/// Strip the zlib wrapper and decompress.
+fn decompress(data: &[u8], header: &Header) -> Result<Vec<u8>, DecodeError> {
+    let Some(head) = data.get(..2) else {
+        return Err(DecodeError::BadZlibHeader { header: [0, 0] });
+    };
+    let head = [head[0], head[1]];
+    // The low nibble of the first byte is the compression method, which
+    // PNG fixes at 8; bit 5 of the second is a preset dictionary, which
+    // PNG forbids; and the pair read big-endian must divide by 31.
+    let checked = (u32::from(head[0]) << 8 | u32::from(head[1])) % 31 == 0;
+    if head[0] & 0x0f != 8 || head[1] & 0x20 != 0 || !checked {
+        return Err(DecodeError::BadZlibHeader { header: head });
+    }
+    // The trailing Adler-32 is not read: the chunk CRCs already covered
+    // these bytes on the way in, and a second checksum over the same
+    // bytes says nothing new.
+    let stream = data.get(2..).unwrap_or(&[]);
+    let want = (header.row() + 1) * header.height as usize;
+    inflate(stream, want.min(CEILING)).map_err(|cause| DecodeError::Deflate { cause })
+}
+
+/// Undo the per-row filters, leaving raw samples.
+///
+/// **In place, row by row, and each row needs the one above it** — which
+/// is why this consumes the filtered buffer rather than borrowing it: the
+/// reconstructed bytes of row `n - 1` are what row `n` is reconstructed
+/// against, so the two cannot be separate buffers without copying every
+/// row twice.
+fn unfilter(mut raw: Vec<u8>, header: &Header) -> Result<Vec<u8>, DecodeError> {
+    let row = header.row();
+    let stride = header.stride();
+    let height = header.height as usize;
+    let expected = (row + 1) * height;
+    if raw.len() != expected {
+        return Err(DecodeError::BadImageLength {
+            expected,
+            found: raw.len(),
+        });
+    }
+
+    let mut out = vec![0u8; row * height];
+    for line in 0..height {
+        let filter = raw[line * (row + 1)];
+        let from = line * (row + 1) + 1;
+        let source: Vec<u8> = raw[from..from + row].to_vec();
+        for at in 0..row {
+            let left = if at >= stride {
+                out[line * row + at - stride]
+            } else {
+                0
+            };
+            let up = if line > 0 {
+                out[(line - 1) * row + at]
+            } else {
+                0
+            };
+            let corner = if line > 0 && at >= stride {
+                out[(line - 1) * row + at - stride]
+            } else {
+                0
+            };
+            let value = source[at];
+            out[line * row + at] = match filter {
+                0 => value,
+                1 => value.wrapping_add(left),
+                2 => value.wrapping_add(up),
+                // The specification's `Average` is the floor of the two
+                // neighbours' mean, computed without overflowing — which
+                // is exactly `midpoint`.
+                3 => value.wrapping_add(left.midpoint(up)),
+                4 => value.wrapping_add(paeth(left, up, corner)),
+                other => {
+                    return Err(DecodeError::BadFilter {
+                        filter: other,
+                        row: line,
+                    });
+                }
+            };
+        }
+    }
+    raw.clear();
+    Ok(out)
+}
+
+/// The Paeth predictor: whichever of the three neighbours is nearest to
+/// their linear estimate.
+const fn paeth(left: u8, up: u8, corner: u8) -> u8 {
+    let estimate = left as i16 + up as i16 - corner as i16;
+    let to_left = (estimate - left as i16).abs();
+    let to_up = (estimate - up as i16).abs();
+    let to_corner = (estimate - corner as i16).abs();
+    if to_left <= to_up && to_left <= to_corner {
+        left
+    } else if to_up <= to_corner {
+        up
+    } else {
+        corner
+    }
+}
+
+/// Turn raw samples into 8-bit RGBA.
+fn expand(
+    samples: &[u8],
+    header: &Header,
+    palette: &[[u8; 3]],
+    alpha: &[u8],
+) -> Result<Image, DecodeError> {
+    let count = header.width as usize * header.height as usize;
+    let mut pixels = Vec::with_capacity(count * 4);
+    let stride = header.stride();
+    // Sixteen-bit samples are taken by their high byte. The low byte is
+    // a precision this decoder's output cannot carry, and averaging the
+    // pair would invent a value neither of them holds.
+    let step = header.depth as usize / 8;
+    for index in 0..count {
+        let at = index * stride;
+        let sample =
+            |channel: usize| -> u8 { samples.get(at + channel * step).copied().unwrap_or(0) };
+        let rgba = match header.colour {
+            0 => {
+                let grey = sample(0);
+                [grey, grey, grey, grey_alpha(alpha, grey, header)]
+            }
+            2 => {
+                let (r, g, b) = (sample(0), sample(1), sample(2));
+                [r, g, b, colour_alpha(alpha, [r, g, b], header)]
+            }
+            3 => {
+                let index = usize::from(sample(0));
+                let entry = palette.get(index).copied().ok_or(DecodeError::BadPalette {
+                    entries: palette.len(),
+                    index,
+                })?;
+                let opacity = alpha.get(index).copied().unwrap_or(255);
+                [entry[0], entry[1], entry[2], opacity]
+            }
+            4 => {
+                let grey = sample(0);
+                [grey, grey, grey, sample(1)]
+            }
+            _ => [sample(0), sample(1), sample(2), sample(3)],
+        };
+        pixels.extend_from_slice(&rgba);
+    }
+    Ok(Image {
+        width: header.width,
+        height: header.height,
+        pixels,
+    })
+}
+
+/// Which byte of a `tRNS` sample this decoder compares against.
+///
+/// **The specification writes every `tRNS` value as sixteen bits**, so an
+/// 8-bit image's transparent shade sits in the *low* byte of the pair and
+/// a 16-bit image's meaningful half is the high one — which is the half
+/// this decoder keeps. Reading index zero for both is the obvious mistake
+/// and it makes transparency work on exactly the images that do not need
+/// it.
+const fn trns_byte(header: &Header) -> usize {
+    if header.depth == 16 { 0 } else { 1 }
+}
+
+/// `tRNS` for a greyscale image names one fully transparent shade.
+fn grey_alpha(alpha: &[u8], grey: u8, header: &Header) -> u8 {
+    match alpha.get(trns_byte(header)) {
+        Some(clear) if *clear == grey => 0,
+        _ => 255,
+    }
+}
+
+/// `tRNS` for a truecolour image names one fully transparent colour.
+fn colour_alpha(alpha: &[u8], rgb: [u8; 3], header: &Header) -> u8 {
+    let pick = trns_byte(header);
+    let named = [
+        alpha.get(pick).copied(),
+        alpha.get(2 + pick).copied(),
+        alpha.get(4 + pick).copied(),
+    ];
+    match named {
+        [Some(r), Some(g), Some(b)] if [r, g, b] == rgb => 0,
+        _ => 255,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DecodeError, decode};
+
+    /// A picture with runs, gradients and sharp edges in it, so the
+    /// stream exercises literals and back-references rather than one row
+    /// of one colour.
+    fn picture(width: u32, height: u32) -> Vec<u8> {
+        let mut pixels = Vec::new();
+        for y in 0..height {
+            for x in 0..width {
+                let banded = u8::try_from((x / 3 + y / 5) * 37 % 256).unwrap_or(0);
+                let edge = if (x + y) % 11 == 0 { 255 } else { 0 };
+                pixels.extend_from_slice(&[banded, edge, u8::try_from(y % 256).unwrap_or(0), 255]);
+            }
+        }
+        pixels
+    }
+
+    /// **What this crate writes, it reads.**
+    ///
+    /// The assertion that binds the two halves together: a format one
+    /// half of a crate cannot read back is a format the two halves
+    /// disagree about, and that disagreement is invisible until somebody
+    /// hands a file to the other one.
+    ///
+    /// Probed by taking every filtered row's bytes one to the left in
+    /// `unfilter`: the round trip fails on the first row and names it.
+    #[test]
+    fn what_this_crate_writes_it_reads() {
+        for (width, height) in [(1, 1), (16, 9), (37, 5), (5, 37), (64, 64)] {
+            let pixels = picture(width, height);
+            let file = crate::encode(width, height, &pixels).expect("the encoder accepts this");
+            let image = decode(&file)
+                .unwrap_or_else(|error| panic!("{width}x{height} did not decode: {error:?}"));
+            assert_eq!(image.width, width, "{width}x{height} changed width");
+            assert_eq!(image.height, height, "{width}x{height} changed height");
+            assert_eq!(
+                image.pixels, pixels,
+                "{width}x{height} came back with different pixels"
+            );
+        }
+    }
+
+    /// **Files written by something else.**
+    ///
+    /// The encoder here writes one fixed-Huffman block with no filtering,
+    /// so a decoder tested only against this crate's own output is never
+    /// asked about dynamic Huffman — which every other encoder writes.
+    /// These are the repository's own brand images, made by a design
+    /// tool, and they are in the tree already.
+    ///
+    /// **Embedded rather than read.** This crate never touches the
+    /// filesystem — that is its contract and its clippy configuration
+    /// enforces it — so the fixtures are compiled in. A hundred and fifty
+    /// kilobytes of test binary is a cheap price for the only fixtures in
+    /// the tree that no part of this crate produced.
+    ///
+    /// Probed by refusing dynamic blocks in `inflate`: both files fail
+    /// and the message names the kind.
+    #[test]
+    fn files_written_by_another_tool_read() {
+        let files: [(&str, &[u8]); 2] = [
+            (
+                "renew-icon-512.png",
+                include_bytes!("../../../assets/brand/renew-icon-512.png"),
+            ),
+            (
+                "renew-banner.png",
+                include_bytes!("../../../assets/brand/renew-banner.png"),
+            ),
+        ];
+        for (name, bytes) in files {
+            let image =
+                decode(bytes).unwrap_or_else(|error| panic!("{name} did not decode: {error:?}"));
+            assert!(
+                image.width > 0 && image.height > 0,
+                "{name} decoded to nothing"
+            );
+            assert_eq!(
+                image.pixels.len(),
+                image.width as usize * image.height as usize * 4,
+                "{name} decoded to the wrong number of bytes"
+            );
+            // A brand image is not one flat colour, and a decoder that
+            // produced a solid field would pass every assertion above it.
+            let first = image.pixels.get(..4).unwrap_or(&[]);
+            assert!(
+                image
+                    .pixels
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .any(|pixel| pixel != first),
+                "{name} decoded to a single flat colour"
+            );
+        }
+    }
+
+    /// Something that is not a PNG is said to be not a PNG, which is
+    /// worth distinguishing from a PNG that is damaged.
+    #[test]
+    fn a_file_that_is_not_a_png_is_named_as_such() {
+        assert_eq!(decode(b"not a png at all"), Err(DecodeError::NotAPng));
+        assert_eq!(decode(&[]), Err(DecodeError::NotAPng));
+    }
+
+    /// **A damaged chunk is refused rather than read.** Every chunk
+    /// carries a CRC and this checks it, so a file that changed in
+    /// transit is an error with a name instead of an image with a stripe
+    /// through it.
+    #[test]
+    fn a_chunk_whose_checksum_fails_is_refused() {
+        let mut file = crate::encode(8, 8, &picture(8, 8)).expect("the encoder accepts this");
+        // The last byte of `IHDR`'s body: the interlace flag, which is
+        // covered by the checksum four bytes later.
+        let at = 8 + 8 + 12;
+        file[at] ^= 0x01;
+        assert!(
+            matches!(decode(&file), Err(DecodeError::BadChecksum { .. })),
+            "a chunk with a broken checksum was read anyway"
+        );
+    }
+
+    /// A truncated file is refused by name rather than decoded to
+    /// whatever arrived — a half-downloaded sprite must not look like a
+    /// short one.
+    #[test]
+    fn a_truncated_file_is_refused() {
+        let file = crate::encode(16, 16, &picture(16, 16)).expect("the encoder accepts this");
+        for keep in [12, 30, file.len() / 2, file.len() - 5] {
+            assert!(
+                decode(&file[..keep]).is_err(),
+                "{keep} bytes of a file decoded without complaint"
+            );
+        }
+    }
+
+    /// The header's own fields are checked against what the format
+    /// allows, so a file claiming an impossible shape is an error rather
+    /// than an allocation.
+    #[test]
+    fn an_impossible_header_is_refused() {
+        let mut file = crate::encode(8, 8, &picture(8, 8)).expect("the encoder accepts this");
+        // Width to zero, and the checksum rewritten so the refusal comes
+        // from the field rather than from the CRC that would also catch it.
+        let body_at = 8 + 8;
+        file[body_at..body_at + 4].copy_from_slice(&0u32.to_be_bytes());
+        let body = file[body_at..body_at + 13].to_vec();
+        let fixed = crate::checksum(*b"IHDR", &body);
+        file[body_at + 13..body_at + 17].copy_from_slice(&fixed.to_be_bytes());
+        assert_eq!(
+            decode(&file),
+            Err(DecodeError::ZeroExtent {
+                width: 0,
+                height: 8
+            }),
+            "a zero-width image was accepted"
+        );
+    }
+}
+
+#[cfg(test)]
+mod filters {
+    use super::decode;
+
+    /// The five scanline filters, applied **forwards**.
+    ///
+    /// **Written here rather than reused from the decoder**, which is the
+    /// whole point: the decoder implements the inverse, so a test that
+    /// called the decoder's own arithmetic to build its fixture would
+    /// agree with any mistake in it. These are transcribed from the
+    /// specification, and the two meet in the middle.
+    fn apply(filter: u8, row: &[u8], above: &[u8], bpp: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(row.len());
+        for (at, raw) in row.iter().enumerate() {
+            let left = if at >= bpp { row[at - bpp] } else { 0 };
+            let up = above.get(at).copied().unwrap_or(0);
+            let corner = if at >= bpp {
+                above.get(at - bpp).copied().unwrap_or(0)
+            } else {
+                0
+            };
+            let predicted = match filter {
+                0 => 0,
+                1 => left,
+                2 => up,
+                3 => left.midpoint(up),
+                _ => {
+                    let estimate = i16::from(left) + i16::from(up) - i16::from(corner);
+                    let (dl, du, dc) = (
+                        (estimate - i16::from(left)).abs(),
+                        (estimate - i16::from(up)).abs(),
+                        (estimate - i16::from(corner)).abs(),
+                    );
+                    if dl <= du && dl <= dc {
+                        left
+                    } else if du <= dc {
+                        up
+                    } else {
+                        corner
+                    }
+                }
+            };
+            out.push(raw.wrapping_sub(predicted));
+        }
+        out
+    }
+
+    /// Wrap bytes as a PNG chunk: length, type, body, checksum.
+    fn chunk(id: [u8; 4], body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&u32::try_from(body.len()).unwrap_or(0).to_be_bytes());
+        out.extend_from_slice(&id);
+        out.extend_from_slice(body);
+        out.extend_from_slice(&crate::checksum(id, body).to_be_bytes());
+        out
+    }
+
+    /// A whole PNG, hand-built, whose rows each use a different filter.
+    ///
+    /// The image data goes in a **stored** deflate block, so the fixture
+    /// needs no compressor of its own and the thing under test is the
+    /// filtering rather than the Huffman coding — which the other tests
+    /// already cover from both directions.
+    fn built(width: u32, pixels: &[u8], filters: &[u8]) -> Vec<u8> {
+        const BPP: usize = 4;
+        let stride = width as usize * BPP;
+        let height = u32::try_from(filters.len()).unwrap_or(0);
+
+        let mut raw = Vec::new();
+        let mut above = vec![0u8; stride];
+        for (line, filter) in filters.iter().enumerate() {
+            let row = &pixels[line * stride..(line + 1) * stride];
+            raw.push(*filter);
+            raw.extend_from_slice(&apply(*filter, row, &above, BPP));
+            above = row.to_vec();
+        }
+
+        let mut zlib = vec![0x78, 0x01, 0b0000_0001];
+        let length = u16::try_from(raw.len()).expect("a small fixture");
+        zlib.extend_from_slice(&length.to_le_bytes());
+        zlib.extend_from_slice(&(!length).to_le_bytes());
+        zlib.extend_from_slice(&raw);
+        zlib.extend_from_slice(&crate::adler32(&raw).to_be_bytes());
+
+        let mut header = Vec::new();
+        header.extend_from_slice(&width.to_be_bytes());
+        header.extend_from_slice(&height.to_be_bytes());
+        header.extend_from_slice(&[8, 6, 0, 0, 0]);
+
+        let mut file = crate::SIGNATURE.to_vec();
+        file.extend_from_slice(&chunk(*b"IHDR", &header));
+        file.extend_from_slice(&chunk(*b"IDAT", &zlib));
+        file.extend_from_slice(&chunk(*b"IEND", &[]));
+        file
+    }
+
+    /// **Every scanline filter, undone.**
+    ///
+    /// The encoder in this crate writes filter zero and nothing else, and
+    /// the repository's own brand images turned out not to use all five
+    /// either — so breaking the Paeth predictor outright left both of the
+    /// other decoder tests green. Four of the five filters were unverified
+    /// and looked verified, which is the failure this fixture exists for.
+    ///
+    /// Probed by breaking each predictor in turn: Paeth to always take
+    /// the left neighbour, the average to take their sum, `Sub` to add
+    /// nothing, and `Up` to read the wrong row. Each names its row.
+    #[test]
+    fn every_scanline_filter_is_undone() {
+        let width = 5u32;
+        // Values chosen to make the predictors disagree: neighbours that
+        // differ in both directions, and wrapping past 255 and below 0.
+        let pixels: Vec<u8> = (0..width * 5 * 4)
+            .map(|at| u8::try_from((at * 37 + at / 7 * 91) % 256).unwrap_or(0))
+            .collect();
+        for filters in [
+            vec![0, 1, 2, 3, 4],
+            vec![4, 3, 2, 1, 0],
+            vec![4, 4, 4, 4, 4],
+            vec![3, 3, 3, 3, 3],
+            vec![1, 2, 1, 2, 1],
+        ] {
+            let file = built(width, &pixels, &filters);
+            let image = decode(&file)
+                .unwrap_or_else(|error| panic!("{filters:?} did not decode: {error:?}"));
+            assert_eq!(image.width, width);
+            assert_eq!(image.height, 5);
+            for (row, (got, want)) in image
+                .pixels
+                .chunks(width as usize * 4)
+                .zip(pixels.chunks(width as usize * 4))
+                .enumerate()
+            {
+                assert_eq!(
+                    got, want,
+                    "row {row} under filter {} came back different",
+                    filters[row]
+                );
+            }
+        }
+    }
+}

--- a/crates/png/src/inflate.rs
+++ b/crates/png/src/inflate.rs
@@ -346,9 +346,12 @@ fn dynamic(bits: &mut Bits<'_>) -> Result<(Huffman, Huffman), InflateError> {
     let literals = short(bits, 5)? as usize + 257;
     let distances = short(bits, 5)? as usize + 1;
     let codes = short(bits, 4)? as usize + 4;
-    if literals > 288 || distances > 32 || codes > LENGTH_ORDER.len() {
-        return Err(InflateError::BadCodeLengths);
-    }
+    // **No bounds check on the three counts, because the bit widths are
+    // the bounds.** `literals` is five bits plus 257, so at most 288;
+    // `distances` five bits plus one, so at most 32; `codes` four bits
+    // plus four, so at most 19 — which are exactly the ceilings the
+    // format states. A guard against them would be a condition that
+    // cannot fail, which reads as a check and is not one.
 
     // The table that describes the other two tables.
     let mut code_lengths = [0u8; LENGTH_ORDER.len()];
@@ -501,11 +504,16 @@ mod tests {
     fn a_stored_block_with_a_bad_complement_is_refused() {
         let mut bytes = stored_block(b"hello");
         bytes[3] ^= 0x01;
-        assert!(
-            matches!(
-                inflate(&bytes, 1 << 20),
-                Err(InflateError::StoredLengthMismatch { .. })
-            ),
+        // Named exactly rather than matched loosely: the pair it reports
+        // is the evidence that it read the header where it thought it
+        // did, and a pattern that ignores them would pass on a decoder
+        // that had lost its place entirely.
+        assert_eq!(
+            inflate(&bytes, 1 << 20),
+            Err(InflateError::StoredLengthMismatch {
+                length: 5,
+                complement: !5u16 ^ 1
+            }),
             "a corrupt stored header was accepted"
         );
     }
@@ -604,6 +612,233 @@ mod tests {
             inflate(&stored_block(&body), 100),
             Err(InflateError::TooLarge { limit: 100 }),
             "a stream past the ceiling was allowed through"
+        );
+    }
+}
+
+#[cfg(test)]
+mod refusals {
+    use super::{Huffman, InflateError, inflate};
+
+    /// A deflate stream's own bytes, built bit by bit, least significant
+    /// first — which is how the format packs everything except the
+    /// Huffman codes themselves.
+    #[derive(Default)]
+    struct Writer {
+        bytes: Vec<u8>,
+        bit: u32,
+    }
+
+    impl Writer {
+        /// `count` bits of `value`, low bit first.
+        fn low(&mut self, value: u32, count: u32) {
+            for step in 0..count {
+                self.one((value >> step) & 1);
+            }
+        }
+
+        /// `count` bits of `value`, **high bit first** — the order a
+        /// Huffman code is written in.
+        fn high(&mut self, value: u32, count: u32) {
+            for step in (0..count).rev() {
+                self.one((value >> step) & 1);
+            }
+        }
+
+        fn one(&mut self, value: u32) {
+            if self.bit == 0 {
+                self.bytes.push(0);
+            }
+            if value & 1 == 1
+                && let Some(last) = self.bytes.last_mut()
+            {
+                *last |= 1 << self.bit;
+            }
+            self.bit = (self.bit + 1) % 8;
+        }
+    }
+
+    /// A final block using the fixed tables, ready for symbols.
+    fn fixed_block() -> Writer {
+        let mut out = Writer::default();
+        out.low(1, 1);
+        out.low(1, 2);
+        out
+    }
+
+    /// **Block kind three does not exist**, and its presence means the
+    /// stream is not deflate at all rather than that it is damaged.
+    #[test]
+    fn a_block_kind_that_does_not_exist_is_refused() {
+        let mut out = Writer::default();
+        out.low(1, 1);
+        out.low(3, 2);
+        assert_eq!(
+            inflate(&out.bytes, 1 << 20),
+            Err(InflateError::BadBlockKind { kind: 3 })
+        );
+    }
+
+    /// **A back-reference cannot reach further back than the output.**
+    /// A stream that opens with one is asking to read from before the
+    /// beginning, and a decoder that answered with zeros would hand back
+    /// a picture built out of a bug.
+    #[test]
+    fn a_back_reference_before_the_beginning_is_refused() {
+        let mut out = fixed_block();
+        // Length symbol 257 — seven bits in the fixed table, code
+        // 0000001 — then distance symbol 0, five bits of zero.
+        out.high(0b000_0001, 7);
+        out.high(0, 5);
+        assert_eq!(
+            inflate(&out.bytes, 1 << 20),
+            Err(InflateError::BadDistance {
+                distance: 1,
+                produced: 0
+            })
+        );
+    }
+
+    /// The fixed table names two length symbols the format never assigns
+    /// a meaning to. They decode, and then they are refused.
+    #[test]
+    fn a_length_symbol_the_format_never_defined_is_refused() {
+        let mut out = fixed_block();
+        // Symbol 286: eight bits in the fixed table, code 11000110.
+        out.high(0b1100_0110, 8);
+        assert_eq!(inflate(&out.bytes, 1 << 20), Err(InflateError::BadSymbol));
+    }
+
+    /// The ceiling holds inside a Huffman block as well as a stored one —
+    /// a literal past it is refused rather than pushed.
+    #[test]
+    fn a_literal_past_the_ceiling_is_refused() {
+        let mut out = fixed_block();
+        // Three literals: 'A', 'B', 'C', each eight bits in the fixed
+        // table at code 0x30 + value.
+        for byte in [b'A', b'B', b'C'] {
+            out.high(0b0011_0000 + u32::from(byte), 8);
+        }
+        assert_eq!(
+            inflate(&out.bytes, 2),
+            Err(InflateError::TooLarge { limit: 2 })
+        );
+    }
+
+    /// A back-reference that would run past the ceiling is refused before
+    /// it is copied, rather than after.
+    #[test]
+    fn a_match_past_the_ceiling_is_refused() {
+        let mut out = fixed_block();
+        out.high(0b0011_0000 + u32::from(b'A'), 8);
+        // Length symbol 257 is three bytes; distance symbol 0 is one
+        // back, which is the 'A' just written.
+        out.high(0b000_0001, 7);
+        out.high(0, 5);
+        assert_eq!(
+            inflate(&out.bytes, 2),
+            Err(InflateError::TooLarge { limit: 2 })
+        );
+    }
+
+    /// **A code-length table no canonical code can satisfy is refused at
+    /// construction**, not at first use — an over-subscribed table would
+    /// otherwise decode a few symbols and then wander.
+    #[test]
+    fn a_table_no_canonical_code_can_satisfy_is_refused() {
+        // Three one-bit codes, where one bit holds two.
+        assert!(Huffman::new(&[1, 1, 1]).is_none(), "over-subscribed");
+        // A length past the fifteen the format allows.
+        assert!(Huffman::new(&[16]).is_none(), "a code of sixteen bits");
+        // And a legal table is built.
+        assert!(Huffman::new(&[1, 1]).is_some(), "two one-bit codes");
+    }
+
+    /// A run that overshoots the tables it is filling would silently steal
+    /// from the distance table, so the lengths are counted afterwards.
+    #[test]
+    fn a_code_length_run_that_overshoots_is_refused() {
+        let mut out = Writer::default();
+        out.low(1, 1);
+        out.low(2, 2);
+        // HLIT = 0 (257 literals), HDIST = 0 (1 distance), HCLEN = 0 (4).
+        out.low(0, 5);
+        out.low(0, 5);
+        out.low(0, 4);
+        // Four code lengths in the format's own order: 16, 17, 18, 0.
+        // Give 18 and 0 one bit each so both are usable.
+        for length in [0u32, 1, 1, 0] {
+            out.low(length, 3);
+        }
+        // Symbol 18 writes a run of 11..138 zeros; enough of them
+        // overshoot 258.
+        for _ in 0..3 {
+            out.high(1, 1);
+            out.low(127, 7);
+        }
+        assert_eq!(
+            inflate(&out.bytes, 1 << 20),
+            Err(InflateError::BadCodeLengths)
+        );
+    }
+
+    /// **A table with a hole in it refuses the bits that fall into the
+    /// hole.** The format allows a table that does not use every code —
+    /// one back-reference in a whole stream leaves a distance table with a
+    /// single entry — so an under-subscribed table is built rather than
+    /// rejected, and the refusal has to come at the moment a code walks
+    /// off the end of it.
+    #[test]
+    fn a_code_that_names_no_symbol_is_refused() {
+        let mut out = Writer::default();
+        out.low(1, 1);
+        out.low(2, 2);
+        out.low(0, 5);
+        out.low(0, 5);
+        out.low(0, 4);
+        // One usable code-length symbol, `18`, which writes runs of
+        // zeros: every literal length comes out zero, so the literal
+        // table has no codes at all and the first bit read against it
+        // falls through all fifteen lengths.
+        for length in [0u32, 0, 1, 0] {
+            out.low(length, 3);
+        }
+        // 257 + 1 lengths of zero, in runs of at most 138.
+        for times in [138u32, 120] {
+            out.high(0, 1);
+            out.low(times - 11, 7);
+        }
+        out.bytes.extend_from_slice(&[0u8; 8]);
+        assert_eq!(inflate(&out.bytes, 1 << 20), Err(InflateError::BadSymbol));
+    }
+
+    /// A repeat-previous symbol with nothing before it is a stream that
+    /// opens by copying what it has not written.
+    #[test]
+    fn a_repeat_with_nothing_to_repeat_is_refused() {
+        let mut out = Writer::default();
+        out.low(1, 1);
+        out.low(2, 2);
+        out.low(0, 5);
+        out.low(0, 5);
+        out.low(0, 4);
+        // Lengths for 16, 17, 18, 0: give 16 and 0 one bit each.
+        for length in [1u32, 0, 0, 1] {
+            out.low(length, 3);
+        }
+        // Symbol 16 first: repeat the previous length, of which there is
+        // none. Padded afterwards so the refusal comes from the missing
+        // previous length rather than from the stream running out.
+        //
+        // Code 1, not 0: among the two one-bit codes the canonical
+        // assignment gives symbol 0 the zero and symbol 16 the one, and
+        // asking for the wrong one reads a run of zero lengths instead.
+        out.high(1, 1);
+        out.low(0, 2);
+        out.bytes.extend_from_slice(&[0u8; 8]);
+        assert_eq!(
+            inflate(&out.bytes, 1 << 20),
+            Err(InflateError::BadCodeLengths)
         );
     }
 }

--- a/crates/png/src/inflate.rs
+++ b/crates/png/src/inflate.rs
@@ -1,0 +1,609 @@
+//! Deflate, decompressed — the half of RFC 1951 this crate could only
+//! write.
+//!
+//! # Why this exists rather than a crate
+//!
+//! The same argument the encoder makes, from the other side. Every
+//! dependency is presumed rejected until it earns itself, and the encoder
+//! already carries the format's tables, its bit order and its
+//! back-reference arithmetic; a decompressor is those same published
+//! constants read in the other direction. Taking a crate for the second
+//! half of something already written by hand would leave the two halves
+//! disagreeing about what the format is.
+//!
+//! # What it does and does not do
+//!
+//! All three block kinds: stored, fixed Huffman, and **dynamic Huffman** —
+//! which the encoder never writes and every other encoder does, so a
+//! decoder without it can read this crate's own output and nothing else.
+//! No preset dictionaries, which zlib streams in the wild do not use and
+//! which PNG forbids outright.
+//!
+//! Decoding is symbol at a time against canonical code tables rather than
+//! through a lookup window. That is slower per byte and it is the version
+//! whose correctness can be read off the specification; a window is an
+//! optimisation to make once something measures it.
+//!
+//! # Refusals
+//!
+//! Every way a stream can be malformed is a named error, never a panic and
+//! never a silent truncation. This runs on bytes from disk and from the
+//! network, so it treats the input as hostile: no index is taken that was
+//! not bounds-checked, and every table is validated as canonical before it
+//! is used to decode anything.
+
+/// Why a stream could not be decompressed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum InflateError {
+    /// The stream ended in the middle of something.
+    Truncated {
+        /// How many bytes had been consumed.
+        at: usize,
+    },
+    /// A block header named a kind that does not exist. Kind 3 is
+    /// reserved and its presence means the stream is not deflate.
+    BadBlockKind {
+        /// The two bits that were read.
+        kind: u32,
+    },
+    /// A stored block's length and its complement disagree, which is the
+    /// format's own check that the stream is aligned where it thinks.
+    StoredLengthMismatch {
+        /// The length as written.
+        length: u16,
+        /// Its complement as written.
+        complement: u16,
+    },
+    /// A code-length table that no canonical Huffman code can be built
+    /// from — over-subscribed, or incomplete where the format requires
+    /// completeness.
+    BadCodeLengths,
+    /// A symbol that decodes to no code in its table.
+    BadSymbol,
+    /// A back-reference reaching further back than the output produced so
+    /// far, which would read from before the beginning.
+    BadDistance {
+        /// How far back it asked to go.
+        distance: usize,
+        /// How much output existed.
+        produced: usize,
+    },
+    /// The decompressed stream is longer than the caller allowed.
+    TooLarge {
+        /// The ceiling that was passed.
+        limit: usize,
+    },
+}
+
+/// Bits, least-significant first within each byte.
+///
+/// **Deflate's own order, and it is not the obvious one.** Huffman codes
+/// are packed most-significant-bit first *within a code* while everything
+/// else is packed least-significant first, which is why the code reader
+/// below shifts a bit in at the bottom and the length reader accumulates
+/// upward. Getting this backwards produces a stream that decodes for a
+/// few symbols and then dissolves, which is the hardest kind of wrong to
+/// read off a hex dump.
+struct Bits<'a> {
+    bytes: &'a [u8],
+    /// Which byte the next bit comes from.
+    at: usize,
+    /// Which bit of that byte, from 0 (least significant) to 7.
+    bit: u32,
+}
+
+impl<'a> Bits<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            bytes,
+            at: 0,
+            bit: 0,
+        }
+    }
+
+    /// One bit, or nothing if the stream has ended.
+    fn one(&mut self) -> Option<u32> {
+        let byte = *self.bytes.get(self.at)?;
+        let value = (u32::from(byte) >> self.bit) & 1;
+        self.bit += 1;
+        if self.bit == 8 {
+            self.bit = 0;
+            self.at += 1;
+        }
+        Some(value)
+    }
+
+    /// `count` bits as a little-endian integer.
+    fn take(&mut self, count: u32) -> Option<u32> {
+        let mut out = 0;
+        for step in 0..count {
+            out |= self.one()? << step;
+        }
+        Some(out)
+    }
+
+    /// Skip to the next byte boundary, as a stored block's header
+    /// requires.
+    const fn align(&mut self) {
+        if self.bit != 0 {
+            self.bit = 0;
+            self.at += 1;
+        }
+    }
+}
+
+/// The longest code deflate allows.
+const MAX_BITS: usize = 15;
+
+/// A canonical Huffman table, as counts per length and symbols in order.
+///
+/// **Stored as the specification describes it** rather than as a decoded
+/// tree: the counts say how many codes have each length, the symbols are
+/// listed in code order, and decoding walks lengths adding one bit at a
+/// time. Thirty-two bytes and a vector, no allocation per symbol, and the
+/// canonical property is checked when it is built rather than assumed at
+/// every use.
+struct Huffman {
+    counts: [u16; MAX_BITS + 1],
+    symbols: Vec<u16>,
+}
+
+impl Huffman {
+    /// Build a table from a symbol-length list.
+    ///
+    /// Returns `None` when the lengths are over-subscribed — more codes of
+    /// some length than that length can hold, which no canonical code can
+    /// satisfy and which a corrupt stream produces readily.
+    ///
+    /// An *under*-subscribed table is allowed here and refused at use: the
+    /// format permits one legitimate case of it (a distance table with a
+    /// single code, in a stream with exactly one back-reference), and
+    /// rejecting it at construction would refuse valid files.
+    fn new(lengths: &[u8]) -> Option<Self> {
+        let mut counts = [0u16; MAX_BITS + 1];
+        for length in lengths {
+            let at = usize::from(*length);
+            if at > MAX_BITS {
+                return None;
+            }
+            counts[at] = counts[at].checked_add(1)?;
+        }
+        // Length zero means "this symbol is not in the table".
+        counts[0] = 0;
+        let mut left = 1i32;
+        for count in counts.iter().skip(1) {
+            left = left.checked_mul(2)?;
+            left -= i32::from(*count);
+            if left < 0 {
+                return None;
+            }
+        }
+        // Where each length's symbols begin in the symbol list.
+        let mut offsets = [0u16; MAX_BITS + 2];
+        for length in 1..=MAX_BITS {
+            offsets[length + 1] = offsets[length].checked_add(counts[length])?;
+        }
+        let mut symbols = vec![0u16; lengths.len()];
+        for (symbol, length) in lengths.iter().enumerate() {
+            if *length == 0 {
+                continue;
+            }
+            let at = usize::from(*length);
+            let slot = usize::from(offsets[at]);
+            *symbols.get_mut(slot)? = u16::try_from(symbol).ok()?;
+            offsets[at] = offsets[at].checked_add(1)?;
+        }
+        Some(Self { counts, symbols })
+    }
+
+    /// The next symbol in the stream.
+    ///
+    /// Codes are packed most-significant bit first, so this shifts each
+    /// bit in at the bottom of the accumulator and compares against the
+    /// running first-code of each length.
+    fn decode(&self, bits: &mut Bits<'_>) -> Result<u16, InflateError> {
+        let mut code = 0i32;
+        let mut first = 0i32;
+        let mut index = 0i32;
+        for length in 1..=MAX_BITS {
+            let bit = bits.one().ok_or(InflateError::Truncated { at: bits.at })?;
+            code |= i32::try_from(bit).unwrap_or(0);
+            let count = i32::from(self.counts[length]);
+            if code - first < count {
+                let at = usize::try_from(index + (code - first)).unwrap_or(usize::MAX);
+                return self.symbols.get(at).copied().ok_or(InflateError::BadSymbol);
+            }
+            index += count;
+            first = (first + count) << 1;
+            code <<= 1;
+        }
+        Err(InflateError::BadSymbol)
+    }
+}
+
+/// The extra bits and base value of each length symbol, 257 through 285.
+const LENGTH_BASE: [u16; 29] = [
+    3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131,
+    163, 195, 227, 258,
+];
+/// How many extra bits each length symbol reads.
+const LENGTH_EXTRA: [u8; 29] = [
+    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0,
+];
+/// The base distance of each distance symbol, 0 through 29.
+const DISTANCE_BASE: [u16; 30] = [
+    1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537,
+    2049, 3073, 4097, 6145, 8193, 12_289, 16_385, 24_577,
+];
+/// How many extra bits each distance symbol reads.
+const DISTANCE_EXTRA: [u8; 30] = [
+    0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13,
+    13,
+];
+/// The order dynamic blocks write their code-length code lengths in.
+///
+/// Not sorted, and not arbitrary: the lengths most often zero are last, so
+/// a block can stop writing early. Reading them in symbol order instead
+/// produces a table that is subtly wrong rather than obviously so.
+const LENGTH_ORDER: [usize; 19] = [
+    16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15,
+];
+
+/// The fixed tables, which every stream may use without writing them.
+fn fixed() -> Option<(Huffman, Huffman)> {
+    let mut lengths = [0u8; 288];
+    for (symbol, slot) in lengths.iter_mut().enumerate() {
+        // Eight bits for 0..=143 and for 280..=287, which is why those
+        // two ranges share the fallthrough rather than being written
+        // out: the published table gives them the same length.
+        *slot = match symbol {
+            144..=255 => 9,
+            256..=279 => 7,
+            _ => 8,
+        };
+    }
+    let literals = Huffman::new(&lengths)?;
+    // Every distance code is five bits in the fixed table, including the
+    // two that are never valid — the specification says so, and a table
+    // built from thirty rather than thirty-two is over-subscribed.
+    let distances = Huffman::new(&[5u8; 32])?;
+    Some((literals, distances))
+}
+
+/// Decompress a raw deflate stream.
+///
+/// `limit` caps the output, so a stream that claims to expand to more than
+/// a caller is willing to hold is refused rather than allocated. A
+/// decompressor without one is a denial of service with a nice interface:
+/// a few hundred bytes of deflate can name gigabytes of output.
+///
+/// # Errors
+///
+/// Every way the stream can be malformed, by name — see [`InflateError`].
+pub fn inflate(bytes: &[u8], limit: usize) -> Result<Vec<u8>, InflateError> {
+    let mut bits = Bits::new(bytes);
+    let mut out = Vec::new();
+    loop {
+        let last = bits.one().ok_or(InflateError::Truncated { at: bits.at })? == 1;
+        let kind = bits
+            .take(2)
+            .ok_or(InflateError::Truncated { at: bits.at })?;
+        match kind {
+            0 => stored(&mut bits, &mut out, limit)?,
+            1 => {
+                let (literals, distances) = fixed().ok_or(InflateError::BadCodeLengths)?;
+                block(&mut bits, &literals, &distances, &mut out, limit)?;
+            }
+            2 => {
+                let (literals, distances) = dynamic(&mut bits)?;
+                block(&mut bits, &literals, &distances, &mut out, limit)?;
+            }
+            other => return Err(InflateError::BadBlockKind { kind: other }),
+        }
+        if last {
+            return Ok(out);
+        }
+    }
+}
+
+/// A stored block: a length, its complement, and that many raw bytes.
+fn stored(bits: &mut Bits<'_>, out: &mut Vec<u8>, limit: usize) -> Result<(), InflateError> {
+    bits.align();
+    let length = bits
+        .take(16)
+        .ok_or(InflateError::Truncated { at: bits.at })?;
+    let complement = bits
+        .take(16)
+        .ok_or(InflateError::Truncated { at: bits.at })?;
+    let (length, complement) = (
+        u16::try_from(length).unwrap_or(0),
+        u16::try_from(complement).unwrap_or(0),
+    );
+    if length != !complement {
+        return Err(InflateError::StoredLengthMismatch { length, complement });
+    }
+    let want = usize::from(length);
+    if out.len().saturating_add(want) > limit {
+        return Err(InflateError::TooLarge { limit });
+    }
+    let from = bits.at;
+    let slice = bytes_at(bits.bytes, from, want).ok_or(InflateError::Truncated { at: from })?;
+    out.extend_from_slice(slice);
+    bits.at = from + want;
+    Ok(())
+}
+
+/// A window into a slice, or nothing if it does not fit.
+fn bytes_at(bytes: &[u8], from: usize, want: usize) -> Option<&[u8]> {
+    bytes.get(from..from.checked_add(want)?)
+}
+
+/// Read a dynamic block's two tables.
+fn dynamic(bits: &mut Bits<'_>) -> Result<(Huffman, Huffman), InflateError> {
+    let short =
+        |bits: &mut Bits<'_>, count: u32| bits.take(count).ok_or(InflateError::Truncated { at: 0 });
+    let literals = short(bits, 5)? as usize + 257;
+    let distances = short(bits, 5)? as usize + 1;
+    let codes = short(bits, 4)? as usize + 4;
+    if literals > 288 || distances > 32 || codes > LENGTH_ORDER.len() {
+        return Err(InflateError::BadCodeLengths);
+    }
+
+    // The table that describes the other two tables.
+    let mut code_lengths = [0u8; LENGTH_ORDER.len()];
+    for at in LENGTH_ORDER.iter().take(codes) {
+        let length = short(bits, 3)?;
+        *code_lengths
+            .get_mut(*at)
+            .ok_or(InflateError::BadCodeLengths)? = u8::try_from(length).unwrap_or(0);
+    }
+    let table = Huffman::new(&code_lengths).ok_or(InflateError::BadCodeLengths)?;
+
+    // The two real tables, run-length coded through it.
+    let want = literals + distances;
+    let mut lengths = Vec::with_capacity(want);
+    while lengths.len() < want {
+        let symbol = table.decode(bits)?;
+        match symbol {
+            0..=15 => lengths.push(u8::try_from(symbol).unwrap_or(0)),
+            16 => {
+                // Repeat the previous length three to six times. There
+                // must *be* a previous length; a stream that opens with
+                // this is corrupt.
+                let last = *lengths.last().ok_or(InflateError::BadCodeLengths)?;
+                let times = short(bits, 2)? as usize + 3;
+                for _ in 0..times {
+                    lengths.push(last);
+                }
+            }
+            // Both write a run of zeros; they differ only in how many
+            // bits the count takes and where it starts, which is the
+            // format's way of spending fewer bits on short runs.
+            17 | 18 => {
+                let (width, base) = if symbol == 17 { (3, 3) } else { (7, 11) };
+                let times = short(bits, width)? as usize + base;
+                lengths.extend(core::iter::repeat_n(0u8, times));
+            }
+            _ => return Err(InflateError::BadCodeLengths),
+        }
+    }
+    // A run that overshoots would silently steal from the distance table.
+    if lengths.len() != want {
+        return Err(InflateError::BadCodeLengths);
+    }
+    let (literal_lengths, distance_lengths) = lengths.split_at(literals);
+    Ok((
+        Huffman::new(literal_lengths).ok_or(InflateError::BadCodeLengths)?,
+        Huffman::new(distance_lengths).ok_or(InflateError::BadCodeLengths)?,
+    ))
+}
+
+/// Decode one Huffman-coded block into `out`.
+fn block(
+    bits: &mut Bits<'_>,
+    literals: &Huffman,
+    distances: &Huffman,
+    out: &mut Vec<u8>,
+    limit: usize,
+) -> Result<(), InflateError> {
+    loop {
+        let symbol = literals.decode(bits)?;
+        match symbol {
+            0..=255 => {
+                if out.len() >= limit {
+                    return Err(InflateError::TooLarge { limit });
+                }
+                out.push(u8::try_from(symbol).unwrap_or(0));
+            }
+            256 => return Ok(()),
+            257..=285 => {
+                let at = usize::from(symbol) - 257;
+                let base = *LENGTH_BASE.get(at).ok_or(InflateError::BadSymbol)?;
+                let extra = *LENGTH_EXTRA.get(at).ok_or(InflateError::BadSymbol)?;
+                let more = bits
+                    .take(u32::from(extra))
+                    .ok_or(InflateError::Truncated { at: bits.at })?;
+                let length = usize::from(base) + more as usize;
+
+                let symbol = distances.decode(bits)?;
+                let at = usize::from(symbol);
+                let base = *DISTANCE_BASE.get(at).ok_or(InflateError::BadSymbol)?;
+                let extra = *DISTANCE_EXTRA.get(at).ok_or(InflateError::BadSymbol)?;
+                let more = bits
+                    .take(u32::from(extra))
+                    .ok_or(InflateError::Truncated { at: bits.at })?;
+                let distance = usize::from(base) + more as usize;
+
+                if distance > out.len() {
+                    return Err(InflateError::BadDistance {
+                        distance,
+                        produced: out.len(),
+                    });
+                }
+                if out.len().saturating_add(length) > limit {
+                    return Err(InflateError::TooLarge { limit });
+                }
+                // **Byte at a time, and that is required rather than
+                // lazy.** A match may overlap its own output — a run of
+                // one byte is written as distance 1, length 200 — so a
+                // block copy of the whole span would read bytes that have
+                // not been produced yet.
+                let from = out.len() - distance;
+                for step in 0..length {
+                    let byte = *out.get(from + step).ok_or(InflateError::BadDistance {
+                        distance,
+                        produced: out.len(),
+                    })?;
+                    out.push(byte);
+                }
+            }
+            _ => return Err(InflateError::BadSymbol),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InflateError, inflate};
+
+    /// A stored block: the header, a length and its complement, then the
+    /// bytes. Written by hand so the test does not depend on the encoder
+    /// to prove the simplest block kind works.
+    fn stored_block(body: &[u8]) -> Vec<u8> {
+        let length = u16::try_from(body.len()).expect("a short body");
+        // BFINAL = 1, BTYPE = 00, then five bits of padding to the byte.
+        let mut out = vec![0b0000_0001];
+        out.extend_from_slice(&length.to_le_bytes());
+        out.extend_from_slice(&(!length).to_le_bytes());
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// **The simplest block kind, end to end.**
+    ///
+    /// Probed by flipping a bit of the complement: the length check fails
+    /// and names both halves.
+    #[test]
+    fn a_stored_block_comes_back_as_itself() {
+        let body = b"the quick brown fox";
+        assert_eq!(
+            inflate(&stored_block(body), 1 << 20),
+            Ok(body.to_vec()),
+            "a stored block did not survive the round trip"
+        );
+    }
+
+    /// A stored block whose length and complement disagree is refused by
+    /// name — that pair is the format's own check that the reader is
+    /// aligned where it thinks it is.
+    #[test]
+    fn a_stored_block_with_a_bad_complement_is_refused() {
+        let mut bytes = stored_block(b"hello");
+        bytes[3] ^= 0x01;
+        assert!(
+            matches!(
+                inflate(&bytes, 1 << 20),
+                Err(InflateError::StoredLengthMismatch { .. })
+            ),
+            "a corrupt stored header was accepted"
+        );
+    }
+
+    /// **The encoder's own output reads back.** This is the assertion
+    /// that matters most: the two halves of the format live in one crate
+    /// and must agree about it, and a decoder that could not read what
+    /// this crate writes would be describing a different format.
+    ///
+    /// The encoder writes a two-byte zlib header before the deflate
+    /// stream and a four-byte checksum after it, so both are stepped
+    /// over here — the PNG reader above does the same thing for real.
+    ///
+    /// Probed by taking the stream from one byte later: the first symbol
+    /// decodes to nothing and it is refused.
+    #[test]
+    fn what_the_encoder_writes_reads_back() {
+        // A picture with runs in it, so the stream exercises
+        // back-references rather than only literals.
+        let (width, height) = (16u32, 8u32);
+        let mut pixels = Vec::new();
+        for y in 0..height {
+            for x in 0..width {
+                let shade = u8::try_from((x / 4 + y / 4) * 40 % 255).unwrap_or(0);
+                pixels.extend_from_slice(&[shade, 20, 200, 255]);
+            }
+        }
+        let file = crate::encode(width, height, &pixels).expect("the encoder accepts this");
+
+        // The `IDAT` body, found by walking the chunks.
+        let mut at = 8;
+        let mut data = Vec::new();
+        while at + 8 <= file.len() {
+            let length =
+                u32::from_be_bytes([file[at], file[at + 1], file[at + 2], file[at + 3]]) as usize;
+            let kind = &file[at + 4..at + 8];
+            if kind == b"IDAT" {
+                data.extend_from_slice(&file[at + 8..at + 8 + length]);
+            }
+            at += 12 + length;
+        }
+        assert!(!data.is_empty(), "the encoder wrote no image data");
+
+        let raw = inflate(&data[2..data.len() - 4], 1 << 20).expect("the stream decompresses");
+        // One filter byte per row, then the row's pixels.
+        let stride = width as usize * 4;
+        assert_eq!(
+            raw.len(),
+            (stride + 1) * height as usize,
+            "the decompressed stream is not a whole number of filtered rows"
+        );
+        for (row, chunk) in raw.chunks(stride + 1).enumerate() {
+            assert_eq!(
+                chunk[0], 0,
+                "row {row} claims a filter this encoder never writes"
+            );
+            let from = row * stride;
+            assert_eq!(
+                &chunk[1..],
+                &pixels[from..from + stride],
+                "row {row} came back different"
+            );
+        }
+    }
+
+    /// A stream that ends mid-symbol is refused rather than returning
+    /// what it managed — a decoder that hands back a partial image lets a
+    /// truncated download look like a small picture.
+    #[test]
+    fn a_truncated_stream_is_refused() {
+        let file = crate::encode(8, 8, &[200u8; 8 * 8 * 4]).expect("the encoder accepts this");
+        let mut at = 8;
+        let mut data = Vec::new();
+        while at + 8 <= file.len() {
+            let length =
+                u32::from_be_bytes([file[at], file[at + 1], file[at + 2], file[at + 3]]) as usize;
+            if &file[at + 4..at + 8] == b"IDAT" {
+                data.extend_from_slice(&file[at + 8..at + 8 + length]);
+            }
+            at += 12 + length;
+        }
+        let stream = &data[2..data.len() - 4];
+        let cut = &stream[..stream.len() / 2];
+        assert!(
+            inflate(cut, 1 << 20).is_err(),
+            "half a stream decompressed without complaint"
+        );
+    }
+
+    /// The ceiling is a refusal, not a truncation: a stream that expands
+    /// past what a caller will hold is an answer they can act on.
+    #[test]
+    fn a_stream_past_the_limit_is_refused() {
+        let body = [7u8; 600];
+        assert_eq!(
+            inflate(&stored_block(&body), 100),
+            Err(InflateError::TooLarge { limit: 100 }),
+            "a stream past the ceiling was allowed through"
+        );
+    }
+}

--- a/crates/png/src/inflate.rs
+++ b/crates/png/src/inflate.rs
@@ -716,7 +716,7 @@ mod refusals {
         let mut out = fixed_block();
         // Three literals: 'A', 'B', 'C', each eight bits in the fixed
         // table at code 0x30 + value.
-        for byte in [b'A', b'B', b'C'] {
+        for byte in *b"ABC" {
             out.high(0b0011_0000 + u32::from(byte), 8);
         }
         assert_eq!(

--- a/crates/png/src/lib.rs
+++ b/crates/png/src/lib.rs
@@ -62,6 +62,8 @@
 // not choose, in a crate whose whole value is being a pure function.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
+#[cfg(test)]
+mod colours;
 pub mod decode;
 pub mod inflate;
 

--- a/crates/png/src/lib.rs
+++ b/crates/png/src/lib.rs
@@ -1,4 +1,8 @@
-//! A PNG encoder, in about a hundred lines and with no dependency.
+//! PNG, both ways, with no dependency.
+//!
+//! [`encode`] turns pixels into a file; [`decode::decode`] turns a file
+//! back into pixels, and [`inflate::inflate`] is the decompressor it needs
+//! — the half of deflate this crate could previously only write.
 //!
 //! # Why this exists rather than a crate
 //!
@@ -9,6 +13,14 @@
 //! for flat-shaded pictures needs no tables of its own and no tuning.
 //!
 //! # What it does and does not do
+//!
+//! **Reading is the wider half.** The encoder writes one shape of file —
+//! 8-bit RGBA, fixed Huffman, no filtering — because that is all a picture
+//! of geometry needs. The decoder has no such freedom: it reads what other
+//! tools wrote, which means dynamic Huffman, all five scanline filters,
+//! palettes, and greyscale. Those are listed in [`decode`]'s own doc
+//! rather than here, along with what it refuses.
+//!
 //!
 //! Fixed Huffman codes over a three-candidate back-reference search: the
 //! pixel to the left, the pixel above, and the byte before. Those are what
@@ -49,6 +61,22 @@
 // go. Printing from here would put a message somewhere the caller did
 // not choose, in a crate whose whole value is being a pure function.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
+
+pub mod decode;
+pub mod inflate;
+
+/// The CRC a chunk carries: its type and its body, hashed together.
+///
+/// **Shared with the decoder deliberately.** Two implementations of one
+/// checksum is two chances to be wrong about it, and the failure — a
+/// writer and a reader that each accept only their own files — is one
+/// nobody would look for.
+pub(crate) fn checksum(id: [u8; 4], body: &[u8]) -> u32 {
+    let mut crc = Crc::new();
+    crc.eat(&id);
+    crc.eat(body);
+    crc.finish()
+}
 
 /// The eight bytes every PNG starts with.
 const SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
@@ -446,7 +474,7 @@ impl Crc {
 ///
 /// Over the *uncompressed* bytes — which is the mistake worth naming,
 /// since every other checksum in the file covers what is written.
-fn adler32(bytes: &[u8]) -> u32 {
+pub(crate) fn adler32(bytes: &[u8]) -> u32 {
     const MOD: u32 = 65521;
     let (mut low, mut high) = (1u32, 0u32);
     for byte in bytes {


### PR DESCRIPTION
A crate that writes pictures and cannot read one leaves every consumer that ships art to find its own way in. Its README named a decoder as the one direction it was allowed to grow — `renew-asset` says outright that there is no PNG decoder anywhere in the engine — and this is that.

Written rather than depended on for the reason the encoder gives: the two halves of a format should not disagree about what the format is, and the tables, the bit order and the chunk layout were already here.

## `inflate` is the harder half

The encoder writes fixed Huffman only. A decoder that could read that and nothing else would read this crate's own output and no other file in the world, because **every other encoder writes dynamic blocks**. All three block kinds are here, decoded symbol at a time against canonical tables — slower per byte than a lookup window, and the version whose correctness can be read off the specification. A window is an optimisation to make once something measures it.

## What the decoder reads

Dynamic Huffman, all five scanline filters, palettes with `tRNS`, greyscale, and 16-bit samples reduced to eight. Output is always 8-bit RGBA, because a consumer that branched on colour type would be doing the decoder's job.

Interlaced images and sub-byte depths are **refused by name** rather than mis-read: Adam7 is a different image layout rather than a different pixel format, and sub-byte depths want a bit-unpacker nothing has asked for.

## Hostile input throughout

Every CRC checked, every declared length validated against the bytes actually present, no index taken that was not bounds-checked, every Huffman table validated as canonical before it decodes anything, and a **ceiling on the decompressed size** — a sixty-byte header can otherwise ask for sixty-four gigabytes.

**A missing `IEND` is a refusal**, which is how truncation is caught: image data is written before the terminator, so a file cut short after its last `IDAT` holds a complete-looking image and would otherwise decode without complaint. A half-downloaded sprite must not look like a whole one.

## The test that exists because a probe went green

Breaking the Paeth predictor outright left both the round-trip test and the real-file test passing. The encoder writes filter zero, and the repository's own brand images turned out not to exercise all five either — so **four of the five filters were unverified and looked verified**.

`every_scanline_filter_is_undone` builds a file whose rows each use a different filter, with the forward filters transcribed from the specification **in the test** rather than reused from the decoder, so the two implementations meet in the middle instead of agreeing with each other's mistakes. Breaking each predictor in turn now names its own row.

The brand images are compiled in with `include_bytes!` rather than read: this crate never touches the filesystem, that is its contract, and its own clippy configuration enforces it.

Ran under the current stable: fmt, clippy over the workspace with all targets and warnings denied, and the full workspace test suite.