### PR TITLE
bench(sprite): a ladder that separates the constructor from the chain

### DIFF
--- a/bench/suite/benches/sprite.rs
+++ b/bench/suite/benches/sprite.rs
@@ -75,6 +75,49 @@ fn sprite_chain(c: &mut Criterion) {
             }
         });
     });
+
+    // **A ladder, not a pair**, because there are two candidate costs
+    // here and a single subtraction cannot separate them. The line above
+    // is a constructor and two builder links; these are the same
+    // constructor with one link and with none. Read as differences:
+    //
+    // - `sprite_build_2048` minus `sprite_build_2048_one_link` is
+    //   exactly one builder call, on identical data.
+    // - `sprite_build_2048_one_link` minus `sprite_new_2048` is the
+    //   other one.
+    // - `sprite_new_2048` on its own is what writing the struct costs
+    //   before any link runs.
+    //
+    // If the rungs are evenly spaced the cost is the by-value chain; if
+    // the bottom rung is most of the height it is the constructor's own
+    // field writes, and the chain is being elided as it looks like it
+    // should be.
+    c.bench_function("sprite_build_2048_one_link", |b| {
+        let rects = destinations();
+        b.iter(|| {
+            for rect in &rects {
+                let sprite = Sprite::new(WHITE, rect[0], rect[1]).size(rect[2], rect[3]);
+                black_box(&sprite);
+            }
+        });
+    });
+
+    // **The weaker rung, and it is weaker on purpose.** Without `size`
+    // this reads only two of the four components a destination carries,
+    // so the compiler sees less to keep alive. That makes it a floor on
+    // the constructor rather than a measurement of it, and the two rungs
+    // above are the controlled pair. Said here because a reader
+    // comparing all three would otherwise assume the spacing is uniform
+    // in what it holds constant.
+    c.bench_function("sprite_new_2048", |b| {
+        let rects = destinations();
+        b.iter(|| {
+            for rect in &rects {
+                let sprite = Sprite::new(WHITE, rect[0], rect[1]);
+                black_box(&sprite);
+            }
+        });
+    });
 }
 
 criterion_group!(benches, sprite_chain);


### PR DESCRIPTION
`sprite_build_2048` went from 1.87 to 4.68 microseconds on a line whose body never changed, and the standing explanation — that the builder chain copies the whole struct at every link — had never been measured.

Two rungs below the existing line make it a subtraction: the constructor with one builder call, and the constructor alone. Three runs each on one machine: constructor ≈3.80 µs, one link ≈4.71, two links ≈4.78. **The constructor is 79% of the chain, and the second link costs 1.4% of the total** — a thirteen-fold difference between two links that a whole-struct copy would have made equal. The copies are elided; the chain is not what got slower.

`Sprite::new` writes sixteen fields into eighty-eight bytes; at 2,048 sprites that is 47 GB/s, which is L1 store bandwidth here. Nothing is optimised — this is the profile that was meant to come first.