### PR TITLE
test(png): every refusal gets a file, and four properties get generated ones

### DIFF
--- a/crates/png/README.md
+++ b/crates/png/README.md
@@ -89,12 +89,40 @@ file was still small, still structurally a PNG, still had a valid header,
 and every test passed. Only a decoder refused it. The symbol tables are
 pinned to the published ones now, so the next mistake fails here.
 
+**Every refusal has a file that provokes it, and the list cannot rot.**
+`decode` returns one of seventeen named refusals. A test beside it builds
+one file for each and asserts that the answers those files reach number
+exactly seventeen -- so a validation check that becomes dead code is
+caught by its file falling through onto some other refusal, which no
+per-refusal test can notice. The guard under that test is a function
+matching the error enum exhaustively with no wildcard: it lives inside
+this crate, where the enum's openness does not apply, so a refusal added
+later stops the file compiling until somebody writes the bytes that
+provoke it. That is the check a test outside the crate cannot make --
+from outside the wildcard is mandatory, and a new refusal lands in it in
+silence.
+
+**Four properties run on generated inputs at every merge.**
+`tests/properties.rs` states what must hold for every file in a shape
+rather than for files somebody sat down and wrote: what the encoder
+writes the decoder returns exactly; every byte string gets an answer and
+never a panic; no proper prefix of a file decodes; and one flipped bit
+anywhere in a file is refused. The last of those is what makes the chunk
+checksums load-bearing rather than decorative -- every byte after the
+signature lies in some chunk's length, type, payload or checksum, so a
+single bit has nowhere to hide. Each property was probed by deleting the
+code it guards, and the one probe that came back green is recorded in
+that property's own documentation rather than left to be discovered: the
+round trip cannot reach filters one to four, because this crate never
+writes them.
+
 **The decoder is fuzzed, and the corpus is generated rather than
 collected.** Everything above is about the encoder — the half this crate
 writes. The half that reads a file somebody else wrote is checked by
 `png_decode`, whose seeds are built by `cargo run -p renew-png --example
-make_corpus`: every input is written by that program, so the corpus
-carries no file this repository did not author. `tests/corpus_replay.rs`
+make_corpus`: every input is first-party, so the corpus carries no
+licence question. All but one are written by that program, and the
+exception is the subject of the next paragraph. `tests/corpus_replay.rs`
 replays them on the stable toolchain at every merge, and asserts two
 things a file count cannot. The seeds must still reach at least ten
 distinct answers between them, and four specific refusals must stay
@@ -115,9 +143,9 @@ the no-borrowed-fixtures rule is untouched.
 
 **What is still unseeded, said plainly.** Palette parsing and the `tRNS`
 chunk have no valid seed — the header-only indexed seed refuses before
-reaching them — and several refusals in the error enum have no seed at
-all. The fuzzer can find its own way there; the corpus does not put it
-there.
+reaching them, and several refusals have no seed in the corpus -- though
+every one of them now has a file in the suite above. The fuzzer can find
+its own way there; the corpus does not put it there.
 
 ## Errors
 

--- a/crates/png/src/decode.rs
+++ b/crates/png/src/decode.rs
@@ -714,7 +714,7 @@ mod filters {
     }
 
     /// Wrap bytes as a PNG chunk: length, type, body, checksum.
-    fn chunk(id: [u8; 4], body: &[u8]) -> Vec<u8> {
+    pub(super) fn chunk(id: [u8; 4], body: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
         out.extend_from_slice(&u32::try_from(body.len()).unwrap_or(0).to_be_bytes());
         out.extend_from_slice(&id);
@@ -831,5 +831,228 @@ mod filters {
                 );
             }
         }
+    }
+}
+
+/// **One file per refusal, and a compile-time guard that the list is
+/// whole.**
+///
+/// The tests above provoke individual refusals and document how each one
+/// is reached; this module asks a different question — *is every named
+/// refusal still reachable at all?* A validation check that becomes dead
+/// code stops being tested by the suite that names it, and nothing else
+/// here notices: the other tests keep passing, because each one asserts
+/// about the refusal it was written for and no test owns the list.
+///
+/// The guard is [`name`], which matches `DecodeError` exhaustively and
+/// **deliberately without a wildcard**. This module is inside the crate
+/// that defines the enum, where `#[non_exhaustive]` does not apply, so a
+/// variant added later stops this file compiling until somebody decides
+/// which bytes provoke it. That is exactly the guard the replay test
+/// beside this crate cannot have: from outside, the wildcard is
+/// mandatory and a new refusal lands in it silently.
+#[cfg(test)]
+mod refusals {
+    use super::filters::chunk;
+    use super::{DecodeError, decode};
+
+    /// Every refusal this decoder can return, by name — the variant
+    /// alone, without its fields.
+    ///
+    /// No wildcard. See this module's own documentation for why that is
+    /// the point of the function rather than an accident of style.
+    fn name(error: DecodeError) -> &'static str {
+        match error {
+            DecodeError::NotAPng => "NotAPng",
+            DecodeError::ChunkOverruns { .. } => "ChunkOverruns",
+            DecodeError::BadChecksum { .. } => "BadChecksum",
+            DecodeError::BadHeader => "BadHeader",
+            DecodeError::ZeroExtent { .. } => "ZeroExtent",
+            DecodeError::BadColourType { .. } => "BadColourType",
+            DecodeError::UnsupportedDepth { .. } => "UnsupportedDepth",
+            DecodeError::Interlaced => "Interlaced",
+            DecodeError::BadMethod { .. } => "BadMethod",
+            DecodeError::BadPalette { .. } => "BadPalette",
+            DecodeError::NoImageData => "NoImageData",
+            DecodeError::MissingEnd => "MissingEnd",
+            DecodeError::BadZlibHeader { .. } => "BadZlibHeader",
+            DecodeError::Deflate { .. } => "Deflate",
+            DecodeError::BadImageLength { .. } => "BadImageLength",
+            DecodeError::BadFilter { .. } => "BadFilter",
+            DecodeError::TooLarge { .. } => "TooLarge",
+        }
+    }
+
+    /// What a file gets: the refusal's name, or `"Ok"`.
+    fn outcome(bytes: &[u8]) -> &'static str {
+        decode(bytes).map_or_else(name, |_| "Ok")
+    }
+
+    /// An `IHDR` body: the extent, then the five one-byte fields.
+    fn header(width: u32, height: u32, fields: [u8; 5]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(13);
+        out.extend_from_slice(&width.to_be_bytes());
+        out.extend_from_slice(&height.to_be_bytes());
+        out.extend_from_slice(&fields);
+        out
+    }
+
+    /// A zlib stream carrying `raw` in one **stored** block.
+    ///
+    /// Stored rather than compressed so a fixture needs no compressor of
+    /// its own: what these files test is the layer above the inflate, and
+    /// a hand-written Huffman block would put a second thing under test
+    /// in every one of them.
+    fn stored(raw: &[u8]) -> Vec<u8> {
+        let mut out = vec![0x78, 0x01, 0b0000_0001];
+        let length = u16::try_from(raw.len()).unwrap_or(0);
+        out.extend_from_slice(&length.to_le_bytes());
+        out.extend_from_slice(&(!length).to_le_bytes());
+        out.extend_from_slice(raw);
+        out.extend_from_slice(&crate::adler32(raw).to_be_bytes());
+        out
+    }
+
+    /// A file from its chunks, signature included.
+    fn file(chunks: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = crate::SIGNATURE.to_vec();
+        for part in chunks {
+            out.extend_from_slice(part);
+        }
+        out
+    }
+
+    /// A one-pixel indexed file whose sole sample is `index`.
+    fn indexed(palette: &[u8], index: u8) -> Vec<u8> {
+        file(&[
+            chunk(*b"IHDR", &header(1, 1, [8, 3, 0, 0, 0])),
+            chunk(*b"PLTE", palette),
+            chunk(*b"IDAT", &stored(&[0, index])),
+            chunk(*b"IEND", &[]),
+        ])
+    }
+
+    /// **Every named refusal has a file that still provokes it.**
+    ///
+    /// Seventeen entries for seventeen variants, and the assertion is on
+    /// the *set* as well as on each entry: if a validation check is
+    /// deleted, its file falls through to whatever the next check says,
+    /// two entries collapse onto one answer, and this names which one
+    /// went missing. That is the failure a per-refusal test cannot
+    /// produce, because a per-refusal test only ever knows about the
+    /// refusal it was written for.
+    ///
+    /// Probed by deleting the interlace rejection: the `Interlaced`
+    /// entry falls through to `MissingEnd` -- measured, not guessed --
+    /// and the message names which refusal stopped being reachable.
+    #[test]
+    fn every_named_refusal_has_a_file_that_provokes_it() {
+        // A real file to damage, so the checksum and truncation entries
+        // start from something that does decode.
+        let sound = crate::encode(2, 2, &[0x40; 16]).expect("the encoder accepts a whole image");
+        let mut broken_crc = sound.clone();
+        // The interlace byte of `IHDR`, four bytes ahead of its checksum.
+        broken_crc[8 + 8 + 12] ^= 0x01;
+        // Everything but the terminator: whole chunks, no `IEND`.
+        let unterminated = sound[..sound.len() - 12].to_vec();
+
+        let cases: [(&str, Vec<u8>); 17] = [
+            ("NotAPng", b"not a png at all".to_vec()),
+            ("ChunkOverruns", {
+                let mut out = crate::SIGNATURE.to_vec();
+                out.extend_from_slice(&0xFFFF_FF00_u32.to_be_bytes());
+                out.extend_from_slice(b"IDAT");
+                out.extend_from_slice(&[0; 8]);
+                out
+            }),
+            ("BadChecksum", broken_crc),
+            ("BadHeader", file(&[chunk(*b"IEND", &[])])),
+            (
+                "ZeroExtent",
+                file(&[chunk(*b"IHDR", &header(0, 1, [8, 6, 0, 0, 0]))]),
+            ),
+            (
+                "BadColourType",
+                file(&[chunk(*b"IHDR", &header(1, 1, [8, 7, 0, 0, 0]))]),
+            ),
+            (
+                "UnsupportedDepth",
+                file(&[chunk(*b"IHDR", &header(1, 1, [1, 6, 0, 0, 0]))]),
+            ),
+            (
+                "Interlaced",
+                file(&[chunk(*b"IHDR", &header(1, 1, [8, 6, 0, 0, 1]))]),
+            ),
+            (
+                "BadMethod",
+                file(&[chunk(*b"IHDR", &header(1, 1, [8, 6, 1, 0, 0]))]),
+            ),
+            ("BadPalette", indexed(&[0, 0, 0], 5)),
+            (
+                "NoImageData",
+                file(&[
+                    chunk(*b"IHDR", &header(1, 1, [8, 6, 0, 0, 0])),
+                    chunk(*b"IEND", &[]),
+                ]),
+            ),
+            ("MissingEnd", unterminated),
+            (
+                "BadZlibHeader",
+                file(&[
+                    chunk(*b"IHDR", &header(1, 1, [8, 6, 0, 0, 0])),
+                    chunk(*b"IDAT", &[0x00, 0x00]),
+                    chunk(*b"IEND", &[]),
+                ]),
+            ),
+            (
+                "Deflate",
+                file(&[
+                    chunk(*b"IHDR", &header(1, 1, [8, 6, 0, 0, 0])),
+                    // A well-formed zlib header over a block whose kind
+                    // is 3, which the format leaves undefined.
+                    chunk(*b"IDAT", &[0x78, 0x01, 0xFF, 0xFF, 0xFF, 0xFF]),
+                    chunk(*b"IEND", &[]),
+                ]),
+            ),
+            (
+                "BadImageLength",
+                file(&[
+                    chunk(*b"IHDR", &header(2, 2, [8, 6, 0, 0, 0])),
+                    // Two rows of two pixels want (8 + 1) * 2 bytes.
+                    chunk(*b"IDAT", &stored(&[0; 10])),
+                    chunk(*b"IEND", &[]),
+                ]),
+            ),
+            (
+                "BadFilter",
+                file(&[
+                    chunk(*b"IHDR", &header(1, 1, [8, 6, 0, 0, 0])),
+                    // Five is one past the last filter the format defines.
+                    chunk(*b"IDAT", &stored(&[5, 0, 0, 0, 0])),
+                    chunk(*b"IEND", &[]),
+                ]),
+            ),
+            (
+                "TooLarge",
+                file(&[chunk(*b"IHDR", &header(0xFFFF, 0xFFFF, [8, 6, 0, 0, 0]))]),
+            ),
+        ];
+
+        let mut reached = std::collections::BTreeSet::new();
+        for (expected, bytes) in &cases {
+            let got = outcome(bytes);
+            assert_eq!(
+                got, *expected,
+                "the file written to provoke {expected} now answers {got}"
+            );
+            reached.insert(got);
+        }
+
+        assert_eq!(
+            reached.len(),
+            cases.len(),
+            "two entries provoke the same refusal, so one of them is not testing what it names: \
+             {reached:?}"
+        );
     }
 }

--- a/crates/png/tests/properties.rs
+++ b/crates/png/tests/properties.rs
@@ -1,0 +1,169 @@
+//! The decoder, over inputs nobody chose.
+//!
+//! The unit suite asserts what happens to files somebody sat down and
+//! wrote: this one asserts what must hold for *every* file in a shape.
+//! Four properties. Each was probed by a named mutant before it was
+//! committed, and the one place a probe came back green is written into
+//! that property's own documentation rather than left for a reader to
+//! discover: the round trip cannot reach filters one to four, because
+//! this crate's encoder never writes them.
+//!
+//! **This is not the fuzz target and does not replace it.** The fuzzer
+//! explores; these are closed statements about a generated population,
+//! and they run on the stable toolchain as part of the ordinary test
+//! suite. The fuzz workspace needs nightly and its own schedule, so
+//! between merges this is what actually exercises the decoder on bytes
+//! nobody wrote.
+
+// A property body is not literally a `#[test]` fn -- the macro wraps it --
+// so the lints that allow a test to panic do not see it. These are
+// assertions about a decoder, and a failure here is a failed test.
+#![allow(clippy::expect_used, clippy::panic)]
+
+use proptest::prelude::*;
+use renew_png::decode::decode;
+
+/// A whole image: an extent and exactly the pixels it needs.
+///
+/// Capped at 24 by 24 because the cost here is real — every case encodes
+/// a whole file and decodes it back, and the properties are about the
+/// shape of the code rather than about scale. A 24-square image still
+/// crosses several deflate blocks' worth of literals and back-references
+/// on random data, which is where the interesting branches are.
+fn image() -> impl Strategy<Value = (u32, u32, Vec<u8>)> {
+    (1u32..=24, 1u32..=24).prop_flat_map(|(width, height)| {
+        let count = width as usize * height as usize * 4;
+        (
+            Just(width),
+            Just(height),
+            prop::collection::vec(any::<u8>(), count),
+        )
+    })
+}
+
+/// A file this crate wrote, with the pixels that went into it.
+fn file() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+    image().prop_map(|(width, height, pixels)| {
+        let bytes =
+            renew_png::encode(width, height, &pixels).expect("the encoder accepts a whole image");
+        (bytes, pixels)
+    })
+}
+
+proptest! {
+    /// **What the encoder writes, the decoder returns — exactly.**
+    ///
+    /// The unit suite makes this claim about five hand-picked extents and
+    /// one generated picture. It is a claim about every extent and every
+    /// pixel, and random pixels are the hard case: a picture with runs
+    /// and gradients compresses into back-references, while noise
+    /// compresses into literals, and the two take different paths through
+    /// the encoder's Huffman coding and the decoder's inflate.
+    ///
+    /// **It reaches filter zero only, and that is a property of the
+    /// encoder rather than a choice made here.** This crate writes every
+    /// row unfiltered, so no round trip through it can exercise the Sub,
+    /// Up, Average or Paeth reconstruction — measured, not assumed:
+    /// undoing Sub with the wrong neighbour leaves this property green
+    /// and is caught instead by the decoder's own filter tests, which
+    /// build their fixtures by hand, and by the recorded corpus, which
+    /// carries a file another tool wrote.
+    ///
+    /// Probed by undoing filter zero as `value + 1`: the pixels come back
+    /// changed and the property fails on the first case.
+    #[test]
+    fn what_the_encoder_writes_the_decoder_returns_exactly((width, height, pixels) in image()) {
+        let bytes = renew_png::encode(width, height, &pixels)
+            .expect("the encoder accepts a whole image");
+        let image = decode(&bytes).expect("this crate reads what it wrote");
+
+        prop_assert_eq!(image.width, width, "the width changed in the round trip");
+        prop_assert_eq!(image.height, height, "the height changed in the round trip");
+        prop_assert_eq!(image.pixels, pixels, "the pixels changed in the round trip");
+    }
+
+    /// **Every byte string gets an answer**, and an answer that says `Ok`
+    /// describes an image that exists.
+    ///
+    /// A decoder is allowed to refuse anything; it is not allowed to
+    /// panic, to read past the end, or to hand back an image whose
+    /// buffer disagrees with the extent it reports. Random bytes almost
+    /// never reach past the signature, so this is deliberately fed a
+    /// mixture: raw noise, and noise behind a real signature, which is
+    /// what gets the chunk walk itself under the property.
+    ///
+    /// Probed by deleting the chunk-overrun guard: a length field of
+    /// noise then asks for a slice that is not there, and the property
+    /// fails as a panic — `range end index 1118395930 out of range for
+    /// slice of length 246` — which is the exact shape it exists to
+    /// refuse.
+    #[test]
+    fn every_byte_string_gets_an_answer(
+        noise in prop::collection::vec(any::<u8>(), 0..2048),
+        signed in any::<bool>(),
+    ) {
+        let mut bytes = Vec::new();
+        if signed {
+            bytes.extend_from_slice(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]);
+        }
+        bytes.extend_from_slice(&noise);
+
+        if let Ok(image) = decode(&bytes) {
+            prop_assert!(image.width > 0 && image.height > 0, "a zero extent decoded");
+            prop_assert_eq!(
+                image.pixels.len(),
+                image.width as usize * image.height as usize * 4,
+                "the buffer disagrees with the extent it was decoded at"
+            );
+        }
+    }
+
+    /// **No proper prefix of a file is a file.**
+    ///
+    /// A half-arrived download must not look like a short image. The
+    /// terminator is the last chunk, so every prefix either cuts it or
+    /// cuts something before it, and there is no length at which the
+    /// decoder should be satisfied except the whole.
+    ///
+    /// Probed by deleting the missing-terminator refusal: a 55-byte
+    /// prefix of a 67-byte file decoded without complaint, because every
+    /// chunk it still held was whole.
+    #[test]
+    fn no_proper_prefix_of_a_file_decodes((bytes, _pixels) in file(), cut in any::<prop::sample::Index>()) {
+        let keep = cut.index(bytes.len());
+        prop_assert!(
+            decode(&bytes[..keep]).is_err(),
+            "{keep} bytes of a {}-byte file decoded without complaint",
+            bytes.len()
+        );
+    }
+
+    /// **One flipped bit anywhere in a file is refused.**
+    ///
+    /// This is the property that makes the chunk checksums load-bearing
+    /// rather than decorative. Every byte after the signature lies in
+    /// some chunk's length, type, payload or checksum: a flip in the
+    /// type, payload or checksum breaks the CRC, and a flip in a length
+    /// re-frames the chunk so the CRC breaks anyway or the chunk runs off
+    /// the end. A flip inside the signature is not a PNG at all. There is
+    /// nowhere left for a single bit to hide.
+    ///
+    /// Probed by deleting the checksum comparison in `decode`: the
+    /// property fails at once, reporting that bit 1 of byte 71 was
+    /// flipped and the file decoded anyway.
+    #[test]
+    fn one_flipped_bit_is_refused(
+        (bytes, _pixels) in file(),
+        at in any::<prop::sample::Index>(),
+        bit in 0u32..8,
+    ) {
+        let mut damaged = bytes.clone();
+        let index = at.index(damaged.len());
+        damaged[index] ^= 1u8 << bit;
+
+        prop_assert!(
+            decode(&damaged).is_err(),
+            "bit {bit} of byte {index} flipped and the file still decoded"
+        );
+    }
+}


### PR DESCRIPTION
The decoder had fifteen of its seventeen named refusals asserted somewhere and nothing asserting that all seventeen stay reachable, so a validation check could become dead code without any test noticing. One file per refusal now, an assertion on the set, and an exhaustive wildcard-free match under it so a refusal added later stops the crate compiling until somebody writes the bytes that provoke it. `Deflate` and `TooLarge` had no assertion at all before this.

Proptest has been a declared dev-dependency of this crate with no property in it. Four now: the round trip, an answer for every byte string, no proper prefix decoding, and one flipped bit anywhere being refused. Each was probed by deleting the code it guards; the one probe that came back green is recorded in that property's own documentation.