### PR TITLE
feat(platform): a window can carry the application's own icon

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -1,6 +1,6 @@
 # Coverage exemptions: the named lines the coverage gate accepts as
 # uncovered. Everything the gate measures and this file does not list must
-# be covered â€” the threshold for the rest of the tree is 100%.
+# be covered — the threshold for the rest of the tree is 100%.
 #
 # The ratchet runs in BOTH directions, and both directions fail CI:
 #
@@ -17,7 +17,7 @@
 # Exemptions are per line, and they are named.
 #
 # Enforced by `renew coverage --report <llvm-cov export>`, which CI runs in
-# the Coverage job. Format â€” one `[[exempt]]` table per group of lines that
+# the Coverage job. Format — one `[[exempt]]` table per group of lines that
 # share one reason:
 #
 #   file    repository-relative, forward slashes, on every platform
@@ -27,12 +27,12 @@
 #           loud error rather than a silent truncation.
 #
 # Line numbers move when the text above them moves. Editing an exempt file
-# means re-checking its entry here â€” and if it is forgotten, the gate says
+# means re-checking its entry here — and if it is forgotten, the gate says
 # so, in whichever direction the mistake went.
 #
 # Drift reads as staleness, so the report distinguishes them for you. An
 # entry left behind by moved code now points at whatever occupies the old
-# number, which is usually covered â€” so the gate calls it covered and, on
+# number, which is usually covered — so the gate calls it covered and, on
 # its own, that reads as "delete this". It is not: the exemption is still
 # earned, at a new number. Whenever a covered-now finding shares its file
 # with lines that are uncovered and unexempted, the finding names them,
@@ -41,7 +41,7 @@
 # there.
 #
 # A `reason` must never cite a line number, and must name the code it
-# describes â€” "the keyboard arm", not "line 390". The gate reads `lines`
+# describes — "the keyboard arm", not "line 390". The gate reads `lines`
 # and never reads this prose, so a number written here has no guard at all
 # and goes stale silently the first time the file grows. That happened
 # once: a note said "line 390" long after the arm it meant had moved to
@@ -127,7 +127,7 @@ reason = "The format-feature pre-check's refusal: every measuring lane's adapter
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
 lines = [387]
-reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs â€” so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
+reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs — so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
@@ -197,7 +197,7 @@ reason = "Required trait methods of four single-purpose test doubles (the epoch-
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
 lines = [930, 934, 936, 937, 938, 939, 940, 941, 942, 943, 944, 945]
-reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one â€” so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue â€” the platform branch, the delegation call, and the park that stops a backgrounded loop polling â€” waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
+reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
@@ -233,12 +233,12 @@ reason = "Two restatements of a bound already proved, re-anchored from 220 and 2
 [[exempt]]
 file = "crates/net/src/wire.rs"
 lines = [255, 259]
-reason = "The overflow arms of the two body-size products: a roster's seat count times an endpoint's width, and an inputs run's frame count times its input width. Every factor is a u8, so neither product can leave u64 â€” no datagram, and no fuzzer, can drive either arm. Both are written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and both are reached from a reader parsing hostile bytes. Neither can be folded away: `Option::and_then` is not callable in a const fn, so each arm has to be spelled out."
+reason = "The overflow arms of the two body-size products: a roster's seat count times an endpoint's width, and an inputs run's frame count times its input width. Every factor is a u8, so neither product can leave u64 — no datagram, and no fuzzer, can drive either arm. Both are written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and both are reached from a reader parsing hostile bytes. Neither can be folded away: `Option::and_then` is not callable in a const fn, so each arm has to be spelled out."
 
 [[exempt]]
 file = "crates/net/src/wire.rs"
 lines = [1481, 1482, 1483, 1484]
-reason = "The narrowing conversion on a chat message's length in the writer, guarded three lines above by a check that bounds the length to MAX_CHAT_BYTES â€” 164, which fits a byte with room to spare. Kept fallible rather than cast because that ceiling is derived from the datagram size rather than chosen, and a cast would stop being safe the day it crosses 255 without anything saying so."
+reason = "The narrowing conversion on a chat message's length in the writer, guarded three lines above by a check that bounds the length to MAX_CHAT_BYTES — 164, which fits a byte with room to spare. Kept fallible rather than cast because that ceiling is derived from the datagram size rather than chosen, and a cast would stop being safe the day it crosses 255 without anything saying so."
 
 [[exempt]]
 file = "crates/net/src/chat.rs"
@@ -253,12 +253,12 @@ reason = "Five arms no input can drive. `render` cannot be called with the termi
 [[exempt]]
 file = "crates/net/src/lib.rs"
 lines = [169, 170, 171]
-reason = "`pick_larger`, which exists only to compute MAX_DATAGRAM_BYTES in a const context â€” `Ord::max` is not callable there. It runs at compile time and never at run time, so no test can execute it and the two compile-time assertions immediately below it are what actually check its answer. Kept as a function rather than inlined because the ceiling must be the widest body of any kind, and spelling that as a comparison is what stopped the constant lying when a roster overtook an inputs run."
+reason = "`pick_larger`, which exists only to compute MAX_DATAGRAM_BYTES in a const context — `Ord::max` is not callable there. It runs at compile time and never at run time, so no test can execute it and the two compile-time assertions immediately below it are what actually check its answer. Kept as a function rather than inlined because the ceiling must be the widest body of any kind, and spelling that as a comparison is what stopped the constant lying when a roster overtook an inputs run."
 
 [[exempt]]
 file = "crates/net/src/lobby.rs"
 lines = [893]
-reason = "The addressless guard inside `seat_of`, unreachable through the only path that reaches it: `deliver` refuses UNKNOWN_ENDPOINT by name before any seat is looked up, and that refusal is covered. Kept because the two statements are one claim â€” seat zero's own slot holds exactly these bytes, so a caller that reached here with them would be told the host already holds the seat â€” and a private helper that depends on its caller having checked something is exactly the arrangement that breaks when a second caller appears."
+reason = "The addressless guard inside `seat_of`, unreachable through the only path that reaches it: `deliver` refuses UNKNOWN_ENDPOINT by name before any seat is looked up, and that refusal is covered. Kept because the two statements are one claim — seat zero's own slot holds exactly these bytes, so a caller that reached here with them would be told the host already holds the seat — and a private helper that depends on its caller having checked something is exactly the arrangement that breaks when a second caller appears."
 
 [[exempt]]
 file = "crates/net/src/desync.rs"
@@ -268,27 +268,27 @@ reason = "The error arms of `write!` inside a Display implementation. A formatte
 [[exempt]]
 file = "crates/net/src/bin/net_digest.rs"
 lines = [99, 100, 105, 106, 195, 231, 245]
-reason = "The scenario binary's refusal arms, and the three ways it gives up. The argument guard exists so a drifted pinned-run row fails loudly rather than running a different scenario under the same name; the not-enough-ticks arm exists so a short run can never print a digest every target would agree on. Each is a message and a nonzero exit, and an exiting process does not reliably flush its coverage counters, so exercising them under instrumentation would hinge on an exit-path detail rather than prove anything â€” the same reason the widget tree's witness exempts its own pair. The remaining three are the give-up paths inside the run: a session that ends mid-scenario, and the pump ceiling running out. Reaching any of them means the scenario deadlocked, which is a failure the lane reports by exit code; a test that drove one would be asserting that a deliberately survivable link is not survivable. The happy path is executed by the lane's own run of the binary."
+reason = "The scenario binary's refusal arms, and the three ways it gives up. The argument guard exists so a drifted pinned-run row fails loudly rather than running a different scenario under the same name; the not-enough-ticks arm exists so a short run can never print a digest every target would agree on. Each is a message and a nonzero exit, and an exiting process does not reliably flush its coverage counters, so exercising them under instrumentation would hinge on an exit-path detail rather than prove anything — the same reason the widget tree's witness exempts its own pair. The remaining three are the give-up paths inside the run: a session that ends mid-scenario, and the pump ceiling running out. Reaching any of them means the scenario deadlocked, which is a failure the lane reports by exit code; a test that drove one would be asserting that a deliberately survivable link is not survivable. The happy path is executed by the lane's own run of the binary."
 
 [[exempt]]
 file = "crates/ui/src/bin/ui_digest.rs"
 lines = [88]
-reason = "The bail arm of the guard that proves the scenario's typed events reached a field. It cannot fire while the scenario is correct â€” the script types two characters and removes one â€” and that is exactly its job: it exists so that a change moving focus off the field before the typing ends the run instead of silently emptying the only part of the scenario that exercises text. Making the field claim a no-op demonstrates that emptiness and watching every test stay green and the reported event count stay at twenty-seven, which is why the guard is here rather than trusted. Exempted rather than driven: reaching it needs the scenario broken, and a test that breaks the scenario to watch the guard fire would be asserting that a deliberately broken scenario is broken."
+reason = "The bail arm of the guard that proves the scenario's typed events reached a field. It cannot fire while the scenario is correct — the script types two characters and removes one — and that is exactly its job: it exists so that a change moving focus off the field before the typing ends the run instead of silently emptying the only part of the scenario that exercises text. Making the field claim a no-op demonstrates that emptiness and watching every test stay green and the reported event count stay at twenty-seven, which is why the guard is here rather than trusted. Exempted rather than driven: reaching it needs the scenario broken, and a test that breaks the scenario to watch the guard fire would be asserting that a deliberately broken scenario is broken."
 
 [[exempt]]
 file = "crates/ui/src/input.rs"
 lines = [213]
-reason = "The slot lookup in `edit_focused`, refused a line after `field_slot` returned the same index. `field_slot` finds it with `position` over the very array being indexed here, so a miss would mean the array shrank between two statements. Written as a refusal because the crate bans unchecked indexing, and kept rather than restructured because the arm above it â€” focus on a node that is not a field â€” looks identical and is entirely reachable: a player clicks a button and types. That one has a test. This one cannot."
+reason = "The slot lookup in `edit_focused`, refused a line after `field_slot` returned the same index. `field_slot` finds it with `position` over the very array being indexed here, so a miss would mean the array shrank between two statements. Written as a refusal because the crate bans unchecked indexing, and kept rather than restructured because the arm above it — focus on a node that is not a field — looks identical and is entirely reachable: a player clicks a button and types. That one has a test. This one cannot."
 
 [[exempt]]
 file = "crates/ui/src/field.rs"
 lines = [124, 133, 139, 145, 240, 243]
-reason = "The bounds arms of the two loops that move bytes inside a field, and the width check above them. Every one is refused by arithmetic the lines before it already did: a field is 64 bytes and a scalar is at most 4, so the `checked_add` cannot leave `usize`; the insert guard refuses anything past the ceiling before either loop runs, so every index the loops build is inside the array; and `remove` only ever walks the region between two cursor positions, both of which are `<= len`. They are written as refusals rather than indexing because the crate bans unchecked indexing outright â€” a widget tree takes its bytes from a driver, and an unchecked index there is a panic somebody else can cause. Kept rather than restructured: the two arms that were merely untested rather than unreachable â€” the forward character walk and backspace at position zero â€” were found by this same measurement and now have tests, which is the line between the two kinds."
+reason = "The bounds arms of the two loops that move bytes inside a field, and the width check above them. Every one is refused by arithmetic the lines before it already did: a field is 64 bytes and a scalar is at most 4, so the `checked_add` cannot leave `usize`; the insert guard refuses anything past the ceiling before either loop runs, so every index the loops build is inside the array; and `remove` only ever walks the region between two cursor positions, both of which are `<= len`. They are written as refusals rather than indexing because the crate bans unchecked indexing outright — a widget tree takes its bytes from a driver, and an unchecked index there is a panic somebody else can cause. Kept rather than restructured: the two arms that were merely untested rather than unreachable — the forward character walk and backspace at position zero — were found by this same measurement and now have tests, which is the line between the two kinds."
 
 [[exempt]]
 file = "crates/png/src/inflate.rs"
 lines = [391]
-reason = "The fallthrough arm of the code-length symbol match, which a nineteen-entry table cannot reach: `Huffman::new` is built from exactly nineteen lengths, so every symbol it can hand back is 0..=18 and the arms above cover all of them. Kept because the match is on a `u16` and the compiler requires an arm â€” deleting it is not an option, and returning something other than a refusal there would be a decoder that trusted a value it had not checked."
+reason = "The fallthrough arm of the code-length symbol match, which a nineteen-entry table cannot reach: `Huffman::new` is built from exactly nineteen lengths, so every symbol it can hand back is 0..=18 and the arms above cover all of them. Kept because the match is on a `u16` and the compiler requires an arm — deleting it is not an option, and returning something other than a refusal there would be a decoder that trusted a value it had not checked."
 
 [[exempt]]
 file = "crates/png/src/colours.rs"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -1,6 +1,6 @@
 # Coverage exemptions: the named lines the coverage gate accepts as
 # uncovered. Everything the gate measures and this file does not list must
-# be covered — the threshold for the rest of the tree is 100%.
+# be covered â€” the threshold for the rest of the tree is 100%.
 #
 # The ratchet runs in BOTH directions, and both directions fail CI:
 #
@@ -17,7 +17,7 @@
 # Exemptions are per line, and they are named.
 #
 # Enforced by `renew coverage --report <llvm-cov export>`, which CI runs in
-# the Coverage job. Format — one `[[exempt]]` table per group of lines that
+# the Coverage job. Format â€” one `[[exempt]]` table per group of lines that
 # share one reason:
 #
 #   file    repository-relative, forward slashes, on every platform
@@ -27,12 +27,12 @@
 #           loud error rather than a silent truncation.
 #
 # Line numbers move when the text above them moves. Editing an exempt file
-# means re-checking its entry here — and if it is forgotten, the gate says
+# means re-checking its entry here â€” and if it is forgotten, the gate says
 # so, in whichever direction the mistake went.
 #
 # Drift reads as staleness, so the report distinguishes them for you. An
 # entry left behind by moved code now points at whatever occupies the old
-# number, which is usually covered — so the gate calls it covered and, on
+# number, which is usually covered â€” so the gate calls it covered and, on
 # its own, that reads as "delete this". It is not: the exemption is still
 # earned, at a new number. Whenever a covered-now finding shares its file
 # with lines that are uncovered and unexempted, the finding names them,
@@ -41,7 +41,7 @@
 # there.
 #
 # A `reason` must never cite a line number, and must name the code it
-# describes — "the keyboard arm", not "line 390". The gate reads `lines`
+# describes â€” "the keyboard arm", not "line 390". The gate reads `lines`
 # and never reads this prose, so a number written here has no guard at all
 # and goes stale silently the first time the file grows. That happened
 # once: a note said "line 390" long after the arm it meant had moved to
@@ -127,7 +127,7 @@ reason = "The format-feature pre-check's refusal: every measuring lane's adapter
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
 lines = [387]
-reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs — so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
+reason = "The depthless-adapter arm of target creation: no depth image is built when the adapter refused the whole depth format chain. The pinned software rasterizer offers D32_SFLOAT, the format query is a void call no fault layer can mutate, and the device suite's probe asserts a format exists wherever the strict lane runs â€” so the arm is reachable only on hardware the lanes do not have. Its logic is one None."
 
 [[exempt]]
 file = "crates/rhi/src/vk/offscreen.rs"
@@ -176,23 +176,28 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
+lines = [785, 786, 787, 788]
+reason = "The body of the window-creation branch that hands an application's icon to the windowing crate. It is inside `open`, which needs a live event loop no unit test can host: the branch is reached only when a real window is about to exist, and the windowed smoke test that does reach `open` uses an application with no icon, because an application that had one would be asserting on a picture nobody can see from a test. The parts that can be checked without a window are, and they are the parts that can be wrong - `WindowIcon::from_rgba` refuses bytes that do not match their dimensions, `IconError` says which refusal and with what numbers, and the trait method defaults to nothing. What is left here is three lines of handing validated bytes to a builder."
+
+[[exempt]]
+file = "crates/core/platform/src/window.rs"
 lines = [1036, 1037]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1836]
+lines = [1859]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1933, 1934, 1935, 2001, 2002, 2003, 2027, 2028, 2029, 2086, 2087, 2088]
+lines = [1956, 1957, 1958, 2024, 2025, 2026, 2050, 2051, 2052, 2109, 2110, 2111]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
 lines = [930, 934, 936, 937, 938, 939, 940, 941, 942, 943, 944, 945]
-reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
+reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one â€” so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue â€” the platform branch, the delegation call, and the park that stops a backgrounded loop polling â€” waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
@@ -228,12 +233,12 @@ reason = "Two restatements of a bound already proved, re-anchored from 220 and 2
 [[exempt]]
 file = "crates/net/src/wire.rs"
 lines = [255, 259]
-reason = "The overflow arms of the two body-size products: a roster's seat count times an endpoint's width, and an inputs run's frame count times its input width. Every factor is a u8, so neither product can leave u64 — no datagram, and no fuzzer, can drive either arm. Both are written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and both are reached from a reader parsing hostile bytes. Neither can be folded away: `Option::and_then` is not callable in a const fn, so each arm has to be spelled out."
+reason = "The overflow arms of the two body-size products: a roster's seat count times an endpoint's width, and an inputs run's frame count times its input width. Every factor is a u8, so neither product can leave u64 â€” no datagram, and no fuzzer, can drive either arm. Both are written anyway because a size computation that trusts its own ceilings stops being true the day one of them widens, and both are reached from a reader parsing hostile bytes. Neither can be folded away: `Option::and_then` is not callable in a const fn, so each arm has to be spelled out."
 
 [[exempt]]
 file = "crates/net/src/wire.rs"
 lines = [1481, 1482, 1483, 1484]
-reason = "The narrowing conversion on a chat message's length in the writer, guarded three lines above by a check that bounds the length to MAX_CHAT_BYTES — 164, which fits a byte with room to spare. Kept fallible rather than cast because that ceiling is derived from the datagram size rather than chosen, and a cast would stop being safe the day it crosses 255 without anything saying so."
+reason = "The narrowing conversion on a chat message's length in the writer, guarded three lines above by a check that bounds the length to MAX_CHAT_BYTES â€” 164, which fits a byte with room to spare. Kept fallible rather than cast because that ceiling is derived from the datagram size rather than chosen, and a cast would stop being safe the day it crosses 255 without anything saying so."
 
 [[exempt]]
 file = "crates/net/src/chat.rs"
@@ -248,12 +253,12 @@ reason = "Five arms no input can drive. `render` cannot be called with the termi
 [[exempt]]
 file = "crates/net/src/lib.rs"
 lines = [169, 170, 171]
-reason = "`pick_larger`, which exists only to compute MAX_DATAGRAM_BYTES in a const context — `Ord::max` is not callable there. It runs at compile time and never at run time, so no test can execute it and the two compile-time assertions immediately below it are what actually check its answer. Kept as a function rather than inlined because the ceiling must be the widest body of any kind, and spelling that as a comparison is what stopped the constant lying when a roster overtook an inputs run."
+reason = "`pick_larger`, which exists only to compute MAX_DATAGRAM_BYTES in a const context â€” `Ord::max` is not callable there. It runs at compile time and never at run time, so no test can execute it and the two compile-time assertions immediately below it are what actually check its answer. Kept as a function rather than inlined because the ceiling must be the widest body of any kind, and spelling that as a comparison is what stopped the constant lying when a roster overtook an inputs run."
 
 [[exempt]]
 file = "crates/net/src/lobby.rs"
 lines = [893]
-reason = "The addressless guard inside `seat_of`, unreachable through the only path that reaches it: `deliver` refuses UNKNOWN_ENDPOINT by name before any seat is looked up, and that refusal is covered. Kept because the two statements are one claim — seat zero's own slot holds exactly these bytes, so a caller that reached here with them would be told the host already holds the seat — and a private helper that depends on its caller having checked something is exactly the arrangement that breaks when a second caller appears."
+reason = "The addressless guard inside `seat_of`, unreachable through the only path that reaches it: `deliver` refuses UNKNOWN_ENDPOINT by name before any seat is looked up, and that refusal is covered. Kept because the two statements are one claim â€” seat zero's own slot holds exactly these bytes, so a caller that reached here with them would be told the host already holds the seat â€” and a private helper that depends on its caller having checked something is exactly the arrangement that breaks when a second caller appears."
 
 [[exempt]]
 file = "crates/net/src/desync.rs"
@@ -263,27 +268,27 @@ reason = "The error arms of `write!` inside a Display implementation. A formatte
 [[exempt]]
 file = "crates/net/src/bin/net_digest.rs"
 lines = [99, 100, 105, 106, 195, 231, 245]
-reason = "The scenario binary's refusal arms, and the three ways it gives up. The argument guard exists so a drifted pinned-run row fails loudly rather than running a different scenario under the same name; the not-enough-ticks arm exists so a short run can never print a digest every target would agree on. Each is a message and a nonzero exit, and an exiting process does not reliably flush its coverage counters, so exercising them under instrumentation would hinge on an exit-path detail rather than prove anything — the same reason the widget tree's witness exempts its own pair. The remaining three are the give-up paths inside the run: a session that ends mid-scenario, and the pump ceiling running out. Reaching any of them means the scenario deadlocked, which is a failure the lane reports by exit code; a test that drove one would be asserting that a deliberately survivable link is not survivable. The happy path is executed by the lane's own run of the binary."
+reason = "The scenario binary's refusal arms, and the three ways it gives up. The argument guard exists so a drifted pinned-run row fails loudly rather than running a different scenario under the same name; the not-enough-ticks arm exists so a short run can never print a digest every target would agree on. Each is a message and a nonzero exit, and an exiting process does not reliably flush its coverage counters, so exercising them under instrumentation would hinge on an exit-path detail rather than prove anything â€” the same reason the widget tree's witness exempts its own pair. The remaining three are the give-up paths inside the run: a session that ends mid-scenario, and the pump ceiling running out. Reaching any of them means the scenario deadlocked, which is a failure the lane reports by exit code; a test that drove one would be asserting that a deliberately survivable link is not survivable. The happy path is executed by the lane's own run of the binary."
 
 [[exempt]]
 file = "crates/ui/src/bin/ui_digest.rs"
 lines = [88]
-reason = "The bail arm of the guard that proves the scenario's typed events reached a field. It cannot fire while the scenario is correct — the script types two characters and removes one — and that is exactly its job: it exists so that a change moving focus off the field before the typing ends the run instead of silently emptying the only part of the scenario that exercises text. Making the field claim a no-op demonstrates that emptiness and watching every test stay green and the reported event count stay at twenty-seven, which is why the guard is here rather than trusted. Exempted rather than driven: reaching it needs the scenario broken, and a test that breaks the scenario to watch the guard fire would be asserting that a deliberately broken scenario is broken."
+reason = "The bail arm of the guard that proves the scenario's typed events reached a field. It cannot fire while the scenario is correct â€” the script types two characters and removes one â€” and that is exactly its job: it exists so that a change moving focus off the field before the typing ends the run instead of silently emptying the only part of the scenario that exercises text. Making the field claim a no-op demonstrates that emptiness and watching every test stay green and the reported event count stay at twenty-seven, which is why the guard is here rather than trusted. Exempted rather than driven: reaching it needs the scenario broken, and a test that breaks the scenario to watch the guard fire would be asserting that a deliberately broken scenario is broken."
 
 [[exempt]]
 file = "crates/ui/src/input.rs"
 lines = [213]
-reason = "The slot lookup in `edit_focused`, refused a line after `field_slot` returned the same index. `field_slot` finds it with `position` over the very array being indexed here, so a miss would mean the array shrank between two statements. Written as a refusal because the crate bans unchecked indexing, and kept rather than restructured because the arm above it — focus on a node that is not a field — looks identical and is entirely reachable: a player clicks a button and types. That one has a test. This one cannot."
+reason = "The slot lookup in `edit_focused`, refused a line after `field_slot` returned the same index. `field_slot` finds it with `position` over the very array being indexed here, so a miss would mean the array shrank between two statements. Written as a refusal because the crate bans unchecked indexing, and kept rather than restructured because the arm above it â€” focus on a node that is not a field â€” looks identical and is entirely reachable: a player clicks a button and types. That one has a test. This one cannot."
 
 [[exempt]]
 file = "crates/ui/src/field.rs"
 lines = [124, 133, 139, 145, 240, 243]
-reason = "The bounds arms of the two loops that move bytes inside a field, and the width check above them. Every one is refused by arithmetic the lines before it already did: a field is 64 bytes and a scalar is at most 4, so the `checked_add` cannot leave `usize`; the insert guard refuses anything past the ceiling before either loop runs, so every index the loops build is inside the array; and `remove` only ever walks the region between two cursor positions, both of which are `<= len`. They are written as refusals rather than indexing because the crate bans unchecked indexing outright — a widget tree takes its bytes from a driver, and an unchecked index there is a panic somebody else can cause. Kept rather than restructured: the two arms that were merely untested rather than unreachable — the forward character walk and backspace at position zero — were found by this same measurement and now have tests, which is the line between the two kinds."
+reason = "The bounds arms of the two loops that move bytes inside a field, and the width check above them. Every one is refused by arithmetic the lines before it already did: a field is 64 bytes and a scalar is at most 4, so the `checked_add` cannot leave `usize`; the insert guard refuses anything past the ceiling before either loop runs, so every index the loops build is inside the array; and `remove` only ever walks the region between two cursor positions, both of which are `<= len`. They are written as refusals rather than indexing because the crate bans unchecked indexing outright â€” a widget tree takes its bytes from a driver, and an unchecked index there is a panic somebody else can cause. Kept rather than restructured: the two arms that were merely untested rather than unreachable â€” the forward character walk and backspace at position zero â€” were found by this same measurement and now have tests, which is the line between the two kinds."
 
 [[exempt]]
 file = "crates/png/src/inflate.rs"
 lines = [391]
-reason = "The fallthrough arm of the code-length symbol match, which a nineteen-entry table cannot reach: `Huffman::new` is built from exactly nineteen lengths, so every symbol it can hand back is 0..=18 and the arms above cover all of them. Kept because the match is on a `u16` and the compiler requires an arm — deleting it is not an option, and returning something other than a refusal there would be a decoder that trusted a value it had not checked."
+reason = "The fallthrough arm of the code-length symbol match, which a nineteen-entry table cannot reach: `Huffman::new` is built from exactly nineteen lengths, so every symbol it can hand back is 0..=18 and the arms above cover all of them. Kept because the match is on a `u16` and the compiler requires an arm â€” deleting it is not an option, and returning something other than a refusal there would be a decoder that trusted a value it had not checked."
 
 [[exempt]]
 file = "crates/png/src/colours.rs"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -176,37 +176,37 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [904, 905]
+lines = [1036, 1037]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1636]
+lines = [1836]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1733, 1734, 1735, 1801, 1802, 1803, 1827, 1828, 1829, 1886, 1887, 1888]
+lines = [1933, 1934, 1935, 2001, 2002, 2003, 2027, 2028, 2029, 2086, 2087, 2088]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [798, 802, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813]
+lines = [930, 934, 936, 937, 938, 939, 940, 941, 942, 943, 944, 945]
 reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [959, 962]
+lines = [1091, 1094]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [711, 712]
+lines = [843, 844]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [832, 833, 834, 835, 836, 837, 838, 839, 840, 841]
+lines = [964, 965, 966, 967, 968, 969, 970, 971, 972, 973]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -96,6 +96,14 @@ datagrams — each a thin, explicit seam.
   survivor is a contract violation, fatal in dev builds. Desktop
   platforms close no epochs, so desktop-only applications inherit no
   obligation.
+- **A window's icon is the application's picture.** `WindowApp::icon`
+  is asked once per surface epoch, immediately before the window is
+  created, and defaults to nothing. It is on the trait rather than in
+  `WindowConfig` because an icon arrives from a decoder or an asset
+  pack, where the config is a handful of settings written by hand; the
+  bytes are checked against the dimensions when the `WindowIcon` is
+  built, so nothing has to be reported from inside a platform callback.
+  A platform with no notion of a window icon ignores it.
 - **No ambient state.** No global clock, no environment reads; everything
   is a value or an explicit call.
 - **Errors carry context** — paths and thread names, in crate-local
@@ -146,3 +154,7 @@ no `unsafe` code.
   looks like; guessing now would speculate its API.
 - **Named threads or no threads** — a nameless thread in a profiler or a
   panic message is a debugging tax nobody needs to pay.
+- **An icon is validated where the caller is, not where the window is**
+  — four bytes a pixel is an assumption every caller makes and none of
+  them states, and a window is created at the one moment there is
+  nowhere useful to report a mistake to.

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -17,6 +17,105 @@ use core::fmt;
 use winit::application::ApplicationHandler;
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 
+/// A window's icon, as straight RGBA rows.
+///
+/// **Plain data, like everything else that crosses this seam.** No
+/// windowing-library type appears here for the reason the module doc
+/// gives: a consumer naming an icon must not be compiling a windowing
+/// library to do it. The bytes are eight-bit red, green, blue and alpha
+/// in that order, row-major from the top-left, which is what every image
+/// decoder on the way in already produces.
+///
+/// **Validated at construction rather than at the window.** A window is
+/// created once, deep inside a platform callback, at the one moment
+/// there is nowhere useful to report a mistake to; the size of a byte
+/// slice against two dimensions is arithmetic that can be done anywhere,
+/// so it is done where the caller is still holding the error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowIcon {
+    width: u32,
+    height: u32,
+    rgba: Vec<u8>,
+}
+
+impl WindowIcon {
+    /// Take `rgba` as a `width` by `height` image.
+    ///
+    /// # Errors
+    ///
+    /// [`IconError::Empty`] for an image with no pixels in it, and
+    /// [`IconError::WrongLength`] when the bytes and the dimensions
+    /// disagree — which is the mistake this type exists to catch, since
+    /// four bytes a pixel is the assumption every caller makes silently.
+    pub fn from_rgba(width: u32, height: u32, rgba: Vec<u8>) -> Result<Self, IconError> {
+        if width == 0 || height == 0 {
+            return Err(IconError::Empty);
+        }
+        let wanted = usize::try_from(width)
+            .ok()
+            .and_then(|width| usize::try_from(height).ok().map(|height| (width, height)))
+            .and_then(|(width, height)| width.checked_mul(height))
+            .and_then(|pixels| pixels.checked_mul(4))
+            .ok_or(IconError::Empty)?;
+        if rgba.len() != wanted {
+            return Err(IconError::WrongLength {
+                expected: wanted,
+                found: rgba.len(),
+            });
+        }
+        Ok(Self {
+            width,
+            height,
+            rgba,
+        })
+    }
+
+    /// How wide it is, in pixels.
+    #[must_use]
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// How tall it is, in pixels.
+    #[must_use]
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Its rows, as RGBA bytes.
+    #[must_use]
+    pub fn rgba(&self) -> &[u8] {
+        &self.rgba
+    }
+}
+
+/// Why a set of bytes is not an icon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IconError {
+    /// No pixels: a zero on either side.
+    Empty,
+    /// The bytes and the dimensions disagree, at four bytes a pixel.
+    WrongLength {
+        /// What `width * height * 4` came to.
+        expected: usize,
+        /// How many bytes arrived.
+        found: usize,
+    },
+}
+
+impl fmt::Display for IconError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "an icon with no pixels in it"),
+            Self::WrongLength { expected, found } => {
+                write!(f, "an icon of {expected} bytes arrived as {found}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IconError {}
+
 /// Plain-data window configuration.
 #[derive(Debug, Clone)]
 pub struct WindowConfig {
@@ -277,6 +376,27 @@ pub trait WindowApp {
     /// one revoking platform is Android; iOS suspends without revoking
     /// and deliberately does not reach this callback.
     fn surface_lost(&mut self) {}
+
+    /// The icon this application's window should carry, if it has one.
+    ///
+    /// Asked once per surface epoch, immediately before the window is
+    /// created, so an application that rebuilds its icon between epochs
+    /// gets the one it has now.
+    ///
+    /// **Defaulted to nothing, and on the trait rather than in
+    /// [`WindowConfig`].** An icon is a picture the application owns, in
+    /// a format only the application knows how to produce - it arrives
+    /// from a decoder, an asset pack or a build script - where the
+    /// config is a handful of plain settings a caller writes by hand.
+    /// Defaulting it also means every application that already exists
+    /// keeps compiling and keeps the icon the system gives an unadorned
+    /// executable, which is what it had before.
+    ///
+    /// A platform with no notion of a window icon ignores this, which
+    /// is why it answers with a picture rather than a promise.
+    fn icon(&self) -> Option<WindowIcon> {
+        None
+    }
 
     /// The application has stopped being the one in front.
     ///
@@ -648,13 +768,25 @@ impl Adapter<'_> {
         if self.epoch.window().is_some() || self.failure.is_some() {
             return;
         }
-        let attributes = winit::window::Window::default_attributes()
+        let mut attributes = winit::window::Window::default_attributes()
             .with_title(&self.config.title)
             .with_resizable(self.config.resizable)
             .with_inner_size(winit::dpi::LogicalSize::new(
                 self.config.logical_width,
                 self.config.logical_height,
             ));
+        // The icon is asked for here rather than held on the config
+        // because it is the application's picture; see `WindowApp::icon`.
+        // Its bytes were checked against its dimensions when it was
+        // built, so the only way the conversion below can refuse is a
+        // rule this seam does not know about - and a window that opens
+        // without its icon is worth more than one that does not open.
+        if let Some(icon) = self.app.icon() {
+            let (width, height) = (icon.width(), icon.height());
+            if let Ok(icon) = winit::window::Icon::from_rgba(icon.rgba().to_vec(), width, height) {
+                attributes = attributes.with_window_icon(Some(icon));
+            }
+        }
         match create(attributes) {
             Ok(window) => {
                 let window = std::sync::Arc::new(window);
@@ -1138,6 +1270,74 @@ fn translate_wheel(delta: winit::event::MouseScrollDelta) -> (f32, f32) {
 
 #[cfg(test)]
 mod tests {
+
+    /// An icon is its bytes and its dimensions agreeing.
+    ///
+    /// **The mistake this type exists to catch is four bytes a pixel**,
+    /// which every caller assumes and none of them states. A window is
+    /// created once, inside a platform callback, at the one moment
+    /// there is nowhere to report a bad picture to — so the arithmetic
+    /// is done where the caller still holds the error, and the wrong
+    /// count has to be refused there rather than dropped there.
+    ///
+    /// Probed by comparing against `width * height` rather than
+    /// `width * height * 4`: a quarter-sized buffer is accepted and the
+    /// first case fails.
+    #[test]
+    fn an_icon_is_refused_unless_its_bytes_match_its_size() {
+        use super::{IconError, WindowIcon};
+
+        let square = WindowIcon::from_rgba(2, 2, vec![0; 16]).expect("four pixels, sixteen bytes");
+        assert_eq!(square.width(), 2);
+        assert_eq!(square.height(), 2);
+        assert_eq!(square.rgba().len(), 16);
+
+        // A rectangle, so that a rule which multiplied one side by
+        // itself would be caught.
+        assert!(WindowIcon::from_rgba(4, 2, vec![0; 32]).is_ok());
+        assert_eq!(
+            WindowIcon::from_rgba(4, 2, vec![0; 16]),
+            Err(IconError::WrongLength {
+                expected: 32,
+                found: 16
+            })
+        );
+        assert_eq!(
+            WindowIcon::from_rgba(2, 2, vec![0; 17]),
+            Err(IconError::WrongLength {
+                expected: 16,
+                found: 17
+            })
+        );
+        for (width, height) in [(0, 4), (4, 0), (0, 0)] {
+            assert_eq!(
+                WindowIcon::from_rgba(width, height, Vec::new()),
+                Err(IconError::Empty),
+                "{width}x{height} is not a picture"
+            );
+        }
+    }
+
+    /// **An application that says nothing about an icon has none**, which
+    /// is what every application in the tree said until this seam
+    /// existed. The default is what keeps this an addition rather than a
+    /// break: an implementation written before the method has to keep
+    /// compiling and keep behaving.
+    ///
+    /// Probed by defaulting the method to a picture instead of `None`:
+    /// an application that never mentioned an icon suddenly carries one.
+    #[test]
+    fn an_application_that_says_nothing_carries_no_icon() {
+        use super::{LoopControl, WindowApp, WindowEvent, WindowRef};
+
+        struct Silent;
+        impl WindowApp for Silent {
+            fn ready(&mut self, _window: &WindowRef<'_>) {}
+            fn event(&mut self, _event: WindowEvent) {}
+            fn update(&mut self, _control: &mut LoopControl) {}
+        }
+        assert_eq!(Silent.icon(), None, "an icon appeared from nowhere");
+    }
 
     /// Text is delivered; the keys that also report text are not.
     ///

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -1318,25 +1318,33 @@ mod tests {
         }
     }
 
-    /// **An application that says nothing about an icon has none**, which
-    /// is what every application in the tree said until this seam
-    /// existed. The default is what keeps this an addition rather than a
-    /// break: an implementation written before the method has to keep
-    /// compiling and keep behaving.
+    /// Every refusal says which one it is and carries its numbers.
     ///
-    /// Probed by defaulting the method to a picture instead of `None`:
-    /// an application that never mentioned an icon suddenly carries one.
+    /// **A message that does not name the sizes is a message that sends
+    /// somebody to count bytes by hand.** The whole value of validating
+    /// an icon where the caller is standing is that the caller can be
+    /// told what went wrong; a `Display` that said "bad icon" would
+    /// throw that away at the last step.
+    ///
+    /// Probed by printing the same sentence for both variants: the two
+    /// assertions collapse onto each other and the second fails.
     #[test]
-    fn an_application_that_says_nothing_carries_no_icon() {
-        use super::{LoopControl, WindowApp, WindowEvent, WindowRef};
+    fn an_icon_refusal_names_itself_and_its_numbers() {
+        use super::IconError;
 
-        struct Silent;
-        impl WindowApp for Silent {
-            fn ready(&mut self, _window: &WindowRef<'_>) {}
-            fn event(&mut self, _event: WindowEvent) {}
-            fn update(&mut self, _control: &mut LoopControl) {}
+        assert_eq!(IconError::Empty.to_string(), "an icon with no pixels in it");
+        let wrong = IconError::WrongLength {
+            expected: 64,
+            found: 16,
         }
-        assert_eq!(Silent.icon(), None, "an icon appeared from nowhere");
+        .to_string();
+        assert!(wrong.contains("64"), "the wanted size is missing: {wrong}");
+        assert!(wrong.contains("16"), "the found size is missing: {wrong}");
+        assert_ne!(
+            wrong,
+            IconError::Empty.to_string(),
+            "two different refusals read the same"
+        );
     }
 
     /// Text is delivered; the keys that also report text are not.
@@ -1825,6 +1833,21 @@ mod tests {
         /// What to ask of the cursor, if anything. `None` asks nothing,
         /// which is the case that must leave the grab alone.
         ask_cursor: Option<bool>,
+    }
+
+    /// **An application that says nothing about an icon has none.**
+    ///
+    /// The default is what keeps the seam an addition rather than a
+    /// break: an implementation written before the method existed has to
+    /// keep compiling and keep behaving. Asked of a double that was
+    /// written before it, which is the strongest form of that claim
+    /// available here.
+    ///
+    /// Probed by defaulting the trait method to a picture: a recorder
+    /// that has never mentioned an icon starts carrying one.
+    #[test]
+    fn an_application_that_says_nothing_carries_no_icon() {
+        assert_eq!(Recorder::default().icon(), None);
     }
 
     impl WindowApp for Recorder {


### PR DESCRIPTION
A window opened with no icon shows whatever the system gives an unadorned
executable — the first thing anybody sees of an application, in a taskbar,
a dock or an alt-tab strip — and there was no way to say otherwise.

`WindowApp::icon` is asked once per surface epoch, immediately before the
window is created, and defaults to nothing. On the trait rather than in
`WindowConfig` for two reasons: an icon is a picture the application owns,
arriving from a decoder or an asset pack, where the config is a handful of
plain settings a caller writes by hand; and a defaulted trait method is an
addition rather than a break, so every application that already exists keeps
compiling and keeps the icon it had.

`WindowIcon` is plain RGBA and its dimensions, checked against each other
when it is built — no windowing-library type crosses the seam. Validating at
construction rather than at the window is the point of the type: four bytes a
pixel is an assumption every caller makes and none of them states, and a
window is created inside a platform callback at the one moment there is
nowhere useful to report a bad picture to. A conversion that still refuses
there is ignored: a window that opens without its icon is worth more than one
that does not open.

Two tests, both probed red first — sizing the buffer by `width * height`
instead of `width * height * 4` accepts a quarter-sized image; giving the
trait method a picture as its default hands an icon to an application that
never mentioned one.

Gates run locally: `cargo fmt --all --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo test --workspace` (240 suites green),
`cargo run --bin renew -- check`.