### PR TITLE
feat(platform): fullscreen is asked for between events, not at bring-up

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -176,42 +176,42 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [871, 872, 873, 874]
+lines = [905, 906, 907, 908]
 reason = "The body of the window-creation branch that hands an application's icon to the windowing crate. It is inside `open`, which needs a live event loop no unit test can host: the branch is reached only when a real window is about to exist, and the windowed smoke test that does reach `open` uses an application with no icon, because an application that had one would be asserting on a picture nobody can see from a test. The parts that can be checked without a window are, and they are the parts that can be wrong - `WindowIcon::from_rgba` refuses bytes that do not match their dimensions, `IconError` says which refusal and with what numbers, and the trait method defaults to nothing. What is left here is three lines of handing validated bytes to a builder."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1122, 1123]
+lines = [1165, 1166]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1945]
+lines = [2033]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [2251, 2252, 2253, 2319, 2320, 2321, 2345, 2346, 2347, 2404, 2405, 2406]
+lines = [2339, 2340, 2341, 2407, 2408, 2409, 2433, 2434, 2435, 2492, 2493, 2494]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1016, 1020, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031]
+lines = [1059, 1063, 1065, 1066, 1067, 1068, 1069, 1070, 1071, 1072, 1073, 1074]
 reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1177, 1180]
+lines = [1220, 1223]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [929, 930]
+lines = [963, 964]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1050, 1051, 1052, 1053, 1054, 1055, 1056, 1057, 1058, 1059]
+lines = [1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100, 1101, 1102]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -176,8 +176,8 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1017]
-reason = "Handing a fullscreen request to the live window. The decision above it is covered - LoopControl carries the request three-valued, a unit test drives every combination of it, and another drives one through the loop iteration so both conditions on the line above are evaluated. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the conditions above are NOT exempted, because the loop test reaches them."
+lines = [1018, 1019, 1020]
+reason = "Handing a fullscreen request to the live window - the block's brace, its one statement and its close. The decision above it is covered - LoopControl carries the request three-valued, a unit test drives every combination of it, and another drives one through the loop iteration so both conditions on the line above are evaluated. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the conditions above are NOT exempted, because the loop test reaches them."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
@@ -186,27 +186,27 @@ reason = "The body of the window-creation branch that hands an application's ico
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1178, 1179]
+lines = [1180, 1181]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [2089]
+lines = [2091]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [2398, 2399, 2400, 2466, 2467, 2468, 2492, 2493, 2494, 2551, 2552, 2553]
+lines = [2400, 2401, 2402, 2468, 2469, 2470, 2494, 2495, 2496, 2553, 2554, 2555]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1072, 1076, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087]
+lines = [1074, 1078, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087, 1088, 1089]
 reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1233, 1236]
+lines = [1235, 1238]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
@@ -216,7 +216,7 @@ reason = "Delivering the characters an OS key event committed - the delivery lin
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115]
+lines = [1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1116, 1117]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -177,46 +177,46 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
 lines = [1017]
-reason = "Handing a fullscreen request to the live window. The decision above it is covered - LoopControl carries the request three-valued and a unit test drives every combination of it - and so is the guard that there is a window to hand it to. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the two conditions on the line above are NOT exempted, because a quiet iteration evaluates both and the gate reports them covered."
+reason = "Handing a fullscreen request to the live window. The decision above it is covered - LoopControl carries the request three-valued, a unit test drives every combination of it, and another drives one through the loop iteration so both conditions on the line above are evaluated. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the conditions above are NOT exempted, because the loop test reaches them."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [905, 906, 907, 908]
+lines = [918, 919, 920, 921]
 reason = "The body of the window-creation branch that hands an application's icon to the windowing crate. It is inside `open`, which needs a live event loop no unit test can host: the branch is reached only when a real window is about to exist, and the windowed smoke test that does reach `open` uses an application with no icon, because an application that had one would be asserting on a picture nobody can see from a test. The parts that can be checked without a window are, and they are the parts that can be wrong - `WindowIcon::from_rgba` refuses bytes that do not match their dimensions, `IconError` says which refusal and with what numbers, and the trait method defaults to nothing. What is left here is three lines of handing validated bytes to a builder."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1165, 1166]
+lines = [1178, 1179]
 reason = "The scale-factor and keyboard arms of the winit event translation. Neither payload type has a public constructor in the pinned windowing crate, so the input cannot be built outside it, and neither event can be provoked from inside the process. Each arm is a single delegation to a helper that IS driven directly, so the translation logic itself is covered. Note for local runs: on a machine with a live desktop a stray keyboard event can reach the window smoke test's real window and cover the keyboard arm, which then reports as a stale exemption. Under the virtual display CI uses there is no keyboard, so it is stable there; if this flaps locally, that is why."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [2033]
+lines = [2089]
 reason = "A test double's required method that cannot be called: its argument borrows a live OS window, which needs a main-thread event loop the test harness cannot host."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [2339, 2340, 2341, 2407, 2408, 2409, 2433, 2434, 2435, 2492, 2493, 2494]
+lines = [2398, 2399, 2400, 2466, 2467, 2468, 2492, 2493, 2494, 2551, 2552, 2553]
 reason = "Required trait methods of four single-purpose test doubles (the epoch-ordering probe, the defaulted-release app, the interruption counter and the app that ignores interruptions), whose tests drive only the surface-release and interruption paths. ready cannot be called for the same reason as the double above; event and update are empty stubs a test could call but only to color lines while asserting nothing, which is the vacuity this suite exists to refuse."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1059, 1063, 1065, 1066, 1067, 1068, 1069, 1070, 1071, 1072, 1073, 1074]
+lines = [1072, 1076, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087]
 reason = "The suspend handler's body - the delegation to the shared transition and the platform branch beneath it, not the transition itself, which is a free function a unit test drives directly for exactly this reason. No desktop platform ever emits a suspend, the windowing crate's callback argument has no public constructor, and the harness cannot host the loop that would produce one — so no lane that runs on a desktop can enter it. The epoch half IS covered: close_epoch is driven by the unit suite with an epoch genuinely open, and close_surface's delegation to it is pinned by the modifier-reset test. The residue — the platform branch, the delegation call, and the park that stops a backgrounded loop polling — waits on the first execution lane, whose opening suspend cycle is its regression test; none of it is assumed covered."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1220, 1223]
+lines = [1233, 1236]
 reason = "The key arm of typed_characters: the only arm that reads text off an OS key event. winit's KeyEvent carries a pub(crate) platform_specific field, so it cannot be constructed outside that crate and this arm cannot be entered from a test - checked in the pinned source rather than assumed. What the arm decides is covered without it: committed is a free function driven directly with both press and release, printable is driven over the control range, and the synthetic-event filter is a pattern in the match rather than a branch of its own. Deliberately narrow: the `_ => None` arm below is NOT exempted, because every non-key event a test dispatches enters it."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [963, 964]
+lines = [976, 977]
 reason = "Delivering the characters an OS key event committed - the delivery line and the loop close the gate attributes with it. Unreachable for the same root cause as the typed_characters key arm below: the loop only has a body to run when that arm yields text, and that needs an unconstructible KeyEvent. The narrowness is measured rather than asserted: the guard above and the loop head itself are entered by every dispatched non-commanding event and the gate reports both covered. What is exempt here is the delivery, not the decision to deliver."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100, 1101, 1102]
+lines = [1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115]
 reason = "Delivering raw device motion. No lane has a mouse - the windowed runs happen under a virtual display, which reports no device movement - so this callback is never entered there. What it decides IS covered: translate_device_event is driven with constructed winit events, and the sample's accumulator and whole-degree boundary are driven with constructed deltas. This is the arm, not the argument. Deliberately narrow: the cursor grab and its reapplication on focus are NOT exempted, because a window under a virtual display does receive focus events and the gate is the authority on whether those arms run. Note for local runs: a machine with a real mouse enters this callback during the window smoke test and most of these lines then report as stale exemptions; under CI's virtual display they are stable."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -176,8 +176,8 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
-lines = [1018, 1019, 1020]
-reason = "Handing a fullscreen request to the live window - the block's brace, its one statement and its close. The decision above it is covered - LoopControl carries the request three-valued, a unit test drives every combination of it, and another drives one through the loop iteration so both conditions on the line above are evaluated. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the conditions above are NOT exempted, because the loop test reaches them."
+lines = [1018, 1019]
+reason = "Handing a fullscreen request to the live window - its brace and its one statement. The closing brace is reached by every iteration that evaluates the condition, so it is covered and is not listed. The decision above it is covered - LoopControl carries the request three-valued, a unit test drives every combination of it, and another drives one through the loop iteration so both conditions on the line above are evaluated. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the conditions above are NOT exempted, because the loop test reaches them."
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -176,6 +176,11 @@ reason = "The two places a window resize is acted on: rebuilding the crosshair f
 
 [[exempt]]
 file = "crates/core/platform/src/window.rs"
+lines = [1017]
+reason = "Handing a fullscreen request to the live window. The decision above it is covered - LoopControl carries the request three-valued and a unit test drives every combination of it - and so is the guard that there is a window to hand it to. What is left is the one line that touches the windowing crate, and reaching it needs a real window on a real monitor: the harness cannot host the event loop that would produce one, and the runs that do have a window are under a virtual display where nothing asks for fullscreen. Deliberately narrow: the two conditions on the line above are NOT exempted, because a quiet iteration evaluates both and the gate reports them covered."
+
+[[exempt]]
+file = "crates/core/platform/src/window.rs"
 lines = [905, 906, 907, 908]
 reason = "The body of the window-creation branch that hands an application's icon to the windowing crate. It is inside `open`, which needs a live event loop no unit test can host: the branch is reached only when a real window is about to exist, and the windowed smoke test that does reach `open` uses an application with no icon, because an application that had one would be asserting on a picture nobody can see from a test. The parts that can be checked without a window are, and they are the parts that can be wrong - `WindowIcon::from_rgba` refuses bytes that do not match their dimensions, `IconError` says which refusal and with what numbers, and the trait method defaults to nothing. What is left here is three lines of handing validated bytes to a builder."
 

--- a/crates/core/platform/README.md
+++ b/crates/core/platform/README.md
@@ -125,6 +125,15 @@ datagrams — each a thin, explicit seam.
   a floor is the platform's business, and the three differ. Unsupported
   on iOS, Android and Orbital, where the windowing library ignores it —
   the same way a platform with no notion of a window icon ignores one.
+- **Fullscreen is asked for between events, not at bring-up.**
+  `LoopControl::set_fullscreen` fills the screen or gives a window back,
+  borderless, on whichever monitor the window is on. It is a runtime
+  request for the same reason the cursor grab is one: an application
+  learns whether it wants the screen long after the window opened — it
+  is a line in a settings menu and a key on the keyboard — and a flag
+  readable only at bring-up gives a player no way out of a fullscreen
+  they turned on. Exclusive fullscreen would need a monitor handle and a
+  video mode, two windowing-library types this seam exists to keep out.
 - **No ambient state.** No global clock, no environment reads; everything
   is a value or an explicit call.
 - **Errors carry context** — paths and thread names, in crate-local

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -1014,7 +1014,7 @@ impl Adapter<'_> {
             // is on", which is the only answer available without naming
             // one — and naming one would mean a handle crossing this
             // seam.
-            window.set_fullscreen(filling.then(|| winit::window::Fullscreen::Borderless(None)));
+            window.set_fullscreen(filling.then_some(winit::window::Fullscreen::Borderless(None)));
         }
         if control.redraw
             && let Some(window) = self.epoch.window()
@@ -1894,6 +1894,47 @@ mod tests {
         );
     }
 
+    /// **A fullscreen request survives the iteration it was made in and
+    /// reaches the window, and asking nothing reaches nothing.**
+    ///
+    /// The window itself cannot be asserted on — there is none under a
+    /// unit test — so what is checked is that the request is *taken*:
+    /// the loop reads it, evaluates whether there is a window to hand it
+    /// to, and does not fall over when there is not. That last part is
+    /// the whole of what a headless iteration can prove, and it is worth
+    /// proving: an application that asks for the screen before a window
+    /// exists must be an ordinary iteration rather than a panic.
+    ///
+    /// **Unlike the cursor, nothing is remembered**, and that asymmetry
+    /// is deliberate — see `LoopControl::set_fullscreen`. So there is no
+    /// memory to assert against, and the absence of one is the claim.
+    #[test]
+    fn a_fullscreen_request_is_taken_even_with_no_window_to_apply_it_to() {
+        let config = WindowConfig::default();
+
+        for asked in [Some(true), Some(false), None] {
+            let mut app = Recorder {
+                ask_fullscreen: asked,
+                ..Recorder::default()
+            };
+            {
+                let mut adapter = new_adapter(&config, &mut app);
+                assert!(
+                    !adapter.tick(),
+                    "asking about the screen ({asked:?}) was read as asking to leave the loop"
+                );
+                assert!(
+                    !adapter.cursor_wanted.get(),
+                    "asking about the screen ({asked:?}) also took the cursor"
+                );
+            }
+            assert_eq!(
+                app.updates, 1,
+                "the iteration did not reach the application"
+            );
+        }
+    }
+
     /// The accessors report the fields the loop reads, and a silent
     /// iteration is distinguishable from one that asked for something.
     ///
@@ -2020,6 +2061,8 @@ mod tests {
         /// What to ask of the cursor, if anything. `None` asks nothing,
         /// which is the case that must leave the grab alone.
         ask_cursor: Option<bool>,
+        /// What to ask about filling the screen, if anything.
+        ask_fullscreen: Option<bool>,
     }
 
     /// **An application that says nothing about an icon has none.**
@@ -2059,6 +2102,9 @@ mod tests {
             }
             if let Some(held) = self.ask_cursor {
                 control.hold_cursor(held);
+            }
+            if let Some(filling) = self.ask_fullscreen {
+                control.set_fullscreen(filling);
             }
         }
 

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -241,6 +241,9 @@ pub struct LoopControl {
     /// A change of mind about the cursor, if the app had one this
     /// iteration. `None` leaves the grab as it is.
     cursor: Option<bool>,
+    /// A change of mind about filling the screen, on the same terms as
+    /// the cursor: `None` leaves the window as it is.
+    fullscreen: Option<bool>,
 }
 
 impl LoopControl {
@@ -271,6 +274,41 @@ impl LoopControl {
         self.cursor = Some(held);
     }
 
+    /// Fill the screen, or go back to a window.
+    ///
+    /// **Between events, and for the same reason the cursor is.** An
+    /// application learns whether it wants the screen long after the
+    /// window opened: it is a line in a settings menu and a key on the
+    /// keyboard, and a flag readable only at bring-up gives a player no
+    /// way out of a fullscreen they turned on. That argument is
+    /// [`Self::hold_cursor`]'s, unchanged; it was made there first and
+    /// it applies here exactly.
+    ///
+    /// Borderless, on whichever monitor the window is on. Exclusive
+    /// fullscreen needs a monitor handle and a video mode, which are two
+    /// windowing-library types this seam exists to keep out — see the
+    /// module doc — and nothing has asked for one. A `bool` is what an
+    /// application wants to say.
+    ///
+    /// Idempotent, and asking twice for the same thing costs one call to
+    /// the platform that changes nothing.
+    ///
+    /// **Applied to the live window and not remembered**, which is the
+    /// one way this differs from the cursor beside it. The cursor is
+    /// remembered because focus loss makes the OS drop the grab and the
+    /// loop has to put it back; nothing takes fullscreen away, so there
+    /// is nothing to reapply. The case that would need a memory is a
+    /// surface epoch closing and reopening — and it cannot arise:
+    /// desktop platforms close no epochs (see the module doc), and the
+    /// platform that does is one where the windowing library does not
+    /// support fullscreen at all. Written down because "the request is
+    /// dropped when there is no window" is otherwise a silent hole, and
+    /// the day a platform both closes epochs and honours this is the day
+    /// to give it the cursor's treatment.
+    pub fn set_fullscreen(&mut self, filling: bool) {
+        self.fullscreen = Some(filling);
+    }
+
     /// Whether [`exit`](Self::exit) was called this iteration.
     #[must_use]
     pub fn exiting(&self) -> bool {
@@ -288,6 +326,15 @@ impl LoopControl {
     #[must_use]
     pub fn cursor_request(&self) -> Option<bool> {
         self.cursor
+    }
+
+    /// What the app asked about filling the screen this iteration, if
+    /// anything. Three-valued for the same reason the cursor is: saying
+    /// nothing leaves the window alone, which is a different instruction
+    /// from asking for a window back.
+    #[must_use]
+    pub fn fullscreen_request(&self) -> Option<bool> {
+        self.fullscreen
     }
 }
 
@@ -959,6 +1006,15 @@ impl Adapter<'_> {
             // same thing: a desktop that refuses confinement plays on
             // without mouse look, which is not a failure to report.
             let _refused = self.apply_cursor_grab(held);
+        }
+        if let Some(filling) = control.fullscreen
+            && let Some(window) = self.epoch.window()
+        {
+            // `None` is the windowing library's "the monitor this window
+            // is on", which is the only answer available without naming
+            // one — and naming one would mean a handle crossing this
+            // seam.
+            window.set_fullscreen(filling.then(|| winit::window::Fullscreen::Borderless(None)));
         }
         if control.redraw
             && let Some(window) = self.epoch.window()
@@ -1841,11 +1897,15 @@ mod tests {
     /// The accessors report the fields the loop reads, and a silent
     /// iteration is distinguishable from one that asked for something.
     ///
-    /// **The cursor is three-valued and the other two are not.** Saying
+    /// **Two of the four are three-valued and two are not.** Saying
     /// nothing about the cursor leaves the grab alone, which is a
     /// different instruction from asking for it to be released — so a
     /// reader that collapsed `None` into `false` would turn every quiet
-    /// iteration into a release request.
+    /// iteration into a release request. Fullscreen is the same shape
+    /// for the same reason, and is checked here rather than in a test of
+    /// its own because what is being asserted is a property of this
+    /// type: every request is independent, and a quiet iteration asks
+    /// for nothing.
     #[test]
     fn loop_control_reports_what_was_asked() {
         let quiet = LoopControl::default();
@@ -1873,6 +1933,47 @@ mod tests {
         assert!(
             !released.exiting(),
             "a cursor request must not be read as an exit"
+        );
+
+        // **Fullscreen is three-valued on the same terms**, and saying
+        // nothing about it must not read as asking for a window back —
+        // which is the mistake the cursor's own doc above warns of, in
+        // the one other place this type can make it.
+        assert_eq!(
+            quiet.fullscreen_request(),
+            None,
+            "saying nothing about the screen is not asking for a window back"
+        );
+        let mut screen = LoopControl::default();
+        screen.set_fullscreen(true);
+        assert_eq!(screen.fullscreen_request(), Some(true));
+        screen.set_fullscreen(false);
+        assert_eq!(
+            screen.fullscreen_request(),
+            Some(false),
+            "the last word in an iteration must win, as it does for the cursor"
+        );
+
+        // The three requests are independent: asking for one must not
+        // set another. A single `Option` reused for two questions would
+        // pass every assertion above and fail this one.
+        let mut only_screen = LoopControl::default();
+        only_screen.set_fullscreen(true);
+        assert_eq!(
+            only_screen.cursor_request(),
+            None,
+            "asking for the screen also asked something of the cursor"
+        );
+        assert!(
+            !only_screen.exiting() && !only_screen.redraw_requested(),
+            "asking for the screen also asked to exit or to redraw"
+        );
+        let mut only_cursor = LoopControl::default();
+        only_cursor.hold_cursor(true);
+        assert_eq!(
+            only_cursor.fullscreen_request(),
+            None,
+            "asking for the cursor also asked something of the screen"
         );
     }
 

--- a/crates/core/platform/src/window.rs
+++ b/crates/core/platform/src/window.rs
@@ -1007,13 +1007,15 @@ impl Adapter<'_> {
             // without mouse look, which is not a failure to report.
             let _refused = self.apply_cursor_grab(held);
         }
+        // `None` below is the windowing library's "the monitor this
+        // window is on", which is the only answer available without
+        // naming one — and naming one would mean a handle crossing this
+        // seam. Said here rather than inside the block because the
+        // coverage gate measures a block's lines, comments included, and
+        // a body of one statement needs a one-line exemption.
         if let Some(filling) = control.fullscreen
             && let Some(window) = self.epoch.window()
         {
-            // `None` is the windowing library's "the monitor this window
-            // is on", which is the only answer available without naming
-            // one — and naming one would mean a handle crossing this
-            // seam.
             window.set_fullscreen(filling.then_some(winit::window::Fullscreen::Borderless(None)));
         }
         if control.redraw


### PR DESCRIPTION
An application learns whether it wants the screen long after the window
opened: it is a line in a settings menu and a key on the keyboard, and a
flag readable only at bring-up gives a player no way out of a fullscreen
they turned on.

That argument is `hold_cursor`'s, unchanged. Its doc already says a
window property an application learns about after bring-up must not be
creation-time only, and fullscreen is the textbook case — so
`LoopControl::set_fullscreen` sits beside it and works the same way:
three-valued, so saying nothing leaves the window alone, and the last
word in an iteration wins.

Borderless, on whichever monitor the window is on. Exclusive fullscreen
would need a monitor handle and a video mode, two windowing-library
types this seam exists to keep out.

Applied to the live window and deliberately not remembered. The cursor
is remembered because focus loss makes the OS drop the grab and the loop
must put it back; nothing takes fullscreen away. The case that would
need a memory is a surface epoch closing and reopening, and it cannot
arise — desktop platforms close no epochs, and the platform that does is
one where the windowing library does not support fullscreen at all. Said
in the doc, because a dropped request is otherwise a silent hole.

The existing control test gains it rather than a parallel one standing
up beside it: that test already owns the three-valued claim, and it
gains the claim neither half had, which is that the requests are
independent. A single `Option` serving two questions passes everything
else in it and fails only that.

Probed: reusing the cursor's field reddens "asking for the screen also
asked something of the cursor"; collapsing None to false in the accessor
reddens "saying nothing about the screen is not asking for a window
back".

Coverage exemptions re-anchored in the same change, from the diff's
hunks, each verified against the line it now names.

Workspace 2,539 passed, 0 failed; fmt and clippy clean.