### PR TITLE
bench(render3d): time the geometry a frame builds before any device sees it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,10 @@ jobs:
       #
       # renew-bench appears in several exclude lists because its bench
       # targets reach the crates they time (jobs, frame, rng, ecs,
-      # particles, ui, ui-render) and, through those, what they build
-      # on (render2d, rhi, fixed); every cell that removes a crate in
-      # that closure excludes the suite alongside it.
+      # platform, particles, ui, ui-render, render2d, render3d) and,
+      # through those, what they build on (rhi, fixed); every cell
+      # that removes a crate in that closure excludes the suite
+      # alongside it.
       - name: Build and test without the job system
         run: |
           sel="--workspace --exclude renew-jobs --exclude renew-bench"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,15 +392,17 @@ jobs:
           # graph gained the sprite renderer, its normal graph did not.
           RENEW_GRAPH_EDGES="normal,build" bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render2d -p renew-sample-glide
           cargo build -p renew-sample-glide
-      # The 3D renderer: policy over the rendering crate, and no
-      # consumers at all yet -- no sample draws geometry, so nothing is
-      # excluded alongside it. That is what makes this cell cheap to keep
-      # honest now and worth having before it stops being cheap: the
-      # first consumer joins the exclude list rather than discovering,
-      # later, that the crate was never actually removable.
+      # The 3D renderer: policy over the rendering crate. The voxel
+      # sample and the benchmark suite are its consumers, so both are
+      # excluded alongside it. The suite is the newer of the two and
+      # joined the moment it began timing the geometry path -- which is
+      # the arrangement this cell was kept honest for while the crate
+      # had no consumer at all: the first one joins the exclude list
+      # here, rather than discovering later that the crate was never
+      # actually removable.
       - name: Build and test without the 3D renderer
         run: |
-          sel="--workspace --exclude renew-render3d --exclude renew-sample-cube"
+          sel="--workspace --exclude renew-render3d --exclude renew-sample-cube --exclude renew-bench"
           bash "$RUNNER_TEMP/absent-from-graph.sh" renew-render3d $sel
           cargo build $sel
           cargo test $sel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "renew-particles",
  "renew-platform",
  "renew-render2d",
+ "renew-render3d",
  "renew-rhi",
  "renew-rng",
  "renew-ui",

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -56,6 +56,11 @@ renew-render2d = { path = "../../crates/render2d" }
 # crate's runtime-loaded dependency, as they already did through the
 # presenter above.
 renew-rhi = { path = "../../crates/rhi", default-features = false }
+# Bench-target-only, and for `Scene` alone: the device-free half of
+# the 3D renderer, which holds no device and builds on a machine with
+# no adapter. The rendering half of that crate needs one and is not
+# timed here.
+renew-render3d = { path = "../../crates/render3d" }
 
 [lints]
 workspace = true
@@ -102,4 +107,8 @@ harness = false
 
 [[bench]]
 name = "sprite"
+harness = false
+
+[[bench]]
+name = "scene"
 harness = false

--- a/bench/suite/Cargo.toml
+++ b/bench/suite/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 publish = false
 
 [package.metadata.renew]
-purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles, widget tree and its presenter — paired with exact allocation-count assertions."
+purpose = "Criterion benchmarks over engine kernels — math, allocator, jobs, frame, rng, ecs, clock, particles, widget tree and its presenter, the sprite construction chain and its packer, and the 3D scene's geometry path — paired with exact allocation-count assertions."
 maturity = "bootstrap"
 core = false
 extension_points = []
@@ -110,5 +110,5 @@ name = "sprite"
 harness = false
 
 [[bench]]
-name = "scene"
+name = "render3d"
 harness = false

--- a/bench/suite/README.md
+++ b/bench/suite/README.md
@@ -1,7 +1,7 @@
 # renew-bench
 
-The workspace benchmark suite: criterion timings over the math and
-allocator kernels, paired with the assertions that actually gate CI.
+The workspace benchmark suite: criterion timings over the engine's
+device-free kernels, paired with the assertions that actually gate CI.
 
 ## How gating works
 
@@ -15,7 +15,9 @@ splits the two jobs benchmarks usually conflate:
   its overhead is a comparison between two runs; `particles` times the
   particle pool's step and instance pack at 1,024 and 4,096 particles
   (its allocation gate lives with the pool's own crate, which asserts
-  exact zero on every push).
+  exact zero on every push); `render3d` times the 3D scene's geometry
+  path -- building 4,096 faces with and without a size hint, reading
+  the extent back, and the clear-and-refill a steady-state frame runs.
 - **Allocation counts** (`tests/zero_alloc.rs`) gate. The math kernels,
   the arena frame cycle, and pool churn must allocate **exactly zero** —
   an assertion with zero run-to-run variance, checked on every push as
@@ -24,8 +26,9 @@ splits the two jobs benchmarks usually conflate:
 For the math and allocator kernels, both halves call the same kernel
 functions in `src/lib.rs`, so what is timed and what is asserted can
 never drift apart. Benches over other crates (jobs, ecs, rng, frame,
-particles) call those crates directly, and their gating — where they
-have it — lives with the crate that owns the behaviour.
+clock, particles, ui, ui-render, render2d, render3d) call those crates
+directly, and their gating — where they have it — lives with the crate
+that owns the behaviour.
 
 ## Running
 

--- a/bench/suite/benches/render3d.rs
+++ b/bench/suite/benches/render3d.rs
@@ -6,23 +6,42 @@
 //! offset arithmetic over a byte container, which is the part a frame
 //! pays for every visible face, every frame.
 //!
-//! Four lines, and they exist as two pairs so a difference is a
-//! subtraction rather than an edit-and-rebuild:
+//! Four lines. **Exactly one pair of them is controlled**, and saying
+//! which is the whole point of this comment — a reader who assumes the
+//! other differences are subtractions will draw a conclusion the
+//! experiment cannot support:
 //!
-//! - `scene_build_4096` and `scene_build_4096_growing` are the same
-//!   4,096 faces built into a scene that reserved up front and into one
-//!   that grows. **The difference is what `Scene::with_capacity` is
-//!   worth**, and it is measured rather than argued because the
-//!   constructor's own documentation argues for it — "an allocation per
-//!   quad on a four-thousand-face world is a cost with no reason" —
-//!   while the only consumer in the tree calls `Scene::new`.
-//! - `scene_bounds_4096` and `scene_clear_rebuild_4096` are the two
-//!   things a caller does with a scene after building it: read its
-//!   extent, and reuse its buffers for the next frame.
+//! - `scene_build_4096` and `scene_build_4096_growing` **are** a pair.
+//!   The same 4,096 faces into a scene that reserved up front and into
+//!   one that grows; both allocate inside the timed region and both drop
+//!   the scene there, so they differ in one thing and the difference is
+//!   what the reservation is worth. It is measured rather than argued
+//!   because the constructor's documentation argues for it while no
+//!   caller in the tree uses it.
+//! - `scene_bounds_4096` reads the extent of a scene built once outside
+//!   the timed region — a walk over every vertex, which a caller that
+//!   frames or culls a world does per rebuild.
+//! - `scene_clear_rebuild_4096` is the frame-loop shape: keep the
+//!   buffers, drop the contents, fill again. **It is not the third term
+//!   of a subtraction.** It differs from both build lines in three ways
+//!   at once — it allocates nothing inside the timed region, frees
+//!   nothing there, and starts from warm buffers — so its distance from
+//!   them isolates none of the three. Read it as its own number: what a
+//!   steady-state frame pays to refill a scene it already owns.
 //!
 //! `quad_uv` is the widest of the three appenders — corners, per-corner
-//! colours and per-corner texture coordinates — and is the one the
-//! sample actually calls, so it is what the build lines time.
+//! colours and per-corner texture coordinates — so it is what the build
+//! lines time. The voxel sample calls it for every visible face and
+//! calls the plain `quad` for its crosshair; both are exercised in the
+//! tree, and this file times the wider one.
+//!
+//! **The per-face figure is not the cost of `quad_uv` alone.** Each
+//! iteration streams the whole 4,096-face fixture — over half a mebibyte
+//! read, more than a mebibyte touched with the output — which does not
+//! fit in L2 on the machine these were recorded on. A real caller
+//! generates its faces as it goes and pays no such stream. What the
+//! lines compare against each other is sound, because every one of them
+//! pays it; what a single absolute number means on its own is less.
 //!
 //! Nothing here measures the GPU. Upload and draw need a device, and no
 //! lane can time one; the cost of a face on the other side of the
@@ -93,8 +112,8 @@ fn scene_geometry(c: &mut Criterion) {
     });
 
     // The same faces into a scene that reserved nothing — which is what
-    // the one consumer in the tree does. Paired with the line above so
-    // the reservation's worth is a subtraction.
+    // every caller outside this file does. Paired with the line above:
+    // same work, same drop, one difference.
     c.bench_function("scene_build_4096_growing", |b| {
         b.iter(|| {
             let mut scene = Scene::new();
@@ -113,12 +132,16 @@ fn scene_geometry(c: &mut Criterion) {
         built.quad_uv(*corners, *colours, *uvs);
     }
     c.bench_function("scene_bounds_4096", |b| {
-        b.iter(|| black_box(built.bounds()));
+        // The scene is fenced as well as the result: without it the walk
+        // reads a value the optimiser can see is loop-invariant, and
+        // nothing stops it being hoisted out of the iteration entirely.
+        b.iter(|| black_box(black_box(&built).bounds()));
     });
 
     // The frame-loop shape: keep the buffers, drop the contents, fill
-    // again. This is the path a moving world takes every frame, and it
-    // is the one `with_capacity` stops mattering for after frame one.
+    // again. `Scene::clear` clears the vectors rather than dropping
+    // them, so the second iteration onward starts warm — which is what
+    // makes this a steady-state number and not a build number.
     c.bench_function("scene_clear_rebuild_4096", |b| {
         let mut scene = Scene::with_capacity(QUADS);
         b.iter(|| {

--- a/bench/suite/benches/scene.rs
+++ b/bench/suite/benches/scene.rs
@@ -1,0 +1,135 @@
+//! The 3D geometry path a renderer runs before any device sees it.
+//!
+//! `Scene` is the device-free half of `renew-render3d`: it holds no
+//! device and can be built on a machine with no adapter, so everything
+//! here runs anywhere the suite runs. What it does per face is index and
+//! offset arithmetic over a byte container, which is the part a frame
+//! pays for every visible face, every frame.
+//!
+//! Four lines, and they exist as two pairs so a difference is a
+//! subtraction rather than an edit-and-rebuild:
+//!
+//! - `scene_build_4096` and `scene_build_4096_growing` are the same
+//!   4,096 faces built into a scene that reserved up front and into one
+//!   that grows. **The difference is what `Scene::with_capacity` is
+//!   worth**, and it is measured rather than argued because the
+//!   constructor's own documentation argues for it — "an allocation per
+//!   quad on a four-thousand-face world is a cost with no reason" —
+//!   while the only consumer in the tree calls `Scene::new`.
+//! - `scene_bounds_4096` and `scene_clear_rebuild_4096` are the two
+//!   things a caller does with a scene after building it: read its
+//!   extent, and reuse its buffers for the next frame.
+//!
+//! `quad_uv` is the widest of the three appenders — corners, per-corner
+//! colours and per-corner texture coordinates — and is the one the
+//! sample actually calls, so it is what the build lines time.
+//!
+//! Nothing here measures the GPU. Upload and draw need a device, and no
+//! lane can time one; the cost of a face on the other side of the
+//! seam is unmeasured and stays that way until the RHI can be asked.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use renew_render3d::Scene;
+
+/// Faces per frame. The `with_capacity` documentation reasons about "a
+/// four-thousand-face world", so the lines are sized at the scale that
+/// argument is about rather than at a round number chosen here.
+const QUADS: usize = 4096;
+
+/// Corners, colours and texture coordinates that vary per face, so only
+/// the shape of the call is invariant.
+///
+/// Counted in `f32` rather than cast from the index — the cast is denied
+/// in this suite, and the counter is exact for every value this reaches.
+type Face = ([[f32; 3]; 4], [[f32; 4]; 4], [[f32; 2]; 4]);
+
+fn faces() -> Vec<Face> {
+    let mut out = Vec::with_capacity(QUADS);
+    let mut step = 0.0f32;
+    while out.len() < QUADS {
+        let left = step * 0.001;
+        let top = step * 0.002;
+        let depth = step * 0.0005;
+        let corners = [
+            [left, top, depth],
+            [left + 0.05, top, depth],
+            [left + 0.05, top + 0.05, depth],
+            [left, top + 0.05, depth],
+        ];
+        let shade = 0.25 + step * 0.0001;
+        let colours = [
+            [shade, 0.5, 0.75, 1.0],
+            [0.5, shade, 0.75, 1.0],
+            [0.75, 0.5, shade, 1.0],
+            [shade, shade, 0.75, 1.0],
+        ];
+        let texel = step * 0.0002;
+        let uvs = [
+            [texel, 0.0],
+            [texel + 0.01, 0.0],
+            [texel + 0.01, 0.01],
+            [texel, 0.01],
+        ];
+        out.push((corners, colours, uvs));
+        step += 1.0;
+    }
+    out
+}
+
+fn scene_geometry(c: &mut Criterion) {
+    let faces = faces();
+
+    c.bench_function("scene_build_4096", |b| {
+        b.iter(|| {
+            let mut scene = Scene::with_capacity(QUADS);
+            for (corners, colours, uvs) in &faces {
+                scene.quad_uv(*corners, *colours, *uvs);
+            }
+            black_box(scene.index_count());
+            black_box(scene);
+        });
+    });
+
+    // The same faces into a scene that reserved nothing — which is what
+    // the one consumer in the tree does. Paired with the line above so
+    // the reservation's worth is a subtraction.
+    c.bench_function("scene_build_4096_growing", |b| {
+        b.iter(|| {
+            let mut scene = Scene::new();
+            for (corners, colours, uvs) in &faces {
+                scene.quad_uv(*corners, *colours, *uvs);
+            }
+            black_box(scene.index_count());
+            black_box(scene);
+        });
+    });
+
+    // Reading the extent back: a walk over every vertex, which a caller
+    // that frames or culls a world does once per rebuild.
+    let mut built = Scene::with_capacity(QUADS);
+    for (corners, colours, uvs) in &faces {
+        built.quad_uv(*corners, *colours, *uvs);
+    }
+    c.bench_function("scene_bounds_4096", |b| {
+        b.iter(|| black_box(built.bounds()));
+    });
+
+    // The frame-loop shape: keep the buffers, drop the contents, fill
+    // again. This is the path a moving world takes every frame, and it
+    // is the one `with_capacity` stops mattering for after frame one.
+    c.bench_function("scene_clear_rebuild_4096", |b| {
+        let mut scene = Scene::with_capacity(QUADS);
+        b.iter(|| {
+            scene.clear();
+            for (corners, colours, uvs) in &faces {
+                scene.quad_uv(*corners, *colours, *uvs);
+            }
+            black_box(scene.index_count());
+        });
+    });
+}
+
+criterion_group!(geometry, scene_geometry);
+criterion_main!(geometry);

--- a/crates/render3d/src/scene.rs
+++ b/crates/render3d/src/scene.rs
@@ -101,9 +101,18 @@ impl Scene {
     /// count allocates once.
     ///
     /// A hint, not a limit: pushing past it grows the buffers like any
-    /// other vector. This exists because the named consumer knows its
-    /// face count before it starts, and an allocation per quad on a
-    /// four-thousand-face world is a cost with no reason.
+    /// other vector. What it saves is that growth — a vector that starts
+    /// empty reaches four thousand faces in roughly a dozen doublings,
+    /// each one copying everything written before it — and not one
+    /// allocation per quad, which is what an earlier version of this
+    /// sentence claimed and no vector has ever done.
+    ///
+    /// **Its only caller today is the benchmark that measures what it
+    /// saves.** The voxel sample builds every scene with [`Scene::new`],
+    /// including the two on its draw path. That is recorded here rather
+    /// than left implied: a constructor whose documentation describes a
+    /// caller it does not have is a claim about the tree, and this one
+    /// was wrong for as long as it stood.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The 3D renderer had never been timed — `renew-render3d` was not a dependency of the bench suite in any form. `Scene` is its device-free half, so it runs wherever the suite runs.

Four lines as two pairs, so a difference is a subtraction: the same 4,096 faces into a reserved scene and into a growing one, and then what a caller does afterwards — read the extent, reuse the buffers.

Six runs: reserving lands near 190 µs, growing near 370 µs, and the distributions do not overlap. The reservation is worth about 44 ns per face — and so is reuse, since `clear()` and refill lands with the reserved build.

Nothing here measures the GPU; upload and draw need a device and no lane can time one.