### PR TITLE
feat(rhi): the retention table fits a chunked world

### DIFF
--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -417,7 +417,7 @@ fn build(
         cmd,
         fence,
         depth,
-        retained: Default::default(),
+        retained: [const { None }; MAX_RETAINED_RESOURCES],
         wedged: false,
     })
 }

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -1589,15 +1589,20 @@ fn count_matters(records: &[Option<BufferRecord>; MAX_RETAINED_RESOURCES]) -> us
 /// next distinct resource past the bound is refused by name in
 /// [`check_frame_contract`].
 ///
-/// Thirty-two, doubled from sixteen the day a real consumer's fullest
-/// frame — a world mesh, a marker, a held item, billboard layers, two
-/// cutout meshes, machines, two particle pipelines and an interface
-/// overlay, each with its bindings — landed on exactly seventeen. It
-/// was doubled from eight before that, when bindings joined the table.
-/// The table is `Option`s in fixed arrays: the cost of headroom is
-/// thirty-two words of `None` per frame, and the cost of too little is
-/// a consumer cutting a feature to fit a constant this crate chose.
-pub(crate) const MAX_RETAINED_RESOURCES: usize = 32;
+/// Two hundred and fifty-six. The day a consumer moved from one world
+/// mesh to a buffer per chunk — the ordinary shape of any chunked or
+/// streaming world, and the move that makes uploads as incremental as
+/// the meshing — its fullest frame carried a mesh and a vegetation
+/// twin for every visible chunk and crossed thirty-two on the first
+/// real vista. Thirty-two had been doubled from sixteen the day a
+/// fullest frame landed on seventeen, and from eight before that,
+/// when bindings joined the table; each bump waited for a consumer to
+/// hit the wall, and this one grants the headroom class instead of
+/// the next doubling. The table is `Option`s in fixed arrays: the
+/// cost is two hundred and fifty-six words of `None` per frame slot,
+/// and the cost of too little is a consumer cutting a feature to fit
+/// a constant this crate chose.
+pub(crate) const MAX_RETAINED_RESOURCES: usize = 256;
 
 impl LoadOp {
     pub(crate) fn to_vk(self) -> ash::vk::AttachmentLoadOp {

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -738,7 +738,7 @@ fn malformed_frames_are_refused_by_name() {
             let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
         },
     );
-    let many: Vec<renew_rhi::Buffer> = (0..33)
+    let many: Vec<renew_rhi::Buffer> = (0..257)
         .map(|_| {
             device
                 .create_buffer(64, BufferUsage::PerFrame)
@@ -746,7 +746,7 @@ fn malformed_frames_are_refused_by_name() {
         })
         .collect();
     refused(
-        "a thirty-third distinct buffer",
+        "a two-hundred-and-fifty-seventh distinct buffer",
         "distinct resources",
         &|target| {
             let color = clear(black);
@@ -1429,6 +1429,54 @@ fn a_kept_sample_costs_a_frame_slot() {
     drop(sampler);
     drop(one_slot);
     drop(pipeline);
+    drop(target);
+    assert_no_validation_errors(&device);
+}
+
+/// A frame filled to the retention ceiling exactly: two hundred and
+/// fifty-six distinct resources render, because a bound that only ever
+/// refused its successor could quietly shrink and no test would say
+/// so. The refusal battery proves the two-hundred-and-fifty-seventh is
+/// refused; this proves the boundary itself is livable - the shape a
+/// chunked world's fullest vista actually draws.
+#[test]
+fn the_retention_ceiling_is_livable_at_the_boundary() {
+    let Some(device) = required_device().expect("device bring-up") else {
+        return;
+    };
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: 8,
+            height: 8,
+        })
+        .expect("offscreen target");
+    let instanced = device
+        .create_pipeline(
+            &PipelineDesc::new(builtin::INSTANCED, TargetFormat::Rgba8Srgb)
+                .instance_input(builtin::INSTANCED_LAYOUT),
+        )
+        .expect("instanced pipeline");
+    let bytes = [0u8; 24];
+    // One slot is the pipeline's own share of the table; the buffers
+    // take the rest to land the frame exactly on the ceiling.
+    let many: Vec<renew_rhi::Buffer> = (0..255)
+        .map(|_| {
+            device
+                .create_buffer(64, BufferUsage::PerFrame)
+                .expect("boundary buffer")
+        })
+        .collect();
+    let black = Color::new(0.0, 0.0, 0.0, 1.0);
+    let color = clear(black);
+    let items: Vec<Item<'_>> = many
+        .iter()
+        .map(|buffer| Item::new(&instanced).frame_data(FrameData::new(buffer, &bytes, 1)))
+        .collect();
+    target
+        .render(&RenderDesc::new(&[Pass::new(&color, &items)]))
+        .expect("a frame at the ceiling renders");
+    drop(many);
+    drop(instanced);
     drop(target);
     assert_no_validation_errors(&device);
 }


### PR DESCRIPTION
A buffer-per-chunk consumer (the ordinary chunked/streaming-world shape) crosses 32 distinct frame resources on its first real vista. The ceiling rises to 256 — the headroom class, after 8→16→32 each waited for a consumer to hit the wall. Tables stay fixed `Option` arrays; the boundary moves with both test halves (the 257th refused by name, and a new test renders a frame filled to the ceiling exactly, probed red at the old cap). Canonical lint clean, 2447/0 on a real adapter.