### PR TITLE
feat(rhi): a frame holds twice the distinct resources it did

### DIFF
--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -1464,11 +1464,18 @@ fn count_matters(records: &[Option<BufferRecord>; MAX_RETAINED_RESOURCES]) -> us
 /// — the hard bound that keeps retention tables fixed-width and the frame
 /// path allocation-free. Per-frame buffers, meshes, bindings and
 /// pass-target render images share it, because they share one table. The
-/// seventeenth distinct resource is refused by name in
-/// [`check_frame_contract`]. Sixteen, doubled from eight when bindings
-/// joined the table: every draw's sampled slots now spend from the same
-/// budget its geometry does.
-pub(crate) const MAX_RETAINED_RESOURCES: usize = 16;
+/// next distinct resource past the bound is refused by name in
+/// [`check_frame_contract`].
+///
+/// Thirty-two, doubled from sixteen the day a real consumer's fullest
+/// frame — a world mesh, a marker, a held item, billboard layers, two
+/// cutout meshes, machines, two particle pipelines and an interface
+/// overlay, each with its bindings — landed on exactly seventeen. It
+/// was doubled from eight before that, when bindings joined the table.
+/// The table is `Option`s in fixed arrays: the cost of headroom is
+/// thirty-two words of `None` per frame, and the cost of too little is
+/// a consumer cutting a feature to fit a constant this crate chose.
+pub(crate) const MAX_RETAINED_RESOURCES: usize = 32;
 
 impl LoadOp {
     pub(crate) fn to_vk(self) -> ash::vk::AttachmentLoadOp {

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -738,7 +738,7 @@ fn malformed_frames_are_refused_by_name() {
             let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
         },
     );
-    let many: Vec<renew_rhi::Buffer> = (0..17)
+    let many: Vec<renew_rhi::Buffer> = (0..33)
         .map(|_| {
             device
                 .create_buffer(64, BufferUsage::PerFrame)
@@ -746,7 +746,7 @@ fn malformed_frames_are_refused_by_name() {
         })
         .collect();
     refused(
-        "a seventeenth distinct buffer",
+        "a thirty-third distinct buffer",
         "distinct resources",
         &|target| {
             let color = clear(black);


### PR DESCRIPTION
The retention bound doubles to thirty-two. Sixteen — itself doubled from eight when bindings joined the table — was met by a real consumer's fullest frame at exactly seventeen distinct resources (world mesh, held item, billboard layers, two cutout meshes, standing machines, a marker, two particle pipelines, an interface overlay, and their bindings). The bound's purpose is fixed-width retention tables and an allocation-free frame path; thirty-two words of `None` per frame is what the headroom costs. The refusal still fires by name at the boundary and the fixture walks the new edge. Full workspace suite: 240 binaries, 2433 passed, 0 failed.