### PR TITLE
feat(render3d): the lit pass can drop the sides you cannot see

### DIFF
--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -171,7 +171,7 @@ reason = "The determinism emit half past its first child, plus the two arms that
 
 [[exempt]]
 file = "samples/cube/src/windowed.rs"
-lines = [633, 634, 635, 636, 637, 638, 712]
+lines = [634, 635, 636, 637, 638, 639, 713]
 reason = "The two places a window resize is acted on: rebuilding the crosshair for the new shape, and telling the swapchain its new size. Both need a real window-system resize, and the lane that measures coverage has none - its windowed runs happen under a virtual display with no window manager, so the window it opens is the only size it will ever be. Note for anyone running coverage on a desktop: these lines ARE covered there, because a real window manager sends a resize on the way up, and the gate will call this exemption stale. The gate that decides is the headless one. Everything these lines follow from is covered everywhere: record_present drives the recovery from a dormant swapchain with a constructed outcome, the resize event handler is driven with a constructed event, and the crosshair geometry is checked at four aspects without a device."
 
 [[exempt]]

--- a/coverage-exemptions.toml
+++ b/coverage-exemptions.toml
@@ -96,7 +96,7 @@ reason = "The settle arm for an entry that is neither sampled nor targeted. Unre
 
 [[exempt]]
 file = "crates/render3d/src/gpu.rs"
-lines = [1318, 1319]
+lines = [1336, 1337]
 reason = "The depthless-adapter arm of the shadow map's refusal, which translates the rendering crate's DepthUnsupported into this crate's own variant rather than reporting it as a texture failure. Unreachable wherever a depth format exists, which is every measuring lane's adapter: the format is chosen at device bring-up from a void query no fault layer can mutate, and the layer's quirk list carries no depthless-adapter quirk either. The sibling arm (any other creation failure) is driven by the R10 fault scenario."
 
 [[exempt]]

--- a/crates/render3d/README.md
+++ b/crates/render3d/README.md
@@ -29,6 +29,12 @@ mesh comes out, and a draw item goes into a frame the caller composes.
   brightly the scene is lit.
   One record for both, so the map cannot be written with one light and
   sampled with another; the caster simply reads fewer of its members.
+  `new` takes a `Facing` for the **lit** pass, so closed-solid geometry
+  can stop paying to rasterise its own backs; the caster deliberately
+  keeps both sides, because a shadow map wants the faces the *light*
+  sees and culling it by the eye's rule punches holes in shadows nowhere
+  near the camera. `Facing::Both` is what it has always done, and the
+  right answer for anything a viewer may see from behind.
   The light's fourth row is not carried: an orthographic projection over
   a rigid view is affine, so that row is exactly `(0, 0, 0, 1)` and both
   shaders write a literal one. Those sixteen bytes are what let a scene

--- a/crates/render3d/src/gpu.rs
+++ b/crates/render3d/src/gpu.rs
@@ -1269,6 +1269,23 @@ impl ShadowedCameraRenderer {
     /// Build the map at `shadow_size` texels square, both pipelines,
     /// and the bindings, uploading `pixels` as the atlas.
     ///
+    /// `facing` chooses which side of a triangle the **lit** pass draws.
+    /// `Facing::Both` is what this renderer has always done and is the
+    /// right answer for anything a viewer may see from behind. Geometry
+    /// that is a closed solid — a voxel world's outer shell, a set of
+    /// boxes — pays for its own backs under `Both`: every triangle
+    /// turned away from the camera is rasterised, shaded and depth
+    /// tested before being discarded. `Facing::Front` drops them at the
+    /// rasteriser instead, for free.
+    ///
+    /// **Only if the geometry is wound consistently outward.** A single
+    /// triangle wound the other way disappears the moment this is
+    /// anything but `Both`, and disappears *from one side only*, which
+    /// is a fault that looks like correct rendering half the time.
+    ///
+    /// The **caster** pass is not affected, deliberately — see the
+    /// comment where the two pipelines are built.
+    ///
     /// # Errors
     ///
     /// As [`TexturedCameraRenderer::new`], plus the shadow map's own
@@ -1283,6 +1300,7 @@ impl ShadowedCameraRenderer {
         extent: renew_rhi::Extent,
         pixels: &[u8],
         shadow_size: u32,
+        facing: renew_rhi::Facing,
     ) -> Result<Self, Render3dError> {
         let texture = device
             .create_texture(&renew_rhi::TextureDesc::colour(extent, pixels))
@@ -1329,11 +1347,24 @@ impl ShadowedCameraRenderer {
                 .push_constant_size(SHADOW_PUSH_BYTES)
                 .depth_state(renew_rhi::DepthState::read_write()),
         )?;
+        // **The lit pass takes the caller's cull mode; the caster above
+        // deliberately does not.** They draw the same meshes, so the
+        // temptation is to give them the same state — and it would be
+        // wrong. A shadow map wants every surface that can occlude
+        // light, and which faces those are depends on where the *light*
+        // is, not on where the eye is. Culling the caster by the eye's
+        // rule drops occluders the light can see and punches holes in
+        // shadows that are nowhere near the camera. Culling it by the
+        // light's rule is a real technique — front-face culling is how
+        // peter-panning is usually cured — but it is a *different*
+        // choice with a different failure mode, and folding it into this
+        // argument would make one flag mean two things.
         let lit = device.create_pipeline(
             &PipelineDesc::mesh(builtin::MESH_CAMERA_SHADOW, format, LAYOUT)
                 .push_constant_size(SHADOW_PUSH_BYTES)
                 .uniform_block(AIR_BYTES)
                 .sampled_bindings(2)
+                .facing(facing)
                 .depth_state(renew_rhi::DepthState::read_write()),
         )?;
         let air_binding = air_binding(device)?;

--- a/crates/render3d/tests/fault.rs
+++ b/crates/render3d/tests/fault.rs
@@ -27,7 +27,9 @@ use renew_render3d::{
     CameraRenderer, MeshRenderer, Render3dError, Scene, ShadowedCameraRenderer,
     TexturedCameraRenderer, TexturedMeshRenderer,
 };
-use renew_rhi::{Device, DeviceDesc, DeviceError, Extent, TargetError, TargetFormat, Validation};
+use renew_rhi::{
+    Device, DeviceDesc, DeviceError, Extent, Facing, TargetError, TargetFormat, Validation,
+};
 
 /// The CI lane sets this: a skip becomes a failure.
 fn strict() -> bool {
@@ -271,12 +273,25 @@ fn textured_constructors_report_their_own_failures() {
     // second proves the lit one's. A constructor that built them in
     // the other order, or that ignored the first result, would pass
     // one of these and fail the other.
+    // One construction, named once: the same six arguments appear at
+    // every arm below, and `cargo fmt` splits them over eight lines
+    // apiece.
+    let shadowed = |device: &Device| {
+        ShadowedCameraRenderer::new(
+            device,
+            TargetFormat::Rgba8Srgb,
+            small,
+            &WHITE,
+            64,
+            Facing::Both,
+        )
+    };
     for (label, ordinal) in [("R8", 1u32), ("R9", 2)] {
         arm(&format!(
             "vkCreateGraphicsPipelines=ERROR_OUT_OF_HOST_MEMORY@{ordinal}"
         ));
         let device = new_device().expect("the device should come up with only a pipeline armed");
-        match ShadowedCameraRenderer::new(&device, TargetFormat::Rgba8Srgb, small, &WHITE, 64) {
+        match shadowed(&device) {
             Err(error @ Render3dError::Pipeline(_)) => {
                 assert!(
                     error.to_string().starts_with("building the mesh pipeline:"),
@@ -296,7 +311,7 @@ fn textured_constructors_report_their_own_failures() {
     // at the atlas, which is fine.
     arm("vkCreateImage=ERROR_OUT_OF_HOST_MEMORY@2");
     let device = new_device().expect("device for R10");
-    match ShadowedCameraRenderer::new(&device, TargetFormat::Rgba8Srgb, small, &WHITE, 64) {
+    match shadowed(&device) {
         Err(error @ Render3dError::Texture(_)) => {
             assert!(
                 error.to_string().starts_with("creating the texture:"),

--- a/crates/render3d/tests/golden.rs
+++ b/crates/render3d/tests/golden.rs
@@ -1831,6 +1831,7 @@ fn a_caster_between_light_and_floor_dims_the_floor() -> Result<(), Box<dyn std::
         texture_extent,
         &white,
         256,
+        renew_rhi::Facing::Both,
     )?;
     let mesh = renderer.upload(&device, &scene)?;
 
@@ -1937,6 +1938,107 @@ fn a_caster_between_light_and_floor_dims_the_floor() -> Result<(), Box<dyn std::
     Ok(())
 }
 
+/// **The cull mode reaches the lit pass and not the caster, and a
+/// back-wound blocker proves both halves at once.**
+///
+/// `ShadowedCameraRenderer` builds two pipelines over the same meshes.
+/// Giving them one cull mode is the obvious thing and it is wrong: a
+/// shadow map wants every surface that can occlude the *light*, and
+/// which faces those are depends on where the light is, not where the
+/// eye is. Culling the caster by the eye's rule drops occluders and
+/// punches holes in shadows nowhere near the camera.
+///
+/// So the blocker here is wound **backwards** and the renderer is built
+/// `Facing::Front`. Two things must both be true, and each would hide
+/// the other's failure if only one were asked:
+///
+/// * the blocker is **not drawn** — the lit pass culled it,
+/// * its **shadow still falls** on the floor — the caster did not.
+///
+/// The floor is wound the normal way and stays visible throughout, so a
+/// render that drew nothing at all cannot pass either.
+#[test]
+fn the_cull_mode_reaches_the_lit_pass_and_spares_the_caster()
+-> Result<(), Box<dyn std::error::Error>> {
+    const SIZE: u32 = 64;
+    fn at(pixels: &[u8], x: u32, y: u32) -> [u8; 4] {
+        let i = ((y * SIZE + x) * 4) as usize;
+        [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+    }
+    let Some(device) = device_or_skip()? else {
+        return Ok(());
+    };
+    let extent = renew_rhi::Extent {
+        width: SIZE,
+        height: SIZE,
+    };
+    let mut target = device.create_offscreen_target(extent)?;
+
+    let mut scene = Scene::new();
+    full_quad(&mut scene, 0.3, [1.0, 1.0, 1.0, 1.0]);
+    // The same blocker as the shadow golden below, with its corners in
+    // the opposite order — the one difference that decides whether a
+    // `Front` pipeline draws it.
+    scene.quad(
+        [
+            [-0.25, 0.0, 0.8],
+            [0.25, 0.0, 0.8],
+            [0.25, -1.0, 0.8],
+            [-0.25, -1.0, 0.8],
+        ],
+        [1.0, 1.0, 1.0, 1.0],
+    );
+    let mut light_columns = IDENTITY;
+    light_columns[2][0] = 0.5;
+    let camera = ShadowedCamera::from_columns(IDENTITY, light_columns).through(Air::CLEAR_BLACK);
+
+    let renderer = ShadowedCameraRenderer::new(
+        &device,
+        TargetFormat::Rgba8Srgb,
+        renew_rhi::Extent {
+            width: 1,
+            height: 1,
+        },
+        &[255, 255, 255, 255],
+        256,
+        renew_rhi::Facing::Front,
+    )?;
+    let mesh = renderer.upload(&device, &scene)?;
+
+    let clear = [renew_rhi::color_attachment(Color::new(1.0, 0.0, 1.0, 1.0))];
+    let casting = [renderer.caster_item(&mesh, &camera)];
+    let items = [renderer.item(&mesh, &camera)];
+    let passes = [renderer.shadow_pass(&casting), pass(&clear, &items)];
+    target.render(&RenderDesc::new(&passes))?;
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+
+    // Where the blocker's own face would be, if it were drawn: inside
+    // the strip, in the half of the screen it covers.
+    let on_blocker = at(&pixels, SIZE / 2, SIZE / 4);
+    // Its shadow, cast onto the floor beside it.
+    let shadowed = at(&pixels, 11 * SIZE / 16, SIZE / 4);
+    // Open floor, well away from both.
+    let open = at(&pixels, SIZE / 4, 3 * SIZE / 4);
+
+    assert_ne!(
+        open,
+        [255, 0, 255, 255],
+        "the floor is wound the ordinary way and must still be drawn - if this is the clear \
+         colour the render produced nothing and the two claims below are vacuous"
+    );
+    assert_ne!(
+        on_blocker, open,
+        "a back-wound blocker was drawn by a Facing::Front lit pass"
+    );
+    assert_ne!(
+        shadowed, open,
+        "the back-wound blocker cast no shadow, so the caster was culled too - a shadow map \
+         needs the faces the LIGHT sees, not the ones the eye does"
+    );
+    Ok(())
+}
+
 /// **A scene light dims a shadowed world without moving its shadow** —
 /// the thing this path could not do until the light and the light's
 /// matrix fitted in one push block together.
@@ -2015,6 +2117,7 @@ fn a_scene_light_dims_a_shadowed_world_without_moving_its_shadow()
         texture_extent,
         &white,
         256,
+        renew_rhi::Facing::Both,
     )?;
     let mesh = renderer.upload(&device, &scene)?;
     let mut target = device.create_offscreen_target(extent)?;

--- a/crates/render3d/tests/zero_alloc.rs
+++ b/crates/render3d/tests/zero_alloc.rs
@@ -120,6 +120,7 @@ fn the_steady_state_shadowed_frame_allocates_nothing() {
         texture_extent,
         &white,
         SHADOW_MAP,
+        renew_rhi::Facing::Both,
     ) {
         Ok(renderer) => renderer,
         Err(Render3dError::DepthUnsupported { chain })

--- a/samples/cube/src/render.rs
+++ b/samples/cube/src/render.rs
@@ -343,6 +343,11 @@ pub(crate) fn draw_scene(
         },
         &crate::atlas::pixels(),
         SHADOW_MAP_SIZE,
+        // Both sides, which is what this sample has always drawn. Its
+        // geometry is a voxel shell and would take `Front` happily, but
+        // a sample exists to show the ordinary path and changing what it
+        // draws is not part of adding the option.
+        renew_rhi::Facing::Both,
     )
     .map_err(|error| RenderError::Refused(error.to_string()))?;
     let mesh = renderer

--- a/samples/cube/src/windowed.rs
+++ b/samples/cube/src/windowed.rs
@@ -515,6 +515,7 @@ impl CubeApp {
             },
             &crate::atlas::pixels(),
             crate::render::SHADOW_MAP_SIZE,
+            renew_rhi::Facing::Both,
         )
         .map_err(|error| format!("building the camera pipeline: {error}"))?;
         let grid = self.world.grid();


### PR DESCRIPTION
`ShadowedCameraRenderer` built both its pipelines with no cull mode, so
closed-solid geometry paid to rasterise, shade and depth-test every
triangle turned away from the camera before the depth test threw it out.
`PipelineDesc::facing` landed in #294; nothing above it could reach it.

`new` takes a `Facing` and gives it to the **lit** pass.

## The caster deliberately does not take it

Both pipelines draw the same meshes, so handing them one cull mode is the
obvious move — and it is wrong. A shadow map wants every surface that can
occlude **the light**, and which faces those are depends on where the
light is, not where the eye is. Culling the caster by the eye's rule
drops occluders and punches holes in shadows nowhere near the camera.

Culling it by the *light's* rule is a real technique — front-face culling
is the usual cure for peter-panning — but it is a different choice with a
different failure mode, and folding it into this argument would make one
flag mean two things.

## Test

`the_cull_mode_reaches_the_lit_pass_and_spares_the_caster` proves both
halves with one render, on a real adapter with the validation layer
active. The blocker is wound **backwards** and the renderer is built
`Facing::Front`, so:

- the blocker must **not** be drawn — the lit pass culled it;
- its shadow must **still fall** — the caster did not.

Either claim alone would hide the other's failure. The floor is wound the
ordinary way and asserted still visible, so a render that produced
nothing cannot pass either.

| broken | result |
|---|---|
| the caster given the same facing | red — "cast no shadow, so the caster was culled too" |
| the lit pass given none | red — "a back-wound blocker was drawn by a `Facing::Front` lit pass" |

## Evidence

- `renew lint` clean; `renew test` 240 suites, 0 failures.
- All 31 added lines in `gpu.rs` are executed by the crate's own suite
  (llvm-cov), so no new coverage exemption. The manifest's one anchor in
  that file was shifted once from the final diff and re-read against the
  reason naming it.

## Tier

**T2** — a breaking signature change on a `bootstrap` module, which §12
makes free. Seven call sites, all in this crate's own tests and the cube
sample, every one passing `Facing::Both`, so behaviour is unchanged. The
two in `fault.rs` are hoisted into one named closure rather than
repeated: six arguments split over eight lines apiece took that function
past the line limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)