### PR TITLE
feat(rhi): a pipeline can draw one side of a triangle

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -136,7 +136,7 @@ reason = "The DepthUnsupported refusal for a depth-carrying frame on a depthless
 
 [[exempt]]
 file = "crates/rhi/src/vk/pipeline.rs"
-lines = [1320, 1321, 1322]
+lines = [1381, 1382, 1383]
 reason = "The DepthUnsupported refusal for a depth-state pipeline on a depthless adapter - the pipeline-creation twin of the target-side refusal, unreachable for the same reason: the lanes' adapters offer a depth format and the void format query cannot be faulted."
 
 [[exempt]]

--- a/crates/rhi/README.md
+++ b/crates/rhi/README.md
@@ -65,7 +65,14 @@ display server, and the golden-image tests attest the bytes.
   supplies it; `PipelineDesc::depth_mesh` takes one vertex stage over a
   per-vertex layout — no fragment stage, no color attachment,
   `TargetFormat::DepthOnly` — for pipelines that draw only into
-  depth-kinded render images. `builtin` carries the embedded shader bundles — a colored
+  depth-kinded render images. Any of them may drop one side of every
+  triangle (`PipelineDesc::facing`, a `Facing`): closed solids keep
+  `Facing::Front` and pay nothing for their own backs, while foliage,
+  water and anything else meant to be seen from behind stays `Both`,
+  which is the default because a default that can make geometry vanish
+  is not one. Front is counter-clockwise **in clip space** — Vulkan
+  applies its rule in framebuffer space where Y points down, and the
+  rasteriser state undoes that once here so callers do not each meet it. `builtin` carries the embedded shader bundles — a colored
   triangle, textured full-target quads over one and two sampled slots,
   instanced quads with and without per-instance depth, the particle
   billboard, and the mesh pairs (sources and compile record in

--- a/crates/rhi/src/lib.rs
+++ b/crates/rhi/src/lib.rs
@@ -85,7 +85,7 @@ pub use vk::pass::{
     Pass, PassTarget, RenderDesc, StoreOp, color_attachment,
 };
 pub use vk::pipeline::{
-    AddressMode, Blend, DepthState, Filter, FrameData, MAX_PUSH_CONSTANT_BYTES,
+    AddressMode, Blend, DepthState, Facing, Filter, FrameData, MAX_PUSH_CONSTANT_BYTES,
     MAX_UNIFORM_BLOCK_BYTES, MeshShaders, PipelineDesc, RenderPipeline, Sampler, SamplerDesc,
     Shaders, TargetFormat, VertexAttribute,
 };

--- a/crates/rhi/src/vk/pipeline.rs
+++ b/crates/rhi/src/vk/pipeline.rs
@@ -277,6 +277,8 @@ pub struct PipelineDesc<'a> {
     /// [`Blend::Opaque`] — no blending — unless the builder says
     /// otherwise.
     pub blend: Blend,
+    /// Which side of a triangle this pipeline draws. See [`Facing`].
+    pub facing: Facing,
     /// How many sampled-binding slots this pipeline's shaders read;
     /// zero for none.
     ///
@@ -404,6 +406,55 @@ pub(crate) fn validate_sampled_bindings(count: u32) {
         declared <= MAX_SAMPLED_BINDINGS,
         "a pipeline declares at most {MAX_SAMPLED_BINDINGS} sampled bindings (the guaranteed          device minimum for bound sets), got {declared}"
     );
+}
+
+/// Which side of a triangle a pipeline draws.
+///
+/// **Every pipeline drew both, and for closed geometry that is half the
+/// rasterisation thrown away.** A triangle whose back is turned to the
+/// camera is either inside a solid, where nothing can see it, or behind
+/// one, where the depth test discards it *after* it has been rasterised,
+/// shaded and tested at full price. Dropping it before the rasteriser is
+/// what `cull_mode` is for, and it costs nothing: the hardware decides
+/// from the sign of the triangle's screen-space area.
+///
+/// **Per pipeline rather than per device, and that is the whole design.**
+/// Closed solids want their backs dropped. Foliage, water surfaces,
+/// banners, decals and anything else a viewer is meant to see from
+/// behind want both sides — and culling those makes geometry vanish from
+/// one direction only, which is the hardest kind of rendering fault to
+/// notice because half the time it looks right.
+///
+/// **Front is counter-clockwise in clip space** — the winding a
+/// right-handed mesher gives the outside of a solid. So `Front` keeps
+/// what you can see and drops what is inside the rock, which is the only
+/// reading of the name that is any use.
+///
+/// Getting that took a deliberate choice, and it is worth knowing about
+/// before writing a mesher against this. Vulkan applies its front-face
+/// rule in **framebuffer** space, where Y points down, so a
+/// counter-clockwise clip-space triangle arrives at the rasteriser wound
+/// clockwise. Declaring the intuitive `COUNTER_CLOCKWISE` therefore
+/// culls precisely the geometry a caller can see. The rasteriser state
+/// declares `CLOCKWISE` to undo that, once, here — rather than leaving
+/// every caller of this crate to discover the flip by watching their
+/// world turn inside out.
+///
+/// An input enum, so `#[non_exhaustive]`: a fourth mode later must not be
+/// a breaking change for downstream matchers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Facing {
+    /// Draw both sides. Today's behavior, and the default — because it
+    /// is the answer that is never *wrong*, only sometimes wasteful, and
+    /// a default that can make geometry disappear is not a default.
+    Both,
+    /// Draw only triangles wound counter-clockwise on screen: the
+    /// outside of a closed solid.
+    Front,
+    /// Draw only the ones wound clockwise: the inside of a volume, a
+    /// skybox seen from within, a cutaway.
+    Back,
 }
 
 /// How a pipeline's output is combined with what the target already
@@ -535,6 +586,7 @@ impl<'a> PipelineDesc<'a> {
             target_format,
             vertex_count: shaders.vertex_count,
             blend: Blend::Opaque,
+            facing: Facing::Both,
             sampled_bindings: 0,
             uniform_block: 0,
             vertex_input: None,
@@ -542,6 +594,13 @@ impl<'a> PipelineDesc<'a> {
             depth_state: None,
             push_constant_size: 0,
         }
+    }
+
+    /// Draw only one side of each triangle. See [`Facing`].
+    #[must_use]
+    pub const fn facing(mut self, facing: Facing) -> Self {
+        self.facing = facing;
+        self
     }
 
     /// Combine output with the target per `blend` instead of replacing
@@ -587,6 +646,7 @@ impl<'a> PipelineDesc<'a> {
             // supply it and nothing consults it.
             vertex_count: 0,
             blend: Blend::Opaque,
+            facing: Facing::Both,
             sampled_bindings: 0,
             uniform_block: 0,
             vertex_input: Some(layout),
@@ -624,6 +684,7 @@ impl<'a> PipelineDesc<'a> {
             target_format: TargetFormat::DepthOnly,
             vertex_count: 0,
             blend: Blend::Opaque,
+            facing: Facing::Both,
             sampled_bindings: 0,
             uniform_block: 0,
             vertex_input: Some(layout),
@@ -1456,8 +1517,34 @@ impl Device {
             .scissor_count(1);
         let rasterization = vk::PipelineRasterizationStateCreateInfo::default()
             .polygon_mode(vk::PolygonMode::FILL)
-            .cull_mode(vk::CullModeFlags::NONE)
-            .front_face(vk::FrontFace::COUNTER_CLOCKWISE)
+            .cull_mode(match desc.facing {
+                Facing::Both => vk::CullModeFlags::NONE,
+                // Cull the BACK to draw the front, and the front to draw
+                // the back: the flag names what is *discarded*, and
+                // reading it as what is kept is the mistake this match
+                // exists to keep away from callers.
+                Facing::Front => vk::CullModeFlags::BACK,
+                Facing::Back => vk::CullModeFlags::FRONT,
+            })
+            // **Clockwise, and that is not a typo.** Vulkan applies
+            // this in *framebuffer* space, where Y points down — so a
+            // triangle written counter-clockwise in clip space, which
+            // is how every right-handed mesher winds the outside of a
+            // solid, arrives at the rasteriser wound clockwise.
+            // Declaring COUNTER_CLOCKWISE here would make
+            // `Facing::Front` cull exactly the geometry a caller can
+            // see and keep the geometry inside the rock.
+            //
+            // It had no effect at all until `Facing` existed, because
+            // the cull mode was always NONE. So this is a free choice
+            // made once, here, rather than a Y-flip exported to every
+            // caller of this crate for ever.
+            //
+            // `a_pipeline_draws_the_side_of_a_triangle_it_was_asked_for`
+            // is what holds it: it renders one triangle both ways round
+            // under all three modes, and the mirror pair is what would
+            // catch this being flipped back.
+            .front_face(vk::FrontFace::CLOCKWISE)
             .line_width(1.0);
         let multisample = vk::PipelineMultisampleStateCreateInfo::default()
             .rasterization_samples(vk::SampleCountFlags::TYPE_1);

--- a/crates/rhi/tests/golden.rs
+++ b/crates/rhi/tests/golden.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 use renew_rhi::{
     AdapterKind, Attachment, BindingDesc, BindingSource, Blend, ClearValue, Color, DepthState,
-    Device, DeviceDesc, DeviceError, Extent, Item, LoadOp, MeshDesc, Pass, PipelineDesc,
+    Device, DeviceDesc, DeviceError, Extent, Facing, Item, LoadOp, MeshDesc, Pass, PipelineDesc,
     RenderDesc, RenderImageDesc, RenderImageKind, SamplerDesc, StoreOp, TargetFormat, TextureDesc,
     Validation, builtin,
 };
@@ -1597,6 +1597,101 @@ fn mesh_vertex(position: [f32; 3], colour: [f32; 4]) -> Vec<u8> {
 /// either, so every pixel has one right value on every conformant
 /// adapter.
 ///
+/// **A pipeline that draws one side of a triangle draws exactly that
+/// side.**
+///
+/// Every pipeline drew both, and for closed geometry that is half the
+/// rasterisation thrown away: a triangle with its back to the camera is
+/// either inside a solid or behind one, and the depth test discards it
+/// only after it has cost full price.
+///
+/// **Three renders of one triangle**, because the failure modes are
+/// mirror images and each looks like success from the other side:
+/// `Both` draws it whichever way it is wound, `Front` draws only the
+/// counter-clockwise winding, `Back` only the clockwise one. Asked of
+/// the *same* geometry with its corner order reversed rather than of two
+/// different triangles, so nothing but the winding can account for the
+/// difference.
+///
+/// The mirror pair is what makes this more than a smoke test, and it
+/// earned its keep on the first run. A `cull_mode` wired to the wrong
+/// flag — `FRONT` where `BACK` belongs — passes any test that only ever
+/// asks for one mode. **And the first run failed**: `Front` culled the
+/// counter-clockwise triangle, because Vulkan applies its front-face
+/// rule in framebuffer space where Y points down, so a
+/// counter-clockwise clip-space triangle reaches the rasteriser wound
+/// clockwise. The rasteriser declares `CLOCKWISE` to undo that, and this
+/// is what holds it there — the assertions below are written the way a
+/// caller would expect them to read, which is the point.
+#[test]
+fn a_pipeline_draws_the_side_of_a_triangle_it_was_asked_for()
+-> Result<(), Box<dyn std::error::Error>> {
+    const SIZE: u32 = 16;
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+
+    // The middle of the target, so no edge rule can be what decides it.
+    let green = [0.0, 1.0, 0.0, 1.0];
+    let corners = [[-0.5f32, -0.5, 0.0], [0.5, -0.5, 0.0], [0.0, 0.5, 0.0]];
+    let mut anticlockwise = Vec::new();
+    for corner in corners {
+        anticlockwise.extend(mesh_vertex(corner, green));
+    }
+    let mut clockwise = Vec::new();
+    for corner in [corners[0], corners[2], corners[1]] {
+        clockwise.extend(mesh_vertex(corner, green));
+    }
+    let one_way = device.create_mesh(&MeshDesc::new(
+        &anticlockwise,
+        MESH_VERTEX_STRIDE,
+        &[0u32, 1, 2],
+    ))?;
+    let other_way = device.create_mesh(&MeshDesc::new(
+        &clockwise,
+        MESH_VERTEX_STRIDE,
+        &[0u32, 1, 2],
+    ))?;
+
+    let magenta = clear(Color::new(1.0, 0.0, 1.0, 1.0));
+    let mut pixels = vec![0u8; target.byte_len()];
+    let middle = ((SIZE / 2 * SIZE + SIZE / 2) * 4) as usize;
+
+    for (facing, one_shows, other_shows) in [
+        (Facing::Both, true, true),
+        (Facing::Front, true, false),
+        (Facing::Back, false, true),
+    ] {
+        let pipeline = device.create_pipeline(
+            &PipelineDesc::mesh(builtin::MESH, TargetFormat::Rgba8Srgb, builtin::MESH_LAYOUT)
+                .facing(facing),
+        )?;
+        for (mesh, should_show, wound) in [
+            (&one_way, one_shows, "counter-clockwise"),
+            (&other_way, other_shows, "clockwise"),
+        ] {
+            let items = [Item::new(&pipeline).mesh(mesh)];
+            target.render(&RenderDesc::new(&[Pass::new(&magenta, &items)]))?;
+            target.read_back_into(&mut pixels);
+            let drawn = pixels[middle..middle + 4] == [0, 255, 0, 255];
+            assert_eq!(
+                drawn,
+                should_show,
+                "{facing:?}: a {wound} triangle {} drawn and {} have been - the cull flag is \
+                 wired to the wrong side, or to nothing",
+                if drawn { "was" } else { "was not" },
+                if should_show { "should" } else { "should not" }
+            );
+        }
+    }
+    Ok(())
+}
+
 /// **A draw over part of a mesh's index list.**
 ///
 /// The test above proves the index buffer is read, using a second mesh


### PR DESCRIPTION
Every pipeline drew both sides. For closed geometry that is half the
rasterisation thrown away: a triangle with its back to the camera is
either inside a solid, where nothing can see it, or behind one, where the
depth test discards it *after* it has been rasterised, shaded and tested
at full price. Dropping it before the rasteriser costs nothing — the
hardware decides from the sign of the triangle's screen-space area — and
`cull_mode` was hard-coded to `NONE` with no way to ask.

## What this adds

`PipelineDesc::facing(Facing::{Both, Front, Back})`.

**Per pipeline rather than per device, and that is the whole design.**
Closed solids want their backs dropped. Foliage, water surfaces, banners
and decals are meant to be seen from behind, and culling those makes
geometry vanish from one direction only — the hardest kind of rendering
fault to notice, because half the time it looks right. `Both` stays the
default for the same reason: it is never *wrong*, only sometimes
wasteful, and a default that can make geometry disappear is not a
default.

## The part I got wrong first, which is now the contract

**The rasteriser declares `FrontFace::CLOCKWISE`, and that is not a
typo.** Vulkan applies the front-face rule in **framebuffer** space,
where Y points down — so a triangle written counter-clockwise in clip
space, which is how every right-handed mesher winds the outside of a
solid, arrives at the rasteriser wound clockwise. Declaring the intuitive
`COUNTER_CLOCKWISE` makes `Facing::Front` cull precisely the geometry a
caller can see, and keep the geometry inside the rock.

It had no effect at all until now, because the cull mode was always
`NONE`. So this is a free choice made once, here, rather than a Y-flip
exported to every caller of this crate for ever.

I did not know that when I wrote it. **The first run of the test failed**,
reporting that `Front` had culled the counter-clockwise triangle — which
is exactly why the test renders the mirror pair rather than one case.

## Test

`a_pipeline_draws_the_side_of_a_triangle_it_was_asked_for` renders **one**
triangle both ways round under all three modes, on a real adapter with
the validation layer active:

| mode | counter-clockwise | clockwise |
|---|---|---|
| `Both` | drawn | drawn |
| `Front` | drawn | culled |
| `Back` | culled | drawn |

The same geometry with its corner order reversed, so nothing but the
winding can account for the difference. A cull flag wired to the wrong
side passes any test that only ever asks for one mode.

## Evidence

- `renew lint` clean.
- `renew test`: 240 suites, 0 failures.
- Every one of the 89 added lines in `pipeline.rs` is executed by the
  crate's own suite (llvm-cov), so no new coverage exemption. The
  manifest's one anchor in that file was shifted once from the final diff
  and re-read against the reason naming it.

## Probes

| broken | result |
|---|---|
| the two cull flags swapped | red |
| `FrontFace::COUNTER_CLOCKWISE`, the intuitive choice | red — the finding above, pinned |

## Tier

**T2** — additive public API on a `bootstrap` module. `PipelineDesc`
gains a field whose default preserves today's behaviour exactly, and
`Facing` is `#[non_exhaustive]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)