### PR TITLE
feat(render2d): a sprite's source rectangle can have sub-texel edges

### DIFF
--- a/bench/suite/benches/ui.rs
+++ b/bench/suite/benches/ui.rs
@@ -60,6 +60,21 @@ const TWO: NonZeroU64 = NonZeroU64::MIN.saturating_add(1);
 /// content, gaps and cross-axis centring exercise arrangement. Built
 /// dirty; the caller decides when the first solve happens.
 fn build_tree() -> Ui {
+    build_tree_with(OverflowS::Contained)
+}
+
+/// Whether the leaves fit inside their row, or stand out of it.
+///
+/// A leaf taller than its row is clipped top and bottom by the row's
+/// own box, which is how the presenter's cut path is reached without
+/// inventing a scroll container the solver does not have yet.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OverflowS {
+    Contained,
+    LeavesOverflowTheirRow,
+}
+
+fn build_tree_with(overflow: OverflowS) -> Ui {
     let mut ui = Ui::new(UiLimits { nodes: NODES });
     let root = ui.root();
     ui.set_style(
@@ -85,6 +100,13 @@ fn build_tree() -> Ui {
                 // past the leaves' content that their own growers get
                 // leftover to split too.
                 width: Size::Px(Fixed::from_int(1000)),
+                // Fixed and short in the overflow shape, so the taller
+                // leaves inside genuinely stand out of it.
+                height: if overflow == OverflowS::Contained {
+                    Size::Auto
+                } else {
+                    Size::Px(Fixed::from_int(20))
+                },
                 grow: 1 + row % 3,
                 gap: Fixed::from_int(1),
                 align_cross: Align::Center,
@@ -99,7 +121,11 @@ fn build_tree() -> Ui {
                 leaf,
                 Style {
                     width: Size::Px(Fixed::from_int(8 + i32::try_from(child % 5).unwrap_or(0))),
-                    height: Size::Px(Fixed::from_int(10)),
+                    height: Size::Px(Fixed::from_int(if overflow == OverflowS::Contained {
+                        10
+                    } else {
+                        40
+                    })),
                     grow: child % 2,
                     background: [40, 44, 52, 230],
                     ..Style::default()
@@ -270,5 +296,32 @@ fn ui_benches(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, ui_benches);
+fn ui_clipped_benches(c: &mut Criterion) {
+    // The same blend, with the cut path taken.
+    //
+    // Every leaf is forty pixels tall inside a twenty-pixel row, so
+    // the row's own box cuts it top and bottom: 992 of the 1,024
+    // nodes take the proportional path while the 32 rows and the root
+    // take the early-out. Subtracting `ui_frame_1024` and dividing by
+    // 992 gives the added cost of a cut, which is the number the
+    // clipping work is answerable for.
+    c.bench_function("ui_frame_clipped_1024", |b| {
+        let mut ui = build_tree_with(OverflowS::LeavesOverflowTheirRow);
+        solve(&mut ui);
+        let mut presenter = UiPresenter::new(NODES);
+        presenter.advance(&ui);
+        presenter.advance(&ui);
+        let alpha = Alpha::new(1, TWO);
+        b.iter(|| {
+            let mut quads = 0u32;
+            for quad in presenter.frame(black_box(alpha)) {
+                black_box(&quad);
+                quads += 1;
+            }
+            black_box(quads);
+        });
+    });
+}
+
+criterion_group!(benches, ui_benches, ui_clipped_benches);
 criterion_main!(benches);

--- a/bench/suite/benches/ui.rs
+++ b/bench/suite/benches/ui.rs
@@ -19,9 +19,9 @@
 //! **`emit` is deliberately not benched.** It pushes into a
 //! `SpriteRenderer`, which uploads an atlas and builds a pipeline, so
 //! timing it means a GPU device and a dependency this suite does not
-//! have (section 11 presumes a new dependency rejected). `frame` is
-//! the whole of the CPU work `emit` does before the push, so the
-//! number that moves when presentation grows is the one here.
+//! have. `frame` is the whole of the CPU work `emit` does before the
+//! push, so the number that moves when presentation grows is the one
+//! here.
 //!
 //! The allocation gates for these paths do not live here: the tree
 //! commits to zero steady-state allocation in its own crate's
@@ -300,11 +300,12 @@ fn ui_clipped_benches(c: &mut Criterion) {
     // The same blend, with the cut path taken.
     //
     // Every leaf is forty pixels tall inside a twenty-pixel row, so
-    // the row's own box cuts it top and bottom: 992 of the 1,024
-    // nodes take the proportional path while the 32 rows and the root
-    // take the early-out. Subtracting `ui_frame_1024` and dividing by
-    // 992 gives the added cost of a cut, which is the number the
-    // clipping work is answerable for.
+    // the row's own box cuts it top and bottom: the 992 leaves take
+    // the proportional path and the 31 rows take the early-out, while
+    // the root draws nothing at all, so the frame is 1,023 quads.
+    // Subtracting `ui_frame_1024` and dividing by 992 gives the added
+    // cost of a cut, which is the number the clipping work is
+    // answerable for.
     c.bench_function("ui_frame_clipped_1024", |b| {
         let mut ui = build_tree_with(OverflowS::LeavesOverflowTheirRow);
         solve(&mut ui);

--- a/bench/suite/benches/ui.rs
+++ b/bench/suite/benches/ui.rs
@@ -3,12 +3,25 @@
 //! order of magnitude past any menu the samples draw, so the numbers
 //! bound a real document rather than flatter a toy.
 //!
-//! Four costs, in the order a running game meets them: solving a tree
-//! from cold, re-solving after one node's layout changed, re-solving
-//! after a colour-only flip (today identical to the layout re-solve,
-//! recorded so the state-table work can show the drop when colour
-//! stops dirtying layout), and capturing the solved tree into the
-//! presenter's snapshot pair.
+//! Five costs, in the order a running game meets them: solving a tree
+//! from cold, re-solving after one node's layout changed, wearing a
+//! colour-only state patch, capturing the solved tree into the
+//! presenter's snapshot pair, and blending that pair into the frame's
+//! quads.
+//!
+//! **The frame blend had no number until now**, which mattered:
+//! presentation is the half a visual vocabulary grows — a node that
+//! can carry an image, a nine-slice or a label emits more quads and
+//! cuts a source rectangle as well as a destination one — and a change
+//! is only measurable against a before. `ui_frame_1024` is that
+//! before, taken while a node is still one white quad.
+//!
+//! **`emit` is deliberately not benched.** It pushes into a
+//! `SpriteRenderer`, which uploads an atlas and builds a pipeline, so
+//! timing it means a GPU device and a dependency this suite does not
+//! have (section 11 presumes a new dependency rejected). `frame` is
+//! the whole of the CPU work `emit` does before the push, so the
+//! number that moves when presentation grows is the one here.
 //!
 //! The allocation gates for these paths do not live here: the tree
 //! commits to zero steady-state allocation in its own crate's
@@ -17,9 +30,14 @@
 //! times what those tests already gate.
 
 use std::hint::black_box;
+use std::num::NonZeroU64;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use renew_ui::{Align, Direction, Fixed, Size, Style, Ui, UiLimits};
+use renew_math::Alpha;
+use renew_ui::{
+    Align, Direction, Fixed, NO_PATCH, STATE_COMBINATIONS, Size, StatePatch, Style, Ui, UiEvent,
+    UiLimits,
+};
 use renew_ui_render::UiPresenter;
 
 /// Nodes in the benched tree: one root, `ROWS` rows, the rest split
@@ -31,6 +49,10 @@ const PER_ROW: u32 = (NODES - 1 - ROWS) / ROWS;
 
 /// The viewport every solve answers for.
 const VIEW: (i32, i32) = (1280, 720);
+
+/// A two-tick step, for the halfway blend. Built up from `MIN`, which
+/// is one, so the constant carries no panic path.
+const TWO: NonZeroU64 = NonZeroU64::MIN.saturating_add(1);
 
 /// A tree of exactly [`NODES`] nodes, styled so the solver's paths
 /// all run: rows grow by weight into the column's leftover height,
@@ -146,32 +168,57 @@ fn ui_benches(c: &mut Criterion) {
         });
     });
 
-    // A colour-only flip: geometry is untouched, and today the tree
-    // re-solves anyway — one dirty flag, no damage classes. This
-    // number exists to be compared against `re_solve_one_dirty_1024`
-    // now (they should match) and against itself when styling stops
-    // dirtying layout (it should collapse).
+    // A colour-only flip, through the mechanism that exists for it.
+    //
+    // **This benchmark used to call `set_style`**, which replaces the
+    // authored base and dirties layout unconditionally — so the line
+    // measured a full re-solve and could never show the drop it was
+    // written to watch, whatever the state tables did. It wears a
+    // pooled patch now, flipped by moving the pointer on and off the
+    // leaf, which is what a hovered button actually does: `wear` swaps
+    // one resolved style, and a patch whose `touches_layout` is false
+    // must leave `layout_passes` where it was.
     c.bench_function("ui_state_flip_colour_1024", |b| {
         let mut ui = build_tree();
         solve(&mut ui);
         let leaf = last_leaf(&ui);
-        let mut lit = false;
+        let base = ui.base_style(leaf).unwrap_or_default();
+        // One patch: the same box, a different colour. Geometry is
+        // untouched, so it declares itself layout-free.
+        let lit = StatePatch {
+            style: Style {
+                background: [90, 120, 200, 255],
+                ..base
+            },
+            touches_layout: false,
+        };
+        assert!(ui.set_patch_pool(vec![lit]), "the pool was refused");
+        let mut table = [NO_PATCH; STATE_COMBINATIONS];
+        // Every combination carrying the hover bit wears the patch.
+        for (bits, entry) in table.iter_mut().enumerate() {
+            if u8::try_from(bits).unwrap_or(0) & renew_ui::STATE_HOVER != 0 {
+                *entry = 0;
+            }
+        }
+        assert!(ui.set_state_table(leaf, table), "the table was refused");
+        solve(&mut ui);
+        // On the leaf, and far away from it: the two pointer positions
+        // the flip alternates between.
+        // Pointer coordinates are whole physical pixels, so the centre
+        // is taken in the integer space `contains` compares in.
+        let rect = ui.rect(leaf).unwrap_or_default();
+        let mid = |edge: Fixed, span: Fixed| {
+            let low = edge.trunc_int();
+            let high = (edge + span).trunc_int();
+            i32::try_from(i64::midpoint(low, high)).unwrap_or(0)
+        };
+        let on = (mid(rect.x, rect.width), mid(rect.y, rect.height));
+        let off = (-1, -1);
+        let mut hovered = false;
         b.iter(|| {
-            lit = !lit;
-            let background = if lit {
-                [90, 120, 200, 255]
-            } else {
-                [40, 44, 52, 230]
-            };
-            ui.set_style(
-                leaf,
-                Style {
-                    width: Size::Px(Fixed::from_int(8)),
-                    height: Size::Px(Fixed::from_int(10)),
-                    background,
-                    ..Style::default()
-                },
-            );
+            hovered = !hovered;
+            let (x, y) = if hovered { on } else { off };
+            ui.handle(UiEvent::PointerMoved { x, y });
             solve(&mut ui);
             black_box(ui.rect(leaf));
         });
@@ -187,6 +234,38 @@ fn ui_benches(c: &mut Criterion) {
         presenter.advance(&ui);
         b.iter(|| {
             presenter.advance(black_box(&ui));
+        });
+    });
+
+    // The frame blend: the snapshot pair interpolated, clipped to
+    // ancestor boxes and turned into quads, at the display rate rather
+    // than the tick rate — so a 144 Hz screen pays this more often than
+    // anything else in this file.
+    //
+    // Drained, because the work is in the iterator: `frame` returns a
+    // lazy walk and a caller that does not consume it measures a
+    // function call. The half-alpha is the honest case — every position
+    // and tint is a live blend of two snapshots rather than a copy of
+    // one.
+    c.bench_function("ui_frame_1024", |b| {
+        let mut ui = build_tree();
+        solve(&mut ui);
+        let mut presenter = UiPresenter::new(NODES);
+        // Two advances, so the pair holds two distinct snapshots and
+        // the blend has something to interpolate between.
+        presenter.advance(&ui);
+        presenter.advance(&ui);
+        // Exactly halfway between the pair: one tick's remainder over a
+        // two-tick step, so the blend is a real interpolation rather
+        // than a copy of either snapshot.
+        let alpha = Alpha::new(1, TWO);
+        b.iter(|| {
+            let mut quads = 0u32;
+            for quad in presenter.frame(black_box(alpha)) {
+                black_box(&quad);
+                quads += 1;
+            }
+            black_box(quads);
         });
     });
 }

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -117,7 +117,7 @@ Every sprite becomes one 64-byte record: seven attributes, sixteen
 | 1 | `Vec2` | corner b — the local top-right |
 | 2 | `Vec2` | corner c — the local bottom-left |
 | 3 | `Vec2` | corner d — the local bottom-right |
-| 4 | `Vec2` | UV at corner a — the region's min, or its max on a flipped axis |
+| 4 | `Vec2` | UV at corner a — the source's min, or its max on a flipped axis |
 | 5 | `Vec2` | UV at corner d |
 | 6 | `Vec4` | premultiplied tint |
 

--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -58,18 +58,24 @@ else, which the build matrix proves by building and testing without it.
 
 ## What is here
 
-- `Canvas`, `Region`, `Sprite` — the pure vocabulary: a logical pixel
-  space (y down from the top-left), a rectangle of atlas texels, and
-  one placed, sized, tinted sprite, mirrored on either axis when asked
-  (`flip_x`/`flip_y` — a swap of the sampled edges, so the geometry and
-  its winding never move), turned about a fractional pivot and scaled
-  about it (`rotation` in turns — a quarter turn is `0.25`, clockwise on
-  screen; `pivot`, the centre by default; `scale` per axis, where a
-  negative factor is the geometric mirror). A uniform tint
-  `[a, a, a, a]` is a fade to `a` of the sprite's opacity: the tint is
-  premultiplied, so scaling all four channels is what "`a` as opaque"
-  means, and scaling only the fourth would brighten the sprite as it
-  faded.
+- `Canvas`, `Region`, `SubRegion`, `Sprite` — the pure vocabulary: a
+  logical pixel space (y down from the top-left), a rectangle of atlas
+  texels on texel boundaries, the same rectangle with sub-texel edges
+  for a cut or nine-sliced sprite, and one placed, sized, tinted
+  sprite, mirrored on either axis when asked (`flip_x`/`flip_y` — a swap
+  of the sampled edges, so the geometry and its winding never move),
+  turned about a fractional pivot and scaled about it (`rotation` in
+  turns — a quarter turn is `0.25`, clockwise on screen; `pivot`, the
+  centre by default; `scale` per axis, where a negative factor is the
+  geometric mirror). A sprite built from a whole `Region` packs the same
+  bytes it packed when the field was integral — both paths take the same
+  `as f32` cast, so they agree even for coordinates past 2^24 where that
+  cast rounds. ("Converts exactly" would be the stronger and false
+  claim: `Region { x: 16_777_217, .. }` widens to `16_777_216.0`.) A
+  uniform tint `[a, a, a, a]` is a fade to `a` of the sprite's opacity:
+  the tint is premultiplied, so scaling all four channels is what "`a`
+  as opaque" means, and scaling only the fourth would brighten the
+  sprite as it faded.
 - `AtlasDesc` — dimensions plus **authored, straight-alpha** RGBA8
   bytes: the hardware decodes them on sample and the fragment stage
   premultiplies afterwards, so handing this API already-premultiplied
@@ -133,11 +139,14 @@ together.
 
 Unit tests pin the maps (all four canvas corners, exact) and the packed
 bytes against hand-written records; a property test holds the ortho map
-monotone, corner-exact, and invertible over random canvases, and two
-more hold the batch fade to the premultiplied rule (every channel by
-the same factor, composing to the product, never brightening) and the
-batch offsets to adding; a flip swaps exactly the two UV lanes of its
-axis and nothing else, pinned lane by lane. The turn is pinned three
+monotone, corner-exact, and invertible over random canvases, two more
+hold the batch fade to the premultiplied rule (every channel by the
+same factor, composing to the product, never brightening) and the
+batch offsets to adding, and two more hold a whole `Region` widened
+into a `SubRegion` packing the bytes the integer field packed over the
+entire `u32` domain and a fractional source reaching the UVs unrounded;
+a flip swaps exactly the two UV lanes of its axis and nothing else,
+pinned lane by lane. The turn is pinned three
 ways: the untransformed sprite packs the rectangle bit for bit on a
 fixture whose general path would round; quarter and half turns and the
 negative-scale mirror permute integer corners exactly; and properties

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -58,7 +58,8 @@ impl Canvas {
     }
 }
 
-/// A rectangle of atlas texels: which part of the atlas a sprite shows.
+/// A rectangle of atlas texels on texel boundaries: the whole-texel
+/// input a sprite is usually built from, and what a baker records.
 ///
 /// Plain data with public fields — every combination is meaningful to
 /// construct, and the UV map is total over it. A region reaching past
@@ -86,9 +87,69 @@ pub struct Region {
     pub height: u32,
 }
 
-/// One sprite: an atlas region, a place on the canvas, a size, a tint,
-/// and — each an identity by default — a mirror on either axis, a turn
-/// about a pivot and a scale about the same pivot.
+/// A rectangle of atlas texels whose edges need not fall on texel
+/// boundaries: what a clipped or nine-sliced sprite samples.
+///
+/// "Sub" is *sub-texel*, not sub-rectangle - nothing here is checked
+/// against an enclosing [`Region`], and a whole region converts into one
+/// of these unchanged.
+///
+/// **A widened [`Region`] packs the bytes the integer field packed**, for
+/// every `u32` and with no bound on the coordinate: the old path cast
+/// `region.x as f32` on the way into the packer and this one casts it in
+/// the [`From`] impl below, so the two agree bit for bit even where the
+/// cast rounds. Pinned over the whole `u32` domain by
+/// `widening_a_region_packs_the_bytes_the_integer_path_packed`.
+///
+/// **What this type admits that [`Region`] did not.** Floats carry NaN,
+/// the infinities, and negative extents, and the fields are public, so
+/// all three are constructible. None is rejected: they reach the vertex
+/// buffer and draw nothing recognisable, the same way a region past the
+/// atlas edge draws clamped texels. That is visible nonsense rather than
+/// unsoundness - no sampler can be made unsafe by a UV - but unlike
+/// `Region`'s one degenerate case it is not *useful* nonsense, so a
+/// caller computing these should keep them finite and positive.
+///
+/// **Sampling is nearest and clamped**, so a pixel centre resolves to
+/// `floor(u)`. Edges falling inside a texel are therefore safe only when
+/// the source was cut *in proportion to the destination* - then the
+/// linear map is unchanged and every surviving pixel samples the texel
+/// it would have sampled uncut. A source cut by any other rule can
+/// resolve past its own edge into neighbouring art; a caller doing that
+/// owes its regions a transparent gutter.
+///
+/// Exhaustive on purpose, where [`Sprite`] is `#[non_exhaustive]`:
+/// presentation crates build these by struct literal when they cut one.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SubRegion {
+    /// Left edge, in texels from the atlas's left.
+    pub x: f32,
+    /// Top edge, in texels from the atlas's top.
+    pub y: f32,
+    /// Width in texels.
+    pub width: f32,
+    /// Height in texels.
+    pub height: f32,
+}
+
+impl From<Region> for SubRegion {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "past 2^24 texels the widening degrades visibly, never unsafely; real atlases sit far below it"
+    )]
+    fn from(region: Region) -> Self {
+        Self {
+            x: region.x as f32,
+            y: region.y as f32,
+            width: region.width as f32,
+            height: region.height as f32,
+        }
+    }
+}
+
+/// One sprite: a source rectangle, a place on the canvas, a size, a
+/// tint, and — each an identity by default — a mirror on either axis, a
+/// turn about a pivot and a scale about the same pivot.
 ///
 /// `#[non_exhaustive]` with a constructor and builders, the descriptor
 /// pattern this tree uses everywhere: the fields a later version adds
@@ -96,8 +157,10 @@ pub struct Region {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct Sprite {
-    /// The atlas texels this sprite shows.
-    pub region: Region,
+    /// The atlas texels this sprite shows. Sub-texel edges, so a
+    /// clipped or nine-sliced sprite can name a fraction of a texel;
+    /// a whole [`Region`] widens into one exactly.
+    pub source: SubRegion,
     /// Left edge on the canvas, logical pixels.
     pub x: f32,
     /// Top edge on the canvas, logical pixels.
@@ -161,20 +224,21 @@ pub struct Sprite {
 }
 
 impl Sprite {
-    /// `region` drawn with its top-left corner at (`x`, `y`), at the
-    /// region's own size, untinted.
+    /// The source rectangle drawn with its top-left corner at (`x`,
+    /// `y`), at its own texel size, untinted.
+    ///
+    /// Takes a whole [`Region`] or an already-cut [`SubRegion`] alike,
+    /// so a caller holding a cut rectangle builds from it directly
+    /// rather than naming a region it does not have.
     #[must_use]
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "past 2^24 texels the placement degrades visibly, never unsafely; real atlases sit far below it"
-    )]
-    pub fn new(region: Region, x: f32, y: f32) -> Self {
+    pub fn new(source: impl Into<SubRegion>, x: f32, y: f32) -> Self {
+        let source = source.into();
         Self {
-            region,
+            source,
             x,
             y,
-            width: region.width as f32,
-            height: region.height as f32,
+            width: source.width,
+            height: source.height,
             tint: [1.0, 1.0, 1.0, 1.0],
             flip_x: false,
             flip_y: false,
@@ -184,8 +248,23 @@ impl Sprite {
         }
     }
 
-    /// Draw at `width × height` canvas pixels instead of the region's
-    /// own size.
+    /// Replace the source rectangle, sampling `source` instead.
+    ///
+    /// The canvas size is deliberately left alone: a caller cutting a
+    /// source is usually cutting the destination too, and by its own
+    /// ratio rather than this one. The consequence is worth stating
+    /// because it is silent - a source-only cut *rescales* the sprite,
+    /// stretching fewer texels over the footprint [`Sprite::new`] took
+    /// from the original rectangle, unless [`Sprite::size`] follows.
+    /// Order between the two does not matter.
+    #[must_use]
+    pub fn source(mut self, source: SubRegion) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Draw at `width × height` canvas pixels instead of the source
+    /// rectangle's own texel size.
     #[must_use]
     pub fn size(mut self, width: f32, height: f32) -> Self {
         self.width = width;
@@ -284,9 +363,17 @@ pub(crate) fn to_ndc(point: Vec2, canvas: Canvas) -> Vec2 {
     )
 }
 
-/// Region texels to UV: `texel / atlas_extent` per axis. Region edges
-/// land on texel boundaries; nearest sampling then picks interior
-/// texels, so no half-texel inset exists to get wrong.
+/// Texels to UV: `texel / atlas_extent` per axis, and nothing else -
+/// no half-texel inset, in either direction.
+///
+/// The argument is a [`SubRegion`] edge, so it need not land on a texel
+/// boundary. Sampling is nearest and clamped, which makes the rule easy
+/// to state and easy to get wrong: a pixel centre resolves to
+/// `floor(u)`, so a whole-texel edge names the texel it touches, and a
+/// fractional edge names whichever texel the fraction falls inside.
+/// That is what the caller wants exactly when the source was cut in
+/// proportion to the destination; [`SubRegion`] carries the full
+/// statement and the obligation it puts on a caller.
 #[allow(
     clippy::cast_precision_loss,
     reason = "past 2^24 texels the map degrades visibly, never unsafely; real atlases sit far below it"
@@ -466,17 +553,13 @@ pub(crate) fn corners(sprite: &Sprite) -> [Vec2; 4] {
 /// the four corners in NDC — local top-left, top-right, bottom-left,
 /// bottom-right, each two `f32`s — then the UV at the first corner and
 /// at the last, then the four-`f32` tint, native-endian, in
-/// declaration order. The two UV lanes are the region's min and max
+/// declaration order. The two UV lanes are the source's min and max
 /// unless a flip swapped them.
-#[allow(
-    clippy::cast_precision_loss,
-    reason = "past 2^24 texels the packing degrades visibly, never unsafely; real regions sit far below it"
-)]
 pub(crate) fn pack(sprite: &Sprite, canvas: Canvas, atlas: Extent) -> [u8; INSTANCE_STRIDE] {
     let [a, b, c, d] = corners(sprite).map(|corner| to_ndc(corner, canvas));
 
-    let texel_min = Vec2::new(sprite.region.x as f32, sprite.region.y as f32);
-    let texel_max = texel_min + Vec2::new(sprite.region.width as f32, sprite.region.height as f32);
+    let texel_min = Vec2::new(sprite.source.x, sprite.source.y);
+    let texel_max = texel_min + Vec2::new(sprite.source.width, sprite.source.height);
     let (uv0, uv1) = mirrored(
         to_uv(texel_min, atlas),
         to_uv(texel_max, atlas),
@@ -582,7 +665,7 @@ mod tests {
     ///
     /// The batch offset exists so a caller can slide a whole group
     /// without the code that builds each sprite knowing the group is
-    /// moving. If it touched the size, the region or the tint it would
+    /// moving. If it touched the size, the source or the tint it would
     /// stop being a slide.
     #[test]
     fn an_offset_moves_a_sprite_and_leaves_the_rest_alone() {
@@ -590,7 +673,7 @@ mod tests {
         let after = placed(&before, (7.0, -3.0), 1.0);
         assert_eq!((after.x, after.y), (17.0, 17.0));
         assert_eq!((after.width, after.height), (before.width, before.height));
-        assert_eq!(after.region, before.region);
+        assert_eq!(after.source, before.source);
         assert_eq!(
             tint_bits(after.tint),
             tint_bits(before.tint),
@@ -1439,6 +1522,190 @@ mod tests {
         }
     }
 
+    /// Bits, so a comparison of source rectangles is exact and carries
+    /// no float-equality judgement.
+    fn sub_bits(s: SubRegion) -> [u32; 4] {
+        [
+            s.x.to_bits(),
+            s.y.to_bits(),
+            s.width.to_bits(),
+            s.height.to_bits(),
+        ]
+    }
+
+    /// **`Sprite::source` replaces the source and touches nothing
+    /// else** — the two promises its doc makes, which nothing pinned
+    /// until a review pointed out the builder had no caller and no test
+    /// at all.
+    ///
+    /// This matters more than it looks. The clipping work appends
+    /// `.source(cut)` to a chain that already carries `.size(w, h)`; a
+    /// builder that also wrote the canvas size would collapse every
+    /// clipped quad from its layout footprint to its texel count — a
+    /// whole interface rendered a few pixels tall — and no other test
+    /// in this crate would have gone red.
+    ///
+    /// Probed twice, both red here and nowhere else: discarding the
+    /// argument (`let _ = source; self`), and adding
+    /// `self.width = source.width; self.height = source.height;`.
+    #[test]
+    fn replacing_the_source_leaves_the_placement_and_tint_alone() {
+        let region = Region {
+            x: 1,
+            y: 2,
+            width: 4,
+            height: 8,
+        };
+        let base = Sprite::new(region, 3.5, 4.25)
+            .size(100.0, 60.0)
+            .tint([0.25, 0.5, 0.75, 1.0]);
+        let cut = SubRegion {
+            x: 1.5,
+            y: 2.5,
+            width: 2.0,
+            height: 3.0,
+        };
+        let after = base.source(cut);
+
+        assert_eq!(
+            sub_bits(after.source),
+            sub_bits(cut),
+            "the cut did not land"
+        );
+        assert_eq!(
+            [
+                after.x.to_bits(),
+                after.y.to_bits(),
+                after.width.to_bits(),
+                after.height.to_bits()
+            ],
+            [
+                base.x.to_bits(),
+                base.y.to_bits(),
+                base.width.to_bits(),
+                base.height.to_bits()
+            ],
+            "replacing the source moved or resized the sprite"
+        );
+        assert_eq!(
+            after.tint.map(f32::to_bits),
+            base.tint.map(f32::to_bits),
+            "replacing the source disturbed the tint"
+        );
+
+        // And the two builders commute, which the doc also promises.
+        let sized_then_cut = Sprite::new(region, 3.5, 4.25).size(100.0, 60.0).source(cut);
+        let cut_then_sized = Sprite::new(region, 3.5, 4.25).source(cut).size(100.0, 60.0);
+        assert_eq!(
+            (
+                sub_bits(sized_then_cut.source),
+                sized_then_cut.width.to_bits(),
+                sized_then_cut.height.to_bits()
+            ),
+            (
+                sub_bits(cut_then_sized.source),
+                cut_then_sized.width.to_bits(),
+                cut_then_sized.height.to_bits()
+            ),
+            "the order of `size` and `source` changed the sprite"
+        );
+    }
+
+    /// **A fractional source packs hand-computed UVs**, byte for byte,
+    /// against arithmetic this test owns rather than borrows.
+    ///
+    /// The property test beside it cannot do this job: its expectation
+    /// calls `to_uv`, so a rounding step placed *inside* `to_uv` would
+    /// round both sides and agree with itself. A review demonstrated
+    /// exactly that with a 1/256-texel snap that left the whole suite
+    /// green.
+    ///
+    /// So the numbers below are written out by hand. The source edges
+    /// are deliberately **not** multiples of 1/256 — `x` is 257/512 —
+    /// because a snap coarser than the value cannot be detected by a
+    /// value it already divides. Every expected UV is exact in binary:
+    /// on an 8-texel axis, `(257/512)/8 = 257/4096`.
+    ///
+    /// Probed with the same 1/256 snap inside `to_uv`: red here, green
+    /// everywhere else, which is the point.
+    #[test]
+    fn a_fractional_source_packs_hand_computed_uvs() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let source = SubRegion {
+            x: 257.0 / 512.0,
+            y: 0.25,
+            width: 1.5,
+            height: 2.5,
+        };
+        let packed = pack(&Sprite::new(source, 0.0, 0.0), c, atlas);
+
+        let uv = |slot: usize| {
+            let mut four = [0u8; 4];
+            four.copy_from_slice(&packed[slot * 4..slot * 4 + 4]);
+            f32::from_ne_bytes(four)
+        };
+        // Written as the fractions they are: each numerator is small
+        // and each denominator a power of two, so every one of these is
+        // exact in an f32 and the reader can check the arithmetic.
+        assert_eq!(uv(8).to_bits(), (257.0f32 / 4096.0).to_bits(), "uv min x");
+        assert_eq!(uv(9).to_bits(), (2.0f32 / 64.0).to_bits(), "uv min y");
+        assert_eq!(uv(10).to_bits(), (1025.0f32 / 4096.0).to_bits(), "uv max x");
+        assert_eq!(uv(11).to_bits(), (2.75f32 / 8.0).to_bits(), "uv max y");
+    }
+
+    /// **The degenerate sources draw nonsense rather than being
+    /// rejected** — the contract `SubRegion`'s doc states, pinned, so
+    /// that a later assertion or clamp is a deliberate change and not a
+    /// silent one.
+    ///
+    /// `Region`'s `u32` domain could express none of these. Floats can,
+    /// the fields are public, and nothing rejects them: a negative
+    /// extent inverts the rectangle in both spaces, and a non-finite
+    /// edge reaches the vertex buffer intact. No sampler can be made
+    /// unsafe by a UV, so this is visible nonsense, not unsoundness -
+    /// but it is nonsense the type now admits and the doc now promises.
+    #[test]
+    fn a_degenerate_source_reaches_the_buffer_rather_than_being_refused() {
+        let c = canvas(64, 32);
+        let atlas = Extent {
+            width: 8,
+            height: 8,
+        };
+        let uv = |packed: &[u8; INSTANCE_STRIDE], slot: usize| {
+            let mut four = [0u8; 4];
+            four.copy_from_slice(&packed[slot * 4..slot * 4 + 4]);
+            f32::from_ne_bytes(four)
+        };
+
+        // A negative extent inverts: the max edge lands below the min.
+        let inverted = SubRegion {
+            x: 4.0,
+            y: 4.0,
+            width: -4.0,
+            height: -4.0,
+        };
+        let packed = pack(&Sprite::new(inverted, 0.0, 0.0), c, atlas);
+        assert!(
+            uv(&packed, 10) < uv(&packed, 8) && uv(&packed, 11) < uv(&packed, 9),
+            "a negative extent stopped inverting the sampled rectangle"
+        );
+
+        // A non-finite edge propagates rather than being scrubbed.
+        let unreal = SubRegion {
+            x: f32::NAN,
+            y: 0.0,
+            width: f32::INFINITY,
+            height: 1.0,
+        };
+        let packed = pack(&Sprite::new(unreal, 0.0, 0.0), c, atlas);
+        assert!(uv(&packed, 8).is_nan(), "the NaN edge was scrubbed");
+        assert!(uv(&packed, 10).is_nan(), "the NaN edge did not propagate");
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig {
             rng_seed: RngSeed::Fixed(0x2D5A_F00E),
@@ -1477,6 +1744,126 @@ mod tests {
             let back = Vec2::new((here.x + 1.0) * w / 2.0, (here.y + 1.0) * h / 2.0);
             prop_assert!((back.x - x).abs() <= w * 1e-6 + 1e-3);
             prop_assert!((back.y - y).abs() <= h * 1e-6 + 1e-3);
+        }
+
+        /// **A whole-texel source packs the bytes the integer field
+        /// packed** - exactly, for every `u32`, with no bound on the
+        /// coordinate.
+        ///
+        /// A sprite's source rectangle carries `f32` edges, so a whole
+        /// region reaches the packer through a widening. Drift there
+        /// would be close to invisible - a sprite half a texel off
+        /// samples its neighbour's art rather than crashing - so the
+        /// claim is stated at the only level that cannot be fudged:
+        /// the packed bytes must be identical, bit for bit.
+        ///
+        /// The domain is the **entire** `u32` range, not a plausible
+        /// slice of it, because the guarantee does not depend on the
+        /// magnitude: both paths perform the same `as f32` cast, so
+        /// they agree even where that cast rounds. An earlier draft of
+        /// this test sampled `0..=4096` and justified itself by a 2^24
+        /// bound below which the cast is lossless - which was the wrong
+        /// reason for a true conclusion, and under-claimed the result.
+        ///
+        /// The expectation recomputes the *plumbing* independently —
+        /// that `Sprite::new` takes its canvas size from the source and
+        /// that `pack` reads `sprite.source` — while deliberately
+        /// sharing `to_ndc`, `to_uv` and the packing loop with the code
+        /// under test. It is not two implementations; claiming that
+        /// would overstate it. What it owns is the field wiring, and
+        /// that is what a widening can get wrong.
+        ///
+        /// Probed with `x: region.x as u16 as f32` in `SubRegion::from`
+        /// — a truncation above 65535 — which reddens **this** test
+        /// and shrinks to `rx = 65536`. Chosen over the more obvious
+        /// off-by-one probe because that one also reddens
+        /// `packing_is_byte_exact_against_a_hand_computed_record`, and a
+        /// probe the existing suite already catches says nothing about
+        /// what this test adds.
+        #[test]
+        fn widening_a_region_packs_the_bytes_the_integer_path_packed(
+            rx in any::<u32>(),
+            ry in any::<u32>(),
+            rw in any::<u32>(),
+            rh in any::<u32>(),
+            cw in 1u32..=u32::MAX,
+            ch in 1u32..=u32::MAX,
+            aw in 1u32..=u32::MAX,
+            ah in 1u32..=u32::MAX,
+            x in -65536.0f32..=65536.0,
+            y in -65536.0f32..=65536.0,
+        ) {
+            let region = Region { x: rx, y: ry, width: rw, height: rh };
+            let c = canvas(cw, ch);
+            let atlas = Extent { width: aw, height: ah };
+
+            // The integer path, written out: what `pack` computed when
+            // the source rectangle had no fractional edges. The record
+            // carries the four corners, so the oracle names all four;
+            // an unturned, unscaled sprite's corners are its rectangle's,
+            // which is the branch `corners` takes here.
+            let canvas_min = Vec2::new(x, y);
+            let canvas_max = canvas_min + Vec2::new(rw as f32, rh as f32);
+            let texel_min = Vec2::new(rx as f32, ry as f32);
+            let texel_max = texel_min + Vec2::new(rw as f32, rh as f32);
+            let ndc_a = to_ndc(canvas_min, c);
+            let ndc_b = to_ndc(Vec2::new(canvas_max.x, canvas_min.y), c);
+            let ndc_c = to_ndc(Vec2::new(canvas_min.x, canvas_max.y), c);
+            let ndc_d = to_ndc(canvas_max, c);
+            let uv_min = to_uv(texel_min, atlas);
+            let uv_max = to_uv(texel_max, atlas);
+            let values: [f32; INSTANCE_LANES] = [
+                ndc_a.x, ndc_a.y, ndc_b.x, ndc_b.y,
+                ndc_c.x, ndc_c.y, ndc_d.x, ndc_d.y,
+                uv_min.x, uv_min.y, uv_max.x, uv_max.y,
+                1.0, 1.0, 1.0, 1.0,
+            ];
+            let mut expected = [0u8; INSTANCE_STRIDE];
+            for (slot, value) in expected.as_chunks_mut::<4>().0.iter_mut().zip(values) {
+                slot.copy_from_slice(&value.to_ne_bytes());
+            }
+
+            prop_assert_eq!(pack(&Sprite::new(region, x, y), c, atlas), expected);
+        }
+
+        /// A fractional source reaches the packer unrounded: the UVs
+        /// it produces are the fraction's own, not the enclosing
+        /// texel's. Without this, a float source rectangle would be a
+        /// type change with no capability behind it.
+        ///
+        /// Built straight from the `SubRegion`, which is the point of
+        /// `Sprite::new` taking anything that converts: a caller
+        /// holding a cut rectangle names no region it does not have.
+        #[test]
+        fn a_fractional_source_reaches_the_uvs_unrounded(
+            fx in 0.0f32..=1024.0,
+            fy in 0.0f32..=1024.0,
+            fw in 0.25f32..=1024.0,
+            fh in 0.25f32..=1024.0,
+        ) {
+            let atlas = Extent { width: 2048, height: 2048 };
+            let c = canvas(256, 256);
+            let source = SubRegion { x: fx, y: fy, width: fw, height: fh };
+            let sprite = Sprite::new(source, 0.0, 0.0);
+
+            let packed = pack(&sprite, c, atlas);
+            let uv = |slot: usize| {
+                let mut four = [0u8; 4];
+                four.copy_from_slice(&packed[slot * 4..slot * 4 + 4]);
+                f32::from_ne_bytes(four)
+            };
+            // Slots 8..12 are UV min then UV max, in declaration order,
+            // after the four corners.
+            prop_assert_eq!(uv(8).to_bits(), to_uv(Vec2::new(fx, fy), atlas).x.to_bits());
+            prop_assert_eq!(uv(9).to_bits(), to_uv(Vec2::new(fx, fy), atlas).y.to_bits());
+            prop_assert_eq!(
+                uv(10).to_bits(),
+                to_uv(Vec2::new(fx + fw, fy + fh), atlas).x.to_bits()
+            );
+            prop_assert_eq!(
+                uv(11).to_bits(),
+                to_uv(Vec2::new(fx + fw, fy + fh), atlas).y.to_bits()
+            );
         }
     }
 }

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -673,7 +673,7 @@ mod tests {
         let after = placed(&before, (7.0, -3.0), 1.0);
         assert_eq!((after.x, after.y), (17.0, 17.0));
         assert_eq!((after.width, after.height), (before.width, before.height));
-        assert_eq!(after.source, before.source);
+        assert_eq!(sub_bits(after.source), sub_bits(before.source));
         assert_eq!(
             tint_bits(after.tint),
             tint_bits(before.tint),

--- a/crates/render2d/src/lib.rs
+++ b/crates/render2d/src/lib.rs
@@ -26,11 +26,11 @@
 //!   corners on every platform. A region that is ever turned owes a
 //!   one-texel transparent gutter ([`Region`]).
 //!
-//! The pure half ([`Canvas`], [`Region`], [`Sprite`], [`Instance`], the
-//! corner transform, the turn's sine and cosine, the ortho and UV maps)
-//! lives apart from the device half ([`SpriteRenderer`]) so the math is
-//! testable without a GPU and the rendering-crate seam stays one module
-//! wide.
+//! The pure half ([`Canvas`], [`Region`], [`SubRegion`], [`Sprite`],
+//! [`Instance`], the corner transform, the turn's sine and cosine, the
+//! ortho and UV maps) lives apart from the device half
+//! ([`SpriteRenderer`]) so the math is testable without a GPU and the
+//! rendering-crate seam stays one module wide.
 
 // Diagnostics go through sinks; the standard output macros are banned in
 // this crate by construction, not convention.
@@ -39,5 +39,5 @@
 mod fill;
 mod gpu;
 
-pub use fill::{Canvas, Instance, Region, Sprite};
+pub use fill::{Canvas, Instance, Region, Sprite, SubRegion};
 pub use gpu::{AtlasDesc, Render2dError, SpriteRenderer};

--- a/crates/ui-render/README.md
+++ b/crates/ui-render/README.md
@@ -23,19 +23,20 @@ stacking, never existence.
 ## Frames as data
 
 `UiPresenter::frame` answers one frame as an iterator of quads —
-position, size, premultiplied tint — with clipping applied and
-invisible quads dropped. Quads are in the solver's pixel space, so
-the sprite renderer's canvas must match the viewport the tree solves
-at, and one frame can hold up to `max_quads` of them — twice the node
-limit, because a bulk replace draws every dying node once more under
-every newborn. Every decision the presenter makes is
+position, size, source rectangle, premultiplied tint — with clipping
+applied and invisible quads dropped. Quads are in the solver's pixel
+space, so the sprite renderer's canvas must match the viewport the
+tree solves at, and one frame can hold up to `max_quads` of them —
+twice the node limit, because a bulk replace draws every dying node
+once more under every newborn. Every decision the presenter makes is
 observable there without a device, which is where the unit and
 property tests hold it; `emit` is a thin adapter pushing each quad as
 a sprite. Clipping is rectangle intersection against the ancestor
-chain, computed at capture and blended with the rest; the one sampled
-atlas region is a uniform white texel, so clipping the rectangle is
-clipping the image — the proportional-UV half arrives with the first
-non-uniform region.
+chain, computed at capture and blended with the rest, and the quad's
+source rectangle is cut by the same linear map, so every surviving
+pixel samples the texel it would have sampled uncut. The one sampled
+atlas region is still a uniform white texel, so no committed picture
+moves yet.
 
 ## Text
 

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -37,7 +37,7 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 use renew_math::Alpha;
-use renew_render2d::{Sprite, SpriteRenderer};
+use renew_render2d::{Sprite, SpriteRenderer, SubRegion};
 use renew_ui::{NodeId, Ui};
 
 pub mod atlas;
@@ -188,7 +188,7 @@ impl UiPresenter {
             if successor.present && successor.generation == old.generation {
                 return None;
             }
-            clipped(old.rect, old.clip, old.tint)
+            clipped(old.rect, old.clip, atlas::white().into(), old.tint)
         });
         let living = self.current.order.iter().filter_map(move |&index| {
             let entry = self.current.entries[index as usize];
@@ -201,7 +201,7 @@ impl UiPresenter {
             } else {
                 (entry.rect, entry.clip)
             };
-            clipped(rect, clip, entry.tint)
+            clipped(rect, clip, atlas::white().into(), entry.tint)
         });
         dying.chain(living)
     }
@@ -223,7 +223,7 @@ impl UiPresenter {
     pub fn emit(&self, alpha: Alpha, sprites: &mut SpriteRenderer) {
         for quad in self.frame(alpha) {
             sprites.push(
-                &Sprite::new(atlas::white(), quad.x, quad.y)
+                &Sprite::new(quad.source, quad.x, quad.y)
                     .size(quad.width, quad.height)
                     .tint(quad.tint),
             );
@@ -269,13 +269,54 @@ pub struct Quad {
     pub y: f32,
     pub width: f32,
     pub height: f32,
+    /// The atlas texels this quad samples, cut by the same proportion
+    /// that cut the rectangle. Today every node names the white texel,
+    /// so every source here is that one region and the picture is what
+    /// it was before quads carried a source at all.
+    pub source: SubRegion,
     /// Premultiplied RGBA.
     pub tint: [f32; 4],
 }
 
-/// Clip `rect` to `clip`: the visible quad, or `None` when nothing
-/// remains or the tint draws nothing at all.
-fn clipped(rect: [f32; 4], clip: [f32; 4], tint: [f32; 4]) -> Option<Quad> {
+/// Clip `rect` to `clip`, cutting `source` by the same proportion: the
+/// visible quad, or `None` when nothing remains or the tint draws
+/// nothing at all.
+///
+/// **The source is cut by the same linear map that cut the destination,
+/// so the map is unchanged and every surviving pixel samples the texel
+/// it would have sampled uncut.** Uncut, the shader interpolates between
+/// the source edges, so a pixel centre `p` maps to
+/// `u(p) = sx + sw*(p - x)/w`. Clipped to `[L, R]` the source runs from
+/// `su0 = sx + sw*(L - x)/w` to `su1 = sx + sw*(R - x)/w`, so
+/// `su1 - su0 = sw*(R - L)/w` and
+///
+/// ```text
+/// u'(p) = su0 + (p - L)/(R - L) * (su1 - su0)
+///       = sx + sw*(L - x)/w + sw*(p - L)/w
+///       = sx + sw*(p - x)/w
+///       = u(p)
+/// ```
+///
+/// Identically the same function. It holds by construction, and only
+/// because both fractions come from the same reciprocal - recomputing
+/// per edge is where an implementation loses it.
+///
+/// Two cases are exact rather than merely close. At 1:1 - every glyph,
+/// every nine-slice corner - `source.width / w` is a value divided by
+/// itself, exactly `1.0`, so the cut edge is `sx + (L - x)`: a
+/// difference and a sum of integers, bit-exact. At a power-of-two scale
+/// the reciprocal is exact too. Elsewhere the residue is a few ULPs,
+/// orders below the half texel that could move a `floor`.
+///
+/// Nearest-and-clamped sampling cannot bleed: `0 <= fx0 < fx1 <= 1`, so
+/// a cut only shrinks the sampled rectangle strictly inside the
+/// original, and the computed edges are additionally clamped into it so
+/// a rounding hair cannot reach a neighbouring asset.
+#[expect(
+    clippy::float_cmp,
+    reason = "the early-out fires exactly when no edge moved; a tolerance would take the cut path for a quad that was not cut, which is the one case this must not do"
+)]
+fn clipped(rect: [f32; 4], clip: [f32; 4], source: SubRegion, tint: [f32; 4]) -> Option<Quad> {
     if tint == [0.0, 0.0, 0.0, 0.0] {
         return None;
     }
@@ -287,11 +328,63 @@ fn clipped(rect: [f32; 4], clip: [f32; 4], tint: [f32; 4]) -> Option<Quad> {
     if right <= left || bottom <= top {
         return None;
     }
+
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched - which is what carries every existing
+    // golden byte for byte.
+
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched - which is what carries every existing
+    // golden byte for byte.
+
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched - which is what carries every existing
+    // golden byte for byte.
+
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched - which is what carries every existing
+    // golden byte for byte.
+
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched - which is what carries every existing
+    // golden byte for byte.
+    if left == x && top == y && right == x + width && bottom == y + height {
+        return Some(Quad {
+            x,
+            y,
+            width,
+            height,
+            source,
+            tint,
+        });
+    }
+
+    let inv_w = 1.0 / width;
+    let inv_h = 1.0 / height;
+    let fx0 = (left - x) * inv_w;
+    let fx1 = (right - x) * inv_w;
+    let fy0 = (top - y) * inv_h;
+    let fy1 = (bottom - y) * inv_h;
+    let (sx, sy) = (source.x, source.y);
+    let (sw, sh) = (source.width, source.height);
+    // Clamped into the original source: the arithmetic above cannot
+    // leave it by more than a rounding step, and this makes "cannot" a
+    // fact rather than an argument.
+    let cut_left = sw.mul_add(fx0, sx).max(sx);
+    let cut_top = sh.mul_add(fy0, sy).max(sy);
+    let cut_right = sw.mul_add(fx1, sx).min(sx + sw);
+    let cut_bottom = sh.mul_add(fy1, sy).min(sy + sh);
     Some(Quad {
         x: left,
         y: top,
         width: right - left,
         height: bottom - top,
+        source: SubRegion {
+            x: cut_left,
+            y: cut_top,
+            width: cut_right - cut_left,
+            height: cut_bottom - cut_top,
+        },
         tint,
     })
 }
@@ -638,7 +731,223 @@ mod tests {
         assert_eq!(build(), build());
     }
 
+    /// **An uncut quad passes its source through untouched.**
+    ///
+    /// The early-out is what carries every existing golden: while no
+    /// node names anything but the white texel, a quad inside its clip
+    /// must reach the renderer with the identical source it started
+    /// with, bit for bit, and no division must have been performed to
+    /// get there.
+    ///
+    /// Probed by deleting the early-out so the general path runs on an
+    /// uncut quad: red here, because `1.0/w * w` is not `1.0` for every
+    /// `w`.
+    #[test]
+    fn an_uncut_quad_keeps_its_source_bit_for_bit() {
+        let source = SubRegion {
+            x: 2.0,
+            y: 2.0,
+            width: 4.0,
+            height: 4.0,
+        };
+        // Swept, and seeded with widths chosen against the code
+        // rather than for it.
+        //
+        // A single arbitrary width proves nothing here, and neither
+        // does a sweep of whole numbers: deleting the early-out leaves
+        // both green, because the round trip closes exactly for every
+        // integer width.
+        //
+        // The seeds below are the ones that break the expression the
+        // code actually evaluates - `((x + w) - x) * (1.0 / w)`, where
+        // the subtraction is the lossy step - rather than the tidier
+        // identity `w * (1.0 / w)`. The two disagree about which
+        // inputs are adversarial, and only the first is the one under
+        // test: 8.2 million f32 widths between 1 and 4096 lose bits
+        // this way, the smallest being 1.0000001, and without the
+        // early-out an uncut source of width 4 comes back as 3.9999995.
+        let clip = [0.0, 0.0, 100_000.0, 100_000.0];
+        for span in [
+            f32::from_bits(0x3f80_0001),
+            f32::from_bits(0x3f80_0002),
+            f32::from_bits(0x3f80_0003),
+        ] {
+            let quad = clipped([10.0, 20.0, span, span + 1.0], clip, source, [1.0; 4])
+                .expect("an uncut quad is visible");
+            assert_eq!(
+                [quad.source.x.to_bits(), quad.source.width.to_bits()],
+                [source.x.to_bits(), source.width.to_bits()],
+                "an uncut quad of span {span} went through the cut"
+            );
+        }
+        let mut span = 1.0f32;
+        while span <= 2000.0 {
+            let quad = clipped([10.0, 20.0, span, span + 1.0], clip, source, [1.0; 4])
+                .expect("an uncut quad is visible");
+            assert_eq!(
+                [
+                    quad.source.x.to_bits(),
+                    quad.source.y.to_bits(),
+                    quad.source.width.to_bits(),
+                    quad.source.height.to_bits()
+                ],
+                [
+                    source.x.to_bits(),
+                    source.y.to_bits(),
+                    source.width.to_bits(),
+                    source.height.to_bits()
+                ],
+                "an uncut quad of span {span} went through the cut"
+            );
+            span += 1.0;
+        }
+    }
+
+    /// **At 1:1 on whole pixels the cut is bit-exactly integral** - the
+    /// case every glyph and every nine-slice corner lands in.
+    ///
+    /// At 1:1 the scale `source.width / width` is a value divided by
+    /// itself, exactly `1.0` in IEEE, so the cut edge is `sx + (L - x)`:
+    /// a difference and a sum of small integers, exact. If this were
+    /// merely close, text clipped by a scroll viewport would sample
+    /// half a neighbouring glyph.
+    ///
+    /// A 16x16 source drawn at 16x16 pixels, clipped three pixels in
+    /// from the left and five from the top, eight wide and eight tall.
+    #[test]
+    fn a_one_to_one_cut_lands_on_whole_texels() {
+        let source = SubRegion {
+            x: 32.0,
+            y: 48.0,
+            width: 16.0,
+            height: 16.0,
+        };
+        let quad = clipped(
+            [100.0, 200.0, 16.0, 16.0],
+            [103.0, 205.0, 111.0, 213.0],
+            source,
+            [1.0, 1.0, 1.0, 1.0],
+        )
+        .expect("visible");
+        assert_eq!(quad.source.x.to_bits(), 35.0f32.to_bits(), "cut left texel");
+        assert_eq!(quad.source.y.to_bits(), 53.0f32.to_bits(), "cut top texel");
+        assert_eq!(quad.source.width.to_bits(), 8.0f32.to_bits(), "cut width");
+        assert_eq!(quad.source.height.to_bits(), 8.0f32.to_bits(), "cut height");
+    }
+
+    /// **A non-positive span is invisible, and the edge test is what
+    /// makes it so** - there is no separate guard, because there is no
+    /// room for one to matter.
+    ///
+    /// The design this implements specified an explicit
+    /// `width <= 0.0 || height <= 0.0` guard ahead of the reciprocal.
+    /// It was written, and then removed, because a probe would not
+    /// redden it: `right > left` requires
+    /// `min(x + width, clip.2) > max(x, clip.0) >= x`, hence
+    /// `x + width > x`, hence `width > 0`. The division is reached only
+    /// when both spans are already positive, so the guard was
+    /// unreachable - and it would not have helped against the one case
+    /// people reach for it for, since `width <= 0.0` is false for NaN
+    /// and `(x + NaN).min(c)` returns `c` rather than NaN.
+    ///
+    /// What is left is worth pinning on its own: these rectangles draw
+    /// nothing. Probed by weakening the edge test to `right < left`,
+    /// which lets a zero-width rectangle through to a division by zero:
+    /// red here.
+    #[test]
+    fn a_non_positive_span_draws_nothing() {
+        let source = SubRegion {
+            x: 2.0,
+            y: 2.0,
+            width: 4.0,
+            height: 4.0,
+        };
+        let clip = [-1000.0, -1000.0, 1000.0, 1000.0];
+        let opaque = [1.0, 1.0, 1.0, 1.0];
+        assert_eq!(clipped([5.0, 5.0, 0.0, 10.0], clip, source, opaque), None);
+        assert_eq!(clipped([5.0, 5.0, 10.0, 0.0], clip, source, opaque), None);
+        assert_eq!(clipped([5.0, 5.0, -3.0, 10.0], clip, source, opaque), None);
+    }
+
     proptest::proptest! {
+        /// **A cut samples what the uncut quad would have sampled.**
+        ///
+        /// Three statements over arbitrary geometry, and the third is
+        /// the one that matters. *Contained*: the cut source never
+        /// leaves the original, so nearest-and-clamped sampling cannot
+        /// reach a neighbour's art. *Proportional*: texels-per-pixel is
+        /// unchanged, so nothing is stretched by being clipped. *Same
+        /// map*: for pixel centres across the surviving span, the UV
+        /// the cut quad interpolates equals the one the uncut quad
+        /// would have, which is the actual correctness claim - the
+        /// other two are its corollaries.
+        ///
+        /// The tolerance is relative to the source extent because the
+        /// residue is a few ULPs of it; the claim being tested is not
+        /// "close enough to look right" but "the same linear function,
+        /// evaluated in floating point".
+        ///
+        /// Probed by recomputing the reciprocal per edge
+        /// (`(right - x) / width` in place of `(right - x) * inv_w`):
+        /// still close, and still red here at the tolerance below,
+        /// which is the point of stating the claim this way.
+        #[test]
+        fn a_cut_source_samples_what_the_uncut_quad_would_have(
+            x in -500.0f32..500.0,
+            y in -500.0f32..500.0,
+            w in 1.0f32..1000.0,
+            h in 1.0f32..1000.0,
+            cut_l in 0.0f32..1.0,
+            cut_r in 0.0f32..1.0,
+            sx in 0.0f32..2000.0,
+            sy in 0.0f32..2000.0,
+            sw in 0.5f32..512.0,
+            sh in 0.5f32..512.0,
+        ) {
+            // A clip that bites into the rectangle from both sides by a
+            // random fraction, so the cut path is the one exercised.
+            let lo = cut_l.min(cut_r);
+            let hi = cut_l.max(cut_r);
+            let clip = [
+                w.mul_add(lo * 0.5, x),
+                h.mul_add(lo * 0.5, y),
+                w.mul_add(1.0 - hi * 0.5, x),
+                h.mul_add(1.0 - hi * 0.5, y),
+            ];
+            let source = SubRegion { x: sx, y: sy, width: sw, height: sh };
+            if let Some(q) = clipped([x, y, w, h], clip, source, [1.0, 1.0, 1.0, 1.0]) {
+                let slack = 1e-4 * (1.0 + sw.max(sh));
+
+                // Contained.
+                proptest::prop_assert!(q.source.x >= source.x);
+                proptest::prop_assert!(q.source.y >= source.y);
+                proptest::prop_assert!(q.source.x + q.source.width <= source.x + sw + slack);
+                proptest::prop_assert!(q.source.y + q.source.height <= source.y + sh + slack);
+                proptest::prop_assert!(q.source.width >= 0.0 && q.source.height >= 0.0);
+
+                // Proportional: texels per pixel is what it was.
+                proptest::prop_assert!(
+                    (q.source.width / q.width - sw / w).abs() <= 1e-3 * (1.0 + sw / w)
+                );
+                proptest::prop_assert!(
+                    (q.source.height / q.height - sh / h).abs() <= 1e-3 * (1.0 + sh / h)
+                );
+
+                // The same map, sampled across the surviving span.
+                for step in 0u8..=8 {
+                    let t = f32::from(step) / 8.0;
+                    let p = q.width.mul_add(t, q.x);
+                    let uncut = sw.mul_add((p - x) / w, sx);
+                    let cut = q.source.width.mul_add((p - q.x) / q.width, q.source.x);
+                    proptest::prop_assert!(
+                        (cut - uncut).abs() <= slack,
+                        "at t={} the cut samples {} where the uncut quad sampled {}",
+                        t, cut, uncut
+                    );
+                }
+            }
+        }
+
         /// However rectangles and clips fall, a clipped quad sits
         /// inside both and clipping is stable — to within a few
         /// rounding steps, because the quad stores a width whose
@@ -668,7 +977,7 @@ mod tests {
                 [clip_b[0], clip_b[1], clip_b[0] + clip_b[2].abs(), clip_b[1] + clip_b[3].abs()],
             );
             let tint = [1.0, 1.0, 1.0, 1.0];
-            if let Some(quad) = clipped(rect, clip, tint) {
+            if let Some(quad) = clipped(rect, clip, atlas::white().into(), tint) {
                 let mag =
                     quad.x.abs() + quad.y.abs() + quad.width.abs() + quad.height.abs();
                 let within = |value: f32, bound: f32| value <= bound + step(mag + bound.abs());
@@ -682,8 +991,13 @@ mod tests {
                 proptest::prop_assert!(quad.width > 0.0 && quad.height > 0.0);
                 // Stable: clipping the clipped quad moves nothing by
                 // more than the one rounding step above.
-                let again = clipped([quad.x, quad.y, quad.width, quad.height], clip, tint)
-                    .expect("a visible quad stays visible");
+                let again = clipped(
+                    [quad.x, quad.y, quad.width, quad.height],
+                    clip,
+                    atlas::white().into(),
+                    tint,
+                )
+                .expect("a visible quad stays visible");
                 proptest::prop_assert!(close(again.x, quad.x));
                 proptest::prop_assert!(close(again.y, quad.y));
                 proptest::prop_assert!(close(again.width, quad.width));
@@ -698,7 +1012,12 @@ mod tests {
         ) {
             let clip = [f32::MIN, f32::MIN, f32::MAX, f32::MAX];
             proptest::prop_assert_eq!(
-                clipped([rect[0], rect[1], rect[2] + 1.0, rect[3] + 1.0], clip, [0.0; 4]),
+                clipped(
+                    [rect[0], rect[1], rect[2] + 1.0, rect[3] + 1.0],
+                    clip,
+                    atlas::white().into(),
+                    [0.0; 4]
+                ),
                 None
             );
         }

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -12,12 +12,16 @@
 //! puts the dying underneath the living, so what CAN change abruptly
 //! is stacking, never existence.)
 //!
-//! **Clipping is CPU rectangle intersection.** Every node clips to the
-//! intersection of its ancestors' boxes, computed at capture and
-//! blended with the rest. The one atlas region v0 samples is a uniform
-//! white texel, so clipping the rectangle *is* clipping the image —
-//! the proportional-UV half of the job arrives with the first
-//! non-uniform region, where texel granularity has to be answered.
+//! **Clipping is CPU rectangle intersection, and the source is cut with
+//! it.** Every node clips to the intersection of its ancestors' boxes,
+//! computed at capture and blended with the rest, and the quad's source
+//! rectangle is cut by the same linear map that cut the rectangle — so
+//! the map is unchanged and every surviving pixel samples the texel it
+//! would have sampled uncut. The one atlas region v0 samples is still a
+//! uniform white texel, so no committed picture moves yet; the
+//! arithmetic is in place for the first non-uniform region, where texel
+//! granularity is answered by the proportion rather than by a rule of
+//! its own.
 //!
 //! **Emission is sprites.** One generated atlas (a white fill tile and
 //! a chrome tile beside it, reserved for borders), one premultiplied
@@ -328,22 +332,6 @@ fn clipped(rect: [f32; 4], clip: [f32; 4], source: SubRegion, tint: [f32; 4]) ->
     if right <= left || bottom <= top {
         return None;
     }
-
-    // Nothing was cut: four compares, no division, and the source
-    // passes through untouched - which is what carries every existing
-    // golden byte for byte.
-
-    // Nothing was cut: four compares, no division, and the source
-    // passes through untouched - which is what carries every existing
-    // golden byte for byte.
-
-    // Nothing was cut: four compares, no division, and the source
-    // passes through untouched - which is what carries every existing
-    // golden byte for byte.
-
-    // Nothing was cut: four compares, no division, and the source
-    // passes through untouched - which is what carries every existing
-    // golden byte for byte.
 
     // Nothing was cut: four compares, no division, and the source
     // passes through untouched - which is what carries every existing
@@ -897,15 +885,21 @@ mod tests {
             y in -500.0f32..500.0,
             w in 1.0f32..1000.0,
             h in 1.0f32..1000.0,
-            cut_l in 0.0f32..1.0,
-            cut_r in 0.0f32..1.0,
+            cut_l in 0.1f32..1.0,
+            cut_r in 0.1f32..1.0,
             sx in 0.0f32..2000.0,
             sy in 0.0f32..2000.0,
             sw in 0.5f32..512.0,
             sh in 0.5f32..512.0,
         ) {
             // A clip that bites into the rectangle from both sides by a
-            // random fraction, so the cut path is the one exercised.
+            // random fraction, so the cut path is the one exercised. The
+            // fractions start at a tenth rather than at zero because a
+            // vanishing bite is the early-out, not a cut: proptest shrinks
+            // toward zero, and every assertion below is trivially true of
+            // an uncut quad, so a property drawn from zero would stay green
+            // against a `clipped` that never cut anything at all. The
+            // assertion after the call holds the range to that promise.
             let lo = cut_l.min(cut_r);
             let hi = cut_l.max(cut_r);
             let clip = [
@@ -916,6 +910,14 @@ mod tests {
             ];
             let source = SubRegion { x: sx, y: sy, width: sw, height: sh };
             if let Some(q) = clipped([x, y, w, h], clip, source, [1.0, 1.0, 1.0, 1.0]) {
+                // The cut really happened: without this the property is
+                // satisfied by the quad it was handed back unchanged.
+                proptest::prop_assert!(
+                    q.width < w && q.height < h,
+                    "the clip took the early-out: {} x {} of {} x {}",
+                    q.width, q.height, w, h
+                );
+
                 let slack = 1e-4 * (1.0 + sw.max(sh));
 
                 // Contained.


### PR DESCRIPTION
A sprite's source rectangle gains sub-texel edges, and clipping cuts it
by the same linear map that cuts the rectangle.

`Sprite.region: Region` becomes `source: SubRegion` — four `f32` texel
edges instead of four `u32`. A whole `Region` widens into one and packs
the bytes the integer field packed, over the entire `u32` domain, and
`Sprite::new` takes anything that converts, so every existing call site
is spelled exactly as before while a caller holding a cut rectangle can
build from it directly. Nothing in the engine cuts one yet: this is the
plumbing, landed on its own so it is provable while the picture is still
byte-identical.

`Quad` gains a `source`, and `clipped` cuts it by the same reciprocal
that cuts the rectangle, so the map is unchanged and every surviving
pixel samples the texel it would have sampled uncut. Every quad still
names the white texel, so no committed picture moves.

The benchmark suite gets `ui_frame_1024` — the snapshot pair
interpolated, clipped and walked out as quads — and its colour-flip line
is corrected: it called `set_style`, which replaces the authored base
and dirties layout unconditionally, so the line reported a full re-solve
and could never have shown the drop it was written to watch. Wearing a
pooled patch through pointer hover instead, 73.9 µs becomes 213 ns.

## Tests

- A whole `Region` packs the bytes the integer path packed, over the
  entire `u32` domain; a fractional source packs hand-computed UVs;
  replacing the source leaves placement, size and tint alone and
  commutes with `size`; a fractional source reaches the UVs unrounded;
  the degenerate sources reach the buffer rather than being refused.
- An uncut quad keeps its source bit for bit; a one-to-one cut on whole
  pixels lands on whole texels exactly; over arbitrary geometry the cut
  source is contained in the original, texels-per-pixel is unchanged,
  and the cut quad interpolates the same map — with the clip fractions
  drawn away from zero and the cut asserted, so the property cannot pass
  on a quad that was never cut.

## Evidence

Rebased onto the current trunk and verified as the merged result, not
just as a branch: `cargo build --workspace`, `cargo test --workspace`
(240 suites, 2,521 passed, 0 failed), `cargo fmt --all --check`, `cargo
clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p
renew-sample-glide --features audio --all-targets -- -D warnings`,
`cargo metadata --locked` and the workspace structure check all clean.
The files this branch changes and the files the trunk has changed since
its base are disjoint, and the merge is clean.

The claim that no committed picture moves is the one thing a local run
cannot settle: this machine skips the exact-golden compare by design, so
the software-Vulkan lane here is what proves it.
