### PR TITLE
feat(particles): a pool can be read particle by particle

### DIFF
--- a/bench/suite/benches/particles.rs
+++ b/bench/suite/benches/particles.rs
@@ -78,6 +78,20 @@ fn particles(c: &mut Criterion) {
                 black_box(&mut instances);
             });
         });
+
+        c.bench_function(&format!("particle_view_{count}"), |b| {
+            // The view reads the same arrays the packer reads and
+            // writes nothing: a walk that folds every size into a sum,
+            // fenced so the walk cannot be folded away with it.
+            let pool = full_pool(count);
+            b.iter(|| {
+                let total: f32 = black_box(&pool)
+                    .particles()
+                    .map(|particle| particle.size)
+                    .sum();
+                black_box(total)
+            });
+        });
     }
 }
 

--- a/bench/suite/benches/particles.rs
+++ b/bench/suite/benches/particles.rs
@@ -1,9 +1,9 @@
-//! Particle pool timings: the cost of one simulation step and one
-//! instance pack, at the two pool sizes that bracket what a scene asks
-//! for. A thousand particles is a busy scene for the current samples —
-//! the block-break burst tops out in the dozens — and four thousand is
-//! the stress ceiling the pool should absorb before anyone reaches for
-//! a second pool or a coarser effect.
+//! Particle pool timings: the cost of one simulation step, one
+//! instance pack and one walk of the view, at the two pool sizes that
+//! bracket what a scene asks for. A thousand particles is a busy scene
+//! for the current samples — the block-break burst tops out in the
+//! dozens — and four thousand is the stress ceiling the pool should
+//! absorb before anyone reaches for a second pool or a coarser effect.
 //!
 //! Every particle is given an effectively infinite lifetime, so a step
 //! updates exactly the full pool on every iteration: a real effect's
@@ -14,8 +14,8 @@
 //! The allocation gate for these kernels does not live here: the pool
 //! commits to zero steady-state allocation in its own crate, where
 //! `tests/zero_alloc.rs` asserts exact counts over `burst`, `step`,
-//! and `write_instances` on every push. This file only times what that
-//! test already gates.
+//! `write_instances` and the `particles()` walk on every push. This
+//! file only times what that test already gates.
 
 use std::hint::black_box;
 
@@ -81,13 +81,15 @@ fn particles(c: &mut Criterion) {
 
         c.bench_function(&format!("particle_view_{count}"), |b| {
             // The view reads the same arrays the packer reads and
-            // writes nothing: a walk that folds every size into a sum,
+            // writes nothing: every record is fenced whole, so the
+            // position, velocity, colour and progress it computes are
+            // kept live, and its size is folded into a sum,
             // fenced so the walk cannot be folded away with it.
             let pool = full_pool(count);
             b.iter(|| {
                 let total: f32 = black_box(&pool)
                     .particles()
-                    .map(|particle| particle.size)
+                    .map(|particle| black_box(particle).size)
                     .sum();
                 black_box(total)
             });

--- a/crates/particles/README.md
+++ b/crates/particles/README.md
@@ -17,6 +17,11 @@ maturity, dependencies and core status.
   and is authored once; only the caller knows *which* surface, and for
   anything knocked off a face that changes with every burst. `burst` is
   `burst_along` on the effect's axis, held to that by test.
+- `particles()` — the live pool, particle by particle, in the order
+  `write_instances` packs: a `Particle` (centre, velocity, size, colour,
+  progress) per entry, exact-size so a caller can size a batch before
+  pushing, allocating nothing. The same arrays read by the same progress
+  and the same lerps as the packer, held slot by slot by test.
 
 ## Contract
 
@@ -54,11 +59,30 @@ is the rendering crate's contract for per-frame bytes. The feature
 exists so a consumer that only steps pools never compiles a graphics
 API — the pure half stays device-free.
 
+## Drawing through a 2D sprite batch
+
+A consumer with its own atlas and its own draw order — a sprite batch
+rather than the billboard pipeline — reads the pool through
+`particles()` and pushes one of its own sprites per entry. `position`
+is the particle's centre, so a square sprite of side `size` sits at
+`(x - size / 2, y - size / 2)` with `.size(size, size)`; `color` is
+premultiplied and goes straight into a premultiplied tint — `.tint(c)`
+for media that occlude, `.tint([r, g, b, 0.0])` for light that adds and
+never occludes; the source rectangle is the caller's, chosen from its
+own atlas (by `progress`, if a flip-book by age is wanted), because
+`EffectDesc::tile` is the billboard atlas's and is not carried here;
+the painter's order is the caller's. Everything is premultiplied end to
+end — a caller that lerps a straight colour of its own and then
+multiplies alpha in gets fringes. `velocity` is exposed so a sprite can
+be aligned or stretched along its motion; the view costs a walk over
+the same arrays the packer walks and writes nothing.
+
 ## What this deliberately is not, yet
 
 No continuous-rate emission, no per-particle rotation, no tile ranges:
 each lands with the first consumer that needs it, because surface built
 ahead of use is the pattern this repository's own register warns about.
-No sorting: additive blending is order-independent by arithmetic, and
-the alpha mode documents its unsorted artifact where the choice is
-made.
+Through the view, a spin, a flip or a 2D placement is the caller's to
+apply to its own sprite until the pool carries one. No sorting: additive
+blending is order-independent by arithmetic, and the alpha mode
+documents its unsorted artifact where the choice is made.

--- a/crates/particles/README.md
+++ b/crates/particles/README.md
@@ -40,8 +40,9 @@ maturity, dependencies and core status.
   does not touch this: the jitter is drawn before the axis is used, so
   which axis arrives cannot change how many values the generator gives
   out.
-- **All allocation happens at construction**, gate-tested from the
-  first commit; a burst past capacity saturates.
+- **All allocation happens at construction** — `burst`, `step`,
+  `write_instances` and the `particles()` walk, each gate-tested from
+  its own first commit; a burst past capacity saturates.
 
 ## The renderer half, behind the `render` feature
 
@@ -65,10 +66,14 @@ A consumer with its own atlas and its own draw order — a sprite batch
 rather than the billboard pipeline — reads the pool through
 `particles()` and pushes one of its own sprites per entry. `position`
 is the particle's centre, so a square sprite of side `size` sits at
-`(x - size / 2, y - size / 2)` with `.size(size, size)`; `color` is
-premultiplied and goes straight into a premultiplied tint — `.tint(c)`
-for media that occlude, `.tint([r, g, b, 0.0])` for light that adds and
-never occludes; the source rectangle is the caller's, chosen from its
+`(x - size / 2, y - size / 2)` with `.size(size, size)`, where `x` and
+`y` are the first two components of `position`; the third component
+and the sign of the pool's axes are the effect's own — an effect drawn
+on a canvas whose y grows downward is authored with its gravity along
+`+y`, or the caller maps the axes. `color` is premultiplied and goes
+straight into a premultiplied tint (`.tint(color)`); whether a tint can
+add light without occluding is the sprite renderer's contract to state,
+not this crate's. The source rectangle is the caller's, chosen from its
 own atlas (by `progress`, if a flip-book by age is wanted), because
 `EffectDesc::tile` is the billboard atlas's and is not carried here;
 the painter's order is the caller's. Everything is premultiplied end to
@@ -82,7 +87,8 @@ the same arrays the packer walks and writes nothing.
 No continuous-rate emission, no per-particle rotation, no tile ranges:
 each lands with the first consumer that needs it, because surface built
 ahead of use is the pattern this repository's own register warns about.
-Through the view, a spin, a flip or a 2D placement is the caller's to
-apply to its own sprite until the pool carries one. No sorting: additive
-blending is order-independent by arithmetic, and the alpha mode
-documents its unsorted artifact where the choice is made.
+Through the view a spin is the caller's to apply to its own sprite
+until the pool carries one; a flip and the 2D placement stay the
+caller's. No sorting: additive blending is order-independent by
+arithmetic, and the alpha mode documents its unsorted artifact where
+the choice is made.

--- a/crates/particles/src/lib.rs
+++ b/crates/particles/src/lib.rs
@@ -19,16 +19,20 @@
 //!   divide, min, max, and square root. No transcendental function
 //!   runs per particle anywhere in this crate.
 //! - **All allocation happens at construction.** `step`,
-//!   [`ParticleSystem::burst`] and [`ParticleSystem::write_instances`]
-//!   allocate nothing, gate-tested from the crate's first commit; a
-//!   burst past capacity saturates rather than growing.
+//!   [`ParticleSystem::burst`], [`ParticleSystem::write_instances`] and
+//!   the [`ParticleSystem::particles`] view allocate nothing,
+//!   gate-tested from the crate's first commit; a burst past capacity
+//!   saturates rather than growing.
 //!
 //! The GPU-facing half — the billboard pipeline, the atlas, the draw —
-//! arrives as its own module with its own dependency when the renderer
-//! lands; this half never touches a device, which is what makes every
-//! claim above testable on any machine. Which blend mode an effect
-//! draws with belongs to that half too: it is a property of a pipeline,
-//! not of arithmetic.
+//! lives behind the `render` feature as its own module with its own
+//! dependency; this half never touches a device, which is what makes
+//! every claim above testable on any machine. Which blend mode an
+//! effect draws with belongs to that half too: it is a property of a
+//! pipeline, not of arithmetic. A consumer with its own atlas and its
+//! own draw order — a 2D sprite batch — reads the pool through
+//! [`ParticleSystem::particles`] instead and draws each particle as one
+//! of its own sprites.
 
 // Diagnostics go through sinks; the standard output macros are banned in
 // this crate by construction, not convention.
@@ -100,6 +104,61 @@ pub struct VelocityCone {
     /// Speed at the slow and fast ends, drawn uniformly.
     pub speed: (f32, f32),
 }
+
+/// One live particle as the pool sees it this step — what a consumer
+/// with its own atlas and its own draw order turns into a sprite.
+///
+/// A read-side record: `#[non_exhaustive]` and no constructor, because
+/// only the pool makes one. Every value is what the packed record
+/// carries or what it was computed from — `size` and `color` are the
+/// same lerp at the same `progress` — so a caller drawing through this
+/// view and one drawing the packed bytes see the same particle. The
+/// billboard's atlas rectangle is deliberately absent: a caller with its
+/// own atlas names its own source.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct Particle {
+    /// Centre, in the effect's own units.
+    pub position: [f32; 3],
+    /// Velocity after the last step's drag, units per second.
+    pub velocity: [f32; 3],
+    /// Size at this moment of its life — the packed record's fourth
+    /// value.
+    pub size: f32,
+    /// Premultiplied colour at this moment — the packed record's fifth
+    /// to eighth values.
+    pub color: [f32; 4],
+    /// Age over lifetime, clamped to `0.0..=1.0` — the progress the
+    /// packer lerps size and colour by, so a caller lerping its own
+    /// quantity lands where the colour did.
+    pub progress: f32,
+}
+
+/// The live particles in pool order — the order
+/// [`ParticleSystem::write_instances`] packs. Borrows the pool,
+/// allocates nothing, and knows its length exactly, so a caller can
+/// size a sprite batch before pushing.
+pub struct Particles<'a> {
+    pool: &'a ParticleSystem,
+    index: usize,
+}
+
+impl Iterator for Particles<'_> {
+    type Item = Particle;
+
+    fn next(&mut self) -> Option<Particle> {
+        let particle = self.pool.particle(self.index)?;
+        self.index += 1;
+        Some(particle)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = self.pool.position.len().saturating_sub(self.index);
+        (left, Some(left))
+    }
+}
+
+impl ExactSizeIterator for Particles<'_> {}
 
 /// A fixed-capacity particle pool and the generator that feeds it.
 ///
@@ -319,6 +378,34 @@ impl ParticleSystem {
             }
         }
         self.live()
+    }
+
+    /// Every live particle, in pack order, without a device and without
+    /// an allocation — for a consumer that draws particles through its
+    /// own atlas and its own draw order rather than the billboard
+    /// pipeline. Reads the same arrays [`Self::write_instances`] reads by
+    /// the same progress and the same lerps, which a test holds slot by
+    /// slot; the two cannot disagree.
+    #[must_use]
+    pub fn particles(&self) -> Particles<'_> {
+        Particles {
+            pool: self,
+            index: 0,
+        }
+    }
+
+    /// The particle at `index`, or `None` past the live count — the
+    /// second reader of the arrays the packer reads.
+    fn particle(&self, index: usize) -> Option<Particle> {
+        let position = *self.position.get(index)?;
+        let t = progress(self.age[index], self.lifetime[index]);
+        Some(Particle {
+            position,
+            velocity: self.velocity[index],
+            size: lerp(self.desc.size.0, self.desc.size.1, t),
+            color: lerp4(self.desc.color.0, self.desc.color.1, t),
+            progress: t,
+        })
     }
 
     /// A direction inside a cone: `axis` plus a point in a jitter ball,
@@ -769,7 +856,137 @@ mod tests {
         assert!(shown.contains(".."), "{shown}");
     }
 
+    /// The view and the packer read the same particle: over the hash
+    /// fixture's schedule, every `position`, `size` and `color` in the
+    /// view equals the packed record's slots bit for bit, `progress` is
+    /// the packer's own, and `velocity` is the array's.
+    ///
+    /// Probed by lerping the view's size backwards (`end` to `start`):
+    /// red here and nowhere else — the packer is untouched, so the
+    /// committed hash still holds.
+    #[test]
+    fn the_view_and_the_packer_read_the_same_particle() {
+        let mut system = ParticleSystem::new(
+            &burst_effect(),
+            Seed::from_u64(20_260_811),
+            StreamId::from_name("guard"),
+        );
+        system.burst([1.0, 2.0, 3.0], 40);
+        for _ in 0..30 {
+            system.step(DT);
+        }
+        system.burst([0.0, 0.5, 0.0], 24);
+        for _ in 0..10 {
+            system.step(DT);
+        }
+        let mut bytes = vec![0u8; system.live() as usize * INSTANCE_STRIDE];
+        let packed = system.write_instances(&mut bytes) as usize;
+        assert!(packed > 0, "the fixture must leave something to compare");
+        assert_eq!(system.particles().len(), packed, "the view's length");
+        for (index, particle) in system.particles().enumerate() {
+            let base = index * INSTANCE_STRIDE;
+            let slot = |k: usize| {
+                f32::from_ne_bytes(bytes[base + k * 4..base + k * 4 + 4].try_into().unwrap())
+                    .to_bits()
+            };
+            assert_eq!(
+                particle.position.map(f32::to_bits),
+                [slot(0), slot(1), slot(2)],
+                "position of particle {index}"
+            );
+            assert_eq!(particle.size.to_bits(), slot(3), "size of particle {index}");
+            assert_eq!(
+                particle.color.map(f32::to_bits),
+                [slot(4), slot(5), slot(6), slot(7)],
+                "colour of particle {index}"
+            );
+            assert_eq!(
+                particle.progress.to_bits(),
+                progress(system.age[index], system.lifetime[index]).to_bits(),
+                "progress of particle {index}"
+            );
+            assert_eq!(
+                particle.velocity.map(f32::to_bits),
+                system.velocity[index].map(f32::to_bits),
+                "velocity of particle {index}"
+            );
+        }
+    }
+
+    /// The view is empty when the pool is, its length is the live count
+    /// otherwise — before and after expiry — and the length tracks the
+    /// walk, which is what lets a caller size a batch from it.
+    #[test]
+    fn the_view_is_empty_when_the_pool_is_and_exact_size_otherwise() {
+        let mut system = ParticleSystem::new(
+            &burst_effect(),
+            Seed::from_u64(3),
+            StreamId::from_name("expiry"),
+        );
+        assert_eq!(system.particles().len(), 0);
+        assert!(
+            system.particles().next().is_none(),
+            "an empty pool views nothing"
+        );
+        system.burst([0.0, 0.0, 0.0], 16);
+        assert_eq!(system.particles().len(), 16);
+        assert_eq!(
+            system.particles().count(),
+            16,
+            "the walk visits every live particle"
+        );
+        let mut view = system.particles();
+        assert!(view.next().is_some());
+        assert_eq!(view.len(), 15, "the length tracks the walk");
+        // The longest possible lifetime is 1.5 seconds; step past it.
+        for _ in 0..120 {
+            system.step(DT);
+        }
+        assert_eq!(system.live(), 0, "every particle should have died");
+        assert_eq!(system.particles().len(), 0);
+        assert!(system.particles().next().is_none());
+    }
+
     proptest::proptest! {
+        // Fixed RNG seed: the suite explores the same inputs on every
+        // run and every machine, so a property failure anywhere
+        // reproduces everywhere.
+        #![proptest_config(proptest::prelude::ProptestConfig {
+            rng_seed: proptest::test_runner::RngSeed::Fixed(0x2D5A_F010),
+            ..proptest::prelude::ProptestConfig::default()
+        })]
+
+        /// The view walks pack order: over random burst schedules, the
+        /// i-th particle of the view is the i-th packed record, however
+        /// many bursts and expiries have compacted the pool.
+        #[test]
+        fn the_view_walks_pack_order(
+            bursts in proptest::collection::vec((0u32..200, 0u32..40), 1..12),
+        ) {
+            let mut system = ParticleSystem::new(
+                &burst_effect(),
+                Seed::from_u64(41),
+                StreamId::from_name("order"),
+            );
+            for (count, steps) in bursts {
+                system.burst([0.0, 0.0, 0.0], count);
+                for _ in 0..steps {
+                    system.step(DT);
+                }
+            }
+            let mut bytes = vec![0u8; system.live() as usize * INSTANCE_STRIDE];
+            let packed = system.write_instances(&mut bytes) as usize;
+            let viewed: Vec<Particle> = system.particles().collect();
+            proptest::prop_assert_eq!(viewed.len(), packed);
+            for (index, particle) in viewed.iter().enumerate() {
+                let base = index * INSTANCE_STRIDE;
+                let x = f32::from_ne_bytes(bytes[base..base + 4].try_into().unwrap());
+                let size = f32::from_ne_bytes(bytes[base + 12..base + 16].try_into().unwrap());
+                proptest::prop_assert_eq!(particle.position[0].to_bits(), x.to_bits());
+                proptest::prop_assert_eq!(particle.size.to_bits(), size.to_bits());
+            }
+        }
+
         /// The pool never exceeds its capacity, however the bursts land.
         #[test]
         fn the_pool_never_exceeds_capacity(

--- a/crates/particles/src/lib.rs
+++ b/crates/particles/src/lib.rs
@@ -21,7 +21,7 @@
 //! - **All allocation happens at construction.** `step`,
 //!   [`ParticleSystem::burst`], [`ParticleSystem::write_instances`] and
 //!   the [`ParticleSystem::particles`] view allocate nothing,
-//!   gate-tested from the crate's first commit; a burst past capacity
+//!   each gate-tested from its own first commit; a burst past capacity
 //!   saturates rather than growing.
 //!
 //! The GPU-facing half — the billboard pipeline, the atlas, the draw —
@@ -120,7 +120,9 @@ pub struct VelocityCone {
 pub struct Particle {
     /// Centre, in the effect's own units.
     pub position: [f32; 3],
-    /// Velocity after the last step's drag, units per second.
+    /// The velocity `step` last left it, units per second: at birth the
+    /// cone direction times the drawn speed, before any drag, and after
+    /// every step the post-drag velocity the next step integrates from.
     pub velocity: [f32; 3],
     /// Size at this moment of its life — the packed record's fourth
     /// value.
@@ -138,6 +140,7 @@ pub struct Particle {
 /// [`ParticleSystem::write_instances`] packs. Borrows the pool,
 /// allocates nothing, and knows its length exactly, so a caller can
 /// size a sprite batch before pushing.
+#[derive(Clone, Debug)]
 pub struct Particles<'a> {
     pool: &'a ParticleSystem,
     index: usize,
@@ -159,6 +162,10 @@ impl Iterator for Particles<'_> {
 }
 
 impl ExactSizeIterator for Particles<'_> {}
+
+/// Past the end it keeps answering `None`: the index never moves once
+/// the pool has nothing at it.
+impl core::iter::FusedIterator for Particles<'_> {}
 
 /// A fixed-capacity particle pool and the generator that feeds it.
 ///
@@ -957,8 +964,13 @@ mod tests {
         })]
 
         /// The view walks pack order: over random burst schedules, the
-        /// i-th particle of the view is the i-th packed record, however
-        /// many bursts and expiries have compacted the pool.
+        /// i-th particle of the view is the i-th packed record in every
+        /// slot the record carries from the particle — position, size
+        /// and colour — however many bursts and expiries have compacted
+        /// the pool. Each burst spawns at its own x, so newborns of one
+        /// burst are distinguishable from another's; a schedule that
+        /// leaves the pool empty is assumed away rather than passing on
+        /// two empty lists.
         #[test]
         fn the_view_walks_pack_order(
             bursts in proptest::collection::vec((0u32..200, 0u32..40), 1..12),
@@ -968,22 +980,32 @@ mod tests {
                 Seed::from_u64(41),
                 StreamId::from_name("order"),
             );
-            for (count, steps) in bursts {
-                system.burst([0.0, 0.0, 0.0], count);
+            for ((count, steps), origin) in bursts.into_iter().zip(0u8..) {
+                system.burst([f32::from(origin), 0.0, 0.0], count);
                 for _ in 0..steps {
                     system.step(DT);
                 }
             }
             let mut bytes = vec![0u8; system.live() as usize * INSTANCE_STRIDE];
             let packed = system.write_instances(&mut bytes) as usize;
+            proptest::prop_assume!(packed > 0);
             let viewed: Vec<Particle> = system.particles().collect();
             proptest::prop_assert_eq!(viewed.len(), packed);
             for (index, particle) in viewed.iter().enumerate() {
                 let base = index * INSTANCE_STRIDE;
-                let x = f32::from_ne_bytes(bytes[base..base + 4].try_into().unwrap());
-                let size = f32::from_ne_bytes(bytes[base + 12..base + 16].try_into().unwrap());
-                proptest::prop_assert_eq!(particle.position[0].to_bits(), x.to_bits());
-                proptest::prop_assert_eq!(particle.size.to_bits(), size.to_bits());
+                let slot = |k: usize| {
+                    f32::from_ne_bytes(bytes[base + k * 4..base + k * 4 + 4].try_into().unwrap())
+                        .to_bits()
+                };
+                proptest::prop_assert_eq!(
+                    particle.position.map(f32::to_bits),
+                    [slot(0), slot(1), slot(2)]
+                );
+                proptest::prop_assert_eq!(particle.size.to_bits(), slot(3));
+                proptest::prop_assert_eq!(
+                    particle.color.map(f32::to_bits),
+                    [slot(4), slot(5), slot(6), slot(7)]
+                );
             }
         }
 

--- a/crates/particles/tests/zero_alloc.rs
+++ b/crates/particles/tests/zero_alloc.rs
@@ -66,6 +66,16 @@ fn the_steady_state_allocates_nothing() {
                 live > 0,
                 "the measured window went vacuous at round {round}"
             );
+            // The view inside the window too: a walk that folds every
+            // size into a sum, fenced so nothing folds the walk away,
+            // and asserted positive so the walk provably visited a
+            // live particle.
+            let total: f32 = system.particles().map(|particle| particle.size).sum();
+            let total = std::hint::black_box(total);
+            assert!(
+                total.is_finite() && total > 0.0,
+                "the view walked nothing at round {round}"
+            );
         }
     });
     if let Err(activity) = verdict {

--- a/crates/particles/tests/zero_alloc.rs
+++ b/crates/particles/tests/zero_alloc.rs
@@ -1,5 +1,5 @@
 //! Mechanical enforcement of the crate's allocation contract: after
-//! construction, the steady state — burst, step, pack — performs no
+//! construction, the steady state — burst, step, pack, view — performs no
 //! heap allocation through the global allocator.
 //!
 //! Shipped with the crate's first commit rather than after it, because
@@ -70,7 +70,10 @@ fn the_steady_state_allocates_nothing() {
             // size into a sum, fenced so nothing folds the walk away,
             // and asserted positive so the walk provably visited a
             // live particle.
-            let total: f32 = system.particles().map(|particle| particle.size).sum();
+            let total: f32 = system
+                .particles()
+                .map(|particle| std::hint::black_box(particle).size)
+                .sum();
             let total = std::hint::black_box(total);
             assert!(
                 total.is_finite() && total > 0.0,


### PR DESCRIPTION
`ParticleSystem::particles()` walks the live pool in the order
`write_instances` packs it, yielding one `Particle` per entry — centre,
the velocity the last step left it with, the size and premultiplied
colour at this moment of its life, and the progress they were lerped
by — without a device and without an allocation. The iterator knows its
length exactly, is fused, and clones, so a consumer with its own atlas
and its own draw order can size a sprite batch before pushing and draw
each particle as one of its own sprites. The billboard's atlas
rectangle is deliberately absent from the record: such a consumer names
its own source.

## Tests

- The view and the packer read the same particle: over the
  committed-hash fixture, position, size and colour match the packed
  record slot by slot, bit for bit; progress is the packer's own;
  velocity is the array's.
- The walk is pack order: over random burst and expiry schedules, each
  burst spawned at its own x, every one of the eight packed slots —
  position, size, colour — matches the view's record (seeded property;
  a schedule that empties the pool is assumed away).
- The length is empty, populated and mid-walk, before and after expiry.
- The allocation gate walks the view inside its measured window, fences
  every record whole and folds every size into a sum asserted positive.

Lerping the view's size backwards, or freezing its colour at the birth
value, reddens exactly the two view-side tests and nothing else; the
committed hash is untouched because the packer is.

## Evidence

- On `dd7c568`: `cargo build --workspace`, `cargo test --workspace`
  (240 suites, 0 failed), `cargo fmt --all --check`, `cargo clippy
  --workspace --all-targets -- -D warnings` and `cargo clippy -p
  renew-particles --features render --all-targets -- -D warnings` all
  clean; `cargo test -p renew-particles --features render` green with
  the golden on a discrete adapter.
- On `f7431a2` (the review fixes): `cargo test -p renew-particles` with
  and without `--features render` green, the golden included; `cargo
  clippy --workspace --all-targets --all-features -- -D warnings` clean;
  `cargo fmt --all` applied.
- Bench, criterion medians, `cargo bench -p renew-bench --bench
  particles`, rustc 1.98.0 on a Comet Lake i7-10700 under Windows 10,
  three runs each, the whole record fenced: `particle_view_1024` 9.21 /
  10.17 / 9.25 µs beside `particle_pack_1024` 4.04 / 3.97 / 4.03;
  `particle_view_4096` 36.83 / 37.99 / 36.93 beside `particle_pack_4096`
  16.06 / 15.99 / 16.00; `particle_update` unchanged at 3.26 / 3.25 /
  3.26 and 12.95 / 12.96 / 13.07. The view's fence materialises all
  twelve floats of a record where the packer writes eight; an earlier
  figure that folded only the size let the compiler drop the rest and
  is superseded.
