### PR TITLE
refactor(render2d): the destination-and-source cut gets one home

### DIFF
--- a/crates/render2d/README.md
+++ b/crates/render2d/README.md
@@ -96,6 +96,17 @@ else, which the build matrix proves by building and testing without it.
 
 ## What is here
 
+- `cut_to` — cut a rectangle to a clip box and cut its source by the
+  same linear map, so every surviving pixel samples the texel it would
+  have sampled uncut. It takes a rectangle and a source rather than a
+  `Sprite`, deliberately: the arithmetic is about a rectangle, and an
+  earlier shape that took a sprite made its one caller build one to ask
+  a question about a rectangle, which cost 24% of the frame that
+  exercises it. A turned or scaled quad is out of scope here — an
+  axis-aligned cut of a turned quad takes the wrong pixels and cuts the
+  source to match, so a caller that turns its geometry owes the clip to
+  that geometry.
+
 - `Canvas`, `Region`, `SubRegion`, `Sprite` — the pure vocabulary: a
   logical pixel space (y down from the top-left), a rectangle of atlas
   texels on texel boundaries, the same rectangle with sub-texel edges

--- a/crates/render2d/src/fill.rs
+++ b/crates/render2d/src/fill.rs
@@ -511,6 +511,103 @@ pub(crate) fn placed(sprite: &Sprite, offset: (f32, f32), alpha: f32) -> Sprite 
     moved
 }
 
+/// Cut `rect` — x, y, width, height — to the edge rectangle `clip` —
+/// left, top, right, bottom — cutting `source` by the same
+/// proportion. `None` when nothing of it survives.
+///
+/// **The source is cut by the same linear map that cut the destination,
+/// so the map is unchanged and every surviving pixel samples the texel
+/// it would have sampled uncut.** Uncut, the shader interpolates
+/// between the source edges, so a pixel centre `p` maps to
+/// `u(p) = sx + sw*(p - x)/w`. Clipped to `[L, R]` the source runs from
+/// `su0 = sx + sw*(L - x)/w` to `su1 = sx + sw*(R - x)/w`, so
+/// `su1 - su0 = sw*(R - L)/w` and
+///
+/// ```text
+/// u'(p) = su0 + (p - L)/(R - L) * (su1 - su0)
+///       = sx + sw*(L - x)/w + sw*(p - L)/w
+///       = sx + sw*(p - x)/w
+///       = u(p)
+/// ```
+///
+/// Identically the same function. It holds by construction, and only
+/// because both fractions come from the same reciprocal — recomputing
+/// per edge is where an implementation loses it.
+///
+/// Two cases are exact rather than merely close. At 1:1 — every glyph,
+/// every nine-slice corner — `source.width / w` is a value divided by
+/// itself, exactly `1.0`, so the cut edge is `sx + (L - x)`: a
+/// difference and a sum of integers, bit-exact. At a power-of-two scale
+/// the reciprocal is exact too. Elsewhere the residue is a few ULPs,
+/// orders below the half texel that could move a `floor`.
+///
+/// Nearest-and-clamped sampling cannot bleed: `0 <= fx0 < fx1 <= 1`, so
+/// a cut only shrinks the sampled rectangle strictly inside the
+/// original, and the computed edges are additionally clamped into it so
+/// a rounding hair cannot reach a neighbouring asset.
+///
+/// **It takes a rectangle and a source, not a sprite, and that is the
+/// whole of what the arithmetic is about.** An earlier shape of this
+/// took a `&Sprite` and returned one, because the renderer-side clip it
+/// was written alongside had one to hand. The only caller here has a
+/// rectangle, and making it build a sprite to ask a question about a
+/// rectangle cost **24%** on the frame that exercises this path —
+/// measured on one machine, three runs each side, with the two ranges
+/// not overlapping. A wider parameter than the question needs is not
+/// free.
+///
+/// A turned or scaled quad is therefore not this function's business.
+/// The cut is axis-aligned and a turned quad's covered area is not, so
+/// a caller that turns its geometry owes the clip to that geometry —
+/// and owes it a drop test on the turned outline rather than on the
+/// upright rectangle, which are different shapes: an eighth turn sweeps
+/// a quad's corners about a fifth of its width past each edge.
+#[must_use]
+#[expect(
+    clippy::float_cmp,
+    reason = "the early-out fires exactly when no edge moved; a tolerance would take the cut path for a quad that was not cut, which is the one case this must not do"
+)]
+pub fn cut_to(rect: [f32; 4], source: SubRegion, clip: [f32; 4]) -> Option<([f32; 4], SubRegion)> {
+    let [x, y, width, height] = rect;
+    let left = x.max(clip[0]);
+    let top = y.max(clip[1]);
+    let right = (x + width).min(clip[2]);
+    let bottom = (y + height).min(clip[3]);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    // Nothing was cut: four compares, no division, and the source
+    // passes through untouched — which is what carries every existing
+    // golden byte for byte.
+    if left == x && top == y && right == x + width && bottom == y + height {
+        return Some((rect, source));
+    }
+    let inv_w = 1.0 / width;
+    let inv_h = 1.0 / height;
+    let fx0 = (left - x) * inv_w;
+    let fx1 = (right - x) * inv_w;
+    let fy0 = (top - y) * inv_h;
+    let fy1 = (bottom - y) * inv_h;
+    let (sx, sy) = (source.x, source.y);
+    let (sw, sh) = (source.width, source.height);
+    // Clamped into the original source: the arithmetic above cannot
+    // leave it by more than a rounding step, and this makes "cannot" a
+    // fact rather than an argument.
+    let cut_left = sw.mul_add(fx0, sx).max(sx);
+    let cut_top = sh.mul_add(fy0, sy).max(sy);
+    let cut_right = sw.mul_add(fx1, sx).min(sx + sw);
+    let cut_bottom = sh.mul_add(fy1, sy).min(sy + sh);
+    Some((
+        [left, top, right - left, bottom - top],
+        SubRegion {
+            x: cut_left,
+            y: cut_top,
+            width: cut_right - cut_left,
+            height: cut_bottom - cut_top,
+        },
+    ))
+}
+
 /// The UV corners after the flips: the axis that mirrors swaps its two
 /// edges, so the vertex stage's interpolation from the first corner to
 /// the second runs backwards along it.
@@ -2428,5 +2525,133 @@ mod tests {
                 to_uv(Vec2::new(fx + fw, fy + fh), atlas).y.to_bits()
             );
         }
+    }
+
+    /// A rectangle the clip does not touch comes back bit-identical.
+    ///
+    /// The early-out exists so that turning a clip ON cannot move a
+    /// single pixel of anything already inside it — which is what lets
+    /// a caller wrap an existing view in a viewport and keep its
+    /// goldens.
+    ///
+    /// **It is a correctness guard, not only a saved division**, and
+    /// that is worth stating because it looks like an optimisation.
+    /// `width * (1.0 / width)` is not `1.0` for every `f32`: sweeping
+    /// the half-integer widths from 0.5 to 1000, 271 of 2000 come back
+    /// 0.99999994 instead, and 41 is one of them. At such a width the
+    /// division path lands the source edge a ULP inside where it
+    /// started, so an untouched quad would be quietly rebuilt slightly
+    /// cut.
+    ///
+    /// Probed by deleting the early-out: red, the source width shrinks.
+    /// The same probe at width 30 — which does round-trip exactly —
+    /// stays green, which is exactly why the width is not 30.
+    #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "bit-identity is the assertion; a tolerance here would pass with the early-out deleted, which is the one thing this test exists to catch"
+    )]
+    fn a_rectangle_inside_the_clip_is_not_touched() {
+        let source = SubRegion {
+            x: 3.0,
+            y: 7.0,
+            width: 13.0,
+            height: 17.0,
+        };
+        let rect = [10.0, 20.0, 41.0, 20.5];
+        let (cut, cut_source) =
+            cut_to(rect, source, [0.0, 0.0, 100.0, 100.0]).expect("it is inside");
+        assert_eq!(cut, rect, "an untouched rectangle was rebuilt");
+        assert_eq!(
+            cut_source, source,
+            "an untouched source was rebuilt rather than passed"
+        );
+    }
+
+    /// A rectangle with no part inside the clip is not drawn at all.
+    #[test]
+    fn a_rectangle_outside_the_clip_is_dropped() {
+        let source = SubRegion {
+            x: 0.0,
+            y: 0.0,
+            width: 8.0,
+            height: 8.0,
+        };
+        assert!(cut_to([200.0, 0.0, 10.0, 10.0], source, [0.0, 0.0, 100.0, 100.0]).is_none());
+        // Touching the edge is still outside: the clip's right edge is
+        // exclusive, so a rectangle starting exactly there covers
+        // nothing.
+        assert!(cut_to([100.0, 0.0, 10.0, 10.0], source, [0.0, 0.0, 100.0, 100.0]).is_none());
+        // Degenerate extents are refused rather than divided by.
+        assert!(cut_to([5.0, 5.0, 0.0, 10.0], source, [0.0, 0.0, 100.0, 100.0]).is_none());
+        assert!(cut_to([5.0, 5.0, 10.0, 0.0], source, [0.0, 0.0, 100.0, 100.0]).is_none());
+        assert!(cut_to([5.0, 5.0, -3.0, 10.0], source, [0.0, 0.0, 100.0, 100.0]).is_none());
+    }
+
+    /// **The cut leaves every surviving pixel sampling the texel it
+    /// would have sampled uncut.** This is the whole contract, and the
+    /// only one worth testing: a cut that merely shrinks the rectangle
+    /// and shrinks the source by "about" the same amount slides the art
+    /// under the cut edge, which is what a scrolling list would show
+    /// along the header it disappears under.
+    ///
+    /// It checks the sampling function directly at several points
+    /// rather than checking the cut edges, because the edges agreeing
+    /// is a consequence and the function agreeing is the requirement.
+    ///
+    /// Probed by cutting the source on the wrong axis (`fx0` where
+    /// `fy0` belongs): red, `samples v 16.5 where uncut it sampled 19`.
+    /// And by leaving the cut source at its uncut width: red, `samples
+    /// u 22.1875 where uncut it sampled 20.9375`.
+    ///
+    /// **What it does NOT catch, said plainly:** computing the two
+    /// fractions from separate reciprocals rather than one. That is the
+    /// subtlety the derivation above turns on, and it moves the result
+    /// by about a ULP — six orders below this tolerance, so this test
+    /// stays green through it. Measured, not assumed: the mutant was
+    /// applied and the suite passed. What pins the shared reciprocal is
+    /// the untouched early-out and its test, which compares bits rather
+    /// than distances.
+    #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "the cut edges are maxima and minima of exactly representable inputs, so they are exact; the sampling assertions below carry a tolerance because those go through the division"
+    )]
+    fn a_cut_rectangle_samples_exactly_what_it_would_have_sampled() {
+        let source = SubRegion {
+            x: 5.0,
+            y: 9.0,
+            width: 50.0,
+            height: 30.0,
+        };
+        let rect = [10.0, 20.0, 100.0, 60.0];
+        let (cut, cut_source) =
+            cut_to(rect, source, [35.0, 40.0, 90.0, 65.0]).expect("it overlaps");
+        // What the destination became.
+        assert_eq!(cut, [35.0, 40.0, 55.0, 25.0]);
+        // And the map, sampled across the survivor.
+        for step in 0..=8u16 {
+            let f = f32::from(step) / 8.0;
+            let px = cut[2].mul_add(f, cut[0]);
+            let py = cut[3].mul_add(f, cut[1]);
+            let want_u = source.width * (px - rect[0]) / rect[2] + source.x;
+            let want_v = source.height * (py - rect[1]) / rect[3] + source.y;
+            let got_u = cut_source.width * (px - cut[0]) / cut[2] + cut_source.x;
+            let got_v = cut_source.height * (py - cut[1]) / cut[3] + cut_source.y;
+            assert!(
+                (got_u - want_u).abs() < 1e-3,
+                "at {px}: samples u {got_u} where uncut it sampled {want_u}"
+            );
+            assert!(
+                (got_v - want_v).abs() < 1e-3,
+                "at {py}: samples v {got_v} where uncut it sampled {want_v}"
+            );
+        }
+        // The cut source stays strictly inside the original, so nearest
+        // sampling cannot reach a neighbouring asset.
+        assert!(cut_source.x >= source.x);
+        assert!(cut_source.y >= source.y);
+        assert!(cut_source.x + cut_source.width <= source.x + source.width);
+        assert!(cut_source.y + cut_source.height <= source.y + source.height);
     }
 }

--- a/crates/render2d/src/lib.rs
+++ b/crates/render2d/src/lib.rs
@@ -39,5 +39,5 @@
 mod fill;
 mod gpu;
 
-pub use fill::{Canvas, Instance, Region, Sprite, SubRegion};
+pub use fill::{Canvas, Instance, Region, Sprite, SubRegion, cut_to};
 pub use gpu::{AtlasDesc, Render2dError, SpriteRenderer};

--- a/crates/ui-render/README.md
+++ b/crates/ui-render/README.md
@@ -36,6 +36,12 @@ chain, computed at capture and blended with the rest, and the quad's
 source rectangle is cut by the same linear map, so every surviving
 pixel samples the texel it would have sampled uncut. The one sampled
 atlas region is still a uniform white texel, so no committed picture
+The cut itself is `render2d::cut_to` rather than a second copy of it:
+this crate carried the derivation for a while, and the proof belongs
+with the arithmetic in the crate that owns sprites. What stays here is
+what belongs to a node rather than to a quad — a tint that draws
+nothing is dropped before any geometry runs.
+
 moves yet.
 
 ## Text

--- a/crates/ui-render/src/lib.rs
+++ b/crates/ui-render/src/lib.rs
@@ -286,93 +286,27 @@ pub struct Quad {
 /// visible quad, or `None` when nothing remains or the tint draws
 /// nothing at all.
 ///
-/// **The source is cut by the same linear map that cut the destination,
-/// so the map is unchanged and every surviving pixel samples the texel
-/// it would have sampled uncut.** Uncut, the shader interpolates between
-/// the source edges, so a pixel centre `p` maps to
-/// `u(p) = sx + sw*(p - x)/w`. Clipped to `[L, R]` the source runs from
-/// `su0 = sx + sw*(L - x)/w` to `su1 = sx + sw*(R - x)/w`, so
-/// `su1 - su0 = sw*(R - L)/w` and
+/// **The geometry is [`renew_render2d::cut_to`]'s, not a second
+/// copy of it.** This crate carried the whole derivation - the proof
+/// that cutting the source by the map that cut the destination leaves
+/// the sampling function identical - and then the sprite renderer
+/// needed the same cut for scrolling views. Two implementations of one
+/// exacting piece of arithmetic is one too many: the proof lives with
+/// the arithmetic, in the crate that owns sprites, and this asks for it.
 ///
-/// ```text
-/// u'(p) = su0 + (p - L)/(R - L) * (su1 - su0)
-///       = sx + sw*(L - x)/w + sw*(p - L)/w
-///       = sx + sw*(p - x)/w
-///       = u(p)
-/// ```
-///
-/// Identically the same function. It holds by construction, and only
-/// because both fractions come from the same reciprocal - recomputing
-/// per edge is where an implementation loses it.
-///
-/// Two cases are exact rather than merely close. At 1:1 - every glyph,
-/// every nine-slice corner - `source.width / w` is a value divided by
-/// itself, exactly `1.0`, so the cut edge is `sx + (L - x)`: a
-/// difference and a sum of integers, bit-exact. At a power-of-two scale
-/// the reciprocal is exact too. Elsewhere the residue is a few ULPs,
-/// orders below the half texel that could move a `floor`.
-///
-/// Nearest-and-clamped sampling cannot bleed: `0 <= fx0 < fx1 <= 1`, so
-/// a cut only shrinks the sampled rectangle strictly inside the
-/// original, and the computed edges are additionally clamped into it so
-/// a rounding hair cannot reach a neighbouring asset.
-#[expect(
-    clippy::float_cmp,
-    reason = "the early-out fires exactly when no edge moved; a tolerance would take the cut path for a quad that was not cut, which is the one case this must not do"
-)]
+/// What stays here is what belongs to a UI node rather than to a quad:
+/// a tint that draws nothing is dropped before any geometry is done.
 fn clipped(rect: [f32; 4], clip: [f32; 4], source: SubRegion, tint: [f32; 4]) -> Option<Quad> {
     if tint == [0.0, 0.0, 0.0, 0.0] {
         return None;
     }
-    let [x, y, width, height] = rect;
-    let left = x.max(clip[0]);
-    let top = y.max(clip[1]);
-    let right = (x + width).min(clip[2]);
-    let bottom = (y + height).min(clip[3]);
-    if right <= left || bottom <= top {
-        return None;
-    }
-
-    // Nothing was cut: four compares, no division, and the source
-    // passes through untouched - which is what carries every existing
-    // golden byte for byte.
-    if left == x && top == y && right == x + width && bottom == y + height {
-        return Some(Quad {
-            x,
-            y,
-            width,
-            height,
-            source,
-            tint,
-        });
-    }
-
-    let inv_w = 1.0 / width;
-    let inv_h = 1.0 / height;
-    let fx0 = (left - x) * inv_w;
-    let fx1 = (right - x) * inv_w;
-    let fy0 = (top - y) * inv_h;
-    let fy1 = (bottom - y) * inv_h;
-    let (sx, sy) = (source.x, source.y);
-    let (sw, sh) = (source.width, source.height);
-    // Clamped into the original source: the arithmetic above cannot
-    // leave it by more than a rounding step, and this makes "cannot" a
-    // fact rather than an argument.
-    let cut_left = sw.mul_add(fx0, sx).max(sx);
-    let cut_top = sh.mul_add(fy0, sy).max(sy);
-    let cut_right = sw.mul_add(fx1, sx).min(sx + sw);
-    let cut_bottom = sh.mul_add(fy1, sy).min(sy + sh);
+    let (cut, source) = renew_render2d::cut_to(rect, source, clip)?;
     Some(Quad {
-        x: left,
-        y: top,
-        width: right - left,
-        height: bottom - top,
-        source: SubRegion {
-            x: cut_left,
-            y: cut_top,
-            width: cut_right - cut_left,
-            height: cut_bottom - cut_top,
-        },
+        x: cut[0],
+        y: cut[1],
+        width: cut[2],
+        height: cut[3],
+        source,
         tint,
     })
 }


### PR DESCRIPTION
ui-render carried the clip arithmetic — cutting a quad's destination and cutting its source by the same linear map so every surviving pixel samples the texel it would have sampled uncut. The sprite renderer will need the same cut, so the derivation moves to the crate that owns sprites and ui-render asks for it. What stays behind is what belongs to a node rather than to a quad.

`cut_to` takes a rectangle and a source rather than a `Sprite`, and that is a measured decision: the sprite-shaped draft cost 24% of the frame that exercises this path (three runs each side, ranges not overlapping), because its one caller had to build a sprite to ask a question about a rectangle. Narrowed to the question, the ranges overlap the baseline again.

A turned or scaled quad is out of scope here, with the reason and the drop-test hazard written down for the next caller. The renderer-side clip setter is deliberately not included — it has no consumer yet.

One inherited doc claim was false and is corrected: the sampling test's stated probe leaves it green, because the difference it describes is a ULP and the tolerance is six orders looser. The two mutants that do redden it are recorded instead.