### PR TITLE
feat(render2d): a renderer can slide and fade a run of sprites

### DIFF
--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -48,8 +48,12 @@ else, which the build matrix proves by building and testing without it.
   here is zero.
 - `SpriteRenderer` — `new` uploads the atlas and builds the pipeline
   (premultiplied blending, nearest/clamped sampling) and the per-frame
-  buffer; `begin`/`push` fill; `item` is the frame's draw, for a pass
-  the caller composes with `renew_rhi::color_attachment(clear)`:
+  buffer; `begin`/`push` fill; `set_offset` and `set_alpha` move and
+  fade every sprite pushed after them, so a whole group slides or
+  dissolves without the code that builds each sprite knowing (the fade
+  scales all four premultiplied channels, and `begin` resets both);
+  `item` is the frame's draw, for a pass the caller composes with
+  `renew_rhi::color_attachment(clear)`:
 
   ```rust
   let color = [renew_rhi::color_attachment(SKY)];
@@ -66,9 +70,12 @@ exists anywhere in the crate.
 
 Unit tests pin the maps (all four canvas corners, exact) and the packed
 bytes against hand-written records; a property test holds the ortho map
-monotone, corner-exact, and invertible over random canvases. A computed
-image oracle proves placement, region selection, and fill-order
-overwrite byte-exactly on every adapter; a committed golden proves the
+monotone, corner-exact, and invertible over random canvases, and two
+more hold the batch fade to the premultiplied rule (every channel by
+the same factor, composing to the product, never brightening) and the
+batch offsets to adding. A computed image oracle proves placement,
+region selection, fill-order overwrite and the batch offset byte-exactly
+on every adapter; a committed golden proves the
 premultiplied compositing convention on the pinned software-rasterizer
 lane, with the same candidate/provenance ritual as the rendering
 crate's goldens. Two scheduled facts about the oracles: the computed

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -158,6 +158,44 @@ pub(crate) fn to_uv(texel: Vec2, atlas: Extent) -> Vec2 {
     Vec2::new(texel.x / atlas.width as f32, texel.y / atlas.height as f32)
 }
 
+/// `alpha` as an opacity: clamped to `0.0..=1.0`.
+///
+/// # Panics
+///
+/// On NaN. `f32::clamp` passes NaN straight through, so an unguarded
+/// clamp would multiply it into all four channels of every later
+/// sprite and draw nothing, frame after frame, with no error anywhere
+/// — a silent wrong picture rather than a named refusal. Infinities
+/// need no such guard: they clamp.
+///
+/// Split from the renderer so the refusal can be exercised without a
+/// device, which is the only way it gets exercised at all.
+pub(crate) fn fade(alpha: f32) -> f32 {
+    assert!(!alpha.is_nan(), "a NaN fade has no opacity to mean");
+    alpha.clamp(0.0, 1.0)
+}
+
+/// `sprite` moved by `offset` and faded to `alpha` of its opacity.
+///
+/// The whole of what a renderer's batch offset and fade do to one
+/// sprite, in one place, so it can be checked without a device.
+///
+/// **The tint is premultiplied, so the fade scales all four channels
+/// and not just the fourth.** In premultiplied RGBA the colour already
+/// carries its own alpha; halving only the alpha leaves the colour
+/// arriving at full strength while occluding less, so the sprite
+/// BRIGHTENS as it fades. Scaling the whole tuple is what "half as
+/// opaque" means under this convention.
+pub(crate) fn placed(sprite: &Sprite, offset: (f32, f32), alpha: f32) -> Sprite {
+    let mut moved = *sprite;
+    moved.x += offset.0;
+    moved.y += offset.1;
+    for channel in &mut moved.tint {
+        *channel *= alpha;
+    }
+    moved
+}
+
 /// One instance record, packed exactly as the layout slice declares:
 /// NDC min, NDC max, UV min, UV max — each two `f32`s — then the
 /// four-`f32` tint, native-endian, in declaration order.
@@ -214,6 +252,176 @@ mod tests {
     /// these maps promise identities, not approximations.
     fn bits(v: Vec2) -> (u32, u32) {
         (v.x.to_bits(), v.y.to_bits())
+    }
+
+    /// Exact tint claims compare bits, beside `bits` above and for the
+    /// same reason: these are identities, not approximations. A fade of
+    /// one half is an exponent decrement, so it is bit-exact.
+    fn tint_bits(tint: [f32; 4]) -> [u32; 4] {
+        tint.map(f32::to_bits)
+    }
+
+    fn swatch() -> Sprite {
+        Sprite::new(
+            Region {
+                x: 4,
+                y: 8,
+                width: 16,
+                height: 16,
+            },
+            10.0,
+            20.0,
+        )
+        .size(32.0, 48.0)
+        .tint([0.8, 0.4, 0.2, 0.5])
+    }
+
+    /// A fade is clamped, and a NaN fade is refused by name.
+    ///
+    /// Infinities clamp; NaN does not, which is the whole reason the
+    /// guard exists. The asymmetry is asserted rather than left to be
+    /// rediscovered.
+    #[test]
+    fn a_fade_clamps_its_range() {
+        assert_eq!(fade(2.0).to_bits(), 1.0f32.to_bits());
+        assert_eq!(fade(-1.0).to_bits(), 0.0f32.to_bits());
+        assert_eq!(fade(f32::INFINITY).to_bits(), 1.0f32.to_bits());
+        assert_eq!(fade(f32::NEG_INFINITY).to_bits(), 0.0f32.to_bits());
+        assert_eq!(fade(0.25).to_bits(), 0.25f32.to_bits());
+        // The fact the guard rests on: clamp does NOT filter NaN.
+        assert!(
+            f32::NAN.clamp(0.0, 1.0).is_nan(),
+            "clamp began filtering NaN"
+        );
+    }
+
+    /// Probed by dropping the assert from `fade`: this stops panicking
+    /// and goes red.
+    #[test]
+    #[should_panic(expected = "NaN fade")]
+    fn a_nan_fade_is_refused() {
+        let _ = fade(f32::NAN);
+    }
+
+    /// An offset moves a sprite and changes nothing else about it.
+    ///
+    /// The batch offset exists so a caller can slide a whole group
+    /// without the code that builds each sprite knowing the group is
+    /// moving. If it touched the size, the region or the tint it would
+    /// stop being a slide.
+    #[test]
+    fn an_offset_moves_a_sprite_and_leaves_the_rest_alone() {
+        let before = swatch();
+        let after = placed(&before, (7.0, -3.0), 1.0);
+        assert_eq!((after.x, after.y), (17.0, 17.0));
+        assert_eq!((after.width, after.height), (before.width, before.height));
+        assert_eq!(after.region, before.region);
+        assert_eq!(
+            tint_bits(after.tint),
+            tint_bits(before.tint),
+            "an offset recoloured the sprite"
+        );
+        // Identity really is identity.
+        assert_eq!(placed(&before, (0.0, 0.0), 1.0), before);
+    }
+
+    /// **A fade scales all four channels, because the tint is
+    /// premultiplied.**
+    ///
+    /// Halving only the fourth would leave the colour arriving at full
+    /// strength while occluding less, so the sprite brightens as it
+    /// fades - the opposite of the intent, and the classic way to get
+    /// premultiplied alpha wrong.
+    ///
+    /// Probed by fading only `tint[3]`: red on the first channel, which
+    /// is exactly the bug.
+    #[test]
+    fn a_fade_scales_every_channel_because_the_tint_is_premultiplied() {
+        let after = placed(&swatch(), (0.0, 0.0), 0.5);
+        assert_eq!(
+            tint_bits(after.tint),
+            tint_bits([0.4, 0.2, 0.1, 0.25]),
+            "the fade did not scale the premultiplied colour with its alpha"
+        );
+        // Fully faded is fully gone, in every channel - a sprite that
+        // still carries colour at zero alpha is a sprite that adds
+        // light to whatever it is drawn over.
+        assert_eq!(
+            tint_bits(placed(&swatch(), (0.0, 0.0), 0.0).tint),
+            tint_bits([0.0; 4])
+        );
+    }
+
+    proptest! {
+        /// Fading twice is fading once by the product, and a fade never
+        /// makes a sprite more opaque than it was.
+        ///
+        /// The composition law is what lets a caller nest a fading
+        /// group inside a fading group without the two multiplying
+        /// wrongly, and it is the property a channel-by-channel
+        /// implementation can break silently.
+        #[test]
+        fn fades_compose_and_never_brighten(
+            a in 0.0f32..=1.0,
+            b in 0.0f32..=1.0,
+        ) {
+            let once = placed(&placed(&swatch(), (0.0, 0.0), a), (0.0, 0.0), b);
+            let twice = placed(&swatch(), (0.0, 0.0), a * b);
+            for (x, y) in once.tint.iter().zip(twice.tint) {
+                prop_assert!(
+                    (x - y).abs() <= 1e-6,
+                    "fading by {a} then {b} is not fading by their product"
+                );
+            }
+            for (faded, full) in once.tint.iter().zip(swatch().tint) {
+                prop_assert!(*faded <= full + 1e-6, "a fade brightened a channel");
+            }
+            // **Every channel by the SAME factor**, which is the
+            // premultiplied rule stated as a property. Without this the
+            // property passes an alpha-only fade: the colour channels
+            // stay put, so they still compose and still never brighten
+            // - they are simply wrong. Found by probing, when the exact
+            // test went red here and this one did not.
+            let single = placed(&swatch(), (0.0, 0.0), a);
+            for (faded, full) in single.tint.iter().zip(swatch().tint) {
+                prop_assert!(
+                    (faded - full * a).abs() <= 1e-6,
+                    "a fade of {a} scaled a channel to {faded} from {full}"
+                );
+            }
+        }
+
+        /// Offsets add, and they never touch the tint.
+        #[test]
+        fn offsets_add(
+            ax in -4000.0f32..4000.0,
+            ay in -4000.0f32..4000.0,
+            bx in -4000.0f32..4000.0,
+            by in -4000.0f32..4000.0,
+        ) {
+            let twice = placed(&placed(&swatch(), (ax, ay), 1.0), (bx, by), 1.0);
+            let once = placed(&swatch(), (ax + bx, ay + by), 1.0);
+            // **Bounded by the INTERMEDIATES, not the result.** Float
+            // addition is not associative, and the error in summing
+            // three terms scales with the sum of their magnitudes -
+            // not with the answer. Two offsets that nearly cancel
+            // (2046.2 and -1952.1, which proptest found at four
+            // thousand cases) leave a result near a hundred carrying
+            // the rounding of an intermediate near two thousand, so a
+            // tolerance keyed on the result is off by a factor of
+            // twenty. A fixed 1e-3 was worse: it sat exactly on the
+            // f32 ulp at this range, so the test would have passed or
+            // failed on where the generator happened to land.
+            let bound = (swatch().x.abs() + ax.abs() + bx.abs()).max(1.0) * f32::EPSILON * 4.0;
+            prop_assert!(
+                (twice.x - once.x).abs() <= bound,
+                "x differed by {} against a bound of {bound}",
+                (twice.x - once.x).abs()
+            );
+            let bound_y = (swatch().y.abs() + ay.abs() + by.abs()).max(1.0) * f32::EPSILON * 4.0;
+            prop_assert!((twice.y - once.y).abs() <= bound_y);
+            prop_assert_eq!(tint_bits(twice.tint), tint_bits(swatch().tint));
+        }
     }
 
     #[test]

--- a/crates/render2d/src/gpu.rs
+++ b/crates/render2d/src/gpu.rs
@@ -133,6 +133,8 @@ pub struct SpriteRenderer {
     max_sprites: u32,
     canvas: Canvas,
     atlas_extent: Extent,
+    offset: (f32, f32),
+    alpha: f32,
 }
 
 impl SpriteRenderer {
@@ -186,6 +188,8 @@ impl SpriteRenderer {
             max_sprites: max_sprites.get(),
             canvas,
             atlas_extent: atlas.extent,
+            offset: (0.0, 0.0),
+            alpha: 1.0,
         })
     }
 
@@ -197,6 +201,58 @@ impl SpriteRenderer {
     /// empty frame.
     pub fn begin(&mut self) {
         self.count = 0;
+        // The offset and the fade reset with the fill. They are state
+        // that changes what a later call draws, and state that
+        // outlives the frame that set it is the kind a caller forgets
+        // to clear exactly once and then cannot find.
+        self.offset = (0.0, 0.0);
+        self.alpha = 1.0;
+    }
+
+    /// Move every sprite pushed after this by (`x`, `y`) logical
+    /// pixels.
+    ///
+    /// Lets a caller slide a whole group — a panel, a page, a row of
+    /// cards — without threading an offset through the code that
+    /// builds each sprite. Set it back to `(0.0, 0.0)` when the group
+    /// ends; [`Self::begin`] does that for the next fill.
+    pub fn set_offset(&mut self, x: f32, y: f32) {
+        self.offset = (x, y);
+    }
+
+    /// The offset every later push is moved by.
+    #[must_use]
+    pub fn offset(&self) -> (f32, f32) {
+        self.offset
+    }
+
+    /// Fade every sprite pushed after this to `alpha` of its opacity,
+    /// clamped to `0.0..=1.0`.
+    ///
+    /// # Panics
+    ///
+    /// On a NaN `alpha`. `f32::clamp` passes NaN straight through, so
+    /// an unguarded clamp would multiply it into all four channels of
+    /// every later sprite and draw nothing, frame after frame, with no
+    /// error anywhere — a silent wrong picture rather than a named
+    /// refusal. Infinities need no such guard: they clamp.
+    ///
+    /// **The tint is premultiplied, so this scales all four channels
+    /// and not just the fourth.** In premultiplied RGBA the colour
+    /// already carries its own alpha, so halving only the alpha leaves
+    /// the colour arriving at full strength while occluding less — the
+    /// group brightens as it fades, which is the opposite of the
+    /// intent. Scaling the whole tuple is what "half as opaque" means
+    /// under this convention, and the convention is the crate's, end
+    /// to end.
+    pub fn set_alpha(&mut self, alpha: f32) {
+        self.alpha = fill::fade(alpha);
+    }
+
+    /// The fade every later push is multiplied by.
+    #[must_use]
+    pub fn alpha(&self) -> f32 {
+        self.alpha
     }
 
     /// Append `sprite`; it draws over everything pushed before it.
@@ -218,7 +274,13 @@ impl SpriteRenderer {
             "sprite capacity {} exceeded; size the renderer for its scene",
             self.max_sprites
         );
-        let packed = fill::pack(sprite, self.canvas, self.atlas_extent);
+        // Applied here rather than by the caller, which is the whole
+        // point: the code that builds a sprite should not have to know
+        // whether the group it belongs to is mid-slide. The arithmetic
+        // lives in `fill::placed` so it can be checked without a
+        // device.
+        let moved = fill::placed(sprite, self.offset, self.alpha);
+        let packed = fill::pack(&moved, self.canvas, self.atlas_extent);
         let offset = self.count as usize * fill::INSTANCE_STRIDE;
         self.scratch[offset..offset + fill::INSTANCE_STRIDE].copy_from_slice(&packed);
         self.count += 1;

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -240,10 +240,27 @@ fn opaque_sprites_match_the_computed_image_exactly() {
 
     // Three sprites, texel-aligned, the third overlapping the first —
     // push order is draw order, so blue wins the overlap.
+    //
+    // The blue sprite is authored eight pixels LEFT of where the
+    // expected image paints it and reaches its place through the
+    // renderer's batch offset, so the offset is proved by the same
+    // exact oracle as everything else: drop the `set_offset` call and
+    // blue lands at (8, 16), which the computed image refuses. A fade
+    // past one clamps to exactly one, which keeps every sprite opaque
+    // and the oracle exact — the clamp is asserted through the
+    // renderer rather than only through the pure function beneath it.
     renderer.begin();
+    renderer.set_alpha(2.0);
+    assert_eq!(
+        renderer.alpha().to_bits(),
+        1.0f32.to_bits(),
+        "a fade past one must clamp to one"
+    );
     renderer.push(&Sprite::new(RED, 8.0, 8.0).size(16.0, 16.0));
     renderer.push(&Sprite::new(GREEN, 32.0, 8.0).size(16.0, 16.0));
-    renderer.push(&Sprite::new(BLUE, 16.0, 16.0).size(16.0, 16.0));
+    renderer.set_offset(8.0, 0.0);
+    assert_eq!(renderer.offset(), (8.0, 0.0), "the offset must read back");
+    renderer.push(&Sprite::new(BLUE, 8.0, 16.0).size(16.0, 16.0));
     let color = [renew_rhi::color_attachment(CLEAR)];
     let items = [renderer.item()];
     let passes = [Pass::new(&color, &items)];
@@ -263,12 +280,23 @@ fn opaque_sprites_match_the_computed_image_exactly() {
     let mut second = vec![0u8; target.byte_len()];
     target.read_back_into(&mut second);
     assert_eq!(pixels, second, "same frame rendered twice diverged");
+    // A new fill forgets the offset and the fade along with the
+    // sprites: state that outlives the fill that set it is the kind a
+    // caller clears exactly once and then cannot find.
+    renderer.begin();
+    assert_eq!(renderer.offset(), (0.0, 0.0), "begin must reset the offset");
+    assert_eq!(
+        renderer.alpha().to_bits(),
+        1.0f32.to_bits(),
+        "begin must reset the fade"
+    );
     drop(target);
     drop(renderer);
     assert_no_validation_errors(&device);
 
     // The expected image, computed by the same painter's algorithm the
-    // fill promises: clear, then each sprite's rectangle in push order.
+    // fill promises: clear, then each sprite's rectangle in push order
+    // — blue where the offset put it, not where it was authored.
     let mut expected = Vec::with_capacity((SIZE * SIZE * 4) as usize);
     for _ in 0..SIZE * SIZE {
         expected.extend_from_slice(&clear_bytes());


### PR DESCRIPTION
`SpriteRenderer` gains an offset and a fade that apply to every sprite
pushed after them, so a caller can move or dissolve a whole group -- a
panel, a page, a row of cards -- without threading either through the
code that builds each sprite. Both reset with `begin`, because state
that outlives the fill that set it is the kind a caller forgets to
clear exactly once and then cannot find.

The fade scales all four tint channels rather than the fourth alone.
The tint is premultiplied, so the colour already carries its own
alpha; halving only the alpha would leave the colour arriving at full
strength while occluding less, and the group would brighten as it
faded. Scaling the whole tuple is what half as opaque means under this
convention.

`fill::placed` and `fill::fade` hold the arithmetic and the range
check, so both can be exercised without a device -- the renderer needs
one, and an assertion nothing can reach is an assertion nobody has
checked. A NaN fade is refused by name: `f32::clamp` passes NaN
through, so an unguarded clamp would multiply it into every channel of
every later sprite and draw nothing, frame after frame, with no error
anywhere.

Named offset rather than origin: `Sprite` reserves origin for the
per-sprite pivot a later version adds, and a translation is not a
pivot.

Six tests, two of them properties: an offset moves a sprite and
recolours nothing; a fade scales every channel; fades compose to their
product and never brighten; offsets add; the range clamps at both ends
and on both infinities; NaN is refused.

The offsets-add property bounds its tolerance by the sum of the
magnitudes it adds, not by the answer. Float addition is not
associative, and two offsets that nearly cancel -- 2046.2 and -1952.1,
which the generator found -- leave a result near a hundred carrying
the rounding of an intermediate near two thousand. A tolerance keyed
on the result is short by a factor of twenty, and the fixed one it
replaced sat exactly on the f32 ulp at this range, so the property
would have passed or failed on where the generator happened to land.
Stable over thirty-two thousand cases.


## Evidence

- `cargo build --workspace`, `cargo test --workspace`, `cargo fmt --all --check`
  and `cargo clippy --workspace --all-targets -- -D warnings` all exit 0 on
  this tree (Windows, stable toolchain); no failing suite in the output.
- The golden suite ran on a discrete adapter here and skips the exact
  compare by design; no picture changes in this branch, so the pinned
  lane's goldens are expected to carry over untouched.
