### PR TITLE
A file of another format is refused as that, and example targets stop colliding

### DIFF
--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -705,10 +705,13 @@ stored. Carry the field name and the record index. Do not "clamp" it: a
 NaN clamped to zero is a vertex at the origin, which is a wrong model
 that renders, and that is worse than a refusal.
 
-**Nearest thing here.** `TraceErrorKind::NonFinite` refuses a bit pattern
-naming an infinity or a NaN — but for a float written as hexadecimal in a
-text field, not for geometry. The reasoning transfers exactly; the code
-does not.
+**In the tree.** `MeshError::NotFinite { field, index }` — **refused by all
+five mesh readers**, STL, PLY, OBJ, MTL and the blob, on every coordinate,
+normal and texture coordinate as it is read. `TraceErrorKind::NonFinite`
+refuses the same thing for a float written as hexadecimal in a text field.
+
+*This entry read "the reasoning transfers exactly; the code does not" until
+the readers existed. They do, and it does.*
 
 ### 19. Negative zero, and the second spelling of a number
 
@@ -770,9 +773,12 @@ This is entry 11 — outside this build's range — but the range comes from
 the engine's number type rather than from the file format, which is why
 it is easy to forget: nothing in the file is wrong.
 
-**Nearest thing here.** `PackError::TooLarge { field, value }` has the
-shape: a value that cannot be represented on this target, named with the
-field it came from.
+**In the tree.** `MeshError::TooLarge { field, value }` — PLY refuses an
+element count, a list length, or a schema larger than this reader will hold,
+**before the allocation it would imply is attempted**, which is the half that
+matters: a header is a promise about size, and believing it is how a
+twelve-byte file asks for four gigabytes. `PackError::TooLarge { field, value }`
+has the same shape, for a value that cannot be represented on this target.
 
 ## Streams that have to agree
 
@@ -819,9 +825,12 @@ The rule that keeps this honest: an importer may substitute only where
 the substitution is announced and where the wrong outcome is visibly
 wrong. Everything else is a refusal.
 
-**Nearest thing here.** `WavError::MissingChunk { id }` is the shape —
-a required section named by identifier — but it answers about one
-container, not about a set of streams that have to be present together.
+**In the tree.** `MeshError::Unsupported { wanted }` — PLY refuses a file
+whose vertex element declares no `x`, and one carrying no `face` element at
+all, **naming which of the two is missing** rather than reporting the file as
+empty. That is this entry for a single stream. `WavError::MissingChunk { id }`
+is the shape for a container. **Neither yet answers about a set of streams that
+have to be present together**, which is what glTF attributes will need.
 
 ### 23. A component type or stride that contradicts its own accessor
 
@@ -872,6 +881,24 @@ belongs with the entries discussed under [The tolerance
 problem](#the-tolerance-problem) below. Refusing exact degeneracy and
 counting near-degeneracy is a defensible split, as long as the reader
 says which it did.
+
+**In the tree, and the answer is "neither, deliberately".** No mesh reader
+refuses a degenerate triangle. `crates/mesh/README.md` states the rule and the
+reason: degenerate triangles, inconsistent winding and unclosed surfaces "read
+successfully, because they are facts about a model rather than about a file,
+and refusing them would refuse a great deal of real art."
+
+**The consequence this entry predicts is handled where it happens rather than
+at the reader.** `render3d::scene::face_normal` is
+`unit(cross(sub(b, a), sub(c, a))).unwrap_or([0.0, 0.0, 0.0])` — so a
+degenerate face yields a zero normal, **not the NaN this entry warns arrives
+"from a file that contained no NaN at all"**. That is the split this entry asks
+for, made explicit: the file is accepted, and the one computation that would
+have manufactured a NaN from it does not.
+
+**What is still open** is everything downstream of the renderer — collision,
+lightmap parameterisation, adjacency — which this tree does not have yet and
+which each do the same division. The entry stands for them.
 
 ### 25. A normal that is not a unit vector
 
@@ -970,7 +997,16 @@ costs a full traversal and the contract may not require a single winding.
 State the answer either way; the point of this entry is that it should be
 a decision rather than an omission.
 
-**Nearest thing here.** None.
+**In the tree, and it is a decision: counted, not refused.**
+`Mesh::winding_disagreements` returns how many triangles have a stored normal
+pointing away from the face their corners wind. `crates/mesh/README.md` gives
+the reasoning — "a few in a large model is an exporter's rounding, and *all* of
+them is a file with its winding convention inverted, which is worth knowing
+before it is drawn inside out."
+
+**A count says more than a refusal here**, which is why this entry is answered
+by a number rather than by an error: the two failures it distinguishes want
+different responses, and a boolean would collapse them.
 
 ## Topology
 

--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -239,7 +239,24 @@ perfectly good JPEG.
 this), `PackError::NotAPack`, `WavError::NotRiff` and `NotWave` — two
 variants, because the container and the payload kind are separate claims —
 `DocumentError::NotADocument`, `WireError::BadMagic`,
-`TraceErrorKind::NotATrace`.
+`TraceErrorKind::NotATrace`, `MeshError::NotThisFormat { expected }`.
+
+**And the mesh one is the entry's own argument, learned the hard way.**
+For three rounds of work the mesh readers had no such variant. PLY answered
+a file of another format with `ExpectedKeyword` naming `end_header` on line
+1 — because the terminator was searched for before anything checked the
+magic — which is *the identical refusal a genuinely truncated PLY gets*.
+Two faults, one message, and the message described the fault the file did
+not have. That is this entry's "somebody looking for corruption in a
+perfectly good JPEG", reproduced exactly, in the reader written last.
+
+**STL still cannot reach it, and that is not an omission.** The format has
+no magic: its binary encoding opens with eighty bytes of anything at all,
+so "these are not STL bytes" and "these are STL bytes that were cut short"
+are the same observation. OBJ and MTL have no signature either. A reader
+whose format gives it no way to tell should say the more useful thing —
+the count declared and the bytes that arrived — and its refusal census
+should say why it cannot do this one, which all three do.
 
 ### 2. Too short to hold its own header
 
@@ -258,7 +275,14 @@ interesting way, there is nothing there.
 **In the tree.** `PackError::NoHeader { len }`,
 `WavError::TooShort { len }`, `DocumentError::NoHeader { len }`,
 `WireError::TooShort { len }`, `TraceErrorKind::Empty`,
-`DecodeError::BadHeader` (no `IHDR`, or one that is not thirteen bytes).
+`DecodeError::BadHeader` (no `IHDR`, or one that is not thirteen bytes),
+`MeshError::TooShortForHeader { needs, len }` — carrying both numbers, so
+the message is the requirement and the shortfall rather than "too short".
+
+The mesh blob shows the "one comparison up front" argument paying off
+literally: its header offsets are a running sum of field widths and every
+field after the check is read with a total accessor, because the length
+was established once.
 
 ### 3. A version this build does not read
 
@@ -278,7 +302,15 @@ implemented; never a newer one.
 **In the tree.** `PackError::UnknownFormat { found }`,
 `DocumentError::UnknownVersion { found }`,
 `WireError::BadVersion { saw }`,
-`TraceErrorKind::UnsupportedVersion { found, supported }`.
+`TraceErrorKind::UnsupportedVersion { found, supported }`,
+`MeshError::Unsupported { wanted: "a blob of version 1" }`.
+
+The mesh blob also has this entry's subtler member, in its own shape: a
+presence bitmask with a bit set outside this version's vocabulary is
+refused as `Unsupported { wanted: "a blob using only the arrays this
+version defines" }` rather than masked off. A file whose header uses a
+construct the reader does not know is a file a later build wrote, and
+quietly ignoring the bit would read its arrays at the wrong offsets.
 
 There is a subtler member of this family worth copying:
 `TraceErrorKind::EventFromANewerFormat { kind, introduced, declared }`
@@ -331,7 +363,15 @@ equality, never a lower bound.
 **In the tree.** `PackError::SizeMismatch { declared, actual }`,
 `WavError::TrailingBytes`,
 `WireError::SizeMismatch { kind, declared, actual }`,
-`DocumentError::SizeMismatch`, `TraceErrorKind::TrailingText`.
+`DocumentError::SizeMismatch`, `TraceErrorKind::TrailingText`,
+`MeshError::CountMismatch { declared, actual, count }`.
+
+The mesh blob is equality (`wanted != bytes.len()`), and it buys more than
+this entry claims. Because the byte total the header implies must *equal*
+the length in hand, the bytes the reader allocates are the bytes it was
+handed: the amplification factor is exactly one, and a header-only file
+can ask for nothing. An "at least" comparison would have given that up
+along with everything else in this entry.
 
 ### 6. A checksum that does not match its bytes
 
@@ -378,8 +418,19 @@ region arithmetic to 64 bits so a hostile count cannot wrap the sum on a
 
 **In the tree.** `DecodeError::TooLarge { width, height }`,
 `InflateError::TooLarge { limit }`, `PackError::TooLarge { field, value }`,
-`WireError::TooLong` and `TickOverflow`, and — for the seam that reads a
-path rather than bytes — `FsError::TooLarge { path, limit }`.
+`WireError::TooLong` and `TickOverflow`, `MeshError::TooLarge { field,
+value }`, and — for the seam that reads a path rather than bytes —
+`FsError::TooLarge { path, limit }`.
+
+`MeshError::TooLarge` is worth reading for the distinction it draws in its
+own documentation: **a policy ceiling, not a representation limit**. A
+representation limit is reached only after the allocation has been
+attempted; a policy ceiling is a refusal that costs nothing. It bounds a
+schema's element and property counts, the corners one face may name, and
+— separately — the total geometry a file may build, because the first
+three bound factors and none of them bounds the product. That last
+ceiling is this entry's `checked_mul` argument arriving as a fourth
+constant rather than as arithmetic.
 
 Note where that last one lives. The parser crates take bytes and never a
 path; the bound on reading an untrusted *file* belongs at the seam that
@@ -493,8 +544,18 @@ step assumes ran at least once.
 `NoImageData`, `PackError::EmptyName { index }` (an empty name no lookup
 could ever match), `WireError::FrameCountZero`, `InputBytesZero`,
 `ChatEmpty`, `SessionZero` and `DigestPeriodZero`, `DocumentError::Empty`,
-`IconError::Empty`, and the mesh descriptor's `create_mesh(no vertices)`,
-`create_mesh(no indices)` and `create_mesh(zero vertex stride)`.
+`IconError::Empty`, `MeshError::IndexZero { line }` and
+`MeshError::NoGeometry`, and the mesh descriptor's
+`create_mesh(no vertices)`, `create_mesh(no indices)` and
+`create_mesh(zero vertex stride)`.
+
+`IndexZero` is this entry's "separate variant from out of range" written
+out: OBJ numbers vertices from one, so a face naming vertex `0` is a
+default that escaped rather than a number computed wrongly, and the two
+send you to different code. `NoGeometry` is the other half — a file that
+is well-formed and declares nothing — refused rather than returned as an
+empty mesh, because every way a file ends up with zero triangles is a
+mistake upstream and a caller that wanted nothing did not need a file.
 
 ### 13. Redundant fields that disagree with what they are derived from
 
@@ -538,7 +599,11 @@ appears to have.
 
 **In the tree.** `PackError::NameNotUtf8 { index }`,
 `TraceErrorKind::NotADecimalInteger`, `IntegerTooLarge`, `NotTypedText`,
-`NotAHexPattern` and `UnwritableText`, `FsError::InvalidUtf8 { path }`.
+`NotAHexPattern` and `UnwritableText`, `FsError::InvalidUtf8 { path }`,
+`MeshError::NotANumber { found, line }` — the numeric half, for a column
+in an ASCII PLY or an OBJ that is not the number the grammar requires,
+carrying the text truncated to something printable so the message cannot
+itself become an injection of the file's bytes into a log.
 
 The fuzz targets show the boundary version of the same rule. The trace
 reader's contract starts at `&str`, so its target skips non-UTF-8 input
@@ -578,8 +643,18 @@ importer is in the same position: it reads each file once. Do the scan.
 `DocumentError::PatchOutOfPool { index, entry }` and
 `BadParent { index, parent }`,
 `InflateError::BadDistance { distance, produced }`,
-`WireError::SeatNotInRoster`, and
+`WireError::SeatNotInRoster`,
+`MeshError::IndexOutOfRange { index, count, face }`, and
 `create_mesh(index past the last vertex)`.
+
+The mesh one settles a question this entry does not raise: **its `index`
+is signed.** OBJ lets a face count backwards from what has been declared
+so far, so `-5` in a file with three vertices is a real thing a writer
+emits, and reporting its magnitude would send somebody looking for a fifth
+vertex that was never the subject. An index refusal should spell the index
+the way the file spelled it. It carries the face as well, because one bad
+face and an index base that is off by one everywhere are different
+problems and the count alone cannot tell them apart.
 
 ### 16. A required section that is absent
 
@@ -597,7 +672,16 @@ format has an explicit end marker, requiring it is how truncation is
 caught. If it does not, this is the strongest argument for adding one.
 
 **In the tree.** `DecodeError::NoImageData` and `MissingEnd`,
-`WavError::MissingChunk { id }` and `MissingPadByte`.
+`WavError::MissingChunk { id }` and `MissingPadByte`,
+`MeshError::ExpectedKeyword { expected: "end_header", .. }`.
+
+PLY is this entry's argument in a text format: the header is variable
+length and the body follows it immediately, so a file cut short inside the
+header has no terminator, and requiring `end_header` is the only thing
+that catches it. Note what it took to make that refusal *mean* truncation
+— until the magic was checked first, every file of every other format got
+this same answer, and a refusal that fires for two unrelated reasons
+carries no information about either.
 
 ### 17. A second legal spelling of one fact
 
@@ -773,12 +857,22 @@ This is entry 11 — outside this build's range — but the range comes from
 the engine's number type rather than from the file format, which is why
 it is easy to forget: nothing in the file is wrong.
 
-**In the tree.** `MeshError::TooLarge { field, value }` — PLY refuses an
-element count, a list length, or a schema larger than this reader will hold,
-**before the allocation it would imply is attempted**, which is the half that
-matters: a header is a promise about size, and believing it is how a
-twelve-byte file asks for four gigabytes. `PackError::TooLarge { field, value }`
-has the same shape, for a value that cannot be represented on this target.
+**Nearest thing here.** `PackError::TooLarge { field, value }`, for a
+value that cannot be represented on this target. **Nothing in this tree
+refuses a coordinate for being outside the engine's number range**, and
+`crates/mesh` cannot: it has no dependencies at all, so it never converts
+anything to `Fixed` and has no bound to check against. The refusal this
+entry asks for belongs to whatever converts an imported model into
+simulation state, which does not exist yet.
+
+*This entry briefly claimed `MeshError::TooLarge` implemented it. That
+variant is a **policy ceiling**, refusing counts a reader will not hold —
+entry 7 — and its own documentation records that an earlier version of
+*it* made the same conflation in the other direction. Two documents have
+now confused a limit chosen by a reader with a limit imposed by a number
+type, which is a good reason to keep the sentence that tells them
+apart: a representation limit is reached after the work is attempted, a
+policy ceiling before.*
 
 ## Streams that have to agree
 

--- a/crates/json/README.md
+++ b/crates/json/README.md
@@ -160,7 +160,7 @@ mixture was widened, because uniform random bytes essentially never parse
 and the walk over an accepted document was never being reached.
 
 **The reader is fuzzed, and the corpus is generated rather than
-collected.** `cargo run -p renew-json --example make_corpus` builds every
+collected.** `cargo run -p renew-json --example make_json_corpus` builds every
 seed, so the corpus carries no licence question. Between them the
 thirty-eight seeds reach twenty-six different answers — every refusal the
 parse can make, plus `Ok`. `tests/corpus_replay.rs` replays them on the

--- a/crates/json/examples/make_json_corpus.rs
+++ b/crates/json/examples/make_json_corpus.rs
@@ -24,7 +24,7 @@
 //! Run when the corpus needs regenerating:
 //!
 //! ```text
-//! cargo run -p renew-json --example make_corpus
+//! cargo run -p renew-json --example make_json_corpus
 //! ```
 //!
 //! Existing files are left alone. The fuzzer adds its own finds to this

--- a/crates/mesh/README.md
+++ b/crates/mesh/README.md
@@ -199,8 +199,8 @@ refusals, so the usual margin would be a hole rather than a margin.
 **Every fixture is generated.** A model downloaded from a sample
 repository would be a dependency with a licence, and a directory of them
 would be a dependency nobody recorded — and a mesh, unlike a datagram, is
-the kind of file that has an author. `examples/make_corpus.rs` builds the
-25 STL seeds, `examples/make_ply_corpus.rs` the 24 PLY ones,
+the kind of file that has an author. `examples/make_stl_corpus.rs` builds
+the 25 STL seeds, `examples/make_ply_corpus.rs` the 24 PLY ones,
 `examples/make_obj_corpus.rs` the 25 OBJ ones and
 `examples/make_mtl_corpus.rs` the 21 MTL ones; between them every
 committed seed is built here rather than found. **The blob's 25 seeds

--- a/crates/mesh/examples/make_stl_corpus.rs
+++ b/crates/mesh/examples/make_stl_corpus.rs
@@ -16,7 +16,7 @@
 //! Run when the corpus needs regenerating:
 //!
 //! ```text
-//! cargo run -p renew-mesh --example make_corpus
+//! cargo run -p renew-mesh --example make_stl_corpus
 //! ```
 //!
 //! Existing files are left alone. The fuzzer adds its own finds to this

--- a/crates/mesh/src/blob.rs
+++ b/crates/mesh/src/blob.rs
@@ -293,10 +293,8 @@ pub fn read(bytes: &[u8]) -> Result<Mesh, MeshError> {
         });
     }
     if bytes.get(..MAGIC.len()) != Some(&MAGIC[..]) {
-        return Err(MeshError::ExpectedKeyword {
+        return Err(MeshError::NotThisFormat {
             expected: "RENEWMS\\0",
-            found: String::new(),
-            line: 1,
         });
     }
 

--- a/crates/mesh/src/error.rs
+++ b/crates/mesh/src/error.rs
@@ -15,21 +15,31 @@
 //! that is not one, then a value that is a number and not a usable one.
 //!
 //! **Nothing here is a variant no reader constructs**, and getting to
-//! that took three deletions. Two variants were written from the shape
-//! of the format rather than the shape of the code — a truncated-record
+//! that took two deletions. Both were written from the shape of the
+//! format rather than the shape of the code — a truncated-record
 //! refusal and a trailing-bytes one — and neither was reachable once
 //! the length arithmetic had already accounted for the file exactly.
 //!
-//! **The third is a fact about STL worth keeping.** There was a "these
-//! bytes are not this format" refusal, on the reasoning that a caller
-//! who fed a PNG to a mesh reader has a routing bug and a caller with a
-//! truncated file has a download problem. Sound reasoning, and STL
-//! gives no way to act on it: **the format has no magic number.** Its
-//! binary encoding opens with eighty bytes of anything at all, so
-//! "these are not STL bytes" and "these are STL bytes that were cut
-//! short" are the same observation. The reader says the more useful of
-//! the two — the count that was declared and the bytes that arrived —
-//! and does not pretend to the distinction.
+//! **A third was deleted and has since come back, which is the more
+//! useful story.** `NotThisFormat` was removed on the reasoning that a
+//! caller who fed a PNG to a mesh reader has a routing bug and a caller
+//! with a truncated file has a download problem — sound — and that STL
+//! gives no way to act on the distinction, which is also sound: **that
+//! format has no magic number.** Its binary encoding opens with eighty
+//! bytes of anything at all, so "these are not STL bytes" and "these are
+//! STL bytes that were cut short" are the same observation. STL says the
+//! more useful of the two, the count declared and the bytes that
+//! arrived, and does not pretend to a distinction it cannot make.
+//!
+//! **The error was generalising one format's limitation to the enum.**
+//! PLY opens with the word `ply` and the blob with an eight-byte magic,
+//! and both could tell the two faults apart the whole time. PLY instead
+//! answered a foreign file with `ExpectedKeyword` naming `end_header` —
+//! a claim about a truncated PLY, made about a file that had never been
+//! one, and byte-identical to what a genuinely truncated PLY got. A
+//! refusal reachable by two unrelated faults says nothing about either.
+//! The variant is back, the readers that can reach it do, and the three
+//! that cannot say so in their own censuses.
 //!
 //! An error vocabulary with unreachable variants in it is a claim that
 //! cases exist which do not, and a caller matching exhaustively pays
@@ -92,6 +102,26 @@ pub enum MeshError {
         field: &'static str,
         /// The value, widened so the message is the same everywhere.
         value: u64,
+    },
+
+    /// These bytes are not this format at all.
+    ///
+    /// **The difference from every refusal below is what it tells the
+    /// caller to go and look at.** A malformed file of the right kind
+    /// sends a person to the file; a file of the wrong kind sends them
+    /// to the wiring — the wrong path, the wrong entry, a mislabelled
+    /// asset. Folding the two together sends somebody hunting for
+    /// corruption in a perfectly good file of another format.
+    ///
+    /// **Every other parser in this repository has this refusal** — the
+    /// PNG decoder, the pack reader, the WAV reader, the UI document,
+    /// the wire codec and the trace codec each name it. The mesh readers
+    /// did not, and answered instead with a keyword and a line number
+    /// they had invented, which was worse than a generic failure because
+    /// it was specific and wrong.
+    NotThisFormat {
+        /// What the opening bytes would have had to say.
+        expected: &'static str,
     },
 
     /// A word the grammar requires is not there.
@@ -221,6 +251,7 @@ impl MeshError {
             Self::TooShortForHeader { .. } => "TooShortForHeader",
             Self::CountMismatch { .. } => "CountMismatch",
             Self::TooLarge { .. } => "TooLarge",
+            Self::NotThisFormat { .. } => "NotThisFormat",
             Self::ExpectedKeyword { .. } => "ExpectedKeyword",
             Self::NotANumber { .. } => "NotANumber",
             Self::NotFinite { .. } => "NotFinite",
@@ -236,6 +267,14 @@ impl MeshError {
 impl fmt::Display for MeshError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            // Says what the file is not, and does not guess at what it
+            // is: the caller knows what it meant to open, and naming
+            // another format here would be a second guess on top of a
+            // first.
+            Self::NotThisFormat { expected } => write!(
+                f,
+                "these bytes do not open with {expected}, so they are not this format at all"
+            ),
             Self::TooShortForHeader { needs, len } => write!(
                 f,
                 "a {needs}-byte header is the least this format can be, and there are {len} bytes"
@@ -384,6 +423,16 @@ mod tests {
     /// **Matched exhaustively with no wildcard**, which is the whole
     /// benefit of the enum being closed: a refusal added later stops
     /// this file compiling until somebody writes what it says.
+    ///
+    /// **The match is checked by the compiler and the list below is
+    /// not, and that gap has already been fallen into.** Adding
+    /// `NotThisFormat` forced a new arm — the enum is closed, so it had
+    /// to — and the arm was written while the list was not touched, so
+    /// the new variant had a rule about its message and no instance to
+    /// apply it to. The test went on passing and measured one variant
+    /// fewer. The count below is the only part of this that fails when
+    /// that happens again; it is a hand-maintained number, and it is
+    /// here because the compiler cannot be made to hold this half.
     #[test]
     fn every_refusal_names_its_numbers() {
         let all = [
@@ -422,7 +471,12 @@ mod tests {
             },
             MeshError::Unsupported { wanted: "vertex" },
             MeshError::NoGeometry,
+            MeshError::NotThisFormat { expected: "ply" },
         ];
+
+        // One per variant. Raise it when the enum grows, in the same
+        // change that writes the new arm below.
+        assert_eq!(all.len(), 12, "a variant is missing an instance here");
 
         for refusal in &all {
             let shown = refusal.to_string();
@@ -430,6 +484,7 @@ mod tests {
             // Rule two: the numbers a caller would otherwise go to a hex
             // editor for are in the message.
             let numbers: Vec<&str> = match refusal {
+                MeshError::NotThisFormat { .. } => vec!["ply"],
                 MeshError::TooShortForHeader { .. } => vec!["84", "3"],
                 MeshError::CountMismatch { .. } => vec!["134", "90", "1"],
                 MeshError::TooLarge { .. } => vec!["element count", "4000000000"],

--- a/crates/mesh/src/format.rs
+++ b/crates/mesh/src/format.rs
@@ -18,9 +18,10 @@
 //!
 //! **STL is last because it cannot answer for itself.** The format has
 //! no magic number, so "these are not STL bytes" and "these are STL
-//! bytes cut short" are the same observation — which is why a
-//! `NotThisFormat` refusal was deleted from that reader for pretending
-//! to a distinction the format does not offer. Its own dispatch between
+//! bytes cut short" are the same observation — which is why the
+//! `NotThisFormat` refusal that PLY and the blob make has no STL
+//! counterpart, and why that reader's refusal census says so rather
+//! than leaving the gap to be noticed. Its own dispatch between
 //! its two dialects is arithmetic for the same reason. Putting it last
 //! makes it the fallback rather than a competitor, and means a truncated
 //! STL still reaches the reader whose refusals describe it.

--- a/crates/mesh/src/ply.rs
+++ b/crates/mesh/src/ply.rs
@@ -291,6 +291,18 @@ fn header(bytes: &[u8]) -> Result<(Vec<Element>, Encoding, usize), MeshError> {
     // bytes rather than by decoding the file: a body full of binary
     // floats is not text, and decoding the whole file to find where the
     // text stops would refuse every binary PLY there is.
+    // **The magic is asked first, and it used to be asked last.**
+    //
+    // `end_header` was searched for before anything established that
+    // these bytes were a PLY at all, so a file of another format was
+    // told its terminator was missing — a claim about a truncated PLY,
+    // made about a file that was never one. Worse, a genuinely truncated
+    // PLY produced the identical refusal, so two different faults were
+    // one message.
+    if !looks_like(bytes) {
+        return Err(MeshError::NotThisFormat { expected: "ply" });
+    }
+
     let end = header_end(bytes).ok_or(MeshError::ExpectedKeyword {
         expected: "end_header",
         found: String::new(),
@@ -323,7 +335,6 @@ fn header(bytes: &[u8]) -> Result<(Vec<Element>, Encoding, usize), MeshError> {
 fn parse_schema(text: &str) -> Result<(Vec<Element>, Encoding), MeshError> {
     let mut encoding = None;
     let mut elements: Vec<Element> = Vec::new();
-    let mut saw_magic = false;
 
     for (number, source) in text.lines().enumerate() {
         // One-based, as an editor counts, and carried into every refusal
@@ -334,11 +345,13 @@ fn parse_schema(text: &str) -> Result<(Vec<Element>, Encoding), MeshError> {
             continue;
         };
         match keyword {
-            "ply" => saw_magic = true,
-            // Comments and the obsolete `obj_info` carry anything at all
-            // to the end of their line, including bytes that would not
-            // parse as anything else.
-            "comment" | "obj_info" => {}
+            // **Three keywords that contribute nothing to the schema,
+            // and one body between them.** The magic word is here
+            // because `looks_like` has already established it above:
+            // the loop meets it again on line 1 with nothing left to do.
+            // The other two carry free text to the end of their line,
+            // which is by definition not schema.
+            "ply" | "comment" | "obj_info" => {}
             "format" => {
                 let word = words.next().unwrap_or("");
                 encoding = Some(match word {
@@ -418,13 +431,6 @@ fn parse_schema(text: &str) -> Result<(Vec<Element>, Encoding), MeshError> {
         }
     }
 
-    if !saw_magic {
-        return Err(MeshError::ExpectedKeyword {
-            expected: "ply",
-            found: String::new(),
-            line: 1,
-        });
-    }
     let encoding = encoding.ok_or(MeshError::ExpectedKeyword {
         expected: "format",
         found: String::new(),

--- a/crates/mesh/tests/blob.rs
+++ b/crates/mesh/tests/blob.rs
@@ -240,7 +240,7 @@ fn the_magic_keeps_the_shape_the_other_formats_in_this_tree_use() {
 fn bytes_that_do_not_open_with_the_magic_are_refused() {
     let mut bytes = blob::write(&furnished());
     bytes[0] = b'X';
-    let MeshError::ExpectedKeyword { expected, .. } = refusal(&bytes) else {
+    let MeshError::NotThisFormat { expected } = refusal(&bytes) else {
         panic!("a blob opens with its magic");
     };
     assert_eq!(expected, "RENEWMS\\0");
@@ -515,10 +515,10 @@ fn every_byte_string_gets_an_answer() {
 fn blob_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
         // Reachable, and each is provoked by a byte string in this file.
-        MeshError::TooShortForHeader { .. }
+        MeshError::NotThisFormat { .. }
+        | MeshError::TooShortForHeader { .. }
         | MeshError::CountMismatch { .. }
         | MeshError::TooLarge { .. }
-        | MeshError::ExpectedKeyword { .. }
         | MeshError::NotFinite { .. }
         | MeshError::NotAFace { .. }
         | MeshError::Unsupported { .. }
@@ -526,6 +526,9 @@ fn blob_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
         MeshError::NotANumber { .. } => {
             Some("nothing here is text, so there is no word that failed to be a number")
         }
+        MeshError::ExpectedKeyword { .. } => Some(
+            "nothing here is text, so no word can be missing. The one place              this reader used to say it was about its magic, and that is now              `NotThisFormat` — which is the whole point of the new variant.",
+        ),
         MeshError::IndexOutOfRange { .. } | MeshError::IndexZero { .. } => {
             Some("this format is de-indexed: a corner is written out, never pointed at")
         }
@@ -552,7 +555,7 @@ fn the_census_and_the_bytes_agree() {
 
     let provocations: [(&str, Vec<u8>); 8] = [
         ("TooShortForHeader", MAGIC.to_vec()),
-        ("ExpectedKeyword", wrong_magic),
+        ("NotThisFormat", wrong_magic),
         ("Unsupported", later_version),
         ("NotAFace", short_face),
         ("NoGeometry", no_corners),
@@ -575,6 +578,11 @@ fn the_census_and_the_bytes_agree() {
     }
 
     for refusal in [
+        MeshError::ExpectedKeyword {
+            expected: "end_header",
+            found: String::new(),
+            line: 1,
+        },
         MeshError::NotANumber {
             found: String::new(),
             line: 1,

--- a/crates/mesh/tests/mtl.rs
+++ b/crates/mesh/tests/mtl.rs
@@ -339,6 +339,9 @@ fn every_byte_string_gets_an_answer() {
 /// until somebody decides which it is.
 fn mtl_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::NotThisFormat { .. } => Some(
+            "this format has no signature to fail: a file is offered to this reader by detection rather than claiming to be one, and a line it cannot read is refused as a bad line rather than as somebody else's format",
+        ),
         // Reachable, and each is provoked by a file in this suite.
         MeshError::ExpectedKeyword { .. }
         | MeshError::NotANumber { .. }

--- a/crates/mesh/tests/obj.rs
+++ b/crates/mesh/tests/obj.rs
@@ -563,6 +563,9 @@ fn the_names_returned_never_outweigh_the_file_they_came_from() {
 /// the STL reader that no input on any target could produce.
 fn obj_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::NotThisFormat { .. } => Some(
+            "this format has no signature to fail: a file is offered to this reader by detection rather than claiming to be one, and a line it cannot read is refused as a bad line rather than as somebody else's format",
+        ),
         // Reachable, and each is provoked by a file in this suite.
         MeshError::TooLarge { .. }
         | MeshError::ExpectedKeyword { .. }

--- a/crates/mesh/tests/ply.rs
+++ b/crates/mesh/tests/ply.rs
@@ -275,12 +275,16 @@ fn a_header_asking_for_more_than_it_can_hold_is_refused() {
 /// The header's own grammar is checked, and each refusal says where.
 #[test]
 fn a_header_that_is_not_one_is_refused_by_line() {
+    // A file that opens correctly and then says something the header
+    // grammar has no place for. **Its first line has to be `ply`**: a
+    // file opening with anything else is not this format at all, and is
+    // refused before the grammar is ever consulted.
     assert_eq!(
-        refusal(b"not a ply at all\nend_header\n"),
+        refusal(b"ply\nnot a header line\nend_header\n"),
         MeshError::ExpectedKeyword {
             expected: "ply, format, comment, element, property or end_header",
             found: "not".to_owned(),
-            line: 1
+            line: 2
         }
     );
     assert_eq!(
@@ -798,30 +802,53 @@ fn a_header_declaring_more_elements_than_the_schema_holds_is_refused() {
     );
 }
 
-/// **A header without the magic word is refused, even when it ends
-/// properly.**
+/// **A header without the magic word is not this format, and is
+/// refused as that rather than as a broken PLY.**
 ///
-/// The header is located by its terminator rather than its opening,
-/// because a binary body is not text and the opening cannot be trusted
-/// to be where the search starts. So a file can reach the schema parser
-/// having never said `ply`, and the parser is what has to notice.
+/// The header *end* is still found by its terminator, because a binary
+/// body is not text and a scan for `end_header` cannot be replaced by
+/// counting lines. But that scan used to run first, so a file of another
+/// format was told its `end_header` was missing — a claim about a
+/// truncated PLY, made about a file that had never been one.
 ///
 /// Probed by deleting the check: red, a file that never claims to be a
 /// PLY is read as one.
 #[test]
 fn a_header_that_never_says_ply_is_refused_by_name() {
     let anonymous = "format ascii 1.0\nelement vertex 0\nend_header\n";
-    let MeshError::ExpectedKeyword {
-        expected,
-        found,
-        line,
-    } = refusal(anonymous.as_bytes())
-    else {
-        panic!("a file that never says `ply` is refused for that");
+    let MeshError::NotThisFormat { expected } = refusal(anonymous.as_bytes()) else {
+        panic!("a file that never says `ply` is not this format");
     };
     assert_eq!(expected, "ply");
-    assert!(found.is_empty(), "nothing stood in for it: `{found}`");
-    assert_eq!(line, 1, "the word belongs on the first line");
+}
+
+/// **A foreign file and a truncated PLY are two faults, and they now get
+/// two refusals.**
+///
+/// They used to get a byte-identical one — `ExpectedKeyword` naming
+/// `end_header` on line 1 — because the terminator was searched for
+/// before anything established the format. That was worse than a generic
+/// failure: it was specific and wrong, and it sent whoever read it
+/// hunting for corruption in a perfectly good file of another kind.
+///
+/// This is the test the old ordering could not have passed, and no test
+/// in this suite asked for it, which is why the ordering survived three
+/// rows of work on this reader.
+#[test]
+fn a_foreign_file_and_a_truncated_ply_do_not_share_a_refusal() {
+    let foreign = refusal(b"MZ\x90\x00\x03\x00 this is a program, not a model");
+    let truncated = refusal(b"ply\nformat ascii 1.0\nelement vertex 1\n");
+
+    assert_eq!(foreign, MeshError::NotThisFormat { expected: "ply" });
+    assert_eq!(
+        truncated,
+        MeshError::ExpectedKeyword {
+            expected: "end_header",
+            found: String::new(),
+            line: 1
+        }
+    );
+    assert_ne!(foreign, truncated, "two faults, two answers");
 }
 
 /// **A file whose schema is complete and whose faces are absent has no
@@ -939,7 +966,8 @@ fn crowded_schema() -> String {
 fn ply_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
         // Reachable, and each is provoked by a file in this suite.
-        MeshError::CountMismatch { .. }
+        MeshError::NotThisFormat { .. }
+        | MeshError::CountMismatch { .. }
         | MeshError::ExpectedKeyword { .. }
         | MeshError::NotANumber { .. }
         | MeshError::NotFinite { .. }
@@ -988,6 +1016,10 @@ end_header
     let provoked = [
         // A header whose first word is not the magic one.
         refusal(b"not a ply at all\nend_header\n"),
+        // A file that is a PLY and then stops making sense. Nothing
+        // above reaches the grammar refusal any more, now that a foreign
+        // file is turned away before the grammar runs.
+        refusal(b"ply\nformat ebcdic 1.0\nend_header\n"),
         // A vertex element and no face element: geometry this reader
         // has no way to use.
         refusal(
@@ -1025,6 +1057,7 @@ end_header
 
     for name in [
         "CountMismatch",
+        "NotThisFormat",
         "ExpectedKeyword",
         "NotANumber",
         "NotFinite",

--- a/crates/mesh/tests/stl.rs
+++ b/crates/mesh/tests/stl.rs
@@ -168,6 +168,9 @@ endsolid x",
 fn stl_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
         // Reachable, and each is provoked by a file in this suite.
+        MeshError::NotThisFormat { .. } => Some(
+            "this format has no magic at all: a binary STL opens with eighty bytes of whatever its exporter wrote, which is exactly why detection falls back to STL rather than dispatching to it",
+        ),
         MeshError::TooShortForHeader { .. }
         | MeshError::CountMismatch { .. }
         | MeshError::ExpectedKeyword { .. }

--- a/crates/png/README.md
+++ b/crates/png/README.md
@@ -120,7 +120,7 @@ writes them.
 collected.** Everything above is about the encoder — the half this crate
 writes. The half that reads a file somebody else wrote is checked by
 `png_decode`, whose seeds are built by `cargo run -p renew-png --example
-make_corpus`: every input is first-party, so the corpus carries no
+make_png_corpus`: every input is first-party, so the corpus carries no
 licence question. All but one are written by that program, and the
 exception is the subject of the next paragraph. `tests/corpus_replay.rs`
 replays them on the stable toolchain at every merge, and asserts two

--- a/crates/png/examples/make_png_corpus.rs
+++ b/crates/png/examples/make_png_corpus.rs
@@ -23,7 +23,7 @@
 //! Run when the corpus needs regenerating:
 //!
 //! ```text
-//! cargo run -p renew-png --example make_corpus
+//! cargo run -p renew-png --example make_png_corpus
 //! ```
 //!
 //! Existing files are left alone. The fuzzer adds its own finds to this

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -60,14 +60,24 @@ not a first line of defence, a deeper one.
 `corpus/<target>/` is the fuzzers' memory: most committed inputs are ones
 the coverage-guided search found worth keeping, minimized by
 `cargo fuzz cmin`. **Seven corpora start differently** — `png_decode`'s
-seeds are written by `cargo run -p renew-png --example make_corpus`,
-`json_parse`'s by `cargo run -p renew-json --example make_corpus`, and the
-five `renew-mesh` corpora by `cargo run -p renew-mesh --example
-make_corpus` (`stl_read`), `--example make_ply_corpus`, `--example
+seeds are written by `cargo run -p renew-png --example make_png_corpus`,
+`json_parse`'s by `cargo run -p renew-json --example make_json_corpus`,
+and the five `renew-mesh` corpora by `cargo run -p renew-mesh --example
+make_stl_corpus`, `--example make_ply_corpus`, `--example
 make_obj_corpus`, `--example make_mtl_corpus` and `--example
 make_blob_corpus`, each of
 which builds every byte it writes rather than copying a file from
-anywhere, so no licence question arrives with the starting seeds. For
+anywhere, so no licence question arrives with the starting seeds.
+
+**Every one of those names carries its format, and that is load-bearing
+rather than tidy.** Cargo writes an example to
+`target/<profile>/examples/<name>` from the target's own name, ignoring
+which package declared it, so three packages naming one example named one
+file. Building the workspace then had two link steps writing one path;
+on Windows the loser reported `LNK1104: cannot open file
+'make_corpus.exe'` and the run went red on a tree that was fine. Cargo
+warns about the collision and says it may become a hard error. A new
+generator gets the format in its name. For
 the mesh generators that is not only licensing: a mesh is the one format
 here whose sample files are *art*, and art has an author.
 

--- a/tools/cli/tests/workspace_lists.rs
+++ b/tools/cli/tests/workspace_lists.rs
@@ -26,13 +26,12 @@ fn workspace_root() -> PathBuf {
     guess.canonicalize().unwrap_or(guess)
 }
 
-/// Crates whose manifest declares a `sanitized` feature.
+/// The workspace's own packages and targets, as cargo computes them.
 ///
-/// Read from cargo rather than by scraping TOML: the feature table is
-/// exactly what cargo already computes, and a hand-rolled parser here
-/// would be a third copy of a fact, in a test whose whole subject is
-/// duplicated facts.
-fn crates_declaring_sanitized(root: &Path) -> Result<Vec<String>, String> {
+/// Shared by the checks below rather than invoked once each, because a
+/// second copy of this would be the exact thing this file exists to
+/// catch — a fact maintained in two places.
+fn workspace_metadata(root: &Path) -> Result<Value, String> {
     let output = Command::new("cargo")
         .args(["metadata", "--format-version", "1", "--no-deps"])
         .current_dir(root)
@@ -45,7 +44,17 @@ fn crates_declaring_sanitized(root: &Path) -> Result<Vec<String>, String> {
         ));
     }
     let text = String::from_utf8_lossy(&output.stdout).into_owned();
-    let document = json::parse(&text).map_err(|error| format!("metadata is not JSON: {error}"))?;
+    json::parse(&text).map_err(|error| format!("metadata is not JSON: {error}"))
+}
+
+/// Crates whose manifest declares a `sanitized` feature.
+///
+/// Read from cargo rather than by scraping TOML: the feature table is
+/// exactly what cargo already computes, and a hand-rolled parser here
+/// would be a third copy of a fact, in a test whose whole subject is
+/// duplicated facts.
+fn crates_declaring_sanitized(root: &Path) -> Result<Vec<String>, String> {
+    let document = workspace_metadata(root)?;
     let packages = document
         .get("packages")
         .and_then(Value::as_array)
@@ -1538,6 +1547,88 @@ fn only_the_platform_socket_module_names_the_standard_network_types() {
     assert!(
         faults.is_empty(),
         "the socket belongs to one module and these reach around it:\n{}",
+        faults.join("\n")
+    );
+}
+/// Every example target in the workspace has a name no other package
+/// uses.
+///
+/// **Cargo names the output file from the target, not from the package.**
+/// An example called `make_corpus` in three crates is three compilations
+/// writing `target/<profile>/examples/make_corpus.exe`, and a workspace
+/// build runs them concurrently. Cargo warns about the collision and says
+/// it may become a hard error; before that, the symptom is a link step
+/// failing to open a file another link step is holding.
+///
+/// **That is not hypothetical.** `renew-json`, `renew-png` and
+/// `renew-mesh` each shipped a `make_corpus`, and a Windows CI run failed
+/// with `LNK1104: cannot open file 'make_corpus.exe'` on a tree that was
+/// otherwise fine. It was put down to a linker file lock and re-run
+/// green, which is the worst available outcome: the diagnosis was half
+/// right and the cause stayed in the tree. The corpus generators now
+/// carry their format in the name.
+///
+/// The check is over *every* example rather than that one name, because
+/// a corpus generator per format is the shape this repository keeps
+/// producing.
+#[test]
+fn no_two_packages_declare_an_example_of_the_same_name() {
+    let root = workspace_root();
+    let document = workspace_metadata(&root).unwrap_or_else(|error| panic!("{error}"));
+    let packages = document
+        .get("packages")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("cargo metadata carried no packages array"));
+
+    // (example name, declaring package), in metadata order.
+    let mut examples: Vec<(String, String)> = Vec::new();
+    for package in packages {
+        let Some(owner) = package.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(targets) = package.get("targets").and_then(Value::as_array) else {
+            continue;
+        };
+        for target in targets {
+            let is_example = target
+                .get("kind")
+                .and_then(Value::as_array)
+                .is_some_and(|kinds| kinds.iter().any(|kind| kind.as_str() == Some("example")));
+            if !is_example {
+                continue;
+            }
+            if let Some(name) = target.get("name").and_then(Value::as_str) {
+                examples.push((name.to_owned(), owner.to_owned()));
+            }
+        }
+    }
+
+    assert!(
+        !examples.is_empty(),
+        "no example targets found at all, so this check measured nothing"
+    );
+
+    let mut faults = Vec::new();
+    let mut reported: Vec<&str> = Vec::new();
+    for (name, _) in &examples {
+        if reported.contains(&name.as_str()) {
+            continue;
+        }
+        reported.push(name);
+        let sharers: Vec<&str> = examples
+            .iter()
+            .filter(|(other, _)| other == name)
+            .map(|(_, package)| package.as_str())
+            .collect();
+        if sharers.len() > 1 {
+            faults.push(format!("`{name}` in {}", sharers.join(", ")));
+        }
+    }
+
+    assert!(
+        faults.is_empty(),
+        "these example names are declared by more than one package, and cargo \
+         writes them all to one path:\n{}",
         faults.join("\n")
     );
 }


### PR DESCRIPTION
Three commits, each standing on its own.

## `MeshError::NotThisFormat`

The PLY reader searched for `end_header` before anything established that the bytes were a PLY. So a file of another format was told its terminator was missing — a claim about a truncated PLY, made about a file that had never been one — and a **genuinely** truncated PLY got the byte-identical refusal. Two faults, one message, naming the fault the file did not have.

Every other parser in this repository already had this refusal: `DecodeError::NotAPng`, `PackError::NotAPack`, `WavError::NotRiff`, `DocumentError::NotADocument`, `WireError::BadMagic`, `TraceErrorKind::NotATrace`. The mesh crate was the only one without it.

PLY now checks its magic before anything else and the blob answers with the same variant. **STL, OBJ and MTL cannot reach it**, because none of the three has a signature — for those formats "not this format" and "cut short" are one observation — and each refusal census records that rather than leaving the gap to be noticed.

A new test pins the distinction directly: a foreign file and a truncated PLY must not share a refusal. It is the test the old ordering could not have passed, and nothing in the suite had asked for it.

## The refusal catalogue gains the mesh crate

`REFUSALS.md` named no `MeshError` variant at all — five readers had shipped against a catalogue written for exactly that purpose and none had added itself. Nine entries now record the mesh implementation, each mapped by reading the entry rather than by matching names.

**One entry loses a claim.** Entry 20 is "a value the engine's own arithmetic cannot hold"; it had been credited to `MeshError::TooLarge`, which is a *policy ceiling* — entry 7 — and says so in its own documentation. `crates/mesh` has no dependencies, so it never converts anything to `Fixed` and has no such bound to check. Entry 20 is back to honest.

## Example targets carry the format they generate

`renew-json`, `renew-png` and `renew-mesh` each declared an example named `make_corpus`. Cargo names an example's output file from the target rather than the package, so all three wrote `target/<profile>/examples/make_corpus.exe`, and a workspace build had concurrent link steps contending for one path. A Windows CI run failed with `LNK1104: cannot open file 'make_corpus.exe'` on a tree that was otherwise fine, and a re-run went green — the cause stayed in. Cargo warns about the collision and says it may become a hard error.

They are `make_json_corpus`, `make_png_corpus` and `make_stl_corpus` now, the last matching the four mesh generators that already carried their format. A test over every example target in the workspace fails if two packages share a name again; it was probed by adding a duplicate, which reddens it naming both packages.

## Also fixed on the way

The message census in `crates/mesh/src/error.rs` matches exhaustively, so adding a variant forced a new arm — but the *array* it walks is not compiler-checked, and the new variant got a rule with no instance to apply it to. The test kept passing and measured one variant fewer. Both halves are pinned now.

## Verification

Run locally on `x86_64-pc-windows-msvc`: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo test --workspace` **258 suites, 2,762 passed, 0 failed**.
