### PR TITLE
feat(rhi): a draw can name a slice of its mesh's index list

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -81,7 +81,7 @@ reason = "The full-table answer of the block-write tracker, which reports a buff
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [1550]
+lines = [1658]
 reason = "The unreachable arm of the write-claim table: no free slot to record a claim in. The ceiling assert does not bound it directly any more, because a uniform write records a claim without charging a retention slot - so the argument is one step longer. Every distinct uniform buffer implies at least one distinct Binding, charged in the same item iteration just above the uniform loop, so the number of records never exceeds the charged count and that count is what the ceiling bounds. Stated in the arm itself, because it depends on the loop order in check_retention_bound and a reorder would break it silently."
 
 [[exempt]]
@@ -91,33 +91,33 @@ reason = "The unreachable arm of the walk's surface-depth barrier: a depth-carry
 
 [[exempt]]
 file = "crates/rhi/src/vk/pass.rs"
-lines = [1101]
+lines = [1169]
 reason = "The settle arm for an entry that is neither sampled nor targeted. Unreachable by the walk's own construction: an entry is minted either by advance_target, which sets targeted before returning, or by advance_sampling, which either marks the entry sampled or panics the frame away in a refusal - and a refused frame never settles. The arm exists so settle states its answer as a total decision rather than an expect over invariants that live two functions away."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [1313, 1314]
+lines = [1318, 1319]
 reason = "The depthless-adapter arm of the shadow map's refusal, which translates the rendering crate's DepthUnsupported into this crate's own variant rather than reporting it as a texture failure. Unreachable wherever a depth format exists, which is every measuring lane's adapter: the format is chosen at device bring-up from a void query no fault layer can mutate, and the layer's quirk list carries no depthless-adapter quirk either. The sibling arm (any other creation failure) is driven by the R10 fault scenario."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [781]
+lines = [786]
 reason = "The creation-failure propagation on the cutout pipeline's bring-up. Never taken where creation succeeds, which is every measuring lane's adapter: provoking it needs a device refusing a pipeline the sibling paths already build, and the fault layer's quirk list carries no such refusal."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [877]
+lines = [882]
 reason = "The creation-failure propagation on the blended pipeline's bring-up - the same arm the cutout carries above it, for the same reason: no measuring lane's adapter refuses a pipeline its sibling paths already build."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [811, 812, 813]
+lines = [816, 817, 818]
 reason = "A Debug impl writing the renderer's constant name. Calling it needs a live renderer, which needs a device, and a device-bound test that exists to print a constant string would be coverage without a claim; the impl exists so an error context can name the renderer."
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [907, 908, 909]
-reason = "The blended renderer's Debug impl - the cutout's twin at 743, exempt for the same reason: a device-bound test that prints a constant string is coverage without a claim."
+lines = [912, 913, 914]
+reason = "The blended renderer's Debug impl - the cutout's twin at 816, exempt for the same reason: a device-bound test that prints a constant string is coverage without a claim."
 
 [[exempt]]
 file = "crates/rhi/src/vk/render_image.rs"
@@ -156,7 +156,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/swapchain.rs"
-lines = [1462]
+lines = [1463]
 reason = "The depthless-adapter side of chain population, where no per-slot depth images are built. Unreachable wherever a depth format exists, which is every measuring lane's adapter."
 
 [[exempt]]

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -176,7 +176,12 @@ impl MeshRenderer {
 
     /// The draw for `mesh`, ready to sit in a pass.
     ///
-    /// Every index the mesh holds, in the order the scene pushed them.
+    /// Every index the mesh holds, in the order the scene pushed them —
+    /// and a caller wanting fewer narrows the returned item with
+    /// [`Item::indices`], which is why this layer has no opinion about
+    /// ranges of its own. A scene uploaded as one mesh with its pieces
+    /// in contiguous runs can then be culled or sorted per piece against
+    /// that one buffer.
     #[must_use]
     pub fn item<'a>(&'a self, mesh: &'a Mesh) -> Item<'a> {
         Item::new(&self.pipeline).mesh(mesh)

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -29,14 +29,18 @@ display server, and the golden-image tests attest the bytes.
   `ClearValue`, so a clear value without a clearing load is
   unrepresentable); depth is a per-target internal image a pass opts
   into, sized and owned by the target. An `Item` may name geometry
-  (`Item::mesh`), which makes its draw indexed, and may carry push data
+  (`Item::mesh`), which makes its draw indexed — over the whole index list,
+  or over a slice of it (`Item::indices`, an `IndexRange`) so that geometry
+  meshed in contiguous pieces can be culled or sorted per piece without a
+  second buffer — and may carry push data
   (`Item::push_data`) for a pipeline that declares a range. Malformed
   frames — no passes, no surface pass, a first-use `Load` on any
   attachment identity, a clear value of the wrong kind, a
   depth-testing pipeline in a depthless pass, two items carrying
   different data for one per-frame buffer, an item whose geometry and
   whose pipeline's per-vertex input disagree, a mesh whose stride the
-  pipeline does not pack to, push data or bindings missing,
+  pipeline does not pack to, an index range without a mesh or reaching
+  past the end of one, push data or bindings missing,
   mis-counted or of the wrong class against the declaration, uniform data
   missing, surplus or mis-sized, a block buffer a different size from the
   block its pipeline declares, a frame that reads a render

--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -81,8 +81,8 @@ pub use vk::device::{Device, HostAllocationStats, ValidationReport};
 pub use vk::mesh::{Mesh, MeshDesc};
 pub use vk::offscreen::OffscreenTarget;
 pub use vk::pass::{
-    Attachment, Bindings, ClearValue, Item, ItemList, LoadOp, MAX_FRAME_RENDER_IMAGES, Pass,
-    PassTarget, RenderDesc, StoreOp, color_attachment,
+    Attachment, Bindings, ClearValue, IndexRange, Item, ItemList, LoadOp, MAX_FRAME_RENDER_IMAGES,
+    Pass, PassTarget, RenderDesc, StoreOp, color_attachment,
 };
 pub use vk::pipeline::{
     AddressMode, Blend, DepthState, Filter, FrameData, MAX_PUSH_CONSTANT_BYTES,

--- a/crates/rhi/src/vk/offscreen.rs
+++ b/crates/rhi/src/vk/offscreen.rs
@@ -892,14 +892,10 @@ impl OffscreenTarget {
                     // that writes its own vertex list. The frame contract
                     // already refused the mismatch.
                     match item.mesh {
-                        Some(mesh) => device.cmd_draw_indexed(
-                            self.cmd,
-                            mesh.inner.index_count,
-                            instances,
-                            0,
-                            0,
-                            0,
-                        ),
+                        Some(mesh) => {
+                            let (indices, first) = super::pass::indexed_draw(item, mesh);
+                            device.cmd_draw_indexed(self.cmd, indices, instances, first, 0, 0);
+                        }
                         None => {
                             device.cmd_draw(self.cmd, item.pipeline.vertex_count, instances, 0, 0);
                         }

--- a/crates/rhi/src/vk/pass.rs
+++ b/crates/rhi/src/vk/pass.rs
@@ -208,6 +208,51 @@ pub enum ClearValue {
     Depth(f32),
 }
 
+/// A slice of a mesh's index list: `count` indices from `first`.
+///
+/// **Why a draw needs to name part of a mesh.** Geometry that changes in
+/// pieces is meshed in pieces — a terrain chunk, a batched sprite atlas,
+/// an instanced crowd — and the pieces are laid out as contiguous runs of
+/// one index list so that replacing one is a splice rather than a new
+/// allocation. Culling, sorting, or fading such a thing per piece then
+/// wants to draw a run and skip its neighbours, which is a `firstIndex`
+/// and an `indexCount` and nothing more: no second mesh, no re-upload, no
+/// copy. Without this the choice is all of the mesh or none of it, and a
+/// caller who wants finer grain has to give up the shared buffer that
+/// made the layout worth having.
+///
+/// A `count` of zero is a draw that records nothing, deliberately
+/// allowed: a caller looping over pieces should not need a branch for
+/// the piece that turned out empty. An empty range starting exactly at
+/// the end of the list is allowed for the same reason — that is where a
+/// running offset lands after the last piece, and the bound is on
+/// [`Self::end`] rather than on `first` so the walk needs no special
+/// case for its own final step. A `first` past the end is refused
+/// whatever the count, because nothing computes that but a bug.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexRange {
+    /// The first index walked, counted in indices from the list's start.
+    pub first: u32,
+    /// How many indices are walked.
+    pub count: u32,
+}
+
+impl IndexRange {
+    /// `count` indices from `first`.
+    #[must_use]
+    pub const fn new(first: u32, count: u32) -> Self {
+        Self { first, count }
+    }
+
+    /// One past the last index walked, saturating rather than wrapping —
+    /// the contract asserts on this, so it must not itself be the thing
+    /// that loses the overflow it is there to catch.
+    #[must_use]
+    pub const fn end(self) -> u32 {
+        self.first.saturating_add(self.count)
+    }
+}
+
 /// One draw: a pipeline, optionally the geometry it walks, and
 /// optionally this frame's bytes.
 #[derive(Clone, Copy)]
@@ -228,6 +273,15 @@ pub struct Item<'a> {
     /// be pointer-identical under the one-buffer-one-`FrameData` rule
     /// below.
     pub mesh: Option<&'a Mesh>,
+    /// Which slice of [`Item::mesh`]'s index list this draw walks;
+    /// `None` walks all of it.
+    ///
+    /// Present only alongside a mesh, and never reaching past that
+    /// mesh's index count — both refused by the frame contract before
+    /// any GPU call, because a range past the end fetches indices the
+    /// mesh does not own and a range without geometry names a slice of
+    /// nothing.
+    pub indices: Option<IndexRange>,
     /// `FrameData` contained, not forked; room to grow (a
     /// first-instance or vertex-offset field) without touching existing
     /// callers.
@@ -295,6 +349,7 @@ impl<'a> Item<'a> {
         Self {
             pipeline,
             mesh: None,
+            indices: None,
             frame_data: None,
             uniform_data: None,
             push_data: None,
@@ -306,6 +361,14 @@ impl<'a> Item<'a> {
     #[must_use]
     pub fn mesh(mut self, mesh: &'a Mesh) -> Self {
         self.mesh = Some(mesh);
+        self
+    }
+
+    /// Walk only `count` indices from `first` of this item's mesh,
+    /// rather than the whole list. See [`IndexRange`].
+    #[must_use]
+    pub const fn indices(mut self, first: u32, count: u32) -> Self {
+        self.indices = Some(IndexRange::new(first, count));
         self
     }
 
@@ -641,6 +704,11 @@ pub(crate) fn retained_of(item: &Item<'_>) -> [Option<Retained>; MAX_ITEM_RESOUR
     let Item {
         pipeline: _,
         mesh,
+        // Two integers recorded into the draw call itself. They name a
+        // slice of the mesh above, and retaining that mesh is what keeps
+        // the memory the slice reads alive — a range retains nothing of
+        // its own.
+        indices: _,
         frame_data,
         // Copied into the command stream by the record path's push
         // call, so no allocation outlives `render` — nothing to retain.
@@ -1114,6 +1182,22 @@ impl FrameWalk {
 /// two copies into one region) or a draw that renders differently than
 /// written. The per-item device and format checks stay beside each
 /// target's own device state, where they always were.
+/// The `(index_count, first_index)` a mesh draw records: the item's
+/// slice if it named one, the whole list otherwise.
+///
+/// **Shared so the two record paths cannot drift.** The window and
+/// offscreen targets record the same draw twice, in two files, and a
+/// range honoured by one and ignored by the other would show only as a
+/// picture that differs between a golden test and a real window — the
+/// most expensive shape of bug this crate can have. The contract has
+/// already proved the range fits.
+pub(crate) fn indexed_draw(item: &Item<'_>, mesh: &Mesh) -> (u32, u32) {
+    match item.indices {
+        Some(range) => (range.count, range.first),
+        None => (mesh.inner.index_count, 0),
+    }
+}
+
 pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
     assert!(
         !desc.passes.is_empty(),
@@ -1190,6 +1274,30 @@ pub(crate) fn check_frame_contract(desc: &RenderDesc<'_>) {
                      end of the mesh",
                     mesh.vertex_stride(),
                     item.pipeline.vertex_stride
+                );
+            }
+            // A slice of an index list only means something when
+            // there is a list. Refused rather than ignored: silently
+            // dropping the range would draw the whole mesh where the
+            // caller asked for a piece of it, which is the quiet wrong
+            // draw this file refuses everywhere else.
+            assert!(
+                item.indices.is_none() || item.mesh.is_some(),
+                "pass {index}: an item names an index range only alongside geometry — a                  range without a mesh slices a list that does not exist"
+            );
+            // Retained, and for the same reason as the stride rule
+            // above: this bounds the fetch. Mesh creation proved every
+            // index in the list is inside the vertex count, which says
+            // nothing about indices past the list's own end — those are
+            // whatever the allocation happens to hold, fetched as
+            // vertices.
+            if let (Some(mesh), Some(range)) = (item.mesh, item.indices) {
+                assert!(
+                    range.end() <= mesh.index_count(),
+                    "pass {index}: an index range must stay inside its mesh — asked for {}                      indices from {} of a {}-index mesh, and the tail reads indices the mesh                      does not own",
+                    range.count,
+                    range.first,
+                    mesh.index_count()
                 );
             }
             // The same presence rule as geometry and depth, plus an

--- a/crates/rhi/src/vk/swapchain.rs
+++ b/crates/rhi/src/vk/swapchain.rs
@@ -1102,7 +1102,8 @@ impl WindowTarget {
                     // geometry for a mesh draw, the shader for a stage
                     // that writes its own vertex list.
                     if let Some(mesh) = item.mesh {
-                        device.cmd_draw_indexed(cmd, mesh.inner.index_count, instances, 0, 0, 0);
+                        let (indices, first) = super::pass::indexed_draw(item, mesh);
+                        device.cmd_draw_indexed(cmd, indices, instances, first, 0, 0);
                     } else {
                         device.cmd_draw(cmd, item.pipeline.vertex_count, instances, 0, 0);
                     }

--- a/crates/rhi/tests/device.rs
+++ b/crates/rhi/tests/device.rs
@@ -789,6 +789,46 @@ fn malformed_frames_are_refused_by_name() {
             let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
         },
     );
+    // An index range with nothing to slice. Refused rather than
+    // ignored: dropping it would draw the whole mesh where the caller
+    // asked for a piece, which is the quiet wrong draw every rule here
+    // exists to prevent.
+    refused(
+        "an index range on an item that names no mesh",
+        "only alongside geometry",
+        &|target| {
+            let color = clear(black);
+            let items = [Item::new(&pipeline).indices(0, 3)];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+    // A range past the end of the list. The sibling of the stride rule
+    // below and refused for the same reason: creation proved every index
+    // *in* the list is inside the vertex count, which says nothing about
+    // indices past the list's end — those are whatever the allocation
+    // holds, fetched as vertices.
+    refused(
+        "an index range reaching past the end of its mesh",
+        "must stay inside its mesh",
+        &|target| {
+            let color = clear(black);
+            let items = [Item::new(&mesh_pipeline).mesh(&mesh).indices(1, 3)];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+    // The same rule reached by overflow rather than by size, which is
+    // why `IndexRange::end` saturates: a wrapping sum would make this
+    // three-index mesh accept a range of four billion.
+    refused(
+        "an index range whose first plus count wraps",
+        "must stay inside its mesh",
+        &|target| {
+            let color = clear(black);
+            let items = [Item::new(&mesh_pipeline).mesh(&mesh).indices(u32::MAX, 3)];
+            let _ = target.render(&RenderDesc::new(&[Pass::new(&color, &items)]));
+        },
+    );
+
     // A stride the pipeline does not pack to: the mesh's own indices stay
     // inside its own vertex count, and the fetch still runs off the end,
     // which is why this rule exists separately from the creation check.

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -1597,6 +1597,139 @@ fn mesh_vertex(position: [f32; 3], colour: [f32; 4]) -> Vec<u8> {
 /// either, so every pixel has one right value on every conformant
 /// adapter.
 ///
+/// **A draw over part of a mesh's index list.**
+///
+/// The test above proves the index buffer is read, using a second mesh
+/// built from a prefix of the same indices — which means every line of
+/// it is satisfied by a path that honours a count and ignores an offset,
+/// because a prefix has no offset. This one names slices of *one* mesh,
+/// including one that does not start at zero, which nothing a prefix can
+/// express reaches.
+///
+/// Why the feature exists: geometry that changes in pieces is meshed in
+/// pieces laid out as contiguous runs of one index list, so replacing a
+/// piece is a splice. Drawing a piece is then a `firstIndex` and an
+/// `indexCount`, and without them the choice is the whole mesh or none of
+/// it.
+#[test]
+fn an_index_range_draws_the_slice_it_names() -> Result<(), Box<dyn std::error::Error>> {
+    const SIZE: u32 = 32;
+    fn at(pixels: &[u8], x: u32, y: u32) -> [u8; 4] {
+        let i = ((y * SIZE + x) * 4) as usize;
+        [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+    }
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+    let pipeline = device.create_pipeline(&PipelineDesc::mesh(
+        builtin::MESH,
+        TargetFormat::Rgba8Srgb,
+        builtin::MESH_LAYOUT,
+    ))?;
+
+    // The same four corners and two triangles as the test above: 0
+    // top-left, 1 top-right, 2 bottom-right, 3 bottom-left, sharing the
+    // 0-2 diagonal. Indices 0..3 are the top-right half, 3..6 the
+    // bottom-left half, and the two corners that tell them apart are the
+    // ones asserted below.
+    let green = [0.0, 1.0, 0.0, 1.0];
+    let mut vertices = Vec::new();
+    for corner in [
+        [-1.0f32, -1.0, 0.0],
+        [1.0, -1.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [-1.0, 1.0, 0.0],
+    ] {
+        vertices.extend(mesh_vertex(corner, green));
+    }
+    let mesh = device.create_mesh(&MeshDesc::new(
+        &vertices,
+        MESH_VERTEX_STRIDE,
+        &[0u32, 1, 2, 0, 2, 3],
+    ))?;
+    let magenta = clear(Color::new(1.0, 0.0, 1.0, 1.0));
+    let mut pixels = vec![0u8; target.byte_len()];
+
+    // **The other triangle, from the same mesh, by index range.** This
+    // is the half above run backwards, and the asymmetry is the whole
+    // proof: `whole[..3]` can only ever reach a prefix, so every earlier
+    // line here is satisfied by a path that honours `indexCount` and
+    // ignores `firstIndex` entirely. Indices 3..6 are `0, 2, 3` —
+    // top-left, bottom-right, bottom-left — which is the *complement* of
+    // the triangle drawn above. A path that dropped the offset would
+    // draw triangle one again and put green in the top-right corner,
+    // where this asserts the clear colour.
+    let items = [Item::new(&pipeline).mesh(&mesh).indices(3, 3)];
+    target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+    target.read_back_into(&mut pixels);
+    assert_eq!(
+        at(&pixels, 0, SIZE - 1),
+        [0, 255, 0, 255],
+        "the bottom-left corner is inside the second triangle, which only a range starting          at index 3 can name"
+    );
+    assert_eq!(
+        at(&pixels, SIZE - 1, 0),
+        [255, 0, 255, 255],
+        "the top-right corner is outside it — a path honouring the count but ignoring the          first index would draw triangle one and cover this pixel"
+    );
+
+    // And the whole list named explicitly is the whole list: a range
+    // covering everything must equal no range at all, or the offset
+    // arithmetic is off by something that the two partial draws above
+    // both happen to survive.
+    let items = [Item::new(&pipeline).mesh(&mesh).indices(0, 6)];
+    target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+    let mut all = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut all);
+    let items = [Item::new(&pipeline).mesh(&mesh)];
+    target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+    target.read_back_into(&mut pixels);
+    assert_eq!(
+        all, pixels,
+        "a range over the whole index list draws what naming no range draws"
+    );
+
+    // A zero-count range records a draw that covers nothing — the arm a
+    // caller looping over pieces relies on so an empty piece needs no
+    // branch. The target keeps its clear colour everywhere.
+    let items = [Item::new(&pipeline).mesh(&mesh).indices(3, 0)];
+    target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+    target.read_back_into(&mut pixels);
+    assert!(
+        pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .all(|px| *px == [255, 0, 255, 255]),
+        "a zero-count range draws nothing at all, leaving the clear colour"
+    );
+
+    // The loop terminus, and the reason the bound is `end() <= count`
+    // rather than `first < count`: a caller walking contiguous pieces
+    // computes each `first` as a running offset, so the piece after the
+    // last one starts exactly at the end of the list. With a count of
+    // zero that names nothing and must be accepted, or every such loop
+    // needs a special case for its own final step.
+    let items = [Item::new(&pipeline).mesh(&mesh).indices(6, 0)];
+    target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+    target.read_back_into(&mut pixels);
+    assert!(
+        pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .all(|px| *px == [255, 0, 255, 255]),
+        "an empty range starting at the end of the list is the terminus of a walk over          pieces, not a mistake"
+    );
+
+    Ok(())
+}
+
 /// **What makes this prove indices rather than merely draw:** the second
 /// frame keeps the same four vertices and submits half the index list.
 /// A path that ignored the index buffer would draw the same picture


### PR DESCRIPTION
`Item::mesh` draws the whole index list and nothing else could be asked
for, so geometry meshed in contiguous pieces — a chunked terrain, a
batched atlas, a crowd — had to choose between one mesh it could only
draw entirely and one mesh per piece, giving up the shared buffer that
made the layout worth having. Drawing a piece is a `firstIndex` and an
`indexCount`, which is what the underlying call already takes.

## What this adds

`Item::indices(first, count)` narrows a draw to an `IndexRange`. Both
record paths read it through one shared `indexed_draw`, because a range
honoured on the window path and ignored offscreen would show only as a
picture that differs between a golden test and a real window.

The frame contract refuses two shapes by name, before any GPU call, in
the style of the geometry and stride rules beside them:

- a range on an item that names no mesh;
- a range whose end passes the mesh's index count.

The bound is on the **end** rather than the first index, so an empty
range starting exactly at the end of the list — where a running offset
lands after the last piece — is accepted, and a walk over pieces needs
no special case for its final step. `end` saturates, so a wrapping sum
cannot make a three-index mesh accept a range of four billion.

`render3d` needs no change: its `item()` returns the `Item`, so a caller
narrows what it gets back. Its doc now says so.

## Tier

**T2** — additive public API on a `bootstrap` module. `Item` is
`#[non_exhaustive]` and the new field is `Copy`, so no caller breaks.
The retention pattern in `retained_of` refused to compile until the new
field was named, which is that mechanism working as designed: a range is
two integers in the command stream and retains nothing of its own.

## Evidence

All run locally, on a discrete adapter with the validation layer active.

- `renew lint` clean.
- `renew test`: 240 suites, 0 failures.
- `an_index_range_draws_the_slice_it_names` renders four cases: indices
  3..6 draw the triangle **complementary** to the one a prefix can name
  (so the offset is proven, not just the count), a full-range draw is
  byte-identical to naming no range, a zero count draws nothing, and an
  empty range at the end of the list is accepted.
- Every one of the 109 added lines in the three source files is executed
  by the crate's own suite (llvm-cov), so no new coverage exemption. The
  manifest's anchors in the four touched files were shifted once from the
  final diff and each re-read against the reason naming it; one reason's
  cross-reference to a moved line was corrected with it.

## Probes

Each assertion was broken and watched go red before restoring:

| broken | reddens |
|---|---|
| `firstIndex` forced to 0 | the complementary-triangle assertion |
| count forced to the whole mesh | the zero-count assertion |
| range-needs-a-mesh rule removed | `malformed_frames_are_refused_by_name` |
| bounds rule removed | the same test |
| `saturating_add` → `wrapping_add` | the same test, via the overflow case |
| bound weakened to `first < index_count` | red **both ways at once** — rejects the legal terminus, accepts the overrun |

## Known, and not caused by this

`triangle_matches_structure_and_the_committed_golden` and
`depth_test_keeps_the_near_quad_in_either_draw_order` fail here under
`RENEW_GOLDEN=1`. Verified pre-existing: both fail identically at
`017825a` with no changes applied — this machine has a discrete adapter
and those goldens are the software-Vulkan images CI records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)