### PR TITLE
feat(rhi): a render image can keep its contents across frames

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -81,7 +81,7 @@ reason = "The full-table answer of the block-write tracker, which reports a buff
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [1428]
+lines = [1550]
 reason = "The unreachable arm of the write-claim table: no free slot to record a claim in. The ceiling assert does not bound it directly any more, because a uniform write records a claim without charging a retention slot - so the argument is one step longer. Every distinct uniform buffer implies at least one distinct Binding, charged in the same item iteration just above the uniform loop, so the number of records never exceeds the charged count and that count is what the ceiling bounds. Stated in the arm itself, because it depends on the loop order in check_retention_bound and a reorder would break it silently."
 
 [[exempt]]
@@ -91,12 +91,12 @@ reason = "The unreachable arm of the walk's surface-depth barrier: a depth-carry
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [944]
-reason = "The unreachable arm behind the sample-before-write refusal: the assert immediately above proved the entry exists, and the let-else restates it without a banned expect. No frame can drive it."
+lines = [1101]
+reason = "The settle arm for an entry that is neither sampled nor targeted. Unreachable by the walk's own construction: an entry is minted either by advance_target, which sets targeted before returning, or by advance_sampling, which either marks the entry sampled or panics the frame away in a refusal - and a refused frame never settles. The arm exists so settle states its answer as a total decision rather than an expect over invariants that live two functions away."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [1255, 1256]
+lines = [1274, 1275]
 reason = "The depthless-adapter arm of the shadow map's refusal, which translates the rendering crate's DepthUnsupported into this crate's own variant rather than reporting it as a texture failure. Unreachable wherever a depth format exists, which is every measuring lane's adapter: the format is chosen at device bring-up from a void query no fault layer can mutate, and the layer's quirk list carries no depthless-adapter quirk either. The sibling arm (any other creation failure) is driven by the R10 fault scenario."
 
 [[exempt]]
@@ -121,7 +121,7 @@ reason = "The blended renderer's Debug impl - the cutout's twin at 743, exempt f
 
 [[exempt]]
 file = "crates/rhi/src/vk/render_image.rs"
-lines = [228, 229, 230, 231]
+lines = [291, 292, 293, 294]
 reason = "The format-feature pre-check's refusal: every measuring lane's adapter reports SAMPLED_IMAGE and the attachment feature for both kinds' formats, and vkGetPhysicalDeviceFormatProperties is a void query no fault layer can mutate - the same unreachability the depthless-adapter exemptions record. The refusal exists for adapters the lanes do not have."
 
 [[exempt]]
@@ -156,7 +156,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/swapchain.rs"
-lines = [1455]
+lines = [1462]
 reason = "The depthless-adapter side of chain population, where no per-slot depth images are built. Unreachable wherever a depth format exists, which is every measuring lane's adapter."
 
 [[exempt]]

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -1187,6 +1187,17 @@ const _: () = assert!(SHADOW_PUSH_BYTES as usize == 128);
 /// 2. a surface pass whose [`Self::item`]s draw the same world through
 ///    the camera, dimmed where the map recorded something nearer.
 ///
+/// # Contract
+///
+/// **The caster pass runs on the shadow's cadence, not the frame's.**
+/// The map is a kept render image: after any frame has run the caster
+/// pass, later frames may omit step 1 entirely and their lit passes
+/// sample what the last casting frame stored — the frame contract
+/// permits it because the map keeps its contents. Re-render the map
+/// when the light or the casters move; skip it when they have not.
+/// The one obligation is the first frame: nothing may sample a map no
+/// frame has rendered, and the contract refuses it by name.
+///
 /// # Colour is not carried through unchanged
 ///
 /// As [`CameraRenderer`]: this path fades toward a horizon with
@@ -1238,13 +1249,21 @@ impl ShadowedCameraRenderer {
             &sampler,
         ))?;
         let shadow_map = device
-            .create_render_image(&renew_rhi::RenderImageDesc::new(
-                renew_rhi::RenderImageKind::Depth,
-                renew_rhi::Extent {
-                    width: shadow_size,
-                    height: shadow_size,
-                },
-            ))
+            .create_render_image(
+                &renew_rhi::RenderImageDesc::new(
+                    renew_rhi::RenderImageKind::Depth,
+                    renew_rhi::Extent {
+                        width: shadow_size,
+                        height: shadow_size,
+                    },
+                )
+                // Kept, so a consumer may re-render the map on its own
+                // cadence: a frame whose light and casters have not
+                // moved omits the caster pass and the lit pass samples
+                // what the last casting frame stored. See the frame
+                // shape on the type.
+                .kept(),
+            )
             // A depthless adapter refuses the map by name, and that
             // refusal is this crate's own variant rather than a
             // texture failure — the same translation the depth-tested

--- a/crates/render3d/tests/golden.rs
+++ b/crates/render3d/tests/golden.rs
@@ -1661,6 +1661,10 @@ fn the_plain_textured_path_draws_its_texture() -> Result<(), Box<dyn std::error:
 /// strips alike. Same-frame determinism rides along: both frames are
 /// drawn twice and compared byte for byte.
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one fixture, four claims: the dim, the v-flip guard, the empty map, and the kept-map cadence"
+)]
 fn a_caster_between_light_and_floor_dims_the_floor() -> Result<(), Box<dyn std::error::Error>> {
     let Some(device) = device_or_skip()? else {
         return Ok(());
@@ -1758,6 +1762,23 @@ fn a_caster_between_light_and_floor_dims_the_floor() -> Result<(), Box<dyn std::
         let mut target = device.create_offscreen_target(extent)?;
         let first = run(&mut target)?;
         let second = run(&mut target)?;
+        // The cadence contract, end to end, on the casting side: the
+        // map is kept, so a frame may omit the caster pass outright
+        // and its lit pass samples what the last casting frame stored
+        // — the picture must be the shadowed picture, to the byte.
+        // Same target as the frames above: the per-frame block buffer
+        // belongs to one target by the buffer's own rule.
+        if cast {
+            let items = [renderer.item(&mesh, &camera)];
+            let sampling_only = [pass(&clear, &items)];
+            target.render(&RenderDesc::new(&sampling_only))?;
+            let mut omitted = vec![0u8; target.byte_len()];
+            target.read_back_into(&mut omitted);
+            assert_eq!(
+                second, omitted,
+                "a frame that omitted the caster pass must sample what the last casting                  frame kept"
+            );
+        }
         Ok((first, second))
     };
 

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -93,10 +93,16 @@ display server, and the golden-image tests attest the bytes.
 - `RenderImage` — what one pass renders into and a later pass samples:
   one physical image, kinded Color (`Rgba8Unorm`) or Depth (the
   device's chosen format) at creation, with the format pre-checked
-  against the adapter's own sampled/attachment features. Its
+  against the adapter's own sampled/attachment features. By default its
   **contents are frame-scoped** — every frame's first use starts
   undefined, enforced by the same walk that plans its barriers — while
-  the image itself is retained by any frame that names it. A pass
+  the image itself is retained by any frame that names it. An image
+  created **kept** (`RenderImageDesc::kept`) persists its contents
+  instead: a later frame may open it with `LoadOp::Load` or sample it
+  without rendering it at all — the shape of any render-to-texture on
+  its own cadence (a shadow map under a slow sun, a probe, a minimap).
+  The first frame ever must still render before anything reads, and a
+  discarding write takes the permission back; both refused by name. A pass
   renders into one via `Pass::render_to` (the image's kind decides the
   pass shape, so a mismatch is unrepresentable), and items sample it
   through an ordinary binding. The per-frame identity rules — write

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -907,6 +907,9 @@ impl OffscreenTarget {
                 }
                 device.cmd_end_rendering(self.cmd);
             }
+            // Every pass recorded: kept images remember where this
+            // frame left them, so the next frame's walk arrives there.
+            walk.settle();
 
             // COLOR_ATTACHMENT_OPTIMAL → TRANSFER_SRC_OPTIMAL for the
             // copy. Not a pass boundary — the terminal literal, pinned

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -907,9 +907,6 @@ impl OffscreenTarget {
                 }
                 device.cmd_end_rendering(self.cmd);
             }
-            // Every pass recorded: kept images remember where this
-            // frame left them, so the next frame's walk arrives there.
-            walk.settle();
 
             // COLOR_ATTACHMENT_OPTIMAL → TRANSFER_SRC_OPTIMAL for the
             // copy. Not a pass boundary — the terminal literal, pinned
@@ -988,6 +985,15 @@ impl OffscreenTarget {
                         creation("vkQueueSubmit2", code)
                     }
                 })?;
+            // Submitted, so the work executes in queue order or the
+            // device dies and poisons the spine - ONLY NOW may kept
+            // images remember where this frame leaves them. A recorded
+            // frame that never reached the queue must leave no trace:
+            // settling at record time let a failed vkEndCommandBuffer
+            // hand the next frame a layout no GPU work ever produced,
+            // and on a virgin image it quietly defeated the
+            // render-once-before-reading rule itself.
+            walk.settle();
 
             match device.wait_for_fences(&[self.fence], true, FENCE_TIMEOUT_NS) {
                 Ok(()) => {}

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -18,6 +18,8 @@ use crate::vk::transition::ImageUse;
 
 use std::rc::Rc;
 
+use crate::vk::render_image::KeptContents;
+
 /// How many distinct render images one frame may touch — as targets,
 /// as sampled sources, or both. A fixed ceiling so the contract's walk
 /// table and the record paths' barrier arrays are stack-sized and the
@@ -714,6 +716,48 @@ pub(crate) const MAX_ITEM_RESOURCES: usize = 2 + MAX_SAMPLED_BINDINGS;
 /// legal, feeding them to `transition::pass_boundary`. Two targets
 /// selecting masks independently is how barrier drift happens; two
 /// consumers of one walk cannot drift.
+/// Why a first-frame-use `LoadOp::Load` on a render image is refused,
+/// if it is — `None` exactly when kept contents are there to load. A
+/// pure function so the refusals read as one table.
+fn load_refusal(kept: bool, arrived: KeptContents) -> Option<&'static str> {
+    match (kept, arrived) {
+        (true, KeptContents::Stored | KeptContents::Sampled) => None,
+        (true, KeptContents::Undefined) => Some(
+            "LoadOp::Load on a kept render image no frame has ever rendered loads undefined \
+             contents — render it once before loading it",
+        ),
+        (true, KeptContents::Discarded) => Some(
+            "LoadOp::Load on a kept render image whose last keeping frame discarded its \
+             contents loads undefined pixels — store what a later frame loads",
+        ),
+        (false, _) => Some(
+            "LoadOp::Load on a render image's first use this frame loads undefined contents \
+             — render-image contents are frame-scoped and start undefined every frame",
+        ),
+    }
+}
+
+/// Why sampling a render image no pass this frame has rendered is
+/// refused, if it is — `None` exactly when kept contents are there to
+/// read.
+fn sample_refusal(kept: bool, arrived: KeptContents) -> Option<&'static str> {
+    match (kept, arrived) {
+        (true, KeptContents::Stored | KeptContents::Sampled) => None,
+        (true, KeptContents::Undefined) => Some(
+            "an item samples a kept render image no frame has ever rendered — render it once \
+             before reading it",
+        ),
+        (true, KeptContents::Discarded) => Some(
+            "an item samples a kept render image whose last keeping frame discarded its \
+             contents — store what a later frame reads",
+        ),
+        (false, _) => Some(
+            "an item samples a render image no pass in this frame has rendered — render-image \
+             contents are frame-scoped, so a frame that reads one must write it first",
+        ),
+    }
+}
+
 pub(crate) struct FrameWalk {
     surface_color_used: bool,
     target_depth_used: bool,
@@ -729,6 +773,13 @@ struct ImageEntry {
     /// — what decides both whether a later `Load` reads anything and
     /// whether a later sample does.
     discarded: bool,
+    /// What an earlier frame left in it, snapshotted at the entry's
+    /// mint so both walks of one frame read one answer.
+    arrived: KeptContents,
+    /// The image to write the after-state into at [`FrameWalk::settle`]
+    /// — held exactly for kept images (`Some` IS the kept flag), and
+    /// only the record walks settle.
+    write_back: Option<Rc<crate::vk::render_image::RenderImageInner>>,
 }
 
 /// What one pass does to its target identities, as [`ImageUse`] pairs
@@ -768,7 +819,8 @@ impl FrameWalk {
     /// # Panics
     ///
     /// A fifth distinct image is refused by name.
-    fn entry_index(&mut self, key: *const u8, kind: RenderImageKind) -> usize {
+    fn entry_index(&mut self, inner: &Rc<crate::vk::render_image::RenderImageInner>) -> usize {
+        let key = Rc::as_ptr(inner).cast::<u8>();
         let known = self
             .images
             .iter()
@@ -786,10 +838,12 @@ impl FrameWalk {
         );
         self.images[occupied] = Some(ImageEntry {
             key,
-            kind,
+            kind: inner.kind,
             targeted: false,
             sampled: false,
             discarded: false,
+            arrived: inner.contents.get(),
+            write_back: inner.kept.then(|| Rc::clone(inner)),
         });
         occupied
     }
@@ -839,9 +893,8 @@ impl FrameWalk {
                 }
             }
             PassTarget::Image(image, attachment) => {
-                let key = Rc::as_ptr(&image.inner).cast::<u8>();
                 let kind = image.inner.kind;
-                let slot = self.entry_index(key, kind);
+                let slot = self.entry_index(&image.inner);
                 let Some(entry) = self.images[slot].as_mut() else {
                     unreachable!("entry_index returns an occupied slot")
                 };
@@ -852,12 +905,17 @@ impl FrameWalk {
                      writes an image must precede the first pass that reads it"
                 );
                 let first_use = !entry.targeted;
-                assert!(
-                    !first_use || !matches!(attachment.load, LoadOp::Load),
-                    "pass {index}: LoadOp::Load on a render image's first use this frame \
-                     loads undefined contents — render-image contents are frame-scoped and \
-                     start undefined every frame"
-                );
+                if first_use && matches!(attachment.load, LoadOp::Load) {
+                    // A kept image with live contents may open with a
+                    // load; everything else meets the frame-scoped
+                    // refusals, each naming its own reason.
+                    let refusal = load_refusal(entry.write_back.is_some(), entry.arrived);
+                    assert!(
+                        refusal.is_none(),
+                        "pass {index}: {}",
+                        refusal.unwrap_or_default()
+                    );
+                }
                 // Loading what the last targeting pass threw away is the
                 // same undefined read one pass later.
                 assert!(
@@ -866,23 +924,36 @@ impl FrameWalk {
                      pass discarded its contents loads undefined pixels — store what a \
                      later pass loads"
                 );
+                // The first frame-use pair: a frame-scoped image (or a
+                // kept one nothing ever rendered) starts undefined; a
+                // kept image re-enters from whichever layout its last
+                // frame left — the attachment layout preserves through
+                // the plain between-pass arms, the sampled layout walks
+                // back through the Kept*FromSampled arms.
+                let kept = entry.write_back.is_some();
+                let kept_alive = kept && entry.arrived != KeptContents::Undefined;
+                let from_sampled = kept && entry.arrived == KeptContents::Sampled;
                 entry.targeted = true;
                 entry.discarded = matches!(attachment.store, StoreOp::Discard);
                 match kind {
                     RenderImageKind::Color => TargetUses {
-                        color: Some(if first_use {
-                            (ImageUse::RenderColorFirstUse, ImageUse::ColorAttachment)
-                        } else {
+                        color: Some(if !first_use || kept_alive && !from_sampled {
                             (ImageUse::ColorAttachment, ImageUse::ColorAttachment)
+                        } else if from_sampled {
+                            (ImageUse::KeptColorFromSampled, ImageUse::ColorAttachment)
+                        } else {
+                            (ImageUse::RenderColorFirstUse, ImageUse::ColorAttachment)
                         }),
                         depth: None,
                     },
                     RenderImageKind::Depth => TargetUses {
                         color: None,
-                        depth: Some(if first_use {
-                            (ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment)
-                        } else {
+                        depth: Some(if !first_use || kept_alive && !from_sampled {
                             (ImageUse::DepthAttachment, ImageUse::DepthAttachment)
+                        } else if from_sampled {
+                            (ImageUse::KeptDepthFromSampled, ImageUse::DepthAttachment)
+                        } else {
+                            (ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment)
                         }),
                     },
                     // No rest arm: `#[non_exhaustive]` does not bind
@@ -929,22 +1000,32 @@ impl FrameWalk {
                      into -- feedback within one pass is undefined; split it into a \
                      writing pass and a reading pass"
                 );
-                let entry = self
+                // A kept image with live contents may be sampled without
+                // any pass this frame rendering it; everything else must
+                // have been written this frame, refused by name.
+                let slot = self
                     .images
-                    .iter_mut()
-                    .flatten()
-                    .find(|entry| entry.key == key && entry.targeted);
-                assert!(
-                    entry.is_some(),
-                    "pass {index}: an item samples a render image no pass in this frame \
-                     has rendered — render-image contents are frame-scoped, so a frame \
-                     that reads one must write it first"
-                );
-                let Some(entry) = entry else {
-                    unreachable!("asserted just above")
+                    .iter()
+                    .position(|slot| matches!(slot, Some(entry) if entry.key == key));
+                let written_this_frame =
+                    slot.is_some_and(|slot| self.images[slot].iter().any(|entry| entry.targeted));
+                if !written_this_frame {
+                    let refusal = sample_refusal(inner.kept, inner.contents.get());
+                    assert!(
+                        refusal.is_none(),
+                        "pass {index}: {}",
+                        refusal.unwrap_or_default()
+                    );
+                }
+                let slot = match slot {
+                    Some(slot) => slot,
+                    None => self.entry_index(inner),
+                };
+                let Some(entry) = self.images[slot].as_mut() else {
+                    unreachable!("entry_index returns an occupied slot")
                 };
                 assert!(
-                    !entry.discarded,
+                    !(entry.targeted && entry.discarded),
                     "pass {index}: an item samples a render image whose last targeting \
                      pass discarded its contents — a targeting pass whose image is read \
                      later must Store"
@@ -953,6 +1034,16 @@ impl FrameWalk {
                     continue;
                 }
                 entry.sampled = true;
+                // The crossing barrier. Written this frame: from the
+                // attachment life this frame built. Kept and untouched:
+                // from the attachment life an earlier frame stored — the
+                // same pair, because the layouts and hazards match. Kept
+                // and already sampled when it arrived: it never left the
+                // sampled layout, and read-after-read needs no barrier
+                // at all.
+                if !entry.targeted && entry.arrived == KeptContents::Sampled {
+                    continue;
+                }
                 out[count] = Some(SampleUse {
                     image: inner.image,
                     range: match entry.kind {
@@ -980,6 +1071,33 @@ impl FrameWalk {
     /// Whether any pass so far targeted the surface.
     pub(crate) fn surface_used(&self) -> bool {
         self.surface_color_used
+    }
+
+    /// Write each kept image's after-state back onto the image, so the
+    /// next frame's walk arrives where this one left.
+    ///
+    /// **Record walks only.** The contract's dry walk reads the same
+    /// cross-frame state and must not move it — the dry walk and the
+    /// record walk of one frame have to read one answer, and a frame
+    /// that is refused must leave no trace.
+    pub(crate) fn settle(&self) {
+        for entry in self.images.iter().flatten() {
+            let Some(inner) = &entry.write_back else {
+                continue;
+            };
+            let after = if entry.sampled {
+                KeptContents::Sampled
+            } else if entry.targeted {
+                if entry.discarded {
+                    KeptContents::Discarded
+                } else {
+                    KeptContents::Stored
+                }
+            } else {
+                continue;
+            };
+            inner.contents.set(after);
+        }
     }
 }
 

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -176,9 +176,12 @@ pub enum LoadOp {
     Clear(ClearValue),
     /// The attachment keeps the previous pass's contents. Refused on
     /// each identity's first use in the frame — the surface, the
-    /// target's depth image, and every render image all start a frame
-    /// from undefined contents — and on a render image whose last
-    /// targeting pass discarded.
+    /// target's depth image, and every frame-scoped render image all
+    /// start a frame from undefined contents — and on a render image
+    /// whose last targeting pass discarded. The one exception is a
+    /// **kept** render image with live contents
+    /// ([`RenderImageDesc::kept`]): its first frame use may load what
+    /// an earlier frame stored.
     Load,
 }
 
@@ -704,18 +707,6 @@ pub(crate) fn uniform_writes<'a>(
 /// the fill loops stay allocation-free.
 pub(crate) const MAX_ITEM_RESOURCES: usize = 2 + MAX_SAMPLED_BINDINGS;
 
-/// The frame's per-identity image walk: which attachment identities
-/// this frame has used, and how -- ONE definition read by the contract
-/// and by both record paths.
-///
-/// **The rules and the barrier pairs live in the same state machine,
-/// and that is the point.** The contract drives a walk over the whole
-/// frame before any GPU call, so every refusal below fires there, by
-/// name; each record path then drives a fresh walk over the same
-/// frame and reads the [`ImageUse`] pairs the contract already proved
-/// legal, feeding them to `transition::pass_boundary`. Two targets
-/// selecting masks independently is how barrier drift happens; two
-/// consumers of one walk cannot drift.
 /// Why a first-frame-use `LoadOp::Load` on a render image is refused,
 /// if it is — `None` exactly when kept contents are there to load. A
 /// pure function so the refusals read as one table.
@@ -758,6 +749,18 @@ fn sample_refusal(kept: bool, arrived: KeptContents) -> Option<&'static str> {
     }
 }
 
+/// The frame's per-identity image walk: which attachment identities
+/// this frame has used, and how -- ONE definition read by the contract
+/// and by both record paths.
+///
+/// **The rules and the barrier pairs live in the same state machine,
+/// and that is the point.** The contract drives a walk over the whole
+/// frame before any GPU call, so every refusal below fires there, by
+/// name; each record path then drives a fresh walk over the same
+/// frame and reads the [`ImageUse`] pairs the contract already proved
+/// legal, feeding them to `transition::pass_boundary`. Two targets
+/// selecting masks independently is how barrier drift happens; two
+/// consumers of one walk cannot drift.
 pub(crate) struct FrameWalk {
     surface_color_used: bool,
     target_depth_used: bool,
@@ -926,13 +929,19 @@ impl FrameWalk {
                 );
                 // The first frame-use pair: a frame-scoped image (or a
                 // kept one nothing ever rendered) starts undefined; a
-                // kept image re-enters from whichever layout its last
-                // frame left — the attachment layout preserves through
-                // the plain between-pass arms, the sampled layout walks
-                // back through the Kept*FromSampled arms.
+                // kept image OPENING WITH A LOAD re-enters from
+                // whichever layout its last frame left — the attachment
+                // layout preserves through the plain between-pass arms,
+                // the sampled layout walks back through the
+                // Kept*FromSampled arms. A Clear takes the undefined
+                // first-use arm even on a kept image: the clear
+                // overwrites every pixel, so preserving contents the
+                // pass immediately destroys would tax every
+                // clear-each-frame consumer for nothing.
+                let loads = matches!(attachment.load, LoadOp::Load);
                 let kept = entry.write_back.is_some();
-                let kept_alive = kept && entry.arrived != KeptContents::Undefined;
-                let from_sampled = kept && entry.arrived == KeptContents::Sampled;
+                let kept_alive = loads && kept && entry.arrived != KeptContents::Undefined;
+                let from_sampled = kept_alive && entry.arrived == KeptContents::Sampled;
                 entry.targeted = true;
                 entry.discarded = matches!(attachment.store, StoreOp::Discard);
                 match kind {
@@ -1002,28 +1011,23 @@ impl FrameWalk {
                 );
                 // A kept image with live contents may be sampled without
                 // any pass this frame rendering it; everything else must
-                // have been written this frame, refused by name.
-                let slot = self
-                    .images
-                    .iter()
-                    .position(|slot| matches!(slot, Some(entry) if entry.key == key));
-                let written_this_frame =
-                    slot.is_some_and(|slot| self.images[slot].iter().any(|entry| entry.targeted));
-                if !written_this_frame {
-                    let refusal = sample_refusal(inner.kept, inner.contents.get());
+                // have been written this frame, refused by name. Minted
+                // BEFORE the refusal so the verdict reads the same
+                // snapshot the whole frame reads - the refusal is the
+                // one place a live read could have let the dry walk and
+                // the record walk answer differently.
+                let slot = self.entry_index(inner);
+                let Some(entry) = self.images[slot].as_mut() else {
+                    unreachable!("entry_index returns an occupied slot")
+                };
+                if !entry.targeted {
+                    let refusal = sample_refusal(entry.write_back.is_some(), entry.arrived);
                     assert!(
                         refusal.is_none(),
                         "pass {index}: {}",
                         refusal.unwrap_or_default()
                     );
                 }
-                let slot = match slot {
-                    Some(slot) => slot,
-                    None => self.entry_index(inner),
-                };
-                let Some(entry) = self.images[slot].as_mut() else {
-                    unreachable!("entry_index returns an occupied slot")
-                };
                 assert!(
                     !(entry.targeted && entry.discarded),
                     "pass {index}: an item samples a render image whose last targeting \

--- a/crates/rhi/src/vk/render_image.rs
+++ b/crates/rhi/src/vk/render_image.rs
@@ -45,18 +45,59 @@ pub struct RenderImageDesc {
     pub kind: RenderImageKind,
     /// The image's size in pixels.
     pub extent: Extent,
+    /// Whether the image's contents persist across frames. See
+    /// [`RenderImage`]'s contract for what a kept image may do that a
+    /// frame-scoped one may not.
+    pub kept: bool,
 }
 
 impl RenderImageDesc {
-    /// A render image of `kind`, sized `extent`.
+    /// A render image of `kind`, sized `extent`, frame-scoped.
     ///
     /// Positional because neither has a meaningful default: an image
     /// with no kind has no format, and one with no size is not an
-    /// image.
+    /// image. Frame-scoped by default because that is the cheaper
+    /// contract; [`Self::kept`] opts into persistence.
     #[must_use]
     pub fn new(kind: RenderImageKind, extent: Extent) -> Self {
-        Self { kind, extent }
+        Self {
+            kind,
+            extent,
+            kept: false,
+        }
     }
+
+    /// The same image, keeping its contents across frames.
+    #[must_use]
+    pub fn kept(mut self) -> Self {
+        self.kept = true;
+        self
+    }
+}
+
+/// What an earlier frame left in a **kept** render image - the
+/// cross-frame half of the frame walk's state machine, stored on the
+/// image because the image is the thing that outlives frames.
+///
+/// Written back only when a frame is actually recorded (the contract's
+/// dry walk reads it and must not move it), and only ever read and
+/// written on the one thread the crate contract already requires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeptContents {
+    /// No frame has rendered the image yet: contents undefined, exactly
+    /// a frame-scoped image's every-frame state. Also every non-kept
+    /// image's permanent value - the walk never writes those back.
+    Undefined,
+    /// The last frame to touch it wrote and stored: contents live, the
+    /// image sits in its attachment layout.
+    Stored,
+    /// The last frame to touch it wrote and discarded: the layout is
+    /// the attachment layout but the pixels are gone, so loading or
+    /// sampling them is refused by name.
+    Discarded,
+    /// The last frame to touch it left it sampled: contents live, the
+    /// image sits in the sampled layout.
+    Sampled,
 }
 
 /// Refuse a malformed render-image extent. A pure function so both
@@ -89,6 +130,11 @@ pub(crate) struct RenderImageInner {
     pub(crate) view: vk::ImageView,
     pub(crate) format: vk::Format,
     pub(crate) kind: RenderImageKind,
+    /// Whether contents persist across frames (creation-time choice).
+    pub(crate) kept: bool,
+    /// The cross-frame contents state; [`KeptContents::Undefined`]
+    /// forever on a frame-scoped image.
+    pub(crate) contents: core::cell::Cell<KeptContents>,
     extent: Extent,
 }
 
@@ -120,14 +166,27 @@ impl Drop for RenderImageInner {
 ///
 /// # Contract
 ///
-/// The image's **contents are frame-scoped**: every frame's first use
-/// of it starts from undefined pixels, and nothing rendered into it is
-/// promised to a later frame — the frame contract refuses a
+/// By default the image's **contents are frame-scoped**: every frame's
+/// first use of it starts from undefined pixels, and nothing rendered
+/// into it is promised to a later frame — the frame contract refuses a
 /// contents-preserving first-use load exactly as it does for the
 /// surface. The image itself outlives every frame that names it, held
 /// by the target's retention table until that frame's work provably
 /// ended, so a caller may drop the handle mid-frame and take nothing
 /// away from the GPU.
+///
+/// A **kept** image ([`RenderImageDesc::kept`]) persists its contents
+/// across frames instead. What that buys, concretely: a frame may open
+/// it with `LoadOp::Load` and paint over last frame's pixels, and a
+/// frame may **sample it without rendering to it at all** — the shape
+/// of every render-to-texture updated on its own cadence: a shadow map
+/// under a slow sun, a reflection probe, a minimap, an impostor cache.
+/// Two rules survive unchanged: the first frame ever to touch it must
+/// render before anything loads or samples it (there is nothing to
+/// keep yet), and a frame whose last write discarded leaves nothing
+/// for later frames to load or sample — both refused by name. The
+/// within-frame order (every writing pass before the first sampling
+/// pass) binds kept images exactly as it does frame-scoped ones.
 ///
 /// There is no host path — no upload, no readback — and no resize: an
 /// image is its size for its whole life, and a differently-sized frame
@@ -360,6 +419,8 @@ impl Device {
                 view,
                 format,
                 kind: desc.kind,
+                kept: desc.kept,
+                contents: core::cell::Cell::new(KeptContents::Undefined),
                 extent: desc.extent,
             }),
         })

--- a/crates/rhi/src/vk/render_image.rs
+++ b/crates/rhi/src/vk/render_image.rs
@@ -34,7 +34,8 @@ pub enum RenderImageKind {
     Depth,
 }
 
-/// Everything a render image needs: its kind and its size.
+/// Everything a render image needs: its kind, its size, and whether
+/// its contents outlive the frame.
 ///
 /// `#[non_exhaustive]` with a constructor, per the descriptor pattern
 /// this crate uses everywhere.
@@ -79,9 +80,12 @@ impl RenderImageDesc {
 /// cross-frame half of the frame walk's state machine, stored on the
 /// image because the image is the thing that outlives frames.
 ///
-/// Written back only when a frame is actually recorded (the contract's
-/// dry walk reads it and must not move it), and only ever read and
-/// written on the one thread the crate contract already requires.
+/// Written back only when a frame is actually **submitted** - the
+/// contract's dry walk reads it and must not move it, and a recorded
+/// frame that never reaches the queue must leave no trace, or the next
+/// frame's barriers would claim a layout no GPU work ever produced.
+/// Only ever read and written on the one thread the crate contract
+/// already requires.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KeptContents {
     /// No frame has rendered the image yet: contents undefined, exactly

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -1109,9 +1109,6 @@ impl WindowTarget {
                 }
                 device.cmd_end_rendering(cmd);
             }
-            // Every pass recorded: kept images remember where this
-            // frame left them, so the next frame's walk arrives there.
-            walk.settle();
 
             // COLOR_ATTACHMENT_OPTIMAL → PRESENT_SRC; not a pass — the
             // terminal literal, pinned by unit test beside the core it
@@ -1159,6 +1156,13 @@ impl WindowTarget {
                 };
                 return Err(self.abort_frame(error));
             }
+            // Submitted, so the work executes in queue order - ONLY NOW
+            // may kept images remember where this frame leaves them. A
+            // recorded frame that never reached the queue must leave no
+            // trace: kept images are device-scoped, so even a dormant
+            // window target's stale claim would poison an offscreen
+            // sibling on the same device.
+            walk.settle();
             self.pending[frame] = true;
             // Advance only after a successful submit: a frame that failed
             // to submit left its slot unused, and skipping it would leak a

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -1109,6 +1109,9 @@ impl WindowTarget {
                 }
                 device.cmd_end_rendering(cmd);
             }
+            // Every pass recorded: kept images remember where this
+            // frame left them, so the next frame's walk arrives there.
+            walk.settle();
 
             // COLOR_ATTACHMENT_OPTIMAL → PRESENT_SRC; not a pass — the
             // terminal literal, pinned by unit test beside the core it

--- a/crates/rhi/src/vk/transition.rs
+++ b/crates/rhi/src/vk/transition.rs
@@ -473,51 +473,6 @@ mod tests {
     /// These are the barriers the pure core deliberately does not own;
     /// a change to any mask here is a change to a synchronization
     /// argument and must be its own reviewed decision.
-    /// The kept arms, pinned like the rest: these are the only pairs
-    /// whose `old_layout` is the sampled layout, because kept contents
-    /// re-enter attachment life instead of starting undefined.
-    #[test]
-    fn the_kept_arms_are_pinned_field_by_field() {
-        let color = pass_boundary(ImageUse::KeptColorFromSampled, ImageUse::ColorAttachment);
-        assert_eq!(
-            color.src_stage,
-            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
-                | vk::PipelineStageFlags2::FRAGMENT_SHADER
-        );
-        assert_eq!(color.src_access, vk::AccessFlags2::COLOR_ATTACHMENT_WRITE);
-        assert_eq!(
-            color.dst_stage,
-            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
-        );
-        assert_eq!(
-            color.dst_access,
-            vk::AccessFlags2::COLOR_ATTACHMENT_READ | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
-        );
-        assert_eq!(color.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
-        assert_eq!(color.new_layout, vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
-
-        let depth = pass_boundary(ImageUse::KeptDepthFromSampled, ImageUse::DepthAttachment);
-        assert_eq!(
-            depth.src_stage,
-            DEPTH_STAGES | vk::PipelineStageFlags2::FRAGMENT_SHADER
-        );
-        assert_eq!(
-            depth.src_access,
-            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
-        );
-        assert_eq!(depth.dst_stage, DEPTH_STAGES);
-        assert_eq!(
-            depth.dst_access,
-            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
-                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
-        );
-        assert_eq!(depth.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
-        assert_eq!(
-            depth.new_layout,
-            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-        );
-    }
-
     #[test]
     fn the_excluded_sites_keep_their_exact_mask_literals() {
         let acquire = acquire_chained_color_first_use();
@@ -574,6 +529,51 @@ mod tests {
         assert_eq!(host.src_access, vk::AccessFlags2::TRANSFER_WRITE);
         assert_eq!(host.dst_stage, vk::PipelineStageFlags2::HOST);
         assert_eq!(host.dst_access, vk::AccessFlags2::HOST_READ);
+    }
+
+    /// The kept arms, pinned like the rest: these are the only pairs
+    /// whose `old_layout` is the sampled layout, because kept contents
+    /// re-enter attachment life instead of starting undefined.
+    #[test]
+    fn the_kept_arms_are_pinned_field_by_field() {
+        let color = pass_boundary(ImageUse::KeptColorFromSampled, ImageUse::ColorAttachment);
+        assert_eq!(
+            color.src_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(color.src_access, vk::AccessFlags2::COLOR_ATTACHMENT_WRITE);
+        assert_eq!(
+            color.dst_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+        );
+        assert_eq!(
+            color.dst_access,
+            vk::AccessFlags2::COLOR_ATTACHMENT_READ | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+        );
+        assert_eq!(color.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
+        assert_eq!(color.new_layout, vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
+
+        let depth = pass_boundary(ImageUse::KeptDepthFromSampled, ImageUse::DepthAttachment);
+        assert_eq!(
+            depth.src_stage,
+            DEPTH_STAGES | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            depth.src_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(depth.dst_stage, DEPTH_STAGES);
+        assert_eq!(
+            depth.dst_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(depth.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
+        assert_eq!(
+            depth.new_layout,
+            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        );
     }
 
     /// The unreachable pairs are refused, not silently mapped: proving

--- a/crates/rhi/src/vk/transition.rs
+++ b/crates/rhi/src/vk/transition.rs
@@ -15,6 +15,14 @@
 
 use ash::vk;
 
+/// Both depth-test stages as one named value: every depth arm scopes
+/// the pair together, because depth loads run early and depth writes
+/// run late and a barrier that names only one misses half the hazard.
+const DEPTH_STAGES: vk::PipelineStageFlags2 = vk::PipelineStageFlags2::from_raw(
+    vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS.as_raw()
+        | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS.as_raw(),
+);
+
 /// The masks and layouts of one image barrier, ready for a site to pour
 /// into a `vk::ImageMemoryBarrier2` against its own image and aspect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,10 +64,24 @@ pub(crate) enum ImageUse {
     /// This frame's first use of a render image as a depth target —
     /// [`Self::RenderColorFirstUse`]'s reasoning at the depth stages.
     RenderDepthFirstUse,
+    /// This frame's first use of a **kept** render image as a color
+    /// target, arriving from a sampled life: an earlier frame left the
+    /// image in the sampled layout and kept contents survive, so the
+    /// transition preserves instead of discarding. The source scope
+    /// covers what an earlier frame could still be running against
+    /// this one physical image: the fragment-shader reads that put it
+    /// in this layout (execution ordering is enough against reads),
+    /// plus the attachment-write availability belt the first-use arms
+    /// carry, for the writing frame before that.
+    KeptColorFromSampled,
+    /// [`Self::KeptColorFromSampled`]'s reasoning at the depth stages.
+    KeptDepthFromSampled,
     /// A render image a pass in this frame rendered into, now read by
     /// a sampling pass. Emitted once, at the first sampling pass's
-    /// boundary; the contract refuses re-targeting after sampling, so
-    /// no arm leads back out.
+    /// boundary; the contract refuses re-targeting after sampling
+    /// within a frame, so inside one frame no arm leads back out. A
+    /// kept image may be re-targeted by a LATER frame, and arrives
+    /// there through the `Kept*FromSampled` arms.
     SampledInPass,
 }
 
@@ -98,8 +120,7 @@ pub(crate) fn pass_boundary(from: ImageUse, to: ImageUse) -> BarrierMasks {
         (ImageUse::DepthAttachmentFirstUse, ImageUse::DepthAttachment) => BarrierMasks {
             src_stage: vk::PipelineStageFlags2::NONE,
             src_access: vk::AccessFlags2::NONE,
-            dst_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            dst_stage: DEPTH_STAGES,
             dst_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
                 | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
             old_layout: vk::ImageLayout::UNDEFINED,
@@ -108,11 +129,9 @@ pub(crate) fn pass_boundary(from: ImageUse, to: ImageUse) -> BarrierMasks {
         // Between depth-carrying passes: the previous pass's depth
         // writes, ordered before this pass's tests and writes.
         (ImageUse::DepthAttachment, ImageUse::DepthAttachment) => BarrierMasks {
-            src_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            src_stage: DEPTH_STAGES,
             src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
-            dst_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            dst_stage: DEPTH_STAGES,
             dst_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
                 | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
             old_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
@@ -138,15 +157,35 @@ pub(crate) fn pass_boundary(from: ImageUse, to: ImageUse) -> BarrierMasks {
             new_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
         },
         (ImageUse::RenderDepthFirstUse, ImageUse::DepthAttachment) => BarrierMasks {
-            src_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            src_stage: DEPTH_STAGES | vk::PipelineStageFlags2::FRAGMENT_SHADER,
             src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
-            dst_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            dst_stage: DEPTH_STAGES,
             dst_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
                 | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
             old_layout: vk::ImageLayout::UNDEFINED,
+            new_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        },
+        // A kept image re-targeted out of a sampled life: the layout
+        // walks back from sampled to attachment WITHOUT discarding -
+        // kept contents are the point, so `UNDEFINED` never appears.
+        // Cross-frame source scope as the variant doc states.
+        (ImageUse::KeptColorFromSampled, ImageUse::ColorAttachment) => BarrierMasks {
+            src_stage: vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            src_access: vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            dst_stage: vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT,
+            dst_access: vk::AccessFlags2::COLOR_ATTACHMENT_READ
+                | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE,
+            old_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+            new_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+        },
+        (ImageUse::KeptDepthFromSampled, ImageUse::DepthAttachment) => BarrierMasks {
+            src_stage: DEPTH_STAGES | vk::PipelineStageFlags2::FRAGMENT_SHADER,
+            src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            dst_stage: DEPTH_STAGES,
+            dst_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
+            old_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
             new_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
         },
         // Rendered this frame, sampled from here on: the writing
@@ -163,8 +202,7 @@ pub(crate) fn pass_boundary(from: ImageUse, to: ImageUse) -> BarrierMasks {
             new_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
         },
         (ImageUse::DepthAttachment, ImageUse::SampledInPass) => BarrierMasks {
-            src_stage: vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS
-                | vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS,
+            src_stage: DEPTH_STAGES,
             src_access: vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE,
             dst_stage: vk::PipelineStageFlags2::FRAGMENT_SHADER,
             dst_access: vk::AccessFlags2::SHADER_SAMPLED_READ,
@@ -435,6 +473,51 @@ mod tests {
     /// These are the barriers the pure core deliberately does not own;
     /// a change to any mask here is a change to a synchronization
     /// argument and must be its own reviewed decision.
+    /// The kept arms, pinned like the rest: these are the only pairs
+    /// whose `old_layout` is the sampled layout, because kept contents
+    /// re-enter attachment life instead of starting undefined.
+    #[test]
+    fn the_kept_arms_are_pinned_field_by_field() {
+        let color = pass_boundary(ImageUse::KeptColorFromSampled, ImageUse::ColorAttachment);
+        assert_eq!(
+            color.src_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+                | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(color.src_access, vk::AccessFlags2::COLOR_ATTACHMENT_WRITE);
+        assert_eq!(
+            color.dst_stage,
+            vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT
+        );
+        assert_eq!(
+            color.dst_access,
+            vk::AccessFlags2::COLOR_ATTACHMENT_READ | vk::AccessFlags2::COLOR_ATTACHMENT_WRITE
+        );
+        assert_eq!(color.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
+        assert_eq!(color.new_layout, vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL);
+
+        let depth = pass_boundary(ImageUse::KeptDepthFromSampled, ImageUse::DepthAttachment);
+        assert_eq!(
+            depth.src_stage,
+            DEPTH_STAGES | vk::PipelineStageFlags2::FRAGMENT_SHADER
+        );
+        assert_eq!(
+            depth.src_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(depth.dst_stage, DEPTH_STAGES);
+        assert_eq!(
+            depth.dst_access,
+            vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ
+                | vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE
+        );
+        assert_eq!(depth.old_layout, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL);
+        assert_eq!(
+            depth.new_layout,
+            vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        );
+    }
+
     #[test]
     fn the_excluded_sites_keep_their_exact_mask_literals() {
         let acquire = acquire_chained_color_first_use();

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -1330,6 +1330,109 @@ fn a_kept_image_keeps_only_what_was_stored() {
     assert_no_validation_errors(&device);
 }
 
+/// A kept image read without a writing pass still spends a frame
+/// slot: the ceiling counts identities however they are used, so four
+/// targeted images plus a kept sample-only fifth is refused as the
+/// fifth, by the ceiling's own words.
+#[test]
+fn a_kept_sample_costs_a_frame_slot() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 8,
+            height: 8,
+        })
+        .expect("offscreen target");
+    let pipeline = device
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE,
+            TargetFormat::Rgba8Srgb,
+        ))
+        .expect("triangle pipeline");
+    let one_slot = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Srgb).sampled_bindings(1),
+        )
+        .expect("one-slot pipeline");
+    let sampler = device
+        .create_sampler(&renew_rhi::SamplerDesc::atlas())
+        .expect("sampler");
+    let kept = device
+        .create_render_image(
+            &renew_rhi::RenderImageDesc::new(
+                renew_rhi::RenderImageKind::Color,
+                Extent {
+                    width: 8,
+                    height: 8,
+                },
+            )
+            .kept(),
+        )
+        .expect("kept image");
+    let kept_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&kept), &sampler))
+        .expect("kept binding");
+    let black = Color::new(0.0, 0.0, 0.0, 1.0);
+    let store = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+        StoreOp::Store,
+    );
+    // Stored once, so the sample-only mention is legal on its own
+    // terms and the refusal below can only be the ceiling's.
+    {
+        let color = clear(black);
+        let surface = [Item::new(&pipeline)];
+        target
+            .render(&RenderDesc::new(&[
+                Pass::render_to(&kept, store, &[]),
+                Pass::new(&color, &surface),
+            ]))
+            .expect("the storing frame renders");
+    }
+    let four: Vec<renew_rhi::RenderImage> = (0..4)
+        .map(|_| {
+            device
+                .create_render_image(&renew_rhi::RenderImageDesc::new(
+                    renew_rhi::RenderImageKind::Color,
+                    Extent {
+                        width: 8,
+                        height: 8,
+                    },
+                ))
+                .expect("boundary image")
+        })
+        .collect();
+    refused_by_name(
+        "a kept sample as the fifth image",
+        "at most 4 distinct render images",
+        || {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&kept_binding])];
+            let image_passes: Vec<Pass<'_>> = four
+                .iter()
+                .map(|image| Pass::render_to(image, store, &[]))
+                .chain(std::iter::once(Pass::new(&color, &items)))
+                .collect();
+            let _ = target.render(&RenderDesc::new(&image_passes));
+        },
+    );
+    let color = clear(black);
+    let items = [Item::new(&pipeline)];
+    target
+        .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
+        .expect("the target survives the refusal");
+    drop(four);
+    drop(kept_binding);
+    drop(kept);
+    drop(sampler);
+    drop(one_slot);
+    drop(pipeline);
+    drop(target);
+    assert_no_validation_errors(&device);
+}
+
 /// Four distinct render images in one frame — the documented ceiling —
 /// two of them sampled by the same surface pass: the multi-image walk,
 /// the pass-level retention of every image, and a batched sampling

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -1137,6 +1137,199 @@ fn malformed_frames_are_refused_by_name() {
     assert_no_validation_errors(&device);
 }
 
+/// The kept-image rules: persistence changes what is legal, not
+/// whether legality is checked. A virgin kept image refuses loads and
+/// reads by its own name (nothing was ever kept); a stored frame makes
+/// the sample-only frame legal; a discarding frame takes the
+/// permission back. Each refusal is matched to its clause's words, and
+/// the target renders a clean frame afterwards to prove the refusals
+/// fired before any GPU work.
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "one case per kept-contract clause; the matrix is the point"
+)]
+fn a_kept_image_keeps_only_what_was_stored() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 8,
+            height: 8,
+        })
+        .expect("offscreen target");
+    let pipeline = device
+        .create_pipeline(&PipelineDesc::new(
+            builtin::TRIANGLE,
+            TargetFormat::Rgba8Srgb,
+        ))
+        .expect("triangle pipeline");
+    let one_slot = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Srgb).sampled_bindings(1),
+        )
+        .expect("one-slot pipeline");
+    let sampler = device
+        .create_sampler(&renew_rhi::SamplerDesc::atlas())
+        .expect("sampler");
+    let kept = device
+        .create_render_image(
+            &renew_rhi::RenderImageDesc::new(
+                renew_rhi::RenderImageKind::Color,
+                Extent {
+                    width: 8,
+                    height: 8,
+                },
+            )
+            .kept(),
+        )
+        .expect("kept image");
+    let kept_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&kept), &sampler))
+        .expect("kept binding");
+    let black = Color::new(0.0, 0.0, 0.0, 1.0);
+    let store = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+        StoreOp::Store,
+    );
+    let discard = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(0.0, 0.0, 0.0, 1.0))),
+        StoreOp::Discard,
+    );
+    let load = Attachment::new(LoadOp::Load, StoreOp::Store);
+
+    // Virgin: nothing was ever kept, so nothing may be read or loaded.
+    refused_by_name(
+        "sampling a virgin kept image",
+        "render it once before reading it",
+        || {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&kept_binding])];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+    refused_by_name(
+        "loading a virgin kept image",
+        "render it once before loading it",
+        || {
+            let color = clear(black);
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&kept, load, &[]),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+
+    // Stored: the sample-only frame is now legal — the whole point.
+    {
+        let color = clear(black);
+        let surface = [Item::new(&pipeline)];
+        target
+            .render(&RenderDesc::new(&[
+                Pass::render_to(&kept, store, &[]),
+                Pass::new(&color, &surface),
+            ]))
+            .expect("the storing frame renders");
+        let items = [Item::new(&one_slot).bindings(&[&kept_binding])];
+        target
+            .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
+            .expect("a frame may sample what an earlier frame kept");
+        // And a loading re-open of the sampled layout renders too.
+        target
+            .render(&RenderDesc::new(&[
+                Pass::render_to(&kept, load, &[]),
+                Pass::new(&color, &surface),
+            ]))
+            .expect("a frame may load what an earlier frame kept");
+    }
+
+    // Discarded: the permission is taken back, by name.
+    {
+        let color = clear(black);
+        let surface = [Item::new(&pipeline)];
+        target
+            .render(&RenderDesc::new(&[
+                Pass::render_to(&kept, discard, &[]),
+                Pass::new(&color, &surface),
+            ]))
+            .expect("the discarding frame itself is well-formed");
+    }
+    refused_by_name(
+        "sampling a kept image after a discarding frame",
+        "store what a later frame reads",
+        || {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&kept_binding])];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+    refused_by_name(
+        "loading a kept image after a discarding frame",
+        "store what a later frame loads",
+        || {
+            let color = clear(black);
+            let surface = [Item::new(&pipeline)];
+            let _ = target.render(&RenderDesc::new(&[
+                Pass::render_to(&kept, load, &[]),
+                Pass::new(&color, &surface),
+            ]));
+        },
+    );
+
+    // A frame-scoped image's rules did not move: the same sample-only
+    // frame that a kept image earns stays refused for it.
+    let scoped = device
+        .create_render_image(&renew_rhi::RenderImageDesc::new(
+            renew_rhi::RenderImageKind::Color,
+            Extent {
+                width: 8,
+                height: 8,
+            },
+        ))
+        .expect("frame-scoped image");
+    let scoped_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&scoped), &sampler))
+        .expect("scoped binding");
+    {
+        let color = clear(black);
+        let surface = [Item::new(&pipeline)];
+        target
+            .render(&RenderDesc::new(&[
+                Pass::render_to(&scoped, store, &[]),
+                Pass::new(&color, &surface),
+            ]))
+            .expect("the storing frame renders");
+    }
+    refused_by_name(
+        "sampling a frame-scoped image a previous frame stored",
+        "must write it first",
+        || {
+            let color = clear(black);
+            let items = [Item::new(&one_slot).bindings(&[&scoped_binding])];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+
+    // The refusals fired before any GPU work: a clean frame still
+    // renders and validation stayed silent.
+    let color = clear(black);
+    let items = [Item::new(&pipeline)];
+    target
+        .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
+        .expect("the target survives every refusal");
+    drop(scoped_binding);
+    drop(scoped);
+    drop(kept_binding);
+    drop(kept);
+    drop(sampler);
+    drop(one_slot);
+    drop(pipeline);
+    drop(target);
+    assert_no_validation_errors(&device);
+}
+
 /// Four distinct render images in one frame — the documented ceiling —
 /// two of them sampled by the same surface pass: the multi-image walk,
 /// the pass-level retention of every image, and a batched sampling

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -888,6 +888,121 @@ fn a_rendered_image_samples_back_byte_exact() {
     assert_no_validation_errors(&device);
 }
 
+/// **Kept contents cross frames.** Frame one renders the atlas into a
+/// kept image and samples it to the surface; frame two contains ONLY
+/// the sampling pass — the writing half omitted, which is the shape
+/// the kept contract exists for (a shadow map under a slow sun, a
+/// probe, a minimap); frame three re-opens the image with `LoadOp::Load`
+/// and draws nothing over it. All three read back byte-identical to
+/// the same CPU oracle: the pixels are the proof that the contents,
+/// the layouts, and the cross-frame barriers all survived — on a
+/// frame-scoped image frames two and three are refused outright, and
+/// the byte oracle catches a silent discard that a mere absence of
+/// validation errors would wave through.
+#[test]
+fn a_kept_image_survives_frames_that_never_render_it() {
+    const SIZE: u32 = 8;
+    const TEXELS: u32 = 2;
+    #[rustfmt::skip]
+    const ATLAS: [u8; 16] = [
+        10, 20, 30, 255,    40, 50, 60, 255,
+        70, 80, 90, 255,    100, 110, 120, 255,
+    ];
+
+    let Some(device) = device_or_skip().expect("device bring-up") else {
+        return;
+    };
+    let (texture, sampler, atlas_binding) =
+        atlas_fixture(&device, TEXELS, &ATLAS).expect("atlas fixture");
+    let image = device
+        .create_render_image(
+            &RenderImageDesc::new(
+                RenderImageKind::Color,
+                Extent {
+                    width: SIZE,
+                    height: SIZE,
+                },
+            )
+            .kept(),
+        )
+        .expect("kept render image");
+    let image_binding = device
+        .create_binding(&BindingDesc::new(BindingSource::Image(&image), &sampler))
+        .expect("image binding");
+    let into_image_pipeline = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Unorm).sampled_bindings(1),
+        )
+        .expect("render-image pipeline");
+    let pipeline = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::TEXTURED, TargetFormat::Rgba8Srgb).sampled_bindings(1),
+        )
+        .expect("sampled pipeline");
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: SIZE,
+            height: SIZE,
+        })
+        .expect("offscreen target");
+
+    let clear_value = Attachment::new(
+        LoadOp::Clear(ClearValue::Color(Color::new(1.0, 0.0, 1.0, 1.0))),
+        StoreOp::Store,
+    );
+    let load_value = Attachment::new(LoadOp::Load, StoreOp::Store);
+    let color = clear(Color::new(1.0, 0.0, 1.0, 1.0));
+    let into_image = [Item::new(&into_image_pipeline).bindings(&[&atlas_binding])];
+    let onto_surface = [Item::new(&pipeline).bindings(&[&image_binding])];
+
+    let writing_frame = [
+        Pass::render_to(&image, clear_value, &into_image),
+        Pass::new(&color, &onto_surface),
+    ];
+    let sampling_frame = [Pass::new(&color, &onto_surface)];
+    let loading_frame = [
+        Pass::render_to(&image, load_value, &[]),
+        Pass::new(&color, &onto_surface),
+    ];
+
+    let mut pixels = vec![0u8; target.byte_len()];
+    let frames: [(&str, &[Pass<'_>]); 3] = [
+        ("writes and samples", &writing_frame),
+        ("samples what frame one kept", &sampling_frame),
+        ("loads what frame two left sampled", &loading_frame),
+    ];
+    for (label, passes) in frames {
+        target
+            .render(&RenderDesc::new(passes))
+            .expect("a kept frame renders");
+        target.read_back_into(&mut pixels);
+        for y in 0..SIZE {
+            for x in 0..SIZE {
+                let texel = ((y * TEXELS) / SIZE) * TEXELS + (x * TEXELS) / SIZE;
+                let expected = stored(&ATLAS[(texel as usize) * 4..(texel as usize) * 4 + 4]);
+                let offset = ((y * SIZE + x) as usize) * 4;
+                assert_eq!(
+                    &pixels[offset..offset + 4],
+                    expected,
+                    "the frame that {label}: pixel ({x},{y}) should carry texel {texel} on \
+                     adapter {:?}",
+                    device.adapter()
+                );
+            }
+        }
+    }
+
+    drop(target);
+    drop(pipeline);
+    drop(into_image_pipeline);
+    drop(image_binding);
+    drop(atlas_binding);
+    drop(image);
+    drop(texture);
+    drop(sampler);
+    assert_no_validation_errors(&device);
+}
+
 /// A quad over the left half of clip space at `depth`, packed to the
 /// mesh layout's 36-byte records: positions pass straight through the
 /// mesh vertex stage; colour and uv ride along unread — the layout

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -896,9 +896,13 @@ fn a_rendered_image_samples_back_byte_exact() {
 /// and draws nothing over it. All three read back byte-identical to
 /// the same CPU oracle: the pixels are the proof that the contents,
 /// the layouts, and the cross-frame barriers all survived — on a
-/// frame-scoped image frames two and three are refused outright, and
-/// the byte oracle catches a silent discard that a mere absence of
-/// validation errors would wave through.
+/// frame-scoped image frames two and three are refused outright. On
+/// the CPU rasterizer CI runs, the bytes prove contract legality and
+/// layout-tracking cleanliness, not preservation — a transition that
+/// wrongly discarded would still read back intact there, exactly as
+/// the barrier table's own tests say of masks; on a real adapter,
+/// where a transition can actually move memory, these same bytes
+/// become the preservation oracle.
 #[test]
 fn a_kept_image_survives_frames_that_never_render_it() {
     const SIZE: u32 = 8;
@@ -966,10 +970,14 @@ fn a_kept_image_survives_frames_that_never_render_it() {
     ];
 
     let mut pixels = vec![0u8; target.byte_len()];
-    let frames: [(&str, &[Pass<'_>]); 3] = [
+    let frames: [(&str, &[Pass<'_>]); 4] = [
         ("writes and samples", &writing_frame),
         ("samples what frame one kept", &sampling_frame),
-        ("loads what frame two left sampled", &loading_frame),
+        // Twice in a row, deliberately: an image that arrives already
+        // sampled crosses no barrier at all - the boldest arm in the
+        // walk - and this is the frame that executes it.
+        ("samples again with no barrier at all", &sampling_frame),
+        ("loads what frame three left sampled", &loading_frame),
     ];
     for (label, passes) in frames {
         target

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -1053,13 +1053,19 @@ fn a_depth_only_pass_writes_depth_a_sampler_reads_back() {
     let Some(device) = device_or_skip().expect("device bring-up") else {
         return;
     };
-    let image = match device.create_render_image(&RenderImageDesc::new(
-        RenderImageKind::Depth,
-        Extent {
-            width: SIZE,
-            height: SIZE,
-        },
-    )) {
+    // Kept, so the second frame below may re-open what this one wrote:
+    // the depth twin of the colour persistence golden, and the one
+    // place the sampled-to-depth-attachment walk-back arm runs.
+    let image = match device.create_render_image(
+        &RenderImageDesc::new(
+            RenderImageKind::Depth,
+            Extent {
+                width: SIZE,
+                height: SIZE,
+            },
+        )
+        .kept(),
+    ) {
         Ok(image) => image,
         // An adapter whose depth format cannot be sampled refuses at
         // creation by design; off the strict lane that is a skip, on it
@@ -1122,6 +1128,17 @@ fn a_depth_only_pass_writes_depth_a_sampler_reads_back() {
     target
         .render(&RenderDesc::new(&passes))
         .expect("shadow render");
+    // Frame two: the image arrives in its sampled life and a depth
+    // pass re-opens it with Load, drawing nothing - the
+    // sampled-to-attachment walk-back at the depth stages, and the
+    // reader must see the same quad the first frame cast.
+    let second = [
+        Pass::render_to(&image, depth_again, &[]),
+        Pass::new(&color, &reading),
+    ];
+    target
+        .render(&RenderDesc::new(&second))
+        .expect("the kept re-open renders");
     let mut pixels = vec![0u8; target.byte_len()];
     target.read_back_into(&mut pixels);
 


### PR DESCRIPTION
By default a render image's contents are frame-scoped — the cheaper contract, and it stays the default. An image created kept (`RenderImageDesc::kept`) persists instead: a later frame may open it with `LoadOp::Load` or sample it without rendering it at all — the shape of every render-to-texture on its own cadence (a shadow map under a slow sun, a reflection probe, a minimap, an impostor cache).

The mechanics stay in the one state machine that owns barriers: the image carries its cross-frame contents state, the frame walk snapshots it at first mention (dry walk and record walk read one answer; only record walks settle it back, so a refused frame leaves no trace), and the pure barrier core grows exactly two pairs — the only arms whose old layout is the sampled layout. render3d's shadow map is now kept, which makes the caster pass a cadence decision documented on `ShadowedCameraRenderer`.

Evidence: the new pairs are pinned field by field; a device test walks the whole legality matrix (virgin/stored/discarded × load/sample, plus a frame-scoped image's unmoved refusals); a golden reads back byte-identical pixels across a frame that only samples and a frame that only loads. Canonical lint and test green (2445 passed, 0 failed) on a real adapter.