### PR TITLE
fix(sim): ban the float maths the operator lint cannot see

### DIFF
--- a/crates/core/event/clippy.toml
+++ b/crates/core/event/clippy.toml
@@ -24,50 +24,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "this crate is plain data and never reads a clock" },
     { path = "std::time::SystemTime::now", reason = "this crate is plain data and never reads a clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },

--- a/crates/core/event/clippy.toml
+++ b/crates/core/event/clippy.toml
@@ -16,6 +16,58 @@
 # (A crate-local file fully replaces the workspace one, so the test
 # allowances are repeated.)
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "this crate is plain data and never reads a clock" },
     { path = "std::time::SystemTime::now", reason = "this crate is plain data and never reads a clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },

--- a/crates/ecs/clippy.toml
+++ b/crates/ecs/clippy.toml
@@ -28,50 +28,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::fs::read", reason = "this crate is data structures; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/crates/ecs/clippy.toml
+++ b/crates/ecs/clippy.toml
@@ -20,6 +20,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::fs::read", reason = "this crate is data structures; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/crates/fixed/Cargo.toml
+++ b/crates/fixed/Cargo.toml
@@ -18,7 +18,8 @@ core = false
 extension_points = []
 # Not `true`, and the reason is worth a comment because it looks wrong on the
 # crate physics is written in. The float-closure rule asks of a crate a
-# simulation *reaches* only that its root denies float arithmetic. Declaring
+# simulation *reaches* two things: that its root denies float arithmetic, and
+# that its lint file bans the float maths that deny cannot see. Declaring
 # `simulation = true` additionally imposes the platform-closure walk and the
 # cross-target comparison's obligations, which belong to code that has state to
 # reproduce; a stateless number type has none. `renew-event` is the same shape.

--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -39,9 +39,11 @@ finer than anything a game perceives.
 ## What the API refuses
 
 **No `f32` or `f64` in any signature.** Converting to a float is a presentation
-concern; it lives in the maths crate, which depends on this one. A simulation
-cannot reach that crate, so it cannot perform the conversion — enforced by the
-structure checker's float-closure rule rather than by anyone remembering.
+concern; it lives in `renew-math`. A simulation cannot reach that crate — not
+because of the dependency direction, which runs the other way, but because
+`renew-math` computes with floats and so cannot sit in a simulation's shipping
+closure. The float-closure rule is what sees to it, rather than anyone
+remembering.
 
 **That rule asks two questions, because one is not enough.** The first is
 whether a crate denies `clippy::float_arithmetic`, and that deny flags
@@ -51,8 +53,9 @@ question is whether the crate also bans those methods by name in its
 `clippy.toml`, beside the bans for the clock and the filesystem. **`mul_add` is
 the reason the second question exists** — whether the multiply and the add
 round once or twice is a property of the target and the lowering rather than of
-the source, and this repository has already measured the same expression giving
-different answers because of it.
+the source. **This repository has measured it**: `tests/angles.rs` in this crate
+records a sine reference built with `mul_add` that differed between machines,
+passing the accuracy test on one platform and failing on another.
 
 Values are constructed from integers: `from_int`, `from_ratio` (how `9.81` is
 written without a float ever existing — `from_ratio(981, 100)`), and

--- a/crates/fixed/README.md
+++ b/crates/fixed/README.md
@@ -43,6 +43,17 @@ concern; it lives in the maths crate, which depends on this one. A simulation
 cannot reach that crate, so it cannot perform the conversion — enforced by the
 structure checker's float-closure rule rather than by anyone remembering.
 
+**That rule asks two questions, because one is not enough.** The first is
+whether a crate denies `clippy::float_arithmetic`, and that deny flags
+operators. It does not flag method calls: `a.mul_add(b, c)` and `a.sin()`
+compile clean under it, which was measured rather than assumed. So the second
+question is whether the crate also bans those methods by name in its
+`clippy.toml`, beside the bans for the clock and the filesystem. **`mul_add` is
+the reason the second question exists** — whether the multiply and the add
+round once or twice is a property of the target and the lowering rather than of
+the source, and this repository has already measured the same expression giving
+different answers because of it.
+
 Values are constructed from integers: `from_int`, `from_ratio` (how `9.81` is
 written without a float ever existing — `from_ratio(981, 100)`), and
 `from_bits` for serialisation. All three are `const fn`, because game constants

--- a/crates/fixed/clippy.toml
+++ b/crates/fixed/clippy.toml
@@ -23,50 +23,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
     { path = "std::thread::spawn", reason = "this crate has nothing to parallelise and simulation is single-threaded regardless" },

--- a/crates/fixed/clippy.toml
+++ b/crates/fixed/clippy.toml
@@ -15,6 +15,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "arithmetic reads no clock; a number type that consulted one would make every result a function of when it ran" },
     { path = "std::thread::spawn", reason = "this crate has nothing to parallelise and simulation is single-threaded regardless" },

--- a/crates/fixed/tests/angles.rs
+++ b/crates/fixed/tests/angles.rs
@@ -6,18 +6,23 @@
 //! a reference, and `f64::sin` is the reference. The right boundary is that
 //! the shipped code has no float and the proof that its table is right does.
 //!
-//! **The allowance below is what makes that boundary explicit rather than
-//! accidental.** It used to be accidental: this file said the float ban did
+//! **The allowance on the one test that needs it is what makes that
+//! boundary explicit rather than accidental.** It used to be accidental: this file said the float ban did
 //! not reach here because an integration test is its own crate. That was true
 //! of the crate-level `deny`, and it is not true of the method ban, because
 //! `clippy.toml` is read per directory and applies to every target in it. So
 //! the exemption is now written down and carries its reason, which is the
-//! only form an exemption should take — a reader who deletes this line has to
-//! delete the argument with it.
-#![allow(
-    clippy::disallowed_methods,
-    reason = "f64::sin and f64::cos are the reference this file checks the fixed-point table               against; there is no other way to state a table's error, and no value computed               here reaches shipped code, let alone a digest"
-)]
+//! only form an exemption should take — a reader who deletes it has to delete
+//! the argument with it.
+//!
+//! **It is on the test rather than on the file, and that is not tidiness.**
+//! A file-level allow of `disallowed_methods` silences *every* entry in this
+//! crate's lint file — the clock, the filesystem, thread spawning — not the
+//! two float methods its reason names. Measured: with one in place,
+//! `Instant::now()` and `fs::read()` were added here and clippy reported
+//! neither. And it is `expect` rather than `allow`, so the day this file stops
+//! needing it, the compiler says so instead of leaving a permission nobody
+//! rereads.
 
 use proptest::prelude::*;
 use renew_fixed::{Angle, Fixed, Vec2};
@@ -87,6 +92,10 @@ proptest! {
 
     /// The accuracy claim, over the whole circle rather than a sample of it.
     #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "f64::sin and f64::cos are the reference this table is checked against; there is no other way to state a table's error, and nothing computed here reaches shipped code, let alone a digest"
+    )]
     fn sine_and_cosine_are_within_the_stated_error(bits in any::<u32>()) {
         let angle = Angle::from_bits(bits);
         let theta = radians(angle);

--- a/crates/fixed/tests/angles.rs
+++ b/crates/fixed/tests/angles.rs
@@ -3,10 +3,21 @@
 //! **This file uses floating point deliberately**, and it is the only place in
 //! this crate's world that may. The table is a committed approximation of a
 //! transcendental function; the only honest way to state its error is against
-//! a reference, and `f64::sin` is the reference. Integration tests are their
-//! own crate, so the library's float ban does not reach here — which is the
-//! right boundary: the shipped code has no float, and the proof that its
-//! table is right does.
+//! a reference, and `f64::sin` is the reference. The right boundary is that
+//! the shipped code has no float and the proof that its table is right does.
+//!
+//! **The allowance below is what makes that boundary explicit rather than
+//! accidental.** It used to be accidental: this file said the float ban did
+//! not reach here because an integration test is its own crate. That was true
+//! of the crate-level `deny`, and it is not true of the method ban, because
+//! `clippy.toml` is read per directory and applies to every target in it. So
+//! the exemption is now written down and carries its reason, which is the
+//! only form an exemption should take — a reader who deletes this line has to
+//! delete the argument with it.
+#![allow(
+    clippy::disallowed_methods,
+    reason = "f64::sin and f64::cos are the reference this file checks the fixed-point table               against; there is no other way to state a table's error, and no value computed               here reaches shipped code, let alone a digest"
+)]
 
 use proptest::prelude::*;
 use renew_fixed::{Angle, Fixed, Vec2};

--- a/crates/frame/clippy.toml
+++ b/crates/frame/clippy.toml
@@ -12,6 +12,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/crates/frame/clippy.toml
+++ b/crates/frame/clippy.toml
@@ -20,50 +20,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/crates/input/clippy.toml
+++ b/crates/input/clippy.toml
@@ -19,6 +19,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::fs::read", reason = "this crate is data structures; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/crates/input/clippy.toml
+++ b/crates/input/clippy.toml
@@ -27,50 +27,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::fs::read", reason = "this crate is data structures; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/crates/net/clippy.toml
+++ b/crates/net/clippy.toml
@@ -32,50 +32,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
     { path = "std::time::SystemTime::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded, and stays that way until something defines a deterministic parallel-scheduling contract - a fixed partitioning and a fixed reduction order - which this crate does not" },

--- a/crates/net/clippy.toml
+++ b/crates/net/clippy.toml
@@ -24,6 +24,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
     { path = "std::time::SystemTime::now", reason = "a session reads no wall clock; every pacing decision belongs to the driver and arrives as an argument" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded, and stays that way until something defines a deterministic parallel-scheduling contract - a fixed partitioning and a fixed reduction order - which this crate does not" },

--- a/crates/physics2d/clippy.toml
+++ b/crates/physics2d/clippy.toml
@@ -13,6 +13,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },

--- a/crates/physics2d/clippy.toml
+++ b/crates/physics2d/clippy.toml
@@ -21,50 +21,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },

--- a/crates/physics3d/clippy.toml
+++ b/crates/physics3d/clippy.toml
@@ -13,6 +13,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },

--- a/crates/physics3d/clippy.toml
+++ b/crates/physics3d/clippy.toml
@@ -21,50 +21,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "a step advances by its configured timestep and never by the wall clock; reading one would make the world a function of when it ran" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists" },

--- a/crates/replay/clippy.toml
+++ b/crates/replay/clippy.toml
@@ -19,6 +19,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::time::SystemTime::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::thread::spawn", reason = "a translator spawns nothing; it is a pure function of its input" },

--- a/crates/replay/clippy.toml
+++ b/crates/replay/clippy.toml
@@ -27,50 +27,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::time::SystemTime::now", reason = "a translator reads no clock; nothing it produces may depend on when it ran" },
     { path = "std::thread::spawn", reason = "a translator spawns nothing; it is a pure function of its input" },

--- a/crates/rng/clippy.toml
+++ b/crates/rng/clippy.toml
@@ -17,6 +17,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until the deterministic parallel-scheduling decision exists" },

--- a/crates/rng/clippy.toml
+++ b/crates/rng/clippy.toml
@@ -25,50 +25,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the seed comes from the caller" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until the deterministic parallel-scheduling decision exists" },

--- a/crates/scene/clippy.toml
+++ b/crates/scene/clippy.toml
@@ -24,50 +24,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
     { path = "std::time::SystemTime::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists: fixed partitioning and a fixed reduction order" },

--- a/crates/scene/clippy.toml
+++ b/crates/scene/clippy.toml
@@ -16,6 +16,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
     { path = "std::time::SystemTime::now", reason = "a placement reads no clock; one that did would move between two runs of the same tick" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded until a deterministic parallel-scheduling contract exists: fixed partitioning and a fixed reduction order" },

--- a/crates/trace/clippy.toml
+++ b/crates/trace/clippy.toml
@@ -36,50 +36,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem: it parses text a caller already holds" },
     { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the I/O seam, which can refuse an oversized file; this crate never does I/O" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road: a handle plus this method is `fs::read_to_string` spelled in two lines" },

--- a/crates/trace/clippy.toml
+++ b/crates/trace/clippy.toml
@@ -28,6 +28,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem: it parses text a caller already holds" },
     { path = "std::fs::read_to_string", reason = "an unbounded whole-file read of untrusted input belongs at the I/O seam, which can refuse an oversized file; this crate never does I/O" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road: a handle plus this method is `fs::read_to_string` spelled in two lines" },

--- a/crates/ui/clippy.toml
+++ b/crates/ui/clippy.toml
@@ -18,50 +18,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
     { path = "std::time::SystemTime::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },

--- a/crates/ui/clippy.toml
+++ b/crates/ui/clippy.toml
@@ -10,6 +10,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
     { path = "std::time::SystemTime::now", reason = "the tree is stepped by its host at the cadence the host owns; simulation state reads no clock" },
     { path = "std::fs::read", reason = "this crate never touches the filesystem" },

--- a/crates/volume/clippy.toml
+++ b/crates/volume/clippy.toml
@@ -22,6 +22,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::fs::read", reason = "this crate is storage and geometry; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/crates/volume/clippy.toml
+++ b/crates/volume/clippy.toml
@@ -30,50 +30,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::fs::read", reason = "this crate is storage and geometry; it never touches the filesystem" },
     { path = "std::fs::read_to_string", reason = "this crate does no I/O at all" },
     { path = "std::io::Read::read_to_string", reason = "the same unbounded read by the other road" },

--- a/samples/chess/rules/clippy.toml
+++ b/samples/chess/rules/clippy.toml
@@ -12,6 +12,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "the rules advance by moves the caller plays, never by a clock they read" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/chess/rules/clippy.toml
+++ b/samples/chess/rules/clippy.toml
@@ -20,50 +20,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "the rules advance by moves the caller plays, never by a clock they read" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/cube/world/clippy.toml
+++ b/samples/cube/world/clippy.toml
@@ -13,6 +13,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/cube/world/clippy.toml
+++ b/samples/cube/world/clippy.toml
@@ -21,50 +21,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/glide/world/clippy.toml
+++ b/samples/glide/world/clippy.toml
@@ -11,6 +11,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/glide/world/clippy.toml
+++ b/samples/glide/world/clippy.toml
@@ -19,50 +19,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::time::SystemTime::now", reason = "simulation code reads no wall clock; the caller passes the one Timestamp in" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/leap/world/clippy.toml
+++ b/samples/leap/world/clippy.toml
@@ -13,6 +13,58 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 
 disallowed-methods = [
+
+# **Float maths the operator lint cannot see.**
+#
+# `clippy::float_arithmetic`, denied at the top of this crate, flags
+# operators. It does not flag method calls, so `a.mul_add(b, c)` and
+# `a.sin()` compile clean under it — measured, not assumed. Every entry
+# below computes a float by a call rather than by an operator.
+#
+# `mul_add` is first because it is the one this tree has already been
+# bitten by: it lowered to a runtime call on one target and gave different
+# answers than the same expression written out.
+#
+# A tripwire across the roads people actually take, not a proof — the same
+# thing the filesystem bans above are, and for the same reason. Selection,
+# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
+# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
+# `from_bits` and the `is_*` predicates compute nothing that can differ
+# between two correct implementations.
+    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
+    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
+    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
+    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
+    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
+    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
+    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
+    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
+    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
+    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
     { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/samples/leap/world/clippy.toml
+++ b/samples/leap/world/clippy.toml
@@ -21,50 +21,66 @@ disallowed-methods = [
 # `a.sin()` compile clean under it — measured, not assumed. Every entry
 # below computes a float by a call rather than by an operator.
 #
-# `mul_add` is first because it is the one this tree has already been
-# bitten by: it lowered to a runtime call on one target and gave different
-# answers than the same expression written out.
+# **The rule, so that a method not listed here can be placed without
+# guessing: banned if it has to round, legal if it cannot.** Selection,
+# comparison and reinterpretation are exact and stay legal — `abs`, `min`,
+# `max`, `clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`,
+# `to_bits`, `from_bits` and the `is_*` predicates decide nothing two
+# correct implementations could decide differently.
+#
+# **Two entries break that rule on purpose and say so:** `sqrt` and
+# `recip` are correctly rounded by IEEE-754 and are banned anyway,
+# because float maths belongs to presentation and the fixed-point type is
+# the answer here. They are policy, not drift, and their reasons say
+# which.
+#
+# `mul_add` leads because it is the one this tree has been bitten by, and
+# the record is in `crates/fixed/tests/angles.rs`: it fuses on targets
+# with a fused multiply-add and not on targets without, so a reference
+# built with it differed between machines and the accuracy test passed on
+# one platform while failing on another.
 #
 # A tripwire across the roads people actually take, not a proof — the same
-# thing the filesystem bans above are, and for the same reason. Selection,
-# tests and reinterpretation stay legal: `abs`, `min`, `max`, `clamp`,
-# `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
-# `from_bits` and the `is_*` predicates compute nothing that can differ
-# between two correct implementations.
-    { path = "f32::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f64::mul_add", reason = "whether the multiply and the add round once or twice is a property of the target and the lowering, not of the source, so the same expression gives different answers on different machines" },
-    { path = "f32::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f64::sqrt", reason = "float maths belongs to presentation; a simulation that needs a root uses the fixed-point one" },
-    { path = "f32::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f64::hypot", reason = "a root by another name, and its intermediate scaling is implementation-defined" },
-    { path = "f32::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f64::cbrt", reason = "not correctly rounded by any standard, so two libm implementations may differ" },
-    { path = "f32::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f64::powi", reason = "the association order of the repeated multiplications is implementation-defined" },
-    { path = "f32::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f64::powf", reason = "implemented as exp(y * ln(x)) with implementation-defined rounding at each step" },
-    { path = "f32::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::exp", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::ln", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log2", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f64::log10", reason = "not correctly rounded by any standard; libm implementations differ in the last place" },
-    { path = "f32::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::sin", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::cos", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f64::tan", reason = "not correctly rounded by any standard, and argument reduction differs between libms" },
-    { path = "f32::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f64::atan2", reason = "not correctly rounded by any standard; the fixed-point angle type is what a simulation uses to face a direction" },
-    { path = "f32::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f64::recip", reason = "a division written as a call, which is the one spelling the operator lint cannot see" },
-    { path = "f32::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_degrees", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f32::to_radians", reason = "a multiplication written as a call, for the same reason" },
-    { path = "f64::to_radians", reason = "a multiplication written as a call, for the same reason" },
+# thing the filesystem and clock bans in this file are, and for the same
+# reason.
+    { path = "f32::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f64::mul_add", reason = "fused on targets that have a fused multiply-add and not on targets that do not, so the same source rounds once on one machine and twice on another; this crate has been bitten by exactly that, and `crates/fixed/tests/angles.rs` records the case" },
+    { path = "f32::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f64::sqrt", reason = "correctly rounded by IEEE-754, so this one is banned by policy rather than for drift: float maths belongs to presentation, and a simulation that needs a root uses `Fixed::sqrt`" },
+    { path = "f32::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::hypot", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cbrt", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f64::powi", reason = "the order in which the repeated multiplications are associated is unspecified, so the rounding sequence is too" },
+    { path = "f32::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::powf", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::exp", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::ln", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::log10", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::sin", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::cos", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::tan", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f64::sin_cos", reason = "both of the above in one call, and the spelling a reader reaches for after seeing `Angle::sin_cos` in the fixed-point crate" },
+    { path = "f32::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f64::atan2", reason = "Rust does not specify the precision of this, and no mainstream libm rounds it correctly, so two targets can differ in the last place" },
+    { path = "f32::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f64::recip", reason = "a division written as a call, correctly rounded like the operator it replaces and banned for the same policy reason as `sqrt`" },
+    { path = "f32::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f64::rem_euclid", reason = "a modulo written as a call; it is the usual float way to wrap an angle, which is precisely the thing the fixed-point angle type exists to do" },
+    { path = "f32::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_degrees", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f32::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
+    { path = "f64::to_radians", reason = "a multiplication written as a call, which the operator lint cannot see" },
     { path = "std::time::Instant::now", reason = "the world advances by ticks the caller counts, never by a clock it reads" },
     { path = "std::time::SystemTime::now", reason = "same reason as Instant::now, and this one is not even monotonic" },
     { path = "std::thread::spawn", reason = "simulation is single-threaded; no deterministic parallel-scheduling contract exists yet" },

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -409,7 +409,7 @@ pub fn evaluate(shapes: &[CrateShape]) -> Vec<Finding> {
 ///
 /// The zoning policy each engine crate enforces lives in that file —
 /// tripwires that reject a clock, a filesystem call, or a raw thread
-/// spawn from a crate whose contract forbids them. Nine crates have added
+/// spawn from a crate whose contract forbids them. Thirty-one crates have added
 /// it by hand, correctly, every time. That is exactly when the habit
 /// should stop being a habit: the crate that forgets will not fail to
 /// compile, will not fail a test, and will simply have no tripwires,
@@ -1063,7 +1063,7 @@ mod tests {
         let mut lints = String::from("disallowed-methods = [\n");
         for method in REQUIRED_FLOAT_METHOD_BANS {
             for kind in ["f32", "f64"] {
-                lints.push_str("    { path = \"");
+                lints.push_str(" { path = \"");
                 lints.push_str(kind);
                 lints.push_str("::");
                 lints.push_str(method);
@@ -1222,7 +1222,7 @@ disallowed-methods = [
         // the edit the raw `contains` could not see.
         let commented = r#"
 disallowed-methods = [
-#    { path = "f32::mul_add", reason = "temporarily off" },
+# { path = "f32::mul_add", reason = "temporarily off" },
 ]
 "#;
         assert!(
@@ -1294,13 +1294,15 @@ disallowed-methods = [
         // crate answer yes and this whole rule pass vacuously — measured,
         // not supposed: emptying it leaves `check` reporting a healthy
         // workspace and reddens nothing else here.
-        assert!(
-            REQUIRED_FLOAT_METHOD_BANS.len() >= 6,
-            "the sentinels span the classes of hazard; a shorter list is a weaker claim than the              one this rule is documented to make"
-        );
-        assert!(
-            REQUIRED_FLOAT_METHOD_BANS.contains(&"mul_add"),
-            "the fused multiply-add is the one this tree has measured changing its answer between              lowerings, so it is the one entry that may never be dropped"
+        // **Pinned, not counted.** This used to assert `len() >= 6` under
+        // a message claiming the list "spans the classes of hazard" — so
+        // swapping `recip` for `cos` left the operator-in-disguise class
+        // unrepresented with both assertions green. A policy constant is
+        // pinned or it is not checked.
+        assert_eq!(
+            REQUIRED_FLOAT_METHOD_BANS,
+            ["mul_add", "sqrt", "powf", "ln", "sin", "recip"],
+            "one per class: a fused multiply-add, a root, a power, a logarithm, a trigonometric function, and a division written as a call. Changing this list is changing what the gate certifies, so it changes here too."
         );
 
         let shapes = [
@@ -1351,7 +1353,11 @@ disallowed-methods = [
             .iter()
             .find(|finding| finding.rule == "float-closure")
             .expect("the transitive float crate is reported");
-        assert!(found.message.contains("maths"), "{}", found.message);
+        assert!(
+            found.message.contains("maths") && found.message.contains("deny"),
+            "the deny finding and the method-ban finding both name the crate, so the crate name alone does not say which was reported: {}",
+            found.message
+        );
 
         // The same graph with the far crate denying is silent.
         let clean = [

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -1244,11 +1244,16 @@ disallowed-methods = [
     { path = "std::fs::read", reason = "we also used to ban path = \"f32::mul_add\" here" },
 ]
 "#;
-        assert!(
-            !declared_paths(quoted).contains(&"f32::mul_add".to_string())
-                || declared_paths(quoted).len() == 2,
-            "prose that mentions a path does not declare it: {:?}",
-            declared_paths(quoted)
+        // Asserted exactly, because the hedged version this replaces
+        // (`does not contain it, OR there are two of them`) would have
+        // passed if the parser HAD captured the quoted path — accepting
+        // the one bug the case exists to catch. A disjunction written
+        // because the author was unsure what the code does is not a test,
+        // it is a note that the author was unsure.
+        assert_eq!(
+            declared_paths(quoted),
+            ["std::fs::read"],
+            "the escaped path inside the reason is prose, and only the real entry is declared"
         );
     }
 

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -27,6 +27,21 @@ pub const CORE_CRATES: &[&str] = &[
 /// crate claims determinism and this name is absent.
 const PLATFORM_CRATE: &str = "renew-platform";
 
+/// The float methods a crate in a simulation closure must ban by name.
+///
+/// **Not the whole list, and deliberately so.** The bans in each
+/// `clippy.toml` cover seventeen methods; requiring all thirty-four paths
+/// here would make this check a copy of that file, and the copy would rot.
+/// These six span the classes — a fused multiply-add, a root, a power, a
+/// logarithm, a trigonometric function, and a division written as a call —
+/// so a crate that has them has understood the rule rather than pasted a
+/// line.
+///
+/// `mul_add` leads because it is the one this tree has been bitten by:
+/// whether the multiply and the add round once or twice is a property of
+/// the target, not the source.
+const REQUIRED_FLOAT_METHOD_BANS: &[&str] = &["mul_add", "sqrt", "powf", "ln", "sin", "recip"];
+
 const MATURITIES: &[&str] = &["bootstrap", "internal", "stable"];
 const REQUIRED_FIELDS: &[&str] = &[
     "purpose",
@@ -66,6 +81,19 @@ pub struct CrateShape {
     /// rules stay pure functions of the shapes and their tests can
     /// construct a crate that does or does not carry it.
     pub denies_float: bool,
+    /// Does this crate ban the float maths the operator lint cannot see?
+    ///
+    /// **A second question, not a restatement of the first.**
+    /// `denies_float` reads a `deny` out of `src/lib.rs` and that deny
+    /// covers operators. This reads `clippy.toml` and asks whether the
+    /// method spellings are banned too — `a.mul_add(b, c)`, `a.sin()` —
+    /// which the deny does not reach, because they are calls.
+    ///
+    /// Kept separate rather than folded in, because the two are declared
+    /// in different files by different mechanisms and a crate can
+    /// honestly have one without the other. A finding that could not say
+    /// which was missing would send a reader to the wrong file.
+    pub bans_float_methods: bool,
     /// Parsed metadata table, or the list of schema problems.
     pub meta: Result<Meta, Vec<String>>,
 }
@@ -166,6 +194,14 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
         // is the safe direction: the rule reports rather than assumes.
         let denies_float = std::fs::read_to_string(format!("{dir}/src/lib.rs"))
             .is_ok_and(|source| source.contains("clippy::float_arithmetic"));
+        // Read from the lint file rather than the source, because that is
+        // where the ban lives. An unreadable file answers `false`, which
+        // is the safe direction: rule 7 already reports a crate with no
+        // `clippy.toml`, so this cannot be the only thing that noticed.
+        let lints = std::fs::read_to_string(format!("{dir}/clippy.toml")).unwrap_or_default();
+        let bans_float_methods = REQUIRED_FLOAT_METHOD_BANS.iter().all(|method| {
+            lints.contains(&format!("f32::{method}")) && lints.contains(&format!("f64::{method}"))
+        });
         let meta = validate_meta(package);
         shapes.push(CrateShape {
             name,
@@ -175,6 +211,7 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
             runtime_deps,
             foreign_deps,
             denies_float,
+            bans_float_methods,
             meta,
         });
     }
@@ -574,6 +611,15 @@ fn float_closure_rules(shape: &CrateShape, shapes: &[CrateShape], findings: &mut
         let Some(dep) = shapes.iter().find(|candidate| candidate.name == current) else {
             continue;
         };
+        if !dep.bans_float_methods {
+            findings.push(Finding {
+                rule: "float-closure",
+                message: format!(
+                    "{} declares simulation = true and reaches {current} (transitively), which does not ban the float maths the operator lint cannot see — `clippy::float_arithmetic` flags operators, so `a.mul_add(b, c)` and `a.sin()` compile clean under it, and whether a fused multiply-add rounds once or twice is a property of the target rather than of the source; the ban belongs in that crate's `clippy.toml` beside the ones for the clock and the filesystem",
+                    shape.name
+                ),
+            });
+        }
         if !dep.denies_float {
             findings.push(Finding {
                 rule: "float-closure",
@@ -674,6 +720,7 @@ mod tests {
     fn shape(name: &str, engine: bool, deps: &[&str], maturity: &str, core: bool) -> CrateShape {
         CrateShape {
             name: name.to_string(),
+            bans_float_methods: true,
             dir: format!("/w/crates/{name}"),
             engine,
             deps: deps.iter().map(ToString::to_string).collect(),
@@ -753,6 +800,7 @@ mod tests {
     fn schema_problems_surface_per_crate() {
         let shapes = [CrateShape {
             name: "broken".to_string(),
+            bans_float_methods: true,
             dir: "/w/crates/x".to_string(),
             engine: false,
             deps: Vec::new(),
@@ -838,6 +886,7 @@ mod tests {
     fn non_engine_crates_stay_in_their_lane() {
         let flagged = [CrateShape {
             name: "tool".to_string(),
+            bans_float_methods: true,
             dir: "/w/crates/x".to_string(),
             engine: false,
             deps: Vec::new(),
@@ -882,6 +931,7 @@ mod tests {
     fn sim(name: &str, deps: &[&str], simulation: bool) -> CrateShape {
         CrateShape {
             name: name.to_string(),
+            bans_float_methods: true,
             dir: format!("/w/crates/{name}"),
             engine: true,
             deps: deps.iter().map(|d| (*d).to_string()).collect(),
@@ -909,6 +959,7 @@ mod tests {
     ) -> CrateShape {
         CrateShape {
             denies_float,
+            bans_float_methods: true,
             foreign_deps: foreign.iter().map(|d| (*d).to_string()).collect(),
             ..sim(name, deps, simulation)
         }
@@ -922,6 +973,63 @@ mod tests {
             runtime_deps: Vec::new(),
             ..sim(name, &[], simulation)
         }
+    }
+
+    /// **The deny and the method ban are two claims, and the rule asks
+    /// both.**
+    ///
+    /// A crate can honestly deny `clippy::float_arithmetic` and still
+    /// compute with floats, because that lint flags operators and not
+    /// calls. This fixture is that crate: `denies_float` true,
+    /// `bans_float_methods` false. Before the second question existed it
+    /// was indistinguishable from a clean one.
+    #[test]
+    fn float_closure_asks_for_the_method_ban_as_well_as_the_deny() {
+        // **The list is the check.** `all()` over an empty list is true,
+        // so an emptied `REQUIRED_FLOAT_METHOD_BANS` would make every
+        // crate answer yes and this whole rule pass vacuously — measured,
+        // not supposed: emptying it leaves `check` reporting a healthy
+        // workspace and reddens nothing else here.
+        assert!(
+            REQUIRED_FLOAT_METHOD_BANS.len() >= 6,
+            "the sentinels span the classes of hazard; a shorter list is a weaker claim than the              one this rule is documented to make"
+        );
+        assert!(
+            REQUIRED_FLOAT_METHOD_BANS.contains(&"mul_add"),
+            "the fused multiply-add is the one this tree has measured changing its answer between              lowerings, so it is the one entry that may never be dropped"
+        );
+
+        let shapes = [
+            float_sim("world", &["middle"], true, true, &[]),
+            CrateShape {
+                bans_float_methods: false,
+                ..float_sim("middle", &[], false, true, &[])
+            },
+        ];
+        let found = evaluate(&shapes)
+            .into_iter()
+            .find(|finding| finding.rule == "float-closure")
+            .expect("a crate that denies operators but not methods is reported");
+        assert!(
+            found.message.contains("middle") && found.message.contains("mul_add"),
+            "the finding names the crate and an operation it must ban: {}",
+            found.message
+        );
+
+        // The same graph with the ban present is silent — so the finding
+        // is about the ban rather than about the crate being reachable at
+        // all, which is what a fixture with only the first half would
+        // have proved.
+        let clean = [
+            float_sim("world", &["middle"], true, true, &[]),
+            float_sim("middle", &[], false, true, &[]),
+        ];
+        assert!(
+            evaluate(&clean)
+                .iter()
+                .all(|finding| finding.rule != "float-closure"),
+            "a closure whose crates answer both questions has nothing to report"
+        );
     }
 
     #[test]
@@ -1258,6 +1366,7 @@ mod tests {
             shape("renew-diag", true, &["renew-broken"], "bootstrap", true),
             CrateShape {
                 name: "renew-broken".to_string(),
+                bans_float_methods: true,
                 dir: "/w/crates/x".to_string(),
                 engine: true,
                 deps: Vec::new(),

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -30,7 +30,7 @@ const PLATFORM_CRATE: &str = "renew-platform";
 /// The float methods a crate in a simulation closure must ban by name.
 ///
 /// **Not the whole list, and deliberately so.** The bans in each
-/// `clippy.toml` cover seventeen methods; requiring all thirty-four paths
+/// `clippy.toml` cover nineteen methods; requiring all thirty-eight paths
 /// here would make this check a copy of that file, and the copy would rot.
 /// These six span the classes — a fused multiply-add, a root, a power, a
 /// logarithm, a trigonometric function, and a division written as a call —
@@ -249,8 +249,16 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
             .is_ok_and(|source| source.contains("clippy::float_arithmetic"));
         // Read from the lint file rather than the source, because that is
         // where the ban lives. An unreadable file answers `false`, which
-        // is the safe direction: rule 7 already reports a crate with no
-        // `clippy.toml`, so this cannot be the only thing that noticed.
+        // is the safe direction — and the rule below asks that question of
+        // the declaring crate as well as of what it reaches, so a
+        // simulation crate with no lint file is reported whether or not
+        // anything depends on it.
+        //
+        // This used to say the backstop was the rule requiring every
+        // engine crate to carry a `clippy.toml`. **That was false for the
+        // four sample worlds**, which declare `simulation = true` and live
+        // outside the engine roots, so that rule skips them: deleting a
+        // sample world's lint file reported nothing at all.
         let lints = std::fs::read_to_string(format!("{dir}/clippy.toml")).unwrap_or_default();
         let bans_float_methods = bans_the_required_float_methods(&lints);
         let meta = validate_meta(package);

--- a/tools/cli/src/structure.rs
+++ b/tools/cli/src/structure.rs
@@ -42,6 +42,59 @@ const PLATFORM_CRATE: &str = "renew-platform";
 /// the target, not the source.
 const REQUIRED_FLOAT_METHOD_BANS: &[&str] = &["mul_add", "sqrt", "powf", "ln", "sin", "recip"];
 
+/// The `disallowed-methods` and `disallowed-types` paths a lint file
+/// actually declares.
+///
+/// **Parsed, not searched, and this file already knew why.** The same
+/// check in the workspace-list suite carried this note before this
+/// function existed: a raw `contains` over the bytes "passes on a
+/// commented-out entry and on a banned path quoted inside another
+/// entry's `reason` prose", and the reasons in these files do quote
+/// paths at each other. The first version of the float-method gate was
+/// a raw `contains` anyway — measured afterwards: prefixing all
+/// thirty-four entries with `#` left the gate green, and so did deleting
+/// them and adding a prose comment naming them.
+///
+/// Comment lines go first, then each `path = "..."` value is taken.
+/// That is the only position clippy reads, so it is the only position
+/// this accepts.
+#[must_use]
+pub fn declared_paths(lints: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in lints.lines() {
+        let line = line.trim();
+        if line.starts_with('#') {
+            continue;
+        }
+        let mut rest = line;
+        while let Some(at) = rest.find("path = \"") {
+            rest = &rest[at + "path = \"".len()..];
+            let Some(end) = rest.find('"') else { break };
+            paths.push(rest[..end].to_string());
+            rest = &rest[end..];
+        }
+    }
+    paths
+}
+
+/// Whether a lint file bans every float method the closure requires.
+///
+/// Split out from the shape builder so it can be tested without a
+/// directory: the first version of this logic lived inline and **had no
+/// test at all**, which let `true || …`, `.all` to `.any`, and `&&` to
+/// `||` each survive the whole suite.
+#[must_use]
+pub fn bans_the_required_float_methods(lints: &str) -> bool {
+    let declared = declared_paths(lints);
+    REQUIRED_FLOAT_METHOD_BANS.iter().all(|method| {
+        ["f32", "f64"].iter().all(|kind| {
+            declared
+                .iter()
+                .any(|path| path == &format!("{kind}::{method}"))
+        })
+    })
+}
+
 const MATURITIES: &[&str] = &["bootstrap", "internal", "stable"];
 const REQUIRED_FIELDS: &[&str] = &[
     "purpose",
@@ -199,9 +252,7 @@ pub fn shapes_from_metadata(doc: &Value) -> Result<Vec<CrateShape>, String> {
         // is the safe direction: rule 7 already reports a crate with no
         // `clippy.toml`, so this cannot be the only thing that noticed.
         let lints = std::fs::read_to_string(format!("{dir}/clippy.toml")).unwrap_or_default();
-        let bans_float_methods = REQUIRED_FLOAT_METHOD_BANS.iter().all(|method| {
-            lints.contains(&format!("f32::{method}")) && lints.contains(&format!("f64::{method}"))
-        });
+        let bans_float_methods = bans_the_required_float_methods(&lints);
         let meta = validate_meta(package);
         shapes.push(CrateShape {
             name,
@@ -597,6 +648,34 @@ fn float_closure_rules(shape: &CrateShape, shapes: &[CrateShape], findings: &mut
         },
     };
 
+    // **The declaring crate is asked its own two answers.**
+    //
+    // The walk below covers what a simulation *reaches*; for a long time
+    // nothing covered the simulation itself, and `crates/net/src/lib.rs`
+    // carried a hand-written note saying so — "written by hand until that
+    // rule gains the half it is missing". This is that half. Without it,
+    // a simulation crate nothing else depends on — every sample world, and
+    // `renew-input`, `renew-net`, `renew-replay`, `renew-ui` — could drop
+    // its lint file entirely and this rule would report nothing.
+    if !shape.denies_float {
+        findings.push(Finding {
+            rule: "float-closure",
+            message: format!(
+                "{} declares simulation = true and does not itself deny clippy::float_arithmetic — the rule asks this of every crate a simulation ships, and a simulation ships itself",
+                shape.name
+            ),
+        });
+    }
+    if !shape.bans_float_methods {
+        findings.push(Finding {
+            rule: "float-closure",
+            message: format!(
+                "{} declares simulation = true and does not itself ban the float maths the operator lint cannot see — `clippy::float_arithmetic` flags operators, so `a.mul_add(b, c)` and `a.sin()` compile clean under it; the ban belongs in this crate's own `clippy.toml`",
+                shape.name
+            ),
+        });
+    }
+
     for foreign in &shape.foreign_deps {
         findings.push(unreadable(&shape.name, &shape.name, foreign));
     }
@@ -973,6 +1052,231 @@ mod tests {
             runtime_deps: Vec::new(),
             ..sim(name, &[], simulation)
         }
+    }
+
+    /// A lint file declaring every ban the closure requires.
+    ///
+    /// Built from the constant rather than written out, so a method
+    /// added to the requirement cannot leave this fixture behind
+    /// declaring the old set and still passing.
+    fn a_lint_file_with_every_required_ban() -> String {
+        let mut lints = String::from("disallowed-methods = [\n");
+        for method in REQUIRED_FLOAT_METHOD_BANS {
+            for kind in ["f32", "f64"] {
+                lints.push_str("    { path = \"");
+                lints.push_str(kind);
+                lints.push_str("::");
+                lints.push_str(method);
+                lints.push_str("\" },\n");
+            }
+        }
+        lints.push_str("]\n");
+        lints
+    }
+
+    /// **A simulation crate answers for itself, not only for what it
+    /// reaches.**
+    ///
+    /// The walk covers dependencies, so for a long time a simulation
+    /// crate nothing else depended on was covered by nothing — every
+    /// sample world, and `renew-input`, `renew-net`, `renew-replay`,
+    /// `renew-ui`. Measured before the fix: stripping the bans from eight
+    /// of the eighteen lint files produced no finding at all, and
+    /// deleting a sample world's file entirely left the workspace
+    /// "healthy".
+    ///
+    /// The fixture has **no dependencies on purpose** — that is the whole
+    /// case. A crate with dependencies would be covered by the walk even
+    /// if this half were missing again.
+    #[test]
+    fn a_simulation_crate_answers_for_its_own_lint_file() {
+        let lonely = CrateShape {
+            bans_float_methods: false,
+            ..float_sim("world", &[], true, true, &[])
+        };
+        let found = evaluate(&[lonely])
+            .into_iter()
+            .find(|finding| finding.rule == "float-closure")
+            .expect("a simulation crate that bans nothing is reported, even alone");
+        assert!(
+            found.message.contains("world") && found.message.contains("itself"),
+            "the finding says the crate is answering for itself rather than for a dependency: {}",
+            found.message
+        );
+
+        // The deny half of the same question, which the tree carried a
+        // hand-written note about in `crates/net/src/lib.rs` until now.
+        let undenied = CrateShape {
+            denies_float: false,
+            ..float_sim("world", &[], true, true, &[])
+        };
+        assert!(
+            evaluate(&[undenied])
+                .iter()
+                .any(|finding| finding.rule == "float-closure"
+                    && finding.message.contains("does not itself deny")),
+            "a simulation crate that does not deny the operators is reported for itself too"
+        );
+
+        // And a crate that answers both is silent, so the finding is
+        // about the answers rather than about being a simulation.
+        assert!(
+            evaluate(&[float_sim("world", &[], true, true, &[])])
+                .iter()
+                .all(|finding| finding.rule != "float-closure"),
+            "a simulation crate that answers both questions has nothing to report"
+        );
+    }
+
+    /// **The wiring, not just the predicate.**
+    ///
+    /// The tests below drive `bans_the_required_float_methods` over text.
+    /// That leaves the step that finds the text untested — and measured:
+    /// with only those, replacing the call site with `true || …` survived
+    /// the whole suite, as did reading a file that does not exist. This
+    /// builds a real directory, puts a real lint file in it, and asks
+    /// `shapes_from_metadata` what it made of it.
+    #[test]
+    fn the_shape_reads_the_lint_file_beside_the_manifest() {
+        let base = std::env::temp_dir().join(format!(
+            "renew-cli-bans-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let crate_dir = base.join("crates").join("probe");
+        std::fs::create_dir_all(crate_dir.join("src")).expect("a scratch crate directory");
+        std::fs::write(
+            crate_dir.join("src").join("lib.rs"),
+            "#![deny(clippy::float_arithmetic)]",
+        )
+        .expect("a scratch lib");
+
+        let manifest = crate_dir.join("Cargo.toml");
+        let document = format!(
+            r#"{{"workspace_root":"{root}","packages":[{{"name":"probe",
+               "manifest_path":"{manifest}","dependencies":[],
+               "metadata":{{"renew":{{"purpose":"p","maturity":"bootstrap","core":false,
+               "extension_points":[],"simulation":true}}}}}}]}}"#,
+            root = base
+                .display()
+                .to_string()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+            manifest = manifest
+                .display()
+                .to_string()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
+        );
+        let parsed = crate::json::parse(&document).expect("the fixture is valid JSON");
+
+        // No lint file at all: the crate bans nothing.
+        let shapes = shapes_from_metadata(&parsed).expect("metadata-shaped");
+        assert!(
+            !shapes[0].bans_float_methods,
+            "a crate with no clippy.toml has not banned anything"
+        );
+
+        // A lint file with every required ban: the crate bans them.
+        let full = a_lint_file_with_every_required_ban();
+        std::fs::write(crate_dir.join("clippy.toml"), &full).expect("a scratch lint file");
+        let shapes = shapes_from_metadata(&parsed).expect("metadata-shaped");
+        assert!(
+            shapes[0].bans_float_methods,
+            "the file beside the manifest is the one that counts"
+        );
+
+        // And it is read from `clippy.toml` specifically, not from
+        // whatever else sits in the directory.
+        std::fs::rename(
+            crate_dir.join("clippy.toml"),
+            crate_dir.join("clippy.toml.bak"),
+        )
+        .expect("rename the lint file away");
+        let shapes = shapes_from_metadata(&parsed).expect("metadata-shaped");
+        assert!(
+            !shapes[0].bans_float_methods,
+            "renaming the file away takes the bans with it"
+        );
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// **The parser reads what clippy reads, and nothing else.**
+    ///
+    /// Each case here is a shape that defeated the raw `contains` this
+    /// replaced, measured rather than imagined.
+    #[test]
+    fn declared_paths_ignores_everything_clippy_ignores() {
+        let live = r#"
+disallowed-methods = [
+    { path = "f32::mul_add", reason = "measured" },
+    { path = "f64::mul_add", reason = "measured" },
+]
+"#;
+        assert_eq!(
+            declared_paths(live),
+            ["f32::mul_add", "f64::mul_add"],
+            "a live entry is what the parser is for"
+        );
+
+        // Commenting out is at least as common as deleting, and it is
+        // the edit the raw `contains` could not see.
+        let commented = r#"
+disallowed-methods = [
+#    { path = "f32::mul_add", reason = "temporarily off" },
+]
+"#;
+        assert!(
+            declared_paths(commented).is_empty(),
+            "a commented-out entry bans nothing, so it declares nothing"
+        );
+
+        // The reasons in these files quote each other's paths.
+        let quoted = r#"
+disallowed-methods = [
+    { path = "std::fs::read", reason = "we also used to ban path = \"f32::mul_add\" here" },
+]
+"#;
+        assert!(
+            !declared_paths(quoted).contains(&"f32::mul_add".to_string())
+                || declared_paths(quoted).len() == 2,
+            "prose that mentions a path does not declare it: {:?}",
+            declared_paths(quoted)
+        );
+    }
+
+    /// **The predicate needs every required method, in both widths.**
+    ///
+    /// Written because the first version of this logic had no test at
+    /// all: `true || …`, `.all` to `.any`, and `&&` to `||` each survived
+    /// the entire suite and a clean `check`.
+    #[test]
+    fn the_float_ban_predicate_needs_both_widths_of_every_method() {
+        let full = a_lint_file_with_every_required_ban();
+        assert!(
+            bans_the_required_float_methods(&full),
+            "the full set is what every closure crate carries"
+        );
+
+        // One width missing is not a ban: `&&` becoming `||` would pass
+        // this file, and did.
+        let f32_only = full.replace("f64::", "notafloat::");
+        assert!(
+            !bans_the_required_float_methods(&f32_only),
+            "banning one width leaves the other legal"
+        );
+
+        // One method missing is not a ban: `.all` becoming `.any` would
+        // pass this file, and did.
+        let missing_one = full.replace("f32::recip", "f32::notamethod");
+        assert!(
+            !bans_the_required_float_methods(&missing_one),
+            "a required method absent is a required method absent"
+        );
+
+        assert!(
+            !bans_the_required_float_methods(""),
+            "an empty lint file bans nothing"
+        );
     }
 
     /// **The deny and the method ban are two claims, and the rule asks

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -741,7 +741,7 @@ mod tests",
         .collect();
     assert!(
         missing.is_empty(),
-        "the parser accepts {missing:?} and the usage text never mentions them;          a flag a user cannot discover may as well not exist"
+        "the parser accepts {missing:?} and the usage text never mentions them; a flag a user cannot discover may as well not exist"
     );
 }
 

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -398,37 +398,15 @@ const BANNED_IN_SIMULATION: &[&str] = &[
     "std::collections::hash_map::DefaultHasher",
 ];
 
-/// Crates whose manifest sets `simulation = true`, with the text of the
-/// lint file sitting beside it.
-/// Every path a lint file actually bans, read as structure rather than text.
+/// The parser lives in the checker now, so there is one of it.
 ///
-/// The check over these used to be `file.contains(banned)` across the raw
-/// bytes, which passes on a commented-out entry and on a banned path
-/// quoted inside another entry's `reason` prose. No file has that shape
-/// today, so the guard was passing for the right reason -- but it was one
-/// explanatory sentence away from passing for the wrong one, and the
-/// reasons in these files do quote paths at each other.
-///
-/// Comment lines are dropped first, then each `path = "..."` value is
-/// taken. That is the only position clippy reads, so it is the only
-/// position this should accept.
-fn declared_paths(lints: &str) -> Vec<String> {
-    let mut paths = Vec::new();
-    for line in lints.lines() {
-        let line = line.trim();
-        if line.starts_with('#') {
-            continue;
-        }
-        let mut rest = line;
-        while let Some(at) = rest.find("path = \"") {
-            rest = &rest[at + "path = \"".len()..];
-            let Some(end) = rest.find('"') else { break };
-            paths.push(rest[..end].to_string());
-            rest = &rest[end..];
-        }
-    }
-    paths
-}
+/// It was written here first, with a comment explaining that a raw
+/// `contains` over the bytes passes on a commented-out entry and on a
+/// path quoted inside another entry's `reason`. That comment moved with
+/// the function, because the float-method gate was then written with a
+/// raw `contains` anyway — the note was worth more where the next
+/// person to need it would look.
+use renew_cli::structure::declared_paths;
 
 fn simulation_crates(root: &Path) -> Result<Vec<(String, Vec<String>)>, String> {
     let mut found = Vec::new();


### PR DESCRIPTION
A simulation crate may not compute with floats: every crate in its shipping
closure denies `clippy::float_arithmetic`, checked by the float-closure rule.

That deny flags operators. It does not flag method calls. `a.mul_add(b, c)`,
`a.sin()` and `a.sqrt()` compile clean under it — measured, not assumed, by
adding them to a digest in a crate that declares itself simulation code and
denies the lint, and getting zero diagnostics.

`mul_add` is the one that matters, and this repository has already been bitten
by it. `crates/fixed/tests/angles.rs` records a sine reference built with
`mul_add` that differed between machines — it fuses on targets with a fused
multiply-add and does not on targets without — so the accuracy test passed on
one platform and failed on another. The lint whose whole job is keeping such
operations out of a simulation did not flag the one operation already caught
changing its result here.

## The ban

Nineteen float methods, for `f32` and `f64`, join the `disallowed-methods` list
in each of the eighteen crates in a simulation's shipping closure: the fused
multiply-add, the roots, the powers, the logarithms, the trigonometry, and the
four — `recip`, `rem_euclid`, `to_degrees`, `to_radians` — that are an operator
wearing a method's name.

The block states the rule it follows, so a method not listed can be placed
without guessing: **banned if it has to round, legal if it cannot.** Selection,
comparison and reinterpretation are exact and stay legal — `abs`, `min`, `max`,
`clamp`, `signum`, `copysign`, `floor`, `ceil`, `round`, `trunc`, `to_bits`,
`from_bits` and the `is_*` predicates. Two entries break that rule on purpose
and say so: `sqrt` and `recip` are correctly rounded and are banned anyway,
because float maths belongs to presentation and the fixed-point type is the
answer here.

A tripwire across the roads people actually take, not a proof — the same thing
the filesystem and clock bans beside it are.

It caught one use on landing, and that use is right: the fixed-point crate's
angle tests check the sine table against `f64::sin`, which is the only honest
way to state a table's error. That test carries an item-level `expect` naming
the reason — `expect` rather than `allow`, so the day it stops being needed the
compiler says so.

## The ratchet

The float-closure rule now asks each crate two questions rather than one: does
it deny the operators, and does its `clippy.toml` ban the methods that deny
cannot see.

It asks them **of the declaring crate as well as of what it reaches**. It did
not before, and `crates/net/src/lib.rs` carried a hand-written note saying so —
that its deny was "written by hand until that rule gains the half it is
missing". Eight of the eighteen crates were reachable by nothing and therefore
checked by nothing: every sample world, and the input, net, replay and ui
crates. Stripping the bans from those eight produced no finding; deleting a
sample world's lint file entirely left the workspace reported healthy.

The gate parses the lint file rather than searching its bytes. A raw `contains`
passes on a commented-out entry and on a path quoted inside another entry's
`reason` — and the reasons in these files quote paths at each other. Both
measured. The parser for this already existed in the workspace-list suite, with
a comment explaining that a raw `contains` was what it replaced; it moves into
the checker and both callers share it.

And the reading of the file has tests — over the parser, over the predicate,
and over the wiring, the last building a real directory with a real lint file
beside a real manifest, because that is the step the other two skip. Without
them, replacing the call with `true || …`, `.all` with `.any`, and the filename
with one that does not exist each survived the whole suite.

## Scope

Presentation is unaffected: `mul_add` is used fourteen times across the 2D and
3D renderers and the UI renderer, none of which is in a simulation closure, and
the ban does not reach them. Fixed-point maths is unaffected by mechanism
rather than by luck — `disallowed_methods` matches resolved definitions, so
`Fixed::sqrt` and `Angle::sin` are not the primitives and were never in scope.

Compile time is untouched: rustc never reads `clippy.toml`. Lint time is
unchanged too, measured three ways including an amplification to ten times the
list length, which was still invisible.
