### PR TITLE
feat(render2d): a sprite can be mirrored, and its packer is public and benchmarked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,8 @@ dependencies = [
  "renew-memory",
  "renew-particles",
  "renew-platform",
+ "renew-render2d",
+ "renew-rhi",
  "renew-rng",
  "renew-ui",
  "renew-ui-render",

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -46,13 +46,15 @@ renew-particles = { path = "../../crates/particles" }
 # times the solve, the re-solve, and the snapshot copy.
 renew-ui = { path = "../../crates/ui" }
 renew-ui-render = { path = "../../crates/ui-render" }
-# Bench-target-only: the sprite construction chain the presenter runs
-# per quad is device-free, so it is timed here even though the packer
-# behind it is only reachable through a GPU device.
+# Bench-target-only: the sprite construction chain a presenter runs per
+# quad and, through `Sprite::instance`, the packer beneath it — both
+# device-free.
 renew-render2d = { path = "../../crates/render2d" }
 # Bench-target-only, and only for the atlas extent type the packer's
-# device-free entry point takes; no feature, so no windowing or GPU
-# crate enters this graph (the 2D renderer takes it the same way).
+# device-free entry point takes; no feature, so no windowing crate
+# enters this graph. The Vulkan bindings ride along as the rendering
+# crate's runtime-loaded dependency, as they already did through the
+# presenter above.
 renew-rhi = { path = "../../crates/rhi", default-features = false }
 
 [lints]

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -46,6 +46,14 @@ renew-particles = { path = "../../crates/particles" }
 # times the solve, the re-solve, and the snapshot copy.
 renew-ui = { path = "../../crates/ui" }
 renew-ui-render = { path = "../../crates/ui-render" }
+# Bench-target-only: the sprite construction chain the presenter runs
+# per quad is device-free, so it is timed here even though the packer
+# behind it is only reachable through a GPU device.
+renew-render2d = { path = "../../crates/render2d" }
+# Bench-target-only, and only for the atlas extent type the packer's
+# device-free entry point takes; no feature, so no windowing or GPU
+# crate enters this graph (the 2D renderer takes it the same way).
+renew-rhi = { path = "../../crates/rhi", default-features = false }
 
 [lints]
 workspace = true
@@ -88,4 +96,8 @@ harness = false
 
 [[bench]]
 name = "ui"
+harness = false
+
+[[bench]]
+name = "sprite"
 harness = false

--- a/bench/suite/benches/sprite.rs
+++ b/bench/suite/benches/sprite.rs
@@ -1,4 +1,5 @@
-//! The sprite construction chain, at the rate a presenter runs it.
+//! The sprite construction chain and the packer beneath it, at the rate
+//! a presenter runs them.
 //!
 //! `UiPresenter::emit` builds one sprite per quad per frame from a
 //! compile-time-constant atlas region:
@@ -7,22 +8,19 @@
 //! sprites.push(&Sprite::new(atlas::white(), q.x, q.y).size(..).tint(..));
 //! ```
 //!
-//! Everything in that line except `push` is device-free, so it can be
-//! timed here while the packer itself — `pub(crate)`, reachable only
-//! through a `SpriteRenderer` that needs a GPU device — cannot.
+//! Everything in that line except `push` is device-free and is timed
+//! here as `sprite_build_2048`; the packer `push` runs afterwards is
+//! reachable without a device through `Sprite::instance` and is timed
+//! as `sprite_pack_2048`. Both exist so that a change to `Sprite`'s
+//! layout, to its constructor or to the packer's arithmetic has a
+//! before.
 //!
-//! **What this exists to catch.** A whole `Region` reaches the packer
-//! through an integer-to-float widening. When the region is a constant,
-//! that widening is loop-invariant over the entire frame and should cost
-//! nothing — but it can only be hoisted if the constructor is visible to
-//! the caller's optimiser, and nothing here is generic, the workspace
-//! sets no LTO, so visibility means `#[inline]` and only `#[inline]`.
-//! Without it the engine re-converts the same four constants once per
-//! quad per frame, and once per *character* of every label.
-//!
-//! The region is deliberately **not** wrapped in `black_box`: its
-//! constancy is the property under test, and hiding it would measure a
-//! different program. Only the results are fenced.
+//! The region is deliberately **not** wrapped in `black_box`: a
+//! presenter's region is a constant at the call site, and hiding it
+//! would measure a different program. Whether that constant's widening
+//! hoists out of the loop was measured with and without `#[inline]` on
+//! the constructor and builders; the ranges overlapped, so no attribute
+//! is carried. Only the results are fenced.
 
 use std::hint::black_box;
 
@@ -62,9 +60,9 @@ fn sprite_chain(c: &mut Criterion) {
         let rects = destinations();
         b.iter(|| {
             // Each sprite is fenced by reference, not folded into a
-            // scalar. `push` takes `&Sprite` from another crate, so all
-            // 48 bytes must genuinely exist; a fold would let the
-            // optimiser delete the struct and time a different program.
+            // scalar. `push` takes `&Sprite` from another crate, so the
+            // whole struct must genuinely exist; a fold would let the
+            // optimiser delete it and time a different program.
             for rect in &rects {
                 let sprite = Sprite::new(WHITE, rect[0], rect[1])
                     .size(rect[2], rect[3])
@@ -80,8 +78,8 @@ criterion_group!(benches, sprite_chain);
 /// The packer itself: every sprite the chain above builds, turned into
 /// its instance record without a device. `Sprite::instance` is what
 /// `SpriteRenderer::push` runs after applying the batch state, so this
-/// is the per-sprite cost of the fill minus one copy into the frame's
-/// scratch.
+/// is the per-sprite cost of the fill minus the batch placement, the
+/// capacity assertion and the copy into the frame's scratch.
 fn sprite_pack(c: &mut Criterion) {
     c.bench_function("sprite_pack_2048", |b| {
         let Some(canvas) = Canvas::new(320, 240) else {

--- a/bench/suite/benches/sprite.rs
+++ b/bench/suite/benches/sprite.rs
@@ -1,0 +1,110 @@
+//! The sprite construction chain, at the rate a presenter runs it.
+//!
+//! `UiPresenter::emit` builds one sprite per quad per frame from a
+//! compile-time-constant atlas region:
+//!
+//! ```ignore
+//! sprites.push(&Sprite::new(atlas::white(), q.x, q.y).size(..).tint(..));
+//! ```
+//!
+//! Everything in that line except `push` is device-free, so it can be
+//! timed here while the packer itself — `pub(crate)`, reachable only
+//! through a `SpriteRenderer` that needs a GPU device — cannot.
+//!
+//! **What this exists to catch.** A whole `Region` reaches the packer
+//! through an integer-to-float widening. When the region is a constant,
+//! that widening is loop-invariant over the entire frame and should cost
+//! nothing — but it can only be hoisted if the constructor is visible to
+//! the caller's optimiser, and nothing here is generic, the workspace
+//! sets no LTO, so visibility means `#[inline]` and only `#[inline]`.
+//! Without it the engine re-converts the same four constants once per
+//! quad per frame, and once per *character* of every label.
+//!
+//! The region is deliberately **not** wrapped in `black_box`: its
+//! constancy is the property under test, and hiding it would measure a
+//! different program. Only the results are fenced.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_render2d::{Canvas, Region, Sprite};
+use renew_rhi::Extent;
+
+/// Quads per frame, matching the presenter's own ceiling at the tree
+/// size the `ui` suite benches: `max_quads` is twice the node count,
+/// and that suite stands at 1,024 nodes.
+const QUADS: usize = 2048;
+
+/// The white texel every plain background quad samples — a constant at
+/// the real call site, and a constant here.
+const WHITE: Region = Region {
+    x: 2,
+    y: 2,
+    width: 4,
+    height: 4,
+};
+
+/// Destinations that vary per quad, so only the source is invariant.
+fn destinations() -> Vec<[f32; 4]> {
+    let mut out = Vec::with_capacity(QUADS);
+    // Counted in `f32` rather than cast from the index: the cast is
+    // denied here and the counter is exact for every value this reaches.
+    let mut n = 0.0f32;
+    while out.len() < QUADS {
+        out.push([n * 0.5, n * 0.25, 8.0 + n * 0.125, 6.0 + n * 0.0625]);
+        n += 1.0;
+    }
+    out
+}
+
+fn sprite_chain(c: &mut Criterion) {
+    c.bench_function("sprite_build_2048", |b| {
+        let rects = destinations();
+        b.iter(|| {
+            // Each sprite is fenced by reference, not folded into a
+            // scalar. `push` takes `&Sprite` from another crate, so all
+            // 48 bytes must genuinely exist; a fold would let the
+            // optimiser delete the struct and time a different program.
+            for rect in &rects {
+                let sprite = Sprite::new(WHITE, rect[0], rect[1])
+                    .size(rect[2], rect[3])
+                    .tint([1.0, 1.0, 1.0, 1.0]);
+                black_box(&sprite);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, sprite_chain);
+
+/// The packer itself: every sprite the chain above builds, turned into
+/// its instance record without a device. `Sprite::instance` is what
+/// `SpriteRenderer::push` runs after applying the batch state, so this
+/// is the per-sprite cost of the fill minus one copy into the frame's
+/// scratch.
+fn sprite_pack(c: &mut Criterion) {
+    c.bench_function("sprite_pack_2048", |b| {
+        let Some(canvas) = Canvas::new(320, 240) else {
+            unreachable!("320 by 240 is nonzero");
+        };
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let sprites: Vec<Sprite> = destinations()
+            .iter()
+            .map(|rect| Sprite::new(WHITE, rect[0], rect[1]).size(rect[2], rect[3]))
+            .collect();
+        b.iter(|| {
+            for sprite in &sprites {
+                // Fenced by value: the record is forty-eight bytes the
+                // renderer would copy into its scratch, and a fold would
+                // let the optimiser skip lanes nothing reads.
+                black_box(sprite.instance(canvas, atlas));
+            }
+        });
+    });
+}
+
+criterion_group!(packing, sprite_pack);
+criterion_main!(benches, packing);

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -42,7 +42,11 @@ else, which the build matrix proves by building and testing without it.
 - `Canvas`, `Region`, `Sprite` — the pure vocabulary: a logical pixel
   space (y down from the top-left), a rectangle of atlas texels, and
   one placed, sized, tinted sprite.
-- `AtlasDesc` — dimensions plus premultiplied RGBA8 bytes. This crate
+- `AtlasDesc` — dimensions plus **authored, straight-alpha** RGBA8
+  bytes: the hardware decodes them on sample and the fragment stage
+  premultiplies afterwards, so handing this API already-premultiplied
+  bytes double-multiplies them. (This line said "premultiplied" until
+  2026-09-03, contradicting the type's own doc.) This crate
   parses nothing: where the bytes come from (an asset pack, a test
   fixture) is the caller's business, and the untrusted-input surface
   here is zero.
@@ -65,6 +69,27 @@ else, which the build matrix proves by building and testing without it.
 The ortho and UV maps run on the CPU at push time — each instance
 carries its own NDC rectangle, so no uniform, matrix, or push constant
 exists anywhere in the crate.
+
+## The instance record
+
+Every sprite becomes one 48-byte record: five attributes, twelve
+`f32`s, native-endian, in the order the vertex stage declares them.
+
+| location | attribute | content |
+|---|---|---|
+| 0 | `Vec2` | NDC min corner |
+| 1 | `Vec2` | NDC max corner |
+| 2 | `Vec2` | UV min |
+| 3 | `Vec2` | UV max |
+| 4 | `Vec4` | premultiplied tint |
+
+`Sprite::instance(canvas, atlas)` packs one without a device, as an
+opaque `Instance` whose `bytes()` are what `push` writes when no batch
+offset or fade is set — `push` applies the batch state first, then
+packs. Public so the packer can be timed and pinned; opaque so the
+layout stays the pipeline's: the shader's locations, the layout slice
+in the device half and the packer describe the same bytes and change
+together.
 
 ## Testing
 

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -18,10 +18,13 @@ else, which the build matrix proves by building and testing without it.
 - **Fill order is draw order.** Sprites composite in exactly the order
   pushed — painter's algorithm. **No sort keys, no batch splitting**; a
   caller that wants order sorts before pushing.
-- **Everything is premultiplied.** Atlas texels and tints alike carry
-  their alpha multiplied into their color channels, and the pipeline
-  composites `src + dst * (1 - src.a)`. Bytes that break the convention
-  composite wrong — visibly, not unsafely.
+- **Everything composites premultiplied.** Atlas bytes are authored,
+  straight alpha: the hardware decodes them on sample and the fragment
+  stage multiplies each texel's colour by its alpha. Tints are
+  premultiplied by the caller. The pipeline composites
+  `src + dst * (1 - src.a)`. Bytes that break either convention —
+  already-premultiplied atlas bytes, a straight-alpha tint — composite
+  wrong, visibly, not unsafely.
 - **All allocations happen at creation.** `begin`, `push`, and `item`
   allocate nothing; a gate measures it over frames it first proves are
   alive and drawing — including the caller-side frame composition,
@@ -50,11 +53,9 @@ else, which the build matrix proves by building and testing without it.
 - `AtlasDesc` — dimensions plus **authored, straight-alpha** RGBA8
   bytes: the hardware decodes them on sample and the fragment stage
   premultiplies afterwards, so handing this API already-premultiplied
-  bytes double-multiplies them. (This line said "premultiplied" until
-  2026-09-03, contradicting the type's own doc.) This crate
-  parses nothing: where the bytes come from (an asset pack, a test
-  fixture) is the caller's business, and the untrusted-input surface
-  here is zero.
+  bytes double-multiplies them. This crate parses nothing: where the
+  bytes come from (an asset pack, a test fixture) is the caller's
+  business, and the untrusted-input surface here is zero.
 - `SpriteRenderer` — `new` uploads the atlas and builds the pipeline
   (premultiplied blending, nearest/clamped sampling) and the per-frame
   buffer; `begin`/`push` fill; `set_offset` and `set_alpha` move and
@@ -84,8 +85,8 @@ Every sprite becomes one 48-byte record: five attributes, twelve
 |---|---|---|
 | 0 | `Vec2` | NDC min corner |
 | 1 | `Vec2` | NDC max corner |
-| 2 | `Vec2` | UV min |
-| 3 | `Vec2` | UV max |
+| 2 | `Vec2` | UV at the first corner — the region's min, or its max on a flipped axis |
+| 3 | `Vec2` | UV at the last corner |
 | 4 | `Vec4` | premultiplied tint |
 
 `Sprite::instance(canvas, atlas)` packs one without a device, as an

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -41,7 +41,12 @@ else, which the build matrix proves by building and testing without it.
 
 - `Canvas`, `Region`, `Sprite` — the pure vocabulary: a logical pixel
   space (y down from the top-left), a rectangle of atlas texels, and
-  one placed, sized, tinted sprite.
+  one placed, sized, tinted sprite, mirrored on either axis when asked
+  (`flip_x`/`flip_y` — a swap of the sampled edges, so the geometry and
+  its winding never move). A uniform tint `[a, a, a, a]` is a fade to
+  `a` of the sprite's opacity: the tint is premultiplied, so scaling all
+  four channels is what "`a` as opaque" means, and scaling only the
+  fourth would brighten the sprite as it faded.
 - `AtlasDesc` — dimensions plus **authored, straight-alpha** RGBA8
   bytes: the hardware decodes them on sample and the fragment stage
   premultiplies afterwards, so handing this API already-premultiplied
@@ -98,9 +103,11 @@ bytes against hand-written records; a property test holds the ortho map
 monotone, corner-exact, and invertible over random canvases, and two
 more hold the batch fade to the premultiplied rule (every channel by
 the same factor, composing to the product, never brightening) and the
-batch offsets to adding. A computed image oracle proves placement,
-region selection, fill-order overwrite and the batch offset byte-exactly
-on every adapter; a committed golden proves the
+batch offsets to adding; a flip swaps exactly the two UV lanes of its
+axis and nothing else, pinned lane by lane. A computed image oracle
+proves placement, region selection, fill-order overwrite, the batch
+offset and both mirrors byte-exactly on every adapter; a committed
+golden proves the
 premultiplied compositing convention on the pinned software-rasterizer
 lane, with the same candidate/provenance ritual as the rendering
 crate's goldens. Two scheduled facts about the oracles: the computed

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -130,6 +130,34 @@ impl Sprite {
         self.tint = tint;
         self
     }
+
+    /// The bytes [`crate::SpriteRenderer::push`] writes for this sprite
+    /// on `canvas` over an atlas of `atlas` texels when no batch offset
+    /// or fade is set — `push` applies the batch state to the sprite
+    /// first and then packs exactly this. The packer, reachable without
+    /// a device, so it can be timed and pinned.
+    #[must_use]
+    pub fn instance(&self, canvas: Canvas, atlas: Extent) -> Instance {
+        Instance(pack(self, canvas, atlas))
+    }
+}
+
+/// One packed instance record, exactly as the pipeline reads it.
+///
+/// Opaque on purpose: the stride and the lane order belong to the
+/// pipeline, and a caller holding one of these can hand its bytes to a
+/// benchmark, a hash or a buffer without the layout becoming a promise
+/// this crate has to keep. [`Sprite::instance`] makes one without a
+/// device.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Instance([u8; INSTANCE_STRIDE]);
+
+impl Instance {
+    /// The record's bytes, in the order the pipeline declares them.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 /// Canvas pixels to NDC: `2c/extent - 1` per axis, no flip — canvas y
@@ -349,6 +377,51 @@ mod tests {
         assert_eq!(
             tint_bits(placed(&swatch(), (0.0, 0.0), 0.0).tint),
             tint_bits([0.0; 4])
+        );
+    }
+
+    /// `Sprite::instance` is the packer's bytes, no more and no less —
+    /// the doc's claim that a caller holding no device holds the same
+    /// record the renderer would write.
+    ///
+    /// Probed by having `instance` pack a zeroed record: red.
+    #[test]
+    fn the_instance_is_the_packers_bytes() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let instance = swatch().instance(c, atlas);
+        assert_eq!(instance.bytes(), &pack(&swatch(), c, atlas)[..]);
+        assert_eq!(instance.bytes().len(), INSTANCE_STRIDE);
+    }
+
+    /// `push` packs the placed sprite, not the bare one: with a batch
+    /// offset set the renderer's bytes are the moved sprite's record,
+    /// and a caller that wants exactly what the renderer wrote applies
+    /// the batch state first. Device-free through `placed` and `pack`,
+    /// which is all `push` does between its assertion and its copy.
+    ///
+    /// Probed by having `placed` ignore its offset: the two records
+    /// agree and the first assertion reds.
+    #[test]
+    fn push_packs_the_placed_sprite_not_the_bare_one() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let bare = swatch();
+        let moved = placed(&bare, (7.0, -3.0), 1.0);
+        assert_ne!(
+            moved.instance(c, atlas),
+            bare.instance(c, atlas),
+            "an offset must move the record"
+        );
+        assert_eq!(
+            moved.instance(c, atlas).bytes(),
+            &pack(&moved, c, atlas)[..]
         );
     }
 

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -449,16 +449,16 @@ mod tests {
         assert_eq!(instance.bytes().len(), INSTANCE_STRIDE);
     }
 
-    /// `push` packs the placed sprite, not the bare one: with a batch
-    /// offset set the renderer's bytes are the moved sprite's record,
-    /// and a caller that wants exactly what the renderer wrote applies
-    /// the batch state first. Device-free through `placed` and `pack`,
-    /// which is all `push` does between its assertion and its copy.
+    /// A moved sprite packs a moved record: `instance` reads the
+    /// placement it is given, so a caller that wants exactly what the
+    /// renderer wrote under a batch offset applies `placed` first. That
+    /// `push` does so in that order is a device-side fact, pinned by the
+    /// batch-offset oracle in the golden suite, not here.
     ///
     /// Probed by having `placed` ignore its offset: the two records
-    /// agree and the first assertion reds.
+    /// agree and this reds.
     #[test]
-    fn push_packs_the_placed_sprite_not_the_bare_one() {
+    fn a_moved_sprite_packs_a_moved_record() {
         let c = canvas(64, 32);
         let atlas = Extent {
             width: 8,
@@ -470,10 +470,6 @@ mod tests {
             moved.instance(c, atlas),
             bare.instance(c, atlas),
             "an offset must move the record"
-        );
-        assert_eq!(
-            moved.instance(c, atlas).bytes(),
-            &pack(&moved, c, atlas)[..]
         );
     }
 
@@ -534,39 +530,41 @@ mod tests {
         );
     }
 
-    proptest! {
-        /// A flip set and then unset packs the unflipped bytes, whatever
-        /// was asked in between — the last call wins, and the geometry
-        /// never learned about any of it.
-        #[test]
-        fn a_flip_set_back_to_false_packs_the_unflipped_bytes(
-            x in prop::bool::ANY,
-            y in prop::bool::ANY,
-        ) {
-            let c = canvas(64, 32);
-            let atlas = Extent { width: 8, height: 8 };
-            let plain = pack(&swatch(), c, atlas);
-            let unset = pack(&swatch().flip_x(x).flip_y(y).flip_x(false).flip_y(false), c, atlas);
-            prop_assert_eq!(unset, plain);
-        }
-
-        /// A flip never touches placement or tint: over every
-        /// combination of flips the NDC lanes and the tint lanes are the
-        /// unflipped record's, bit for bit.
-        #[test]
-        fn a_flip_never_touches_placement_or_tint(
-            x in prop::bool::ANY,
-            y in prop::bool::ANY,
-        ) {
-            let c = canvas(64, 32);
-            let atlas = Extent { width: 8, height: 8 };
-            let plain = lanes(&pack(&swatch(), c, atlas));
+    /// Over all four combinations of flips: a flip set and then unset
+    /// packs the unflipped bytes (the last call wins), and the placement
+    /// and tint lanes are the unflipped record's, bit for bit. Four
+    /// cases, so a loop rather than a generator — exhaustive and
+    /// deterministic where a random draw over four values is neither.
+    #[test]
+    fn every_flip_combination_leaves_placement_and_tint_alone_and_unsets_cleanly() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let plain = pack(&swatch(), c, atlas);
+        let plain_lanes = lanes(&plain);
+        for (x, y) in [(false, false), (true, false), (false, true), (true, true)] {
             let flipped = lanes(&pack(&swatch().flip_x(x).flip_y(y), c, atlas));
             for lane in (0..4).chain(8..12) {
-                prop_assert_eq!(flipped[lane], plain[lane], "lane {} moved", lane);
+                assert_eq!(
+                    flipped[lane], plain_lanes[lane],
+                    "flip ({x}, {y}) moved lane {lane}"
+                );
             }
+            let unset = pack(
+                &swatch().flip_x(x).flip_y(y).flip_x(false).flip_y(false),
+                c,
+                atlas,
+            );
+            assert_eq!(
+                unset, plain,
+                "flip ({x}, {y}) then unset is not the plain record"
+            );
         }
+    }
 
+    proptest! {
         /// Fading twice is fading once by the product, and a fade never
         /// makes a sprite more opaque than it was.
         ///

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -71,11 +71,12 @@ pub struct Region {
     pub height: u32,
 }
 
-/// One sprite: an atlas region, a place on the canvas, a size, a tint.
+/// One sprite: an atlas region, a place on the canvas, a size, a tint,
+/// and — an identity by default — a mirror on either axis.
 ///
 /// `#[non_exhaustive]` with a constructor and builders, the descriptor
 /// pattern this tree uses everywhere: the fields a later version adds
-/// (rotation, origin) arrive as builders touching no existing caller.
+/// (rotation, a pivot) arrive as builders touching no existing caller.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct Sprite {
@@ -92,8 +93,16 @@ pub struct Sprite {
     /// Premultiplied RGBA tint, multiplied into every sampled texel.
     /// Opaque white — the default — is the identity. Like the atlas
     /// bytes themselves, the tint carries its alpha multiplied in;
-    /// one convention end to end.
+    /// one convention end to end. A uniform tint `[a, a, a, a]` is a
+    /// fade to `a` of the sprite's opacity: the tint is premultiplied,
+    /// so scaling all four channels is what "`a` as opaque" means, and
+    /// scaling only the fourth would brighten the sprite as it faded.
     pub tint: [f32; 4],
+    /// Mirror the sampled texels left for right. The canvas rectangle
+    /// stays where it is; only which texel each pixel reads changes.
+    pub flip_x: bool,
+    /// Mirror top for bottom, the same way.
+    pub flip_y: bool,
 }
 
 impl Sprite {
@@ -112,6 +121,8 @@ impl Sprite {
             width: region.width as f32,
             height: region.height as f32,
             tint: [1.0, 1.0, 1.0, 1.0],
+            flip_x: false,
+            flip_y: false,
         }
     }
 
@@ -128,6 +139,20 @@ impl Sprite {
     #[must_use]
     pub fn tint(mut self, tint: [f32; 4]) -> Self {
         self.tint = tint;
+        self
+    }
+
+    /// Mirror left for right when `flip` is true; the last call wins.
+    #[must_use]
+    pub fn flip_x(mut self, flip: bool) -> Self {
+        self.flip_x = flip;
+        self
+    }
+
+    /// Mirror top for bottom when `flip` is true; the last call wins.
+    #[must_use]
+    pub fn flip_y(mut self, flip: bool) -> Self {
+        self.flip_y = flip;
         self
     }
 
@@ -224,9 +249,32 @@ pub(crate) fn placed(sprite: &Sprite, offset: (f32, f32), alpha: f32) -> Sprite 
     moved
 }
 
+/// The UV corners after the flips: the axis that mirrors swaps its two
+/// edges, so the vertex stage's interpolation from the first corner to
+/// the second runs backwards along it.
+///
+/// A mirror is a UV swap and nothing else. The geometry — and with it
+/// the winding — is untouched, so a flipped sprite costs the pipeline
+/// nothing and cannot be culled by a facing rule.
+pub(crate) fn mirrored(uv_min: Vec2, uv_max: Vec2, flip_x: bool, flip_y: bool) -> (Vec2, Vec2) {
+    let (x0, x1) = if flip_x {
+        (uv_max.x, uv_min.x)
+    } else {
+        (uv_min.x, uv_max.x)
+    };
+    let (y0, y1) = if flip_y {
+        (uv_max.y, uv_min.y)
+    } else {
+        (uv_min.y, uv_max.y)
+    };
+    (Vec2::new(x0, y0), Vec2::new(x1, y1))
+}
+
 /// One instance record, packed exactly as the layout slice declares:
-/// NDC min, NDC max, UV min, UV max — each two `f32`s — then the
-/// four-`f32` tint, native-endian, in declaration order.
+/// NDC min, NDC max, UV at the first corner, UV at the last — each two
+/// `f32`s — then the four-`f32` tint, native-endian, in declaration
+/// order. The two UV lanes are the region's min and max unless a flip
+/// swapped them.
 #[allow(
     clippy::cast_precision_loss,
     reason = "past 2^24 texels the packing degrades visibly, never unsafely; real regions sit far below it"
@@ -239,8 +287,12 @@ pub(crate) fn pack(sprite: &Sprite, canvas: Canvas, atlas: Extent) -> [u8; INSTA
 
     let texel_min = Vec2::new(sprite.region.x as f32, sprite.region.y as f32);
     let texel_max = texel_min + Vec2::new(sprite.region.width as f32, sprite.region.height as f32);
-    let uv_min = to_uv(texel_min, atlas);
-    let uv_max = to_uv(texel_max, atlas);
+    let (uv_min, uv_max) = mirrored(
+        to_uv(texel_min, atlas),
+        to_uv(texel_max, atlas),
+        sprite.flip_x,
+        sprite.flip_y,
+    );
 
     let values: [f32; 12] = [
         ndc_min.x,
@@ -425,7 +477,96 @@ mod tests {
         );
     }
 
+    /// The twelve `f32` lanes of a packed record, for tests that name
+    /// a lane rather than a byte.
+    fn lanes(record: &[u8; INSTANCE_STRIDE]) -> [u32; 12] {
+        let mut out = [0u32; 12];
+        for (lane, chunk) in out.iter_mut().zip(record.as_chunks::<4>().0) {
+            *lane = f32::from_ne_bytes(*chunk).to_bits();
+        }
+        out
+    }
+
+    /// A flip swaps the two UV edges of its axis and touches nothing
+    /// else: the placement lanes, the other axis and the tint are the
+    /// unflipped record's, bit for bit.
+    ///
+    /// Probed by having `mirrored` return its inputs: both flipped
+    /// records equal the plain one and the swap assertions red.
+    #[test]
+    fn a_flip_swaps_the_uv_edges_and_nothing_else() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let plain = lanes(&pack(&swatch(), c, atlas));
+        let across = lanes(&pack(&swatch().flip_x(true), c, atlas));
+        let down = lanes(&pack(&swatch().flip_y(true), c, atlas));
+        // Lanes 4 and 6 are the two u edges; 5 and 7 the two v edges.
+        assert_eq!(
+            (across[4], across[6]),
+            (plain[6], plain[4]),
+            "flip_x swaps u"
+        );
+        assert_eq!(
+            (across[5], across[7]),
+            (plain[5], plain[7]),
+            "flip_x left v alone"
+        );
+        assert_eq!((down[5], down[7]), (plain[7], plain[5]), "flip_y swaps v");
+        assert_eq!(
+            (down[4], down[6]),
+            (plain[4], plain[6]),
+            "flip_y left u alone"
+        );
+        for lane in (0..4).chain(8..12) {
+            assert_eq!(across[lane], plain[lane], "flip_x moved lane {lane}");
+            assert_eq!(down[lane], plain[lane], "flip_y moved lane {lane}");
+        }
+        // The swap is its own inverse, and the two axes commute.
+        let both = lanes(&pack(&swatch().flip_x(true).flip_y(true), c, atlas));
+        let both_reversed = lanes(&pack(&swatch().flip_y(true).flip_x(true), c, atlas));
+        assert_eq!(both, both_reversed);
+        assert_eq!(
+            (both[4], both[6], both[5], both[7]),
+            (plain[6], plain[4], plain[7], plain[5])
+        );
+    }
+
     proptest! {
+        /// A flip set and then unset packs the unflipped bytes, whatever
+        /// was asked in between — the last call wins, and the geometry
+        /// never learned about any of it.
+        #[test]
+        fn a_flip_set_back_to_false_packs_the_unflipped_bytes(
+            x in prop::bool::ANY,
+            y in prop::bool::ANY,
+        ) {
+            let c = canvas(64, 32);
+            let atlas = Extent { width: 8, height: 8 };
+            let plain = pack(&swatch(), c, atlas);
+            let unset = pack(&swatch().flip_x(x).flip_y(y).flip_x(false).flip_y(false), c, atlas);
+            prop_assert_eq!(unset, plain);
+        }
+
+        /// A flip never touches placement or tint: over every
+        /// combination of flips the NDC lanes and the tint lanes are the
+        /// unflipped record's, bit for bit.
+        #[test]
+        fn a_flip_never_touches_placement_or_tint(
+            x in prop::bool::ANY,
+            y in prop::bool::ANY,
+        ) {
+            let c = canvas(64, 32);
+            let atlas = Extent { width: 8, height: 8 };
+            let plain = lanes(&pack(&swatch(), c, atlas));
+            let flipped = lanes(&pack(&swatch().flip_x(x).flip_y(y), c, atlas));
+            for lane in (0..4).chain(8..12) {
+                prop_assert_eq!(flipped[lane], plain[lane], "lane {} moved", lane);
+            }
+        }
+
         /// Fading twice is fading once by the product, and a fade never
         /// makes a sprite more opaque than it was.
         ///

--- a/crates/render2d/src/gpu.rs
+++ b/crates/render2d/src/gpu.rs
@@ -24,8 +24,8 @@ static SPRITE_FS_SPV: &[u8] = include_bytes!("../shaders/sprite.frag.spv");
 const SPRITE_LAYOUT: &[VertexAttribute] = &[
     VertexAttribute::Vec2, // NDC min
     VertexAttribute::Vec2, // NDC max
-    VertexAttribute::Vec2, // UV min
-    VertexAttribute::Vec2, // UV max
+    VertexAttribute::Vec2, // UV at the first corner (swapped by a flip)
+    VertexAttribute::Vec2, // UV at the last corner
     VertexAttribute::Vec4, // premultiplied tint
 ];
 

--- a/crates/render2d/src/lib.rs
+++ b/crates/render2d/src/lib.rs
@@ -6,10 +6,12 @@
 //! - **Fill order is draw order.** Sprites composite in exactly the
 //!   order pushed — painter's algorithm, no sort keys, no batches. A
 //!   caller that wants order sorts before pushing.
-//! - **Everything is premultiplied.** Atlas texels and tints alike
-//!   carry their alpha multiplied into their color channels; the
-//!   pipeline composites `src + dst * (1 - src.a)`. Bytes that break
-//!   the convention composite wrong, visibly, not unsafely.
+//! - **Everything composites premultiplied.** Atlas bytes are authored,
+//!   straight alpha: the hardware decodes them on sample and the
+//!   fragment stage multiplies each texel's colour by its alpha. Tints
+//!   are premultiplied by the caller. The pipeline composites
+//!   `src + dst * (1 - src.a)`. Bytes that break either convention
+//!   composite wrong, visibly, not unsafely.
 //! - **All allocations happen at creation.** `begin`/`push`/`item`
 //!   allocate nothing; the crate's gate measures it.
 //! - **Target-agnostic.** [`SpriteRenderer::item`] returns the

--- a/crates/render2d/src/lib.rs
+++ b/crates/render2d/src/lib.rs
@@ -18,10 +18,10 @@
 //!   and hands it to whichever target it holds. This crate never
 //!   renders, never presents, and never touches a window.
 //!
-//! The pure half ([`Canvas`], [`Region`], [`Sprite`], the ortho and UV
-//! maps) lives apart from the device half ([`SpriteRenderer`]) so the
-//! math is testable without a GPU and the rendering-crate seam stays
-//! one module wide.
+//! The pure half ([`Canvas`], [`Region`], [`Sprite`], [`Instance`], the
+//! ortho and UV maps) lives apart from the device half
+//! ([`SpriteRenderer`]) so the math is testable without a GPU and the
+//! rendering-crate seam stays one module wide.
 
 // Diagnostics go through sinks; the standard output macros are banned in
 // this crate by construction, not convention.
@@ -30,5 +30,5 @@
 mod fill;
 mod gpu;
 
-pub use fill::{Canvas, Region, Sprite};
+pub use fill::{Canvas, Instance, Region, Sprite};
 pub use gpu::{AtlasDesc, Render2dError, SpriteRenderer};

--- a/crates/render2d/tests/golden.rs
+++ b/crates/render2d/tests/golden.rs
@@ -324,6 +324,97 @@ fn opaque_sprites_match_the_computed_image_exactly() {
     }
 }
 
+/// A mirrored sprite reads its texels backwards, exactly: the same
+/// computed oracle as above, over regions whose texels differ along
+/// the flipped axis, so a flip that did nothing — or flipped the
+/// wrong axis — paints the wrong colour into a known pixel.
+///
+/// The atlas's top row is red, red, green, green and its left column
+/// red, red, blue, blue; each texel is drawn over exactly four pixels
+/// per axis, texel-aligned, so nearest sampling is exact on every
+/// adapter. Probed by having `mirrored` return its inputs: the two
+/// flipped sprites paint unflipped and the comparison reds.
+#[test]
+fn a_mirrored_sprite_reads_its_texels_backwards_exactly() {
+    let Some(device) = device_or_skip().expect("device bring-up") else {
+        return;
+    };
+    let atlas = atlas_bytes();
+    let mut renderer = renderer(&device, &atlas, 8).expect("sprite renderer");
+    let mut target = device
+        .create_offscreen_target(Extent {
+            width: SIZE,
+            height: SIZE,
+        })
+        .expect("offscreen target");
+
+    // The top row of the atlas, RED RED GREEN GREEN, four texels wide.
+    let top_row = Region {
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 2,
+    };
+    // The left column, RED over BLUE, four texels tall.
+    let left_column = Region {
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 4,
+    };
+    renderer.begin();
+    renderer.push(&Sprite::new(top_row, 8.0, 8.0).size(16.0, 8.0));
+    renderer.push(&Sprite::new(top_row, 8.0, 24.0).size(16.0, 8.0).flip_x(true));
+    renderer.push(
+        &Sprite::new(left_column, 32.0, 8.0)
+            .size(8.0, 16.0)
+            .flip_y(true),
+    );
+    let color = [renew_rhi::color_attachment(CLEAR)];
+    let items = [renderer.item()];
+    let passes = [Pass::new(&color, &items)];
+    target
+        .render(&RenderDesc::new(&passes))
+        .expect("mirrored render");
+    let mut pixels = vec![0u8; target.byte_len()];
+    target.read_back_into(&mut pixels);
+    drop(target);
+    drop(renderer);
+    assert_no_validation_errors(&device);
+
+    let mut expected = Vec::with_capacity((SIZE * SIZE * 4) as usize);
+    for _ in 0..SIZE * SIZE {
+        expected.extend_from_slice(&clear_bytes());
+    }
+    // Unflipped: red on the left, green on the right.
+    paint(&mut expected, 8, 8, 8, 8, [255, 0, 0, 255]);
+    paint(&mut expected, 16, 8, 8, 8, [0, 255, 0, 255]);
+    // Flipped across: green on the left, red on the right.
+    paint(&mut expected, 8, 24, 8, 8, [0, 255, 0, 255]);
+    paint(&mut expected, 16, 24, 8, 8, [255, 0, 0, 255]);
+    // Flipped down: blue on top, red below.
+    paint(&mut expected, 32, 8, 8, 8, [0, 0, 255, 255]);
+    paint(&mut expected, 32, 16, 8, 8, [255, 0, 0, 255]);
+
+    if pixels != expected {
+        let first_diff = pixels
+            .iter()
+            .zip(expected.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or(usize::MAX);
+        let pixel = first_diff / 4;
+        panic!(
+            "a mirrored sprite diverges from the computed image on adapter {:?}: first \
+             difference at byte {first_diff} (pixel {}, {}), fnv1a {:#018x} vs {:#018x}",
+            device.adapter(),
+            pixel % SIZE as usize,
+            pixel / SIZE as usize,
+            fnv1a(&pixels),
+            fnv1a(&expected)
+        );
+    }
+}
+
 /// Semi-transparent overlaps against the committed golden: the
 /// premultiplied compositing convention, in bytes, on the pinned lane —
 /// structure everywhere else.

--- a/crates/render2d/tests/zero_alloc.rs
+++ b/crates/render2d/tests/zero_alloc.rs
@@ -179,7 +179,15 @@ fn steady_state_fill_and_render_allocates_nothing() {
                  index: usize| {
         renderer.begin();
         renderer.push(&Sprite::new(RED, 8.0, 8.0).size(8.0, 8.0));
-        renderer.push(&Sprite::new(GREEN, WANDER[index % WANDER.len()], 40.0).size(8.0, 8.0));
+        // Mirrored on both axes so the swap is inside the measured
+        // window; the region is one solid colour, so the picture the
+        // liveness checks read is unchanged by it.
+        renderer.push(
+            &Sprite::new(GREEN, WANDER[index % WANDER.len()], 40.0)
+                .size(8.0, 8.0)
+                .flip_x(true)
+                .flip_y(true),
+        );
         assert!(
             renderer.sprites() > 0,
             "the measured frame must be non-empty"


### PR DESCRIPTION
Two commits. The first makes the sprite packer reachable without a
device: `Sprite::instance(canvas, atlas)` packs one sprite into its
48-byte record as an opaque `Instance`, and the bench suite times it
(`sprite_pack_2048`, about 4.6 ns per sprite on the machine that took
the numbers) so a later change to the packer's arithmetic has a before.
The second adds `flip_x`/`flip_y` to `Sprite`: a mirror is a swap of the
two UV edges on its axis and nothing else, so the geometry and its
winding never move and a flipped sprite costs the pipeline nothing.

## Tests

- The instance is the packer's bytes; a moved sprite packs a moved record.
- A flip swaps exactly the two UV lanes of its axis and leaves placement,
  the other axis and the tint bit-identical; two properties hold that a
  flip set and unset packs the unflipped bytes and that no combination
  touches placement or tint.
- A computed-image oracle draws the atlas's red-red-green-green row and
  red-over-blue column both ways and reads the colours back exactly on
  every adapter.

Each new test was probed by breaking the code it pins and watching it
go red: packing zeros, an offset that moves nothing, and a `mirrored`
that returns its inputs (which also diverges the device oracle at pixel
(32, 8)).

## Evidence

- `cargo build --workspace`, `cargo test --workspace`, `cargo fmt --all
  --check`, `cargo clippy --workspace --all-targets -- -D warnings` and
  `renew check` all clean on this tree; `cargo metadata --locked` passes
  with the regenerated lockfile.
- The golden suite ran here on a discrete adapter (the computed oracles
  are exact everywhere; the committed golden's exact compare skips by
  design). No picture moves in this change: the flags default off and
  the stride is unchanged, so every committed golden is expected to
  carry over untouched.
- Bench, three runs each, same machine: `sprite_pack_2048` 9.34 / 9.98 /
  9.45 µs before the mirror, 11.56 / 11.64 / 12.01 µs after;
  `sprite_build_2048` 1.87 / 1.92 / 1.91 µs before, 2.27 / 2.28 / 2.32
  after. `Sprite` grew from 48 to 52 bytes; the movement is recorded, not
  explained.
