### PR TITLE
feat(platform): a window can be told how small it may become

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -141,7 +141,7 @@ reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless
 
 [[exempt]]
 file = "samples/hello_triangle/src/windowed.rs"
-lines = [578]
+lines = [579]
 reason = "The no-adapter fallback of the device-reuse test. Every lane that measures coverage supplies a software adapter, so the skip is never taken there; it exists so a developer machine without one runs the suite rather than failing it. The test's substance - that a second surface epoch takes the device the first one built rather than building beside it - runs wherever an adapter exists, which is every measuring lane."
 
 [[exempt]]
@@ -176,42 +176,42 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [785, 786, 787, 788]
+lines = [871, 872, 873, 874]
 reason = "The body of the window-creation branch that hands an application's icon to the windowing crate. It is inside `open`, which needs a live event loop no unit test can host: the branch is reached only when a real window is about to exist, and the windowed smoke test that does reach `open` uses an application with no icon, because an application that had one would be asserting on a picture nobody can see from a test. The parts that can be checked without a window are, and they are the parts that can be wrong - `WindowIcon::from_rgba` refuses bytes that do not match their dimensions, `IconError` says which refusal and with what numbers, and the trait method defaults to nothing. What is left here is three lines of handing validated bytes to a builder."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1036, 1037]
+lines = [1122, 1123]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1859]
+lines = [1945]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1956, 1957, 1958, 2024, 2025, 2026, 2050, 2051, 2052, 2109, 2110, 2111]
+lines = [2251, 2252, 2253, 2319, 2320, 2321, 2345, 2346, 2347, 2404, 2405, 2406]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [930, 934, 936, 937, 938, 939, 940, 941, 942, 943, 944, 945]
+lines = [1016, 1020, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031]
 reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1091, 1094]
+lines = [1177, 1180]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [843, 844]
+lines = [929, 930]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [964, 965, 966, 967, 968, 969, 970, 971, 972, 973]
+lines = [1050, 1051, 1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]
@@ -221,7 +221,7 @@ reason = "The scenario binary's two refusal arms: the argument guard (a drifted 
 
 [[exempt]]
 file = "samples/glide/src/windowed.rs"
-lines = [412, 413, 414, 415, 416, 417, 418]
+lines = [413, 414, 415, 416, 417, 418, 419]
 reason = "The menu-open half of the draw: the presenter's snapshots advanced and emitted, and a label placed per button. The lane's windowed run is keyboardless under a virtual display, so nothing there ever opens the menu, and no test reaches draw at all - drawing needs the bring-up's live target. Everything the block decides is covered without it: the advance/emit pair by the presentation crate's own tests, the placement arithmetic by a unit test on label_origin (the block's only computation), and the routing, pausing, restarting and rescaling behind it by constructed-event tests on the seam. Deliberately narrow: the is_open check the frame evaluates every draw is measured and not exempt."
 
 [[exempt]]

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -104,6 +104,27 @@ datagrams — each a thin, explicit seam.
   bytes are checked against the dimensions when the `WindowIcon` is
   built, so nothing has to be reported from inside a platform callback.
   A platform with no notion of a window icon ignores it.
+- **A window can be given a floor.** `WindowConfig::min_logical_width`
+  and `min_logical_height` are the smallest the user may drag the window
+  to; nought is no floor and is the default. A layout can always be
+  checked against the live size — `WindowRef::physical_size` and the
+  `Resized` event both give it — and against the size the window opened
+  at. What a floor adds is a size the user cannot take away, so a check
+  made once still holds later.
+
+  Two things happen here rather than on three platforms differently. A
+  floor above the opening size **raises the opening size**, because the
+  backends disagree about that and "no smaller than this" should mean
+  the same everywhere. And a floor that is not a size — negative, NaN,
+  infinite — is **read as no floor**: passed on, NaN and infinity fail an
+  assertion inside the windowing library during window creation, which
+  is not a failure this seam can report. Both are enforced here and
+  tested at the creation call.
+
+  Passed on whatever `resizable` says: what a fixed-size window does with
+  a floor is the platform's business, and the three differ. Unsupported
+  on iOS, Android and Orbital, where the windowing library ignores it —
+  the same way a platform with no notion of a window icon ignores one.
 - **No ambient state.** No global clock, no environment reads; everything
   is a value or an explicit call.
 - **Errors carry context** — paths and thread names, in crate-local

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -119,10 +119,47 @@ impl std::error::Error for IconError {}
 /// Plain-data window configuration.
 #[derive(Debug, Clone)]
 pub struct WindowConfig {
+    /// What the title bar says.
     pub title: String,
+    /// How wide the window opens, in logical pixels, before
+    /// [`Self::min_logical_width`] is applied to it.
     pub logical_width: f64,
+    /// How tall the window opens, in logical pixels, before
+    /// [`Self::min_logical_height`] is applied to it.
     pub logical_height: f64,
+    /// Whether the user may resize it at all.
     pub resizable: bool,
+    /// The narrowest the window may be dragged to, in logical pixels.
+    /// Nought is no floor, and is the default.
+    ///
+    /// **A layout can always be checked against the size the window
+    /// opened at; a floor is the only size it can be checked against
+    /// and rely on.** The opening size is one a user takes away by
+    /// dragging a corner, so a guard measured against it outlives the
+    /// thing it measured. This is the size that is still there.
+    ///
+    /// **Nought rather than an `Option`, because the platform does not
+    /// make the distinction.** A floor of nought and no floor produce
+    /// the same window everywhere this runs, so an `Option` would carry
+    /// a state nothing downstream can tell apart — and two named
+    /// scalars match the two fields above them, where a pair could be
+    /// written the wrong way round and still compile.
+    ///
+    /// Anything not finite, or below nought, is **read as no floor**.
+    /// See [`floor_of`] for why that is a sanitised value rather than
+    /// an error or a pass-through.
+    ///
+    /// A floor above [`Self::logical_width`] raises it, so that the
+    /// window is not smaller than its floor on any platform — the
+    /// backends do not agree about that on their own.
+    ///
+    /// Unsupported on iOS, Android and Orbital, where the windowing
+    /// library ignores it.
+    pub min_logical_width: f64,
+    /// The shortest the window may be dragged to, in logical pixels.
+    /// Nought is no floor, and is the default. See
+    /// [`Self::min_logical_width`], which this matches in every respect.
+    pub min_logical_height: f64,
 }
 
 impl Default for WindowConfig {
@@ -132,7 +169,40 @@ impl Default for WindowConfig {
             logical_width: 1280.0,
             logical_height: 720.0,
             resizable: true,
+            // No floor: what every window did before these two existed,
+            // so a caller that says nothing gets what it used to get.
+            min_logical_width: 0.0,
+            min_logical_height: 0.0,
         }
+    }
+}
+
+/// One floor dimension as the window seam will use it: finite, not
+/// negative, and nought where the caller asked for nonsense.
+///
+/// **Sanitised here rather than passed on, and the reason is a crash.**
+/// The windowing library clamps the requested size between the floor
+/// and a ceiling, and that clamp asserts `min <= max` — so a floor of
+/// `f64::NAN` or `f64::INFINITY` fails an assertion inside a dependency,
+/// during window creation, in a seam whose whole documented character is
+/// that failures come back as a `Result`. A negative floor is the
+/// quieter half of the same problem: it converts to an unsigned pixel
+/// count by saturating at nought, so it silently means no floor already.
+///
+/// **Sanitised rather than refused**, because refusing needs an error
+/// this seam has nowhere to report from: a window is created deep inside
+/// a platform callback, which is the one moment there is nobody to hand
+/// a `Result` to. `WindowIcon` makes the other choice and validates at
+/// construction — it can, because an icon is built by the caller before
+/// the loop starts. A config is a struct literal with no constructor to
+/// check it in, so the check lives here and its answer is documented
+/// rather than surprising.
+#[must_use]
+pub fn floor_of(asked: f64) -> f64 {
+    if asked.is_finite() && asked > 0.0 {
+        asked
+    } else {
+        0.0
     }
 }
 
@@ -768,13 +838,29 @@ impl Adapter<'_> {
         if self.epoch.window().is_some() || self.failure.is_some() {
             return;
         }
+        // **The opening size is raised to the floor here, so that every
+        // platform opens the same window.** Left to the backends they
+        // disagree: two of the three clamp the requested size up to the
+        // minimum and the third sets the minimum as a hint and opens at
+        // whatever was asked for. A caller who writes a floor larger
+        // than the size it opens at has contradicted itself, and the
+        // honest reading of "no smaller than this" is that the window is
+        // not smaller than this — on every machine.
+        let floor = (
+            floor_of(self.config.min_logical_width),
+            floor_of(self.config.min_logical_height),
+        );
         let mut attributes = winit::window::Window::default_attributes()
             .with_title(&self.config.title)
             .with_resizable(self.config.resizable)
             .with_inner_size(winit::dpi::LogicalSize::new(
-                self.config.logical_width,
-                self.config.logical_height,
+                self.config.logical_width.max(floor.0),
+                self.config.logical_height.max(floor.1),
             ));
+        if floor.0 > 0.0 || floor.1 > 0.0 {
+            attributes =
+                attributes.with_min_inner_size(winit::dpi::LogicalSize::new(floor.0, floor.1));
+        }
         // The icon is asked for here rather than held on the config
         // because it is the application's picture; see `WindowApp::icon`.
         // Its bytes were checked against its dimensions when it was
@@ -1893,6 +1979,214 @@ mod tests {
         }
     }
 
+    /// Build an adapter, open one window through a source that records
+    /// what it was handed, and give the attributes back.
+    ///
+    /// **The call is counted, and every caller asserts on the count.**
+    /// A test whose assertions all live inside the source closure
+    /// passes, having run none of them, the moment a change stops
+    /// opening the window at all. The refusal test below had that guard
+    /// already; the first draft of the ones above had dropped it.
+    fn attributes_for(config: &WindowConfig) -> winit::window::WindowAttributes {
+        let seen = core::cell::RefCell::new(None);
+        let calls = core::cell::Cell::new(0_u32);
+        let source: &WindowSource<'_> = &|attributes| {
+            calls.set(calls.get() + 1);
+            *seen.borrow_mut() = Some(attributes);
+            Err("no display".to_string())
+        };
+        let mut app = Recorder::default();
+        new_adapter(config, &mut app).open(source);
+        assert_eq!(calls.get(), 1, "the window was never asked for");
+        seen.into_inner()
+            .unwrap_or_else(winit::window::Window::default_attributes)
+    }
+
+    /// A logical size as the attributes carry it, for comparing.
+    fn logical(width: f64, height: f64) -> winit::dpi::Size {
+        winit::dpi::LogicalSize::new(width, height).into()
+    }
+
+    /// **A floor reaches the window, and no floor reaches it as none.**
+    ///
+    /// Two separate claims: that a floor asked for is passed on, and
+    /// that a window whose caller said nothing is not given one anyway.
+    /// The second is what every caller written before this field existed
+    /// relies on.
+    ///
+    /// **The two dimensions are varied independently.** Setting both and
+    /// then neither leaves a whole class of mutant alive: nesting one
+    /// field's branch inside the other's passes a both-or-neither test
+    /// while silently dropping the floor for anyone who sets one.
+    #[test]
+    fn a_windows_floor_reaches_the_window_and_its_absence_reaches_it_as_absence() {
+        let asked = |width: f64, height: f64| WindowConfig {
+            title: "renew-floored".to_string(),
+            logical_width: 900.0,
+            logical_height: 700.0,
+            resizable: true,
+            min_logical_width: width,
+            min_logical_height: height,
+        };
+        assert_eq!(
+            attributes_for(&asked(320.0, 240.0)).min_inner_size,
+            Some(logical(320.0, 240.0)),
+            "a floor in both dimensions did not reach the window"
+        );
+        assert_eq!(
+            attributes_for(&asked(320.0, 0.0)).min_inner_size,
+            Some(logical(320.0, 0.0)),
+            "a floor on the width alone did not reach the window"
+        );
+        assert_eq!(
+            attributes_for(&asked(0.0, 240.0)).min_inner_size,
+            Some(logical(0.0, 240.0)),
+            "a floor on the height alone did not reach the window"
+        );
+        assert_eq!(
+            attributes_for(&asked(0.0, 0.0)).min_inner_size,
+            None,
+            "a window asked for no floor was given one"
+        );
+        assert_eq!(
+            attributes_for(&WindowConfig::default()).min_inner_size,
+            None,
+            "the default carries a floor, so every caller that predates it has one"
+        );
+    }
+
+    /// **Nonsense is read as no floor, and never handed on.**
+    ///
+    /// Not fussiness. The windowing library clamps the requested size
+    /// between the floor and a ceiling, and that clamp asserts
+    /// `min <= max` — so a floor of `NaN` or `INFINITY` fails an
+    /// assertion inside a dependency, during window creation, in a seam
+    /// whose whole character is that failures come back as a `Result`.
+    /// This crate builds with `panic = "abort"`, so it would not even
+    /// unwind.
+    ///
+    /// Negative is the quiet half of the same problem: it saturates to
+    /// nought on the way to an unsigned pixel count, so it already meant
+    /// no floor, silently. It means it out loud now.
+    #[test]
+    fn a_floor_that_is_not_a_size_is_no_floor() {
+        for nonsense in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.0] {
+            let config = WindowConfig {
+                min_logical_width: nonsense,
+                min_logical_height: nonsense,
+                ..WindowConfig::default()
+            };
+            let attributes = attributes_for(&config);
+            assert_eq!(
+                attributes.min_inner_size, None,
+                "a floor of {nonsense} reached the window instead of reading as no floor"
+            );
+            assert_eq!(
+                attributes.inner_size,
+                Some(logical(1280.0, 720.0)),
+                "a floor of {nonsense} moved the size the window opens at"
+            );
+        }
+    }
+
+    /// **A floor above the opening size raises it here, rather than on
+    /// two platforms out of three.**
+    ///
+    /// Left to the backends they disagree: two clamp the requested size
+    /// up to the minimum, the third opens at what was asked and sets the
+    /// minimum as a hint afterwards. A caller writing a floor larger
+    /// than its opening size has contradicted itself, and the honest
+    /// reading of "no smaller than this" is that the window is not
+    /// smaller than this — on every machine.
+    #[test]
+    fn a_floor_above_the_opening_size_raises_it_on_every_platform() {
+        let config = WindowConfig {
+            logical_width: 640.0,
+            logical_height: 480.0,
+            min_logical_width: 1024.0,
+            min_logical_height: 768.0,
+            ..WindowConfig::default()
+        };
+        let attributes = attributes_for(&config);
+        assert_eq!(
+            attributes.inner_size,
+            Some(logical(1024.0, 768.0)),
+            "the window opens smaller than the floor it was given"
+        );
+        assert_eq!(
+            attributes.min_inner_size,
+            Some(logical(1024.0, 768.0)),
+            "the floor was lost while the opening size was being raised"
+        );
+        // A floor under the opening size leaves it alone, which is the
+        // ordinary case and the one the raise must not disturb.
+        let ordinary = WindowConfig {
+            logical_width: 900.0,
+            logical_height: 700.0,
+            min_logical_width: 320.0,
+            min_logical_height: 240.0,
+            ..WindowConfig::default()
+        };
+        assert_eq!(
+            attributes_for(&ordinary).inner_size,
+            Some(logical(900.0, 700.0)),
+            "an ordinary floor moved the size the window opens at"
+        );
+    }
+
+    /// **A floor is passed on whether or not the window can be resized.**
+    ///
+    /// This crate does not decide what a fixed-size window does with a
+    /// floor — the platforms do, and they differ — but it must not
+    /// quietly drop one on the way, which is the combination the field's
+    /// own doc talks about and nothing checked.
+    #[test]
+    fn a_fixed_size_window_still_carries_the_floor_it_was_given() {
+        let config = WindowConfig {
+            resizable: false,
+            min_logical_width: 320.0,
+            min_logical_height: 240.0,
+            ..WindowConfig::default()
+        };
+        let attributes = attributes_for(&config);
+        assert!(
+            !attributes.resizable,
+            "the fixture stopped being fixed-size"
+        );
+        assert_eq!(
+            attributes.min_inner_size,
+            Some(logical(320.0, 240.0)),
+            "a fixed-size window had its floor dropped on the way to the platform"
+        );
+    }
+
+    /// **Nothing else the window was asked for moved.** The floor is one
+    /// of five things this function sets, and a test reading only the
+    /// one it changed cannot see the others being disturbed.
+    #[test]
+    fn adding_a_floor_disturbs_nothing_else_the_window_was_asked_for() {
+        let config = WindowConfig {
+            title: "renew-intact".to_string(),
+            logical_width: 900.0,
+            logical_height: 700.0,
+            resizable: true,
+            min_logical_width: 320.0,
+            min_logical_height: 240.0,
+        };
+        let attributes = attributes_for(&config);
+        assert_eq!(attributes.title, "renew-intact");
+        assert!(attributes.resizable);
+        assert_eq!(attributes.inner_size, Some(logical(900.0, 700.0)));
+        assert_eq!(
+            attributes.max_inner_size, None,
+            "a ceiling appeared beside the floor, pinning the window to one size"
+        );
+        assert!(
+            attributes.fullscreen.is_none(),
+            "the window opened fullscreen, which nothing asked for"
+        );
+    }
+
     #[test]
     fn a_refused_window_is_reported_once_and_never_retried() {
         let config = WindowConfig {
@@ -1900,6 +2194,7 @@ mod tests {
             logical_width: 640.0,
             logical_height: 480.0,
             resizable: false,
+            ..WindowConfig::default()
         };
         let attempts = std::cell::Cell::new(0_u32);
         let refuse: &WindowSource<'_> = &|attributes| {

--- a/crates/core/platform/tests/window_smoke.rs
+++ b/crates/core/platform/tests/window_smoke.rs
@@ -160,6 +160,7 @@ fn main() -> ExitCode {
         logical_width: 320.0,
         logical_height: 200.0,
         resizable: false,
+        ..WindowConfig::default()
     };
     if one_window_runs_and_exits(&config) && a_second_loop_is_refused_recoverably(&config) {
         ExitCode::SUCCESS

--- a/crates/rhi/tests/fault_present.rs
+++ b/crates/rhi/tests/fault_present.rs
@@ -1364,6 +1364,7 @@ fn main() {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let run = run_window_app(&config, &mut app);
 

--- a/crates/rhi/tests/present_smoke.rs
+++ b/crates/rhi/tests/present_smoke.rs
@@ -688,6 +688,7 @@ fn main() {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let run = run_window_app(&config, &mut app);
     // Tear down GPU objects BEFORE reading the report so validation

--- a/crates/rhi/tests/present_zero_alloc.rs
+++ b/crates/rhi/tests/present_zero_alloc.rs
@@ -651,6 +651,7 @@ fn main() {
         logical_width: 320.0,
         logical_height: 240.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let run = run_window_app(&config, &mut app);
     // Drop GPU objects before the verdict, matching the sibling suite:

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -896,6 +896,7 @@ pub fn run(options: &Options) -> Result<Report, WindowError> {
         logical_width: 960.0,
         logical_height: 720.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     run_window_app(&config, &mut app)?;
     // Said out loud rather than folded into the return: the simulation

--- a/samples/glide/src/windowed.rs
+++ b/samples/glide/src/windowed.rs
@@ -89,6 +89,7 @@ pub fn run(options: &Options) -> Result<Report, SampleError> {
         logical_width: 640.0,
         logical_height: 480.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let outcome = run_window_app(&config, &mut app);
     app.finish(outcome)

--- a/samples/hello_triangle/src/android.rs
+++ b/samples/hello_triangle/src/android.rs
@@ -49,6 +49,7 @@ extern "Rust" fn android_main(activity: AndroidApp) {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let outcome = run_window_app_android(activity, &config, &mut app);
     // Through the sample's own verdict rather than around it: `finish`

--- a/samples/hello_triangle/src/ios.rs
+++ b/samples/hello_triangle/src/ios.rs
@@ -66,6 +66,7 @@ pub fn ios_main() -> ! {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
 
     if let Err(error) = run_window_app(&config, &mut app) {

--- a/samples/hello_triangle/src/windowed.rs
+++ b/samples/hello_triangle/src/windowed.rs
@@ -61,6 +61,7 @@ pub fn run(options: &Options) -> Result<Report, SampleError> {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let outcome = run_window_app(&config, &mut app);
     app.finish(outcome)

--- a/samples/input_echo/src/android.rs
+++ b/samples/input_echo/src/android.rs
@@ -62,6 +62,7 @@ extern "Rust" fn android_main(activity: AndroidApp) {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let outcome = run_window_app_android(activity, &config, &mut app);
     app.note(&match outcome {

--- a/samples/input_echo/src/app.rs
+++ b/samples/input_echo/src/app.rs
@@ -36,6 +36,7 @@ pub fn run(options: &Options) -> Result<Report, SampleError> {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
     let outcome = run_window_app(&config, &mut app);
     verdict(outcome, app.report())

--- a/samples/input_echo/src/ios.rs
+++ b/samples/input_echo/src/ios.rs
@@ -73,6 +73,7 @@ pub fn ios_main() -> ! {
         logical_width: 640.0,
         logical_height: 360.0,
         resizable: true,
+        ..WindowConfig::default()
     };
 
     // A failure here is a loop that never started, which is the only


### PR DESCRIPTION
`WindowConfig` carried a title, a size and `resizable`, and that was all
of it. So an application could open a window and could not say how small
it may get — and a layout guard measured against the size the window
happened to open at is one the user walks past by dragging a corner.
There was no size an application could rely on still having.

`min_logical_width` and `min_logical_height`, nought meaning no floor,
which is the default and is what every window did before they existed.
Two named scalars rather than one pair: every other size in this crate
is two named scalars, and an unnamed pair can be written the wrong way
round and still compile.

Two things happen here rather than on three platforms differently.

A floor above the opening size raises the opening size. Left to the
backends, two clamp the requested size up to the minimum and the third
opens at what was asked and sets the minimum as a hint afterwards, so
one config produced different windows on different machines. "No
smaller than this" should mean the same everywhere.

A floor that is not a size — negative, NaN, infinite — is read as no
floor. This is not fussiness: the requested size is clamped between the
floor and a ceiling, and that clamp asserts `min <= max`, so NaN or
infinity fails an assertion inside a dependency during window creation,
in a seam whose whole character is that failures come back as a
`Result`, in a crate that builds `panic = "abort"`. Negative is the
quiet half of the same problem — it saturates to nought on the way to an
unsigned pixel count, so it already meant no floor, silently.

Breaking: every construction site gains `..WindowConfig::default()`.

Five probes, one per claim, each red by name: never opening the window
at all (which the call counter catches, so no test can pass having run
none of its assertions), nesting one dimension's branch inside the
other's, passing nonsense through, not raising the opening size, and
dropping the floor when the window is fixed-size.

Workspace 2,539 passed, 0 failed; fmt and clippy clean.