### PR TITLE
docs: the claims about refusals and fuzzing match what the tree holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ counted in development builds.
 
 Anything that reads bytes the engine did not write is held to [REFUSALS.md](REFUSALS.md): every way
 input can be wrong gets its own named refusal carrying the numbers, a test that provokes it, and a
-recorded corpus replayed on every merge.
+recorded corpus replayed on every merge. Two readers in the command-line tool do not meet that bar
+today and are named there rather than left to be discovered — a bar with a recorded exception is a
+bar, and one with a silent exception is a slogan.
 
 ## Contributing
 

--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -8,7 +8,7 @@ and answer it — because a parser tested only on the files it can already
 read is exactly the failure that fuzzing exists to catch, and it passes
 its own suite the whole time.
 
-Seven readers in this tree already take bytes nobody here wrote. Their
+Eight readers in this tree already take bytes nobody here wrote. Their
 refusals are the worked examples throughout, so what follows describes the
 house pattern rather than inventing one. The second half is the part no
 reader here has needed yet: geometry. It is written before the importer
@@ -44,6 +44,7 @@ is dead code that reads like safety.
 | UI text | `Diagnostic` | `tools/cli/src/ui_compile.rs` | a message | `ui_text` | 10 |
 | Datagram | `WireError` | `crates/net/src/wire.rs` | 20 | `net_datagram` | 20 |
 | PNG | `DecodeError` | `crates/png/src/decode.rs` | 17 | `png_decode` | 16 |
+| JSON | `JsonErrorKind` | `crates/json/src/error.rs` | 29 | `json_parse` | 30 |
 | Deflate, inside PNG | `InflateError` | `crates/png/src/inflate.rs` | 7 | `png_decode` | — |
 | Mesh descriptor | `TargetError::Creation` | `crates/rhi/src/vk/mesh.rs` | 8, as strings | none | none |
 
@@ -52,7 +53,12 @@ only geometry validation in the tree, it is real, and its refusals are
 formatted strings rather than variants — which is the shape the rest of
 this document argues against.
 
-## Six rules every refusal here follows
+## Six rules the refusals here are held to
+
+**"Held to" rather than "follow":** two readers do not hold rule one, and
+this document said rule five more strongly than any reader holds it. Both
+are recorded below rather than quietly softened, because a rule with a
+named exception is a design and a rule with a hidden one is a lie.
 
 **One.** *One variant per way the input can be wrong.* No `Other`, no
 string-typed catch-all. `crates/asset/src/error.rs` states the reason: a
@@ -79,12 +85,28 @@ reader's table is the thing that is incomplete. Skipping converts somebody
 else's bug into your silent wrong answer, and it surfaces years later as
 an asset that did not change when it was changed.
 
-**Five.** *A refused input costs no allocation.* Validate the length
-before you slice, and the shape before you reserve. `Pack` returns borrows
-of the caller's buffer, so a malformed pack allocates nothing at all; the
-PNG decoder computes its full expanded size and compares it against a
-ceiling before a single byte is reserved. A reader that allocates first
-turns a refusal into an out-of-memory kill, which is not an answer.
+**Five.** *A refused input never allocates more than its own length buys.*
+Validate the arithmetic before you reserve. A reader that reserves on a
+declared number turns a refusal into an out-of-memory kill, which is not
+an answer — sixty bytes of header can ask for sixty-four gigabytes.
+
+**An earlier version of this rule said "a refused input costs no
+allocation", and that was false of both readers it named.** `Pack::read`
+reserves its entry vector before parsing a single entry, so a pack that
+refuses on entry four hundred has already reserved for all of them; the
+PNG decoder accumulates `PLTE`, `tRNS` and every `IDAT` body before it can
+reach the error that rejects the file. What both actually hold is the
+weaker and sufficient property: **the reservation is bounded by a linear
+function of the bytes the caller already had in memory.** `Pack` checks
+that header, table, names and data account for the file *exactly* before
+reserving, which caps the vector at one entry per thirty-two bytes of
+input; the PNG decoder's accumulations are slices of the file, and the one
+number that is not — the expanded image — is computed in full and
+compared against `CEILING` before a byte of it is reserved.
+
+That is the distinction worth keeping: the danger is never allocation, it
+is *amplification*. A hostile file that costs its own size to refuse is
+fine. One that costs a million times its size is the attack.
 
 **Six.** *The writer's mistakes are a different enum from the reader's.*
 `PackError` and `BuildError` are split, and `WireError` and `WriteError`
@@ -93,16 +115,30 @@ whoever is packing, in their own inputs, and it can name them; a read
 failure is a statement about a file of unknown origin. An importer will
 want the same split the moment it can also write.
 
-### The one place this tree does not hold rule one
+### Two places in this tree do not hold rule one
 
 `tools/cli/src/ui_compile.rs` returns `Diagnostic { line, column, message }`
-— a formatted string. It holds rules two through five completely, and it
-is fuzzed and corpus-gated like the others, but a caller cannot match on
-*why* it refused. It is a compiler for text a person is editing, where
-prose is what the reader wants, so the trade was deliberate. Copy it only
-if your consumer is a human at a terminal. An importer's consumer is a
-build step that has to decide whether to retry, substitute, or fail the
-run, and it cannot decide that from a sentence.
+— a formatted string. It is fuzzed and corpus-gated like the others, but a
+caller cannot match on *why* it refused. It is a compiler for text a person
+is editing, where prose is what the reader wants, so the trade was
+deliberate.
+
+`tools/cli/src/json.rs` is the second, and it was missed when this section
+claimed there was one. It is a hand-rolled JSON reader serving the CLI's
+own `--json` output and its reading of `cargo metadata`; it refuses with
+strings and has no fuzz target of its own. Its input is a program this
+repository invoked rather than a file a stranger supplied — a real
+distinction, and not the same as being safe.
+
+**The correction is worth more than the entry.** The heading said "the one
+place", which is a claim about every reader in the tree, and it was checked
+by confirming that `ui_compile.rs` is such a place. That is a different
+proposition. **A universal is not verified by an example**, and this
+document is made almost entirely of universals.
+
+Copy either only if your consumer is a person at a terminal. An importer's
+consumer is a build step deciding whether to retry, substitute or fail, and
+it cannot decide that from a sentence.
 
 ## Keeping the catalogue reachable
 
@@ -121,11 +157,18 @@ refusal are caught, and one of them was not testing what it claimed.
 
 **A replay gate over the committed corpus.** Every input under
 `fuzz/corpus/<target>/` is fed back through the parser on the stable
-toolchain at every merge. It gates on three things: a low-water mark on
-*distinct* inputs, counted by content so the corpus cannot be padded back
-to strength with copies; a floor on how many distinct outcomes the seeds
-reach between them; and a list of refusals that must stay reachable by
-name.
+toolchain at every merge, so a recorded input that starts panicking fails a
+merge rather than a nightly job nobody is watching.
+
+**What each gate asserts is NOT uniform across the tree, and an earlier
+version of this section said it was.** The strongest form — a low-water
+mark on *distinct* inputs counted by content, a floor on how many distinct
+outcomes the seeds reach between them, and a list of refusals that must
+stay reachable **by name** — is carried by `crates/png` and `crates/json`.
+The rest replay their corpus and assert that every input still answers,
+without the distinctness and by-name floors. **The three-part form is what
+an importer should copy; it is not what it will find if it opens whichever
+gate is nearest.**
 
 That last one exists because a count floor alone is not enough, and the
 evidence is recorded rather than assumed: deleting the PNG decoder's
@@ -660,9 +703,20 @@ representable, or not usefully representable, once converted into the
 fixed-point type simulation runs on.
 
 **Provoked by.** A coordinate of `1e30` — a common sentinel in exported
-scenes, and about 24 orders of magnitude past what Q47.16 holds. Also by
-values so small they convert to zero, which turns a thin triangle into a
-degenerate one somewhere the importer is no longer looking.
+scenes, and about **16** orders of magnitude past what Q47.16 represents
+(±1.4 × 10¹⁴). Also by values so small they convert to zero, which turns a
+thin triangle into a degenerate one somewhere the importer is no longer
+looking.
+
+An earlier version of this entry said 24, which is the distance to the
+*squarable* bound rather than the representable one, and the mistake is
+worth keeping visible because the two numbers are both real and eight
+orders apart. `crates/fixed` publishes both: ±1.4 × 10¹⁴ representable,
+±1.2 × 10⁷ squarable — because physics squares things and a squared
+value has to fit the type it lands in. **For a coordinate that will be
+fed to physics, the squarable bound is the one that binds**, so the
+distance that matters here is nearer 23 orders than 16. A refusal at the
+boundary should say which bound it checked.
 
 **Why refuse at the boundary.** Because the conversion is where the
 information is lost, and it is the last place anything knows both

--- a/crates/json/README.md
+++ b/crates/json/README.md
@@ -179,12 +179,26 @@ compile cleanly and pass every other test in the crate.
 
 ## A note on the tool's own reader
 
-The command-line tool carries a small JSON reader of its own, for reading
-the build system's output. It is not this crate and cannot be replaced by
-it in the same change: it is a tool crate that depends on engine crates,
-so an engine crate depending on it would invert the layering. Whether it
-should go on existing is a question for whoever owns that tool, not a
-thing to settle by deleting it here.
+The command-line tool carries a small JSON reader of its own, in
+`tools/cli/src/json.rs`, for reading the build system's output and
+emitting the tool's `--json`. It refuses with strings and has no fuzz
+target.
+
+**An earlier version of this section argued the tool could not adopt this
+crate because doing so would invert the layering. That argument was
+backwards.** The tool crate already depends on `renew-asset` and
+`renew-ui`; depending on `renew-json` is the same direction, and this
+crate depends on nothing at all, so there is no cycle to create. The
+layering is not what stands in the way.
+
+What actually stands in the way is that it is a behaviour change to a
+shipped tool — the two readers do not refuse the same inputs with the same
+messages — and that is a decision with an owner. The honest statement of
+the position is therefore the reverse of what was written: **the tool
+could adopt this crate, this crate currently has no production consumer,
+and those two facts are the same fact.** Whoever owns the tool should
+decide it on those terms rather than on a dependency argument that does
+not hold.
 
 ## Manifest
 

--- a/crates/json/src/parse.rs
+++ b/crates/json/src/parse.rs
@@ -778,18 +778,22 @@ mod tests {
     /// malformed, which is rule five of `REFUSALS.md` inverted.
     ///
     /// Probed by deleting the `MAX_WORD_LEN` term from `word()`'s loop
-    /// condition: red, `found` comes back with all 100,000 letters.
+    /// condition: red, and the refusal comes back holding all hundred
+    /// thousand letters.
     #[test]
     fn a_run_of_letters_is_refused_without_quoting_all_of_it() {
-        let letters = "a".repeat(100_000);
-        let JsonErrorKind::BadLiteral { found } = refusal(&letters) else {
-            panic!("a run of letters should be refused as a bad literal");
-        };
-        assert!(
-            found.len() <= MAX_WORD_LEN,
-            "the refusal quoted {} letters of a {}-letter run; the message \n             a malformed input can make this reader build is bounded by \n             MAX_WORD_LEN ({MAX_WORD_LEN}) and nothing else",
-            found.len(),
-            letters.len()
+        // Stated as the exact refusal rather than as a bound on its
+        // length. The two claims cost the same to write and the exact
+        // one says more: the reader stops at the bound, and it stops
+        // *there* rather than anywhere at or before it.
+        assert_eq!(
+            refusal(&"a".repeat(100_000)),
+            JsonErrorKind::BadLiteral {
+                found: "a".repeat(MAX_WORD_LEN)
+            },
+            "a hundred thousand letters must cost a refusal quoting MAX_WORD_LEN of \
+             them; the size of the message a malformed input can make this reader \
+             build is bounded by that constant and by nothing else"
         );
     }
 

--- a/crates/json/src/parse.rs
+++ b/crates/json/src/parse.rs
@@ -46,6 +46,38 @@ const NOT_JSON_WORDS: [&str; 8] = [
     "null",
 ];
 
+/// The word bound must clear the longest word above, strictly.
+///
+/// Not a tidiness check. `word()` stops at `MAX_WORD_LEN` and returns what
+/// it consumed, so if the bound equalled a listed word's length, a longer
+/// run of letters would be truncated to exactly that word and reported as
+/// that word — `undefinedx` answering "undefined is a value in some other
+/// language" while naming a word the document does not contain. Strict
+/// inequality is what makes a match mean the input really ended there.
+///
+/// Checked here rather than in a test because it relates two constants and
+/// nothing about it needs to run.
+///
+/// Probed by setting the bound to 9, `undefined`'s own length: this stops
+/// the build. With the assertion relaxed to `>=` at that same bound,
+/// `undefinedx` answers `NonJsonLiteral { word: "undefined" }` — naming a
+/// word the document does not contain, which is the failure this rules out.
+const _: () = {
+    let mut longest = 0;
+    let mut at = 0;
+    while at < NOT_JSON_WORDS.len() {
+        let len = NOT_JSON_WORDS[at].len();
+        if len > longest {
+            longest = len;
+        }
+        at += 1;
+    }
+    assert!(
+        MAX_WORD_LEN > longest,
+        "MAX_WORD_LEN must strictly exceed the longest word in NOT_JSON_WORDS"
+    );
+};
+
 /// Check the whole slice as text, and refuse the two things that are
 /// wrong before a single value is looked at.
 ///
@@ -565,6 +597,7 @@ fn skip_digits(cursor: &mut Cursor<'_>) {
 
 #[cfg(test)]
 mod tests {
+    use crate::parse::MAX_WORD_LEN;
     use crate::{Json, JsonErrorKind, Kind, MAX_DEPTH, MAX_NUMBER_LEN};
 
     /// The refusal a document gets, or a panic naming the document that
@@ -587,7 +620,7 @@ mod tests {
     /// **A document cut short says which piece went missing**, at every
     /// place the grammar can be waiting for one.
     ///
-    /// Eight places, eight prefixes. This is the test that stops
+    /// Nine places, nine prefixes. This is the test that stops
     /// `EndOfDocument` from becoming one message doing seven jobs badly:
     /// each `expected` is asserted by its own words, so a call site that
     /// starts passing another's string is a failure here rather than a
@@ -734,6 +767,32 @@ mod tests {
     /// Probed by replacing `infinity` in the list with a word nothing
     /// writes: `Infinity` answers `BadLiteral` instead, which tells a
     /// reader to go looking for a misspelt `true`.
+    /// A huge run of letters is refused in a message of bounded size.
+    ///
+    /// The other half of `MAX_WORD_LEN`'s reason for existing, and the
+    /// half a compile-time assertion cannot state: the bound has to be
+    /// applied, not merely declared. Without the length term in `word()`
+    /// the loop runs to the end of the letters and the refusal carries
+    /// every one of them, so a megabyte of `a` becomes a megabyte-long
+    /// error message — an allocation the input asked for by being
+    /// malformed, which is rule five of `REFUSALS.md` inverted.
+    ///
+    /// Probed by deleting the `MAX_WORD_LEN` term from `word()`'s loop
+    /// condition: red, `found` comes back with all 100,000 letters.
+    #[test]
+    fn a_run_of_letters_is_refused_without_quoting_all_of_it() {
+        let letters = "a".repeat(100_000);
+        let JsonErrorKind::BadLiteral { found } = refusal(&letters) else {
+            panic!("a run of letters should be refused as a bad literal");
+        };
+        assert!(
+            found.len() <= MAX_WORD_LEN,
+            "the refusal quoted {} letters of a {}-letter run; the message \n             a malformed input can make this reader build is bounded by \n             MAX_WORD_LEN ({MAX_WORD_LEN}) and nothing else",
+            found.len(),
+            letters.len()
+        );
+    }
+
     #[test]
     fn a_word_from_another_language_is_named_as_one() {
         for text in [

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -13,10 +13,13 @@ typed question asked of every value in it, because validation claims an
 accepted document has nothing deferred left in it. An input that breaks
 any of those claims is a finding.
 
-`json_parse` is also the only target given its bytes unfiltered.
-`trace_parse` guards its input with `from_utf8`, because that parser
-takes text and every crash found past a lossy conversion would be
-unreachable from a real file; the JSON reader takes bytes on purpose, so
+**Six of the eight take their bytes unfiltered; two do not, and the
+dividing line is what the parser's own signature accepts.**
+`trace_parse` and `ui_text` guard their input with `from_utf8` and return
+early on failure, because both of those parsers take `&str` — a crash
+found past a lossy conversion would be unreachable from any real file.
+The other six take `&[u8]`, so there is nothing for them to guard. The
+JSON reader in particular takes bytes on purpose, so
 that a caller holding one chunk of a larger file need not answer the "is
 this even text" question itself — which means the fuzzer is the thing
 that has to ask it.
@@ -34,7 +37,8 @@ dependencies, so the scheduled job runs that check here instead.
 
 ## What these add over the existing suites
 
-Both parsers already assert the property these targets test. The pack
+**Two of these parsers already assert the property their own target
+tests, in their stable-workspace suites.** The pack
 reader's suite says it "answers, one way or the other, for every byte
 string it can be handed"; the codec has the same over arbitrary text, plus
 a mutation property shaped like a real file.
@@ -51,10 +55,24 @@ not a first line of defence, a deeper one.
 the coverage-guided search found worth keeping, minimized by
 `cargo fuzz cmin`. **Two corpora start differently** — `png_decode`'s
 seeds are written by `cargo run -p renew-png --example make_corpus` and
-`json_parse`'s by `cargo run -p renew-json --example make_corpus`, each
-of which builds every one, so those directories carry no file this
-repository did not author and no licence question with them. Each
-generator is committed beside its seeds and they change together. Once a target's
+`json_parse`'s by `cargo run -p renew-json --example make_corpus`, each of
+which builds every byte it writes rather than copying a file from
+anywhere, so no licence question arrives with the starting seeds.
+
+**What is *not* gated is which of those seeds survive, and that is
+deliberate.** Neither generator runs in CI, and no test compares the
+committed directory against what a generator would produce today —
+because `cargo fuzz cmin` renames what it keeps to a content hash and
+drops what adds no coverage, so a check that demanded seed-for-seed
+identity would forbid the minimisation the procedure requires. **The
+property the merge gate holds instead is about reach, not identity:**
+`corpus_replay.rs` beside each parser asserts a floor on the number of
+*distinct* answers the surviving corpus provokes and names the individual
+refusals that must stay reachable. A corpus can be minimised freely; it
+cannot quietly stop exercising a guard. Running a generator after
+changing it is a manual step, and nothing here will notice if it is
+skipped — the reach floor is what would eventually catch the
+consequence. Once a target's
 corpus exists the rule below is the same for all of them: the fuzzer adds
 its own finds, and nothing here deletes them. Runs start from it (locally
 and on the schedule),
@@ -92,7 +110,13 @@ scheduled job uploads the directory when a run fails.
 
 ## What these targets deliberately do not assert
 
-Only that the parser answers. Whether the answer is *correct* belongs to
-the round-trip properties beside each parser — a fuzz target that asserted
-on content would fail on inputs that are legitimately malformed, and the
-corpus would fill with noise.
+**That an accepted input is *meaningful*.** Four of the eight do assert
+something past "it answered" — the datagram re-encodes to its own bytes,
+a UI document instantiates, compiled text reads back, a JSON document
+answers every typed question — but each of those is a claim the parser
+itself makes about what it accepts, checked only on inputs it accepted.
+**None of them assert anything about a rejected input, and none assert
+that a decoded value is the right value.** Whether the answer is correct
+belongs to the round-trip properties beside each parser: a fuzz target
+that asserted on content would fail on inputs that are legitimately
+malformed, and the corpus would fill with noise.


### PR DESCRIPTION
A pass over the documents describing how this tree reads untrusted input turned up several claims stated more strongly than any code holds them. Each is corrected in place, and each correction says what was wrong rather than quietly replacing it — these documents are made almost entirely of universals, and a universal checked against one example is the failure mode worth naming.

### Corrections

**`REFUSALS.md`**
- Rule five said a refused input costs no allocation. False of both readers it named: `Pack::read` reserves its entry vector before parsing an entry, and the PNG decoder accumulates `PLTE`, `tRNS` and every `IDAT` body before it can reach the error that rejects the file. What they do hold is that the reservation is bounded by a linear function of the caller's own bytes. Amplification is the danger, not allocation.
- Entry 20 put `1e30` at 24 orders of magnitude past Q47.16. That is the distance to the *squarable* bound, not the representable one — they are eight orders apart and both are real. Both are now given, with a note on which binds a coordinate headed for physics.
- The census of readers omitted the JSON reader, which landed two commits after it.
- "Six rules every refusal follows" is a universal this document itself refutes twice.

**`fuzz/README.md`**
- `json_parse` was called the only target given its bytes unfiltered. Six of the eight are; the two that filter do so because their parsers take `&str`.
- "Both parsers already assert…" predates six of the eight targets.
- "These targets assert only that the parser answers" contradicted the same file's opening paragraph, which lists four that assert more.
- The corpus generators are run by nothing and compared against nothing. Seed-for-seed identity is deliberately not gated — `cmin` renames and drops — so the section now states the property the merge gate does hold, which is about reach.

**`crates/json/README.md`**
- The argument that the command-line tool cannot adopt this crate ran backwards: the tool already depends on two engine crates and this one depends on nothing, so there is no cycle to create. What actually stands in the way is that it changes a shipped tool's behaviour.

**`README.md`**
- The bar for readers of untrusted input was stated as met by everything in the tree. Two readers in the command-line tool do not meet it, and are named in `REFUSALS.md` rather than left to be discovered.

### One code change

`MAX_WORD_LEN` in `crates/json` carried two claims and nothing held either.

The first relates it to `NOT_JSON_WORDS`: the bound must clear the longest word in that list, *strictly*. `word()` stops at the bound and returns what it consumed, so a bound equal to a listed word's length truncates a longer run of letters into exactly that word — at 9, `undefinedx` answers `NonJsonLiteral { word: "undefined" }`, naming a word the document does not contain. It relates two constants, so it is a `const` assertion; at 9 the build stops.

The second is that the bound is *applied*, which no assertion can state. Without the length term in `word()`'s loop the refusal quotes the whole run: 100,000 letters in, 100,000 letters of error message out. That is now a test, and deleting the term reddens it with exactly that count.

Full suite green locally: 2,594 tests across 248 suites, `fmt` and `clippy -D warnings` clean.