### PR TITLE
Placing geometry under a node transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,7 @@ name = "renew-mesh"
 version = "0.1.1"
 dependencies = [
  "proptest",
+ "renew-math",
 ]
 
 [[package]]

--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -860,10 +860,15 @@ it is easy to forget: nothing in the file is wrong.
 **Nearest thing here.** `PackError::TooLarge { field, value }`, for a
 value that cannot be represented on this target. **Nothing in this tree
 refuses a coordinate for being outside the engine's number range**, and
-`crates/mesh` cannot: it has no dependencies at all, so it never converts
-anything to `Fixed` and has no bound to check against. The refusal this
-entry asks for belongs to whatever converts an imported model into
-simulation state, which does not exist yet.
+`crates/mesh` cannot: nothing it depends on publishes a fixed-point
+type, so it never converts anything to `Fixed` and has no bound to check
+against. The refusal this entry asks for belongs to whatever converts an
+imported model into simulation state, which does not exist yet.
+
+*This paragraph read "it has no dependencies at all" until that stopped
+being true. The conclusion survived the reason, which is the good case;
+the sentence is corrected in the change that made it false rather than
+left for somebody to find and have to work out which half had moved.*
 
 *This entry briefly claimed `MeshError::TooLarge` implemented it. That
 variant is a **policy ceiling**, refusing counts a reader will not hold —

--- a/crates/core/math/src/mat4.rs
+++ b/crates/core/math/src/mat4.rs
@@ -91,6 +91,110 @@ impl Mat4 {
     pub fn transform_vector(self, vector: Vec3) -> Vec3 {
         self.transform(vector.extend(0.0)).truncate()
     }
+
+    /// The inverse of an **affine** matrix, or `None` when there is not
+    /// one.
+    ///
+    /// # Affine, and named that way on purpose
+    ///
+    /// A general 4×4 inverse would be a larger and less accurate
+    /// computation whose only subjects are projective matrices, and
+    /// nothing in this tree inverts one. Calling this `inverse` would
+    /// promise that; calling it `affine_inverse` says what it does, and
+    /// the bottom-row check below turns the assumption into a refusal
+    /// rather than a wrong answer.
+    ///
+    /// # What `None` means
+    ///
+    /// Either the bottom row is not `0, 0, 0, 1` — the matrix is not
+    /// affine and this is the wrong function — or the basis is
+    /// degenerate: a scale of zero on some axis flattens space onto a
+    /// plane, and nothing maps that back. **A determinant that is merely
+    /// small is not refused**, because "small" has no threshold that is
+    /// right for every scene: a model in millimetres and one in metres
+    /// differ by a factor of a thousand in each axis and a billion in
+    /// the determinant, and a bound that rejected the first would be a
+    /// bound about units rather than about invertibility.
+    #[must_use]
+    pub fn affine_inverse(self) -> Option<Self> {
+        let [c0, c1, c2, c3] = self.cols;
+        // **Exact, and a tolerance here would be worse than the lint it
+        // silences.** Every constructor of this type writes the bottom
+        // row as literal zeros and a one, and a product of two such
+        // matrices computes it as sums of exact zeros and one exact
+        // product of ones -- so an affine matrix has exactly this row,
+        // arrived at by construction or by arithmetic. A margin would
+        // admit a matrix that is slightly projective and then return an
+        // inverse that is wrong rather than absent, which is the failure
+        // this check exists to prevent. (`-0.0 != 0.0` is false in IEEE,
+        // so a negative zero passes, as it should.)
+        #[expect(
+            clippy::float_cmp,
+            reason = "an affine bottom row is exact by construction; see the comment above"
+        )]
+        let projective = c0.w != 0.0 || c1.w != 0.0 || c2.w != 0.0 || c3.w != 1.0;
+        if projective {
+            return None;
+        }
+
+        // The upper-left basis, by columns.
+        let a = Vec3::new(c0.x, c0.y, c0.z);
+        let b = Vec3::new(c1.x, c1.y, c1.z);
+        let c = Vec3::new(c2.x, c2.y, c2.z);
+
+        // Cofactors of the basis, which are its adjugate's rows and also
+        // the cross products of its column pairs.
+        let r0 = b.cross(c);
+        let r1 = c.cross(a);
+        let r2 = a.cross(b);
+
+        let determinant = a.dot(r0);
+        if determinant == 0.0 || !determinant.is_finite() {
+            return None;
+        }
+        let scale = 1.0 / determinant;
+        let r0 = r0 * scale;
+        let r1 = r1 * scale;
+        let r2 = r2 * scale;
+
+        // The adjugate's rows become the inverse's columns, which is the
+        // transpose the inverse of a column-major basis needs.
+        let translation = Vec3::new(c3.x, c3.y, c3.z);
+        let back = Vec3::new(
+            -r0.dot(translation),
+            -r1.dot(translation),
+            -r2.dot(translation),
+        );
+
+        Some(Self::from_cols(
+            Vec4::new(r0.x, r1.x, r2.x, 0.0),
+            Vec4::new(r0.y, r1.y, r2.y, 0.0),
+            Vec4::new(r0.z, r1.z, r2.z, 0.0),
+            Vec4::new(back.x, back.y, back.z, 1.0),
+        ))
+    }
+
+    /// The matrix that transforms a **normal** the way this one
+    /// transforms a point.
+    ///
+    /// **A normal is not a direction and does not transform like one.**
+    /// Under a non-uniform scale a surface tilts one way and its normal
+    /// tilts the other: flatten a sphere into a disc and its equator's
+    /// normals should splay outward, while `transform_vector` would
+    /// squash them flat with the surface. The inverse transpose is what
+    /// separates the two, and it is the identity exactly when the basis
+    /// is a rotation — which is why a reader that skipped it looks
+    /// correct on every model whose transforms are rigid.
+    ///
+    /// Returns `None` for the same reasons [`Mat4::affine_inverse`]
+    /// does. The result is **not** renormalised: a scale changes a
+    /// normal's length, and whoever needs a unit vector knows better
+    /// than this function whether a zero-length result is a refusal or a
+    /// degenerate face.
+    #[must_use]
+    pub fn normal_matrix(self) -> Option<Self> {
+        Some(self.affine_inverse()?.transpose())
+    }
 }
 
 // Layout is API (see the type docs); hold it at compile time.
@@ -119,6 +223,148 @@ mod tests {
 
     fn close(a: Vec3, b: Vec3) -> bool {
         (a - b).length() < 1e-5
+    }
+
+    /// An inverse undoes what its matrix did, for every affine shape.
+    #[test]
+    fn an_affine_inverse_undoes_its_matrix() {
+        let cases = [
+            Mat4::IDENTITY,
+            Mat4::from_translation(Vec3::new(10.0, -20.0, 30.0)),
+            Mat4::from_scale(Vec3::new(2.0, 3.0, 4.0)),
+            Mat4::from_quat(Quat::from_axis_angle(Vec3::new(0.6, 0.0, 0.8), 1.1)),
+            // The composition a node transform actually is: scale, then
+            // rotate, then translate.
+            Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0))
+                * Mat4::from_quat(Quat::from_axis_angle(Vec3::Y, 0.7))
+                * Mat4::from_scale(Vec3::new(2.0, 0.5, 4.0)),
+        ];
+        let point = Vec3::new(1.5, -2.5, 3.5);
+        for m in cases {
+            let inverse = m.affine_inverse().expect("these are all invertible");
+            assert!(
+                close(inverse.transform_point(m.transform_point(point)), point),
+                "an inverse must return the point its matrix moved"
+            );
+            assert!(
+                close(m.transform_point(inverse.transform_point(point)), point),
+                "and it must work in the other order too"
+            );
+        }
+    }
+
+    /// A rotation's inverse is its transpose, which is the case an
+    /// implementation gets right by accident and the others by design.
+    #[test]
+    fn a_rotations_inverse_is_its_transpose() {
+        let m = Mat4::from_quat(Quat::from_axis_angle(Vec3::new(0.6, 0.0, 0.8), 1.1));
+        let inverse = m.affine_inverse().expect("a rotation is invertible");
+        let transpose = m.transpose();
+        for column in 0..4 {
+            let a = inverse.cols[column];
+            let b = transpose.cols[column];
+            assert!(
+                close(Vec3::new(a.x, a.y, a.z), Vec3::new(b.x, b.y, b.z)),
+                "column {column} of a rotation's inverse is its transpose"
+            );
+        }
+    }
+
+    /// **A basis that flattens space has no inverse, and neither does a
+    /// matrix that is not affine.**
+    #[test]
+    fn what_cannot_be_inverted_says_so() {
+        // A scale of zero on one axis maps everything onto a plane, and
+        // nothing maps a plane back into space.
+        assert_eq!(
+            Mat4::from_scale(Vec3::new(1.0, 0.0, 1.0)).affine_inverse(),
+            None
+        );
+        assert_eq!(Mat4::from_scale(Vec3::ZERO).affine_inverse(), None);
+
+        // Two columns the same is a basis of two dimensions wearing
+        // three, which the determinant catches without a special case.
+        let flat = Mat4::from_cols(
+            Vec4::new(1.0, 0.0, 0.0, 0.0),
+            Vec4::new(1.0, 0.0, 0.0, 0.0),
+            Vec4::new(0.0, 0.0, 1.0, 0.0),
+            Vec4::new(0.0, 0.0, 0.0, 1.0),
+        );
+        assert_eq!(flat.affine_inverse(), None);
+
+        // Not affine: this function is the wrong one for it, and says so
+        // rather than answering with a matrix that is wrong in a way
+        // nothing downstream would notice.
+        let projective = Mat4::from_cols(
+            Vec4::new(1.0, 0.0, 0.0, 0.0),
+            Vec4::new(0.0, 1.0, 0.0, 0.0),
+            Vec4::new(0.0, 0.0, 1.0, -1.0),
+            Vec4::new(0.0, 0.0, 0.0, 0.0),
+        );
+        assert_eq!(projective.affine_inverse(), None);
+    }
+
+    /// **A normal is not a direction, and a non-uniform scale is where
+    /// the difference shows.**
+    ///
+    /// Flatten space along one axis and a surface tilts one way while
+    /// its normal tilts the other. This pins it concretely: the
+    /// transformed normal stays perpendicular to the transformed
+    /// tangent, and transforming the normal as a direction does not.
+    #[test]
+    fn a_normal_matrix_keeps_normals_perpendicular_to_their_surface() {
+        let squash = Mat4::from_scale(Vec3::new(2.0, 1.0, 1.0));
+        let tangent = Vec3::new(-1.0, 1.0, 0.0);
+        let normal = Vec3::new(1.0, 1.0, 0.0);
+        assert!(
+            tangent.dot(normal).abs() < 1e-6,
+            "the fixture starts perpendicular"
+        );
+
+        let moved_tangent = squash.transform_vector(tangent);
+        let correct = squash
+            .normal_matrix()
+            .expect("a scale is invertible")
+            .transform_vector(normal);
+        assert!(
+            moved_tangent.dot(correct).abs() < 1e-5,
+            "the normal matrix keeps them perpendicular: {}",
+            moved_tangent.dot(correct)
+        );
+
+        // And the thing a reader does when it forgets: transforming the
+        // normal as though it were a direction.
+        let wrong = squash.transform_vector(normal);
+        assert!(
+            moved_tangent.dot(wrong).abs() > 1.0,
+            "transforming a normal as a direction tilts it the wrong way: {}",
+            moved_tangent.dot(wrong)
+        );
+    }
+
+    /// Under a rotation the two agree, which is why skipping the normal
+    /// matrix looks correct on every rigidly-placed model.
+    #[test]
+    fn a_rotation_needs_no_normal_matrix_and_that_is_the_trap() {
+        let m = Mat4::from_quat(Quat::from_axis_angle(Vec3::new(0.0, 1.0, 0.0), 0.9));
+        let normal = Vec3::new(0.6, 0.8, 0.0);
+        let via_normal_matrix = m
+            .normal_matrix()
+            .expect("a rotation is invertible")
+            .transform_vector(normal);
+        assert!(
+            close(via_normal_matrix, m.transform_vector(normal)),
+            "identical under a rotation, which is what hides the bug"
+        );
+    }
+
+    /// What cannot be inverted has no normal matrix either.
+    #[test]
+    fn a_degenerate_basis_has_no_normal_matrix() {
+        assert_eq!(
+            Mat4::from_scale(Vec3::new(1.0, 0.0, 1.0)).normal_matrix(),
+            None
+        );
     }
 
     #[test]

--- a/crates/core/math/src/mat4.rs
+++ b/crates/core/math/src/mat4.rs
@@ -326,19 +326,24 @@ mod tests {
             .normal_matrix()
             .expect("a scale is invertible")
             .transform_vector(normal);
+        // **Computed into a name rather than called inside the message.**
+        // A method call in a format argument runs only when the assert
+        // fails, which makes it a line nothing executes on a green run;
+        // the rest of this file captures variables inline for the same
+        // reason.
+        let kept = moved_tangent.dot(correct);
         assert!(
-            moved_tangent.dot(correct).abs() < 1e-5,
-            "the normal matrix keeps them perpendicular: {}",
-            moved_tangent.dot(correct)
+            kept.abs() < 1e-5,
+            "the normal matrix keeps them perpendicular: {kept}"
         );
 
         // And the thing a reader does when it forgets: transforming the
         // normal as though it were a direction.
         let wrong = squash.transform_vector(normal);
+        let tilted = moved_tangent.dot(wrong);
         assert!(
-            moved_tangent.dot(wrong).abs() > 1.0,
-            "transforming a normal as a direction tilts it the wrong way: {}",
-            moved_tangent.dot(wrong)
+            tilted.abs() > 1.0,
+            "transforming a normal as a direction tilts it the wrong way: {tilted}"
         );
     }
 

--- a/crates/core/math/tests/properties.rs
+++ b/crates/core/math/tests/properties.rs
@@ -33,6 +33,31 @@ fn unit_vec3() -> impl Strategy<Value = Vec3> {
     vec3().prop_filter_map("needs a direction", Vec3::try_normalize)
 }
 
+/// A scale with no component near zero, so the matrix it makes is
+/// invertible and the inverse's arithmetic stays in a sane range.
+///
+/// **The floor is about the test, not about the type.** `affine_inverse`
+/// deliberately refuses only an exactly-zero determinant, because a
+/// bound on "small" would be a bound about units; a property that
+/// sampled scales of `1e-30` would be measuring how much precision a
+/// round trip loses rather than whether the inverse is the inverse.
+fn invertible_scale() -> impl Strategy<Value = Vec3> {
+    let axis = prop_oneof![-1e3f32..-1e-2f32, 1e-2f32..1e3f32];
+    (axis.clone(), axis.clone(), axis).prop_map(|(x, y, z)| Vec3::new(x, y, z))
+}
+
+/// The shape a node transform actually is: scale, then rotate, then
+/// translate.
+fn affine() -> impl Strategy<Value = Mat4> {
+    (vec3(), unit_vec3(), -3.0f32..3.0f32, invertible_scale()).prop_map(
+        |(translation, axis, angle, scale)| {
+            Mat4::from_translation(translation)
+                * Mat4::from_quat(Quat::from_axis_angle(axis, angle))
+                * Mat4::from_scale(scale)
+        },
+    )
+}
+
 fn bits(v: Vec3) -> [u32; 3] {
     [v.x.to_bits(), v.y.to_bits(), v.z.to_bits()]
 }
@@ -264,5 +289,100 @@ proptest! {
             Alpha::new(remainder, step_nz).get().to_bits(),
             Alpha::new(remainder, step_nz).get().to_bits()
         );
+    }
+}
+
+// ---------------------------------------------------------------------
+// The affine inverse.
+//
+// **Tolerance tier, and not by preference.** An inverse divides by a
+// determinant and multiplies the result through, so a round trip is
+// three roundings deep before it is compared. A bit-exact law here would
+// be a law about this order of operations rather than about inversion.
+// ---------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        rng_seed: RngSeed::Fixed(0x00D1_A601),
+        ..ProptestConfig::default()
+    })]
+
+    /// **An inverse returns what its matrix moved**, for every affine
+    /// transform a node can carry.
+    ///
+    /// The named cases beside the type check a handful of shapes. This
+    /// says it of translations, rotations and non-uniform scales in
+    /// composition — including the ones with a scale of a hundredth on
+    /// one axis and a thousand on another, which is where a wrong
+    /// adjugate stops looking like the right one.
+    #[test]
+    fn an_affine_inverse_returns_the_point_its_matrix_moved(
+        m in affine(),
+        p in vec3(),
+    ) {
+        let inverse = m.affine_inverse().expect("an invertible scale was sampled");
+        let there = m.transform_point(p);
+        let back = inverse.transform_point(there);
+        // Relative, because a translation of a million and a point of a
+        // million put the round trip's error where an absolute epsilon
+        // would call it a failure of inversion rather than of f32.
+        let scale = p.length().max(there.length()).max(1.0);
+        prop_assert!(
+            (back - p).length() <= 1e-3 * scale,
+            "round trip moved the point by {} at scale {scale}",
+            (back - p).length()
+        );
+    }
+
+    /// **A normal matrix keeps a normal perpendicular to its surface**,
+    /// for every affine transform and every surface.
+    ///
+    /// This is the property the named case pins at one angle and one
+    /// scale. Transforming a normal as a direction satisfies it only
+    /// when the transform is a rotation, which is why a suite of rigid
+    /// fixtures cannot tell the two apart.
+    #[test]
+    fn a_normal_matrix_keeps_normals_perpendicular(
+        m in affine(),
+        a in unit_vec3(),
+        b in unit_vec3(),
+    ) {
+        // Any two directions in a surface; their cross product is its
+        // normal. Skip the pair that names no surface.
+        let normal = a.cross(b);
+        prop_assume!(normal.length() > 1e-3);
+
+        let moved_tangent = m.transform_vector(a);
+        let moved_normal = m
+            .normal_matrix()
+            .expect("an invertible scale was sampled")
+            .transform_vector(normal);
+        prop_assume!(moved_tangent.length() > 1e-3 && moved_normal.length() > 1e-3);
+
+        let cosine = moved_tangent.dot(moved_normal)
+            / (moved_tangent.length() * moved_normal.length());
+        prop_assert!(
+            cosine.abs() < 1e-3,
+            "the transformed normal is {cosine} off perpendicular to its transformed surface"
+        );
+    }
+
+    /// **A basis with a zero axis has no inverse**, wherever the zero is
+    /// and whatever else the transform does.
+    #[test]
+    fn a_flattened_basis_never_inverts(
+        translation in vec3(),
+        axis in unit_vec3(),
+        angle in -3.0f32..3.0f32,
+        which in 0usize..3,
+        other in 1e-2f32..1e3f32,
+    ) {
+        let mut scale = [other, other, other];
+        scale[which] = 0.0;
+        let m = Mat4::from_translation(translation)
+            * Mat4::from_quat(Quat::from_axis_angle(axis, angle))
+            * Mat4::from_scale(Vec3::new(scale[0], scale[1], scale[2]));
+        prop_assert_eq!(m.affine_inverse(), None);
+        prop_assert_eq!(m.normal_matrix(), None);
     }
 }

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -25,8 +25,17 @@ simulation = false
 # filesystem, and leaves the size bound on a whole-file read where it can
 # actually be enforced -- with the caller doing the reading.
 [dependencies]
+# **The first thing this crate depends on**, and the alternative was
+# worse. Placing geometry under a node transform needs a matrix and the
+# inverse transpose a normal is moved by; writing a second four-by-four
+# multiply here to keep the dependency list empty would be two copies of
+# one fact. An empty list was a description, not a promise.
+renew-math = { version = "0.1.1", path = "../core/math", default-features = false }
 
 [dev-dependencies]
+# The suite for placement builds transforms with the same types the
+# library takes, so the matrix crate is here as well as above.
+renew-math = { version = "0.1.1", path = "../core/math", default-features = false }
 proptest = "1.11"
 
 [lints]

--- a/crates/mesh/src/error.rs
+++ b/crates/mesh/src/error.rs
@@ -244,6 +244,18 @@ pub enum MeshError {
         found: usize,
     },
 
+    /// A transform with no inverse, applied to geometry that carries
+    /// normals.
+    ///
+    /// **Refused only when there are normals**, and the distinction is
+    /// the whole content of the refusal. A scale of zero on one axis is
+    /// how a modelling tool flattens something and is a legal thing for
+    /// a file to ask: the positions land on a plane, which is what was
+    /// asked. What cannot be done is transforming a **normal**, because
+    /// there is no inverse to transpose — and a reader that pressed on
+    /// would produce a bad value out of a file that contained none.
+    TransformNotInvertible,
+
     /// A file that declares no geometry at all.
     ///
     /// **A refusal rather than an empty mesh**, and the distinction is
@@ -282,6 +294,7 @@ impl MeshError {
             Self::NotAFace { .. } => "NotAFace",
             Self::Unsupported { .. } => "Unsupported",
             Self::StreamLengthMismatch { .. } => "StreamLengthMismatch",
+            Self::TransformNotInvertible => "TransformNotInvertible",
             Self::NoGeometry => "NoGeometry",
         }
     }
@@ -351,6 +364,10 @@ impl fmt::Display for MeshError {
             } => write!(
                 f,
                 "`{stream}` holds {found} and the positions hold {expected}"
+            ),
+            Self::TransformNotInvertible => write!(
+                f,
+                "this transform flattens space, and a normal needs an inverse to be transposed"
             ),
             Self::NoGeometry => write!(
                 f,
@@ -506,13 +523,14 @@ mod tests {
                 expected: 512,
                 found: 511,
             },
+            MeshError::TransformNotInvertible,
             MeshError::NoGeometry,
             MeshError::NotThisFormat { expected: "ply" },
         ];
 
         // One per variant. Raise it when the enum grows, in the same
         // change that writes the new arm below.
-        assert_eq!(all.len(), 13, "a variant is missing an instance here");
+        assert_eq!(all.len(), 14, "a variant is missing an instance here");
 
         for refusal in &all {
             let shown = refusal.to_string();
@@ -522,6 +540,11 @@ mod tests {
             let numbers: Vec<&str> = match refusal {
                 MeshError::NotThisFormat { .. } => vec!["ply"],
                 MeshError::StreamLengthMismatch { .. } => vec!["NORMAL", "512", "511"],
+                // No numbers: the fault is a matrix a caller passed in
+                // rather than bytes in a file, so there is nothing to
+                // send anybody to a hex editor for. The message names
+                // the consequence instead.
+                MeshError::TransformNotInvertible => vec!["normal"],
                 MeshError::TooShortForHeader { .. } => vec!["84", "3"],
                 MeshError::CountMismatch { .. } => vec!["134", "90", "1"],
                 MeshError::TooLarge { .. } => vec!["element count", "4000000000"],

--- a/crates/mesh/src/error.rs
+++ b/crates/mesh/src/error.rs
@@ -532,6 +532,25 @@ mod tests {
         // change that writes the new arm below.
         assert_eq!(all.len(), 14, "a variant is missing an instance here");
 
+        // **Every variant is asked its name here, and that is a fix for
+        // a gap that has now appeared three times.** A refusal added to
+        // this list got its message checked and its `name` arm executed
+        // by nothing, so the coverage gate named that arm on three
+        // separate occasions and three separate call sites were patched
+        // to ask. Asking once, here, covers every variant that will ever
+        // be added — and a refusal a caller cannot key on is half a
+        // refusal, so the census is the right place for the question.
+        let mut named: Vec<&'static str> = Vec::new();
+        for refusal in &all {
+            let name = refusal.name();
+            assert!(!name.is_empty(), "{refusal:?} has no name");
+            assert!(
+                !named.contains(&name),
+                "`{name}` is the name of two different refusals"
+            );
+            named.push(name);
+        }
+
         for refusal in &all {
             let shown = refusal.to_string();
             assert!(!shown.is_empty(), "{refusal:?} says nothing");

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -62,6 +62,7 @@ pub mod format;
 pub mod glb;
 pub mod mtl;
 pub mod obj;
+pub mod place;
 pub mod ply;
 pub mod primitive;
 pub mod stl;

--- a/crates/mesh/src/place.rs
+++ b/crates/mesh/src/place.rs
@@ -1,0 +1,153 @@
+//! Moving geometry into another space, and joining what was separate.
+//!
+//! A format that arranges its meshes in a hierarchy hands a reader two
+//! things this crate has so far had no use for: a transform per node,
+//! and several pieces of geometry that are one model. Both are handled
+//! here, and both have a refusal that is easy to leave out.
+//!
+//! # A normal is not a direction
+//!
+//! Under a non-uniform scale a surface tilts one way and its normal
+//! tilts the other, so a normal is transformed by the **inverse
+//! transpose** rather than by the matrix. Under a rotation the two are
+//! identical, which is exactly why a reader that skips it looks correct
+//! on every rigidly-placed model and is wrong the moment something is
+//! squashed.
+//!
+//! # Why a singular transform is refused only sometimes
+//!
+//! A scale of zero on one axis is how a modelling tool flattens
+//! something, and it is a legal thing for a file to ask for: the
+//! positions land on a plane, which is what was asked. **What cannot be
+//! done is transforming a normal**, because there is no inverse to
+//! transpose — and a reader that pressed on would produce a normal of
+//! zero length or of nothing at all, manufacturing a bad value out of a
+//! file that contained none.
+//!
+//! So geometry that carries no normals is placed under a singular
+//! transform without complaint, and geometry that carries them is
+//! refused. The refusal is about what the reader was asked to compute,
+//! not about the matrix in the abstract.
+
+use renew_math::{Mat4, Vec3};
+
+use crate::error::MeshError;
+use crate::{Mesh, refuse_over_ceiling};
+
+/// Move `mesh` into the space `transform` describes.
+///
+/// Positions move by the matrix; normals move by its inverse transpose.
+/// **Normals are not renormalised**, because a scale changes their
+/// length and whoever needs a unit vector knows better than this
+/// function whether a short one is a refusal or a degenerate face.
+///
+/// # Errors
+///
+/// [`MeshError::TransformNotInvertible`] when the mesh carries normals
+/// and the transform has no inverse, and [`MeshError::NotFinite`] when a
+/// transformed coordinate is not a number a bounding box can hold —
+/// which a large enough transform can produce from a file whose own
+/// coordinates were all finite.
+pub fn place(mesh: &mut Mesh, transform: Mat4) -> Result<(), MeshError> {
+    let carries_normals = !mesh.face_normals.is_empty() || !mesh.corner_normals.is_empty();
+    let normal_matrix = match transform.normal_matrix() {
+        Some(matrix) => Some(matrix),
+        None if carries_normals => return Err(MeshError::TransformNotInvertible),
+        // Legal: the positions flatten, which is what the file asked
+        // for, and there are no normals to be wrong about.
+        None => None,
+    };
+
+    for (index, position) in mesh.positions.iter_mut().enumerate() {
+        let moved = transform.transform_point(Vec3::new(position[0], position[1], position[2]));
+        *position = finite(moved, "position", index)?;
+    }
+
+    let Some(normals) = normal_matrix else {
+        return Ok(());
+    };
+    for (index, normal) in mesh.face_normals.iter_mut().enumerate() {
+        let moved = normals.transform_vector(Vec3::new(normal[0], normal[1], normal[2]));
+        *normal = finite(moved, "face normal", index)?;
+    }
+    for (index, normal) in mesh.corner_normals.iter_mut().enumerate() {
+        let moved = normals.transform_vector(Vec3::new(normal[0], normal[1], normal[2]));
+        *normal = finite(moved, "corner normal", index)?;
+    }
+    Ok(())
+}
+
+/// A transformed vector, refused at the boundary if it is not finite.
+fn finite(value: Vec3, field: &'static str, index: usize) -> Result<[f32; 3], MeshError> {
+    let out = [value.x, value.y, value.z];
+    for component in out {
+        if !component.is_finite() {
+            return Err(MeshError::NotFinite {
+                field,
+                index: u32::try_from(index).unwrap_or(u32::MAX),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Append `other`'s geometry to `mesh`.
+///
+/// **The refusal here is that two meshes disagree about what they
+/// carry.** A format that stores one model as several pieces lets each
+/// piece declare its own attributes, so one may have normals and the
+/// next may not — and a reader that simply concatenated would produce a
+/// mesh whose normal array is shorter than its triangle count, which is
+/// the ragged shape [`MeshError::StreamLengthMismatch`] exists to
+/// prevent one layer down.
+///
+/// **Empty is not a disagreement about nothing.** A piece that carries
+/// no normals and a piece that does cannot be joined, even though
+/// appending would "work" — the result would silently be a model whose
+/// second half has no lighting information and whose arrays no longer
+/// line up.
+///
+/// # Errors
+///
+/// [`MeshError::StreamLengthMismatch`] when the two disagree about an
+/// optional array, and [`MeshError::TooLarge`] when the total passes the
+/// ceiling this crate sets on geometry.
+pub fn append(mesh: &mut Mesh, other: &Mesh) -> Result<(), MeshError> {
+    let pairs: [(&str, bool, bool); 3] = [
+        (
+            "face normal",
+            mesh.face_normals.is_empty(),
+            other.face_normals.is_empty(),
+        ),
+        (
+            "corner normal",
+            mesh.corner_normals.is_empty(),
+            other.corner_normals.is_empty(),
+        ),
+        (
+            "corner texture coordinate",
+            mesh.corner_texcoords.is_empty(),
+            other.corner_texcoords.is_empty(),
+        ),
+    ];
+    for (stream, here, there) in pairs {
+        if here != there {
+            // The counts say which way the disagreement runs: one side
+            // has a stream for its geometry and the other has none.
+            return Err(MeshError::StreamLengthMismatch {
+                stream,
+                expected: if here { 0 } else { mesh.triangles() },
+                found: if there { 0 } else { other.triangles() },
+            });
+        }
+    }
+
+    refuse_over_ceiling(mesh.positions.len(), other.positions.len())?;
+
+    mesh.positions.extend_from_slice(&other.positions);
+    mesh.face_normals.extend_from_slice(&other.face_normals);
+    mesh.corner_normals.extend_from_slice(&other.corner_normals);
+    mesh.corner_texcoords
+        .extend_from_slice(&other.corner_texcoords);
+    Ok(())
+}

--- a/crates/mesh/tests/blob.rs
+++ b/crates/mesh/tests/blob.rs
@@ -514,6 +514,9 @@ fn every_byte_string_gets_an_answer() {
 /// until somebody decides which it is.
 fn blob_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::TransformNotInvertible => Some(
+            "the blob stores geometry already in its own space and this reader applies\n             nothing to it",
+        ),
         // Reachable, and each is provoked by a byte string in this file.
         MeshError::NotThisFormat { .. }
         | MeshError::TooShortForHeader { .. }

--- a/crates/mesh/tests/mtl.rs
+++ b/crates/mesh/tests/mtl.rs
@@ -339,6 +339,9 @@ fn every_byte_string_gets_an_answer() {
 /// until somebody decides which it is.
 fn mtl_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::TransformNotInvertible => {
+            Some("a material library carries no geometry to place anywhere")
+        }
         MeshError::StreamLengthMismatch { .. } => Some(
             "a material library carries no vertex streams at all, so it has nothing for two\n             of them to disagree about",
         ),

--- a/crates/mesh/tests/obj.rs
+++ b/crates/mesh/tests/obj.rs
@@ -563,6 +563,9 @@ fn the_names_returned_never_outweigh_the_file_they_came_from() {
 /// the STL reader that no input on any target could produce.
 fn obj_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::TransformNotInvertible => Some(
+            "this format has no node hierarchy, so there is no transform for this reader\n             to be handed and none to be singular",
+        ),
         MeshError::StreamLengthMismatch { .. } => Some(
             "each face names its own attribute indices, so a normal this file does not have\n             is an index out of range rather than a stream that came up short",
         ),

--- a/crates/mesh/tests/place.rs
+++ b/crates/mesh/tests/place.rs
@@ -1,0 +1,247 @@
+//! Geometry moved into another space, and pieces joined into one model.
+//!
+//! **The test this file exists for is the normal.** Under a rotation a
+//! normal transformed as a direction and a normal transformed properly
+//! are identical, so a reader that skips the inverse transpose passes
+//! every rigidly-placed fixture. Only a non-uniform scale tells them
+//! apart, and there is one here for that reason.
+
+// An integration test is its own crate, so the `allow-*-in-tests`
+// settings in `clippy.toml` do not reach it.
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+
+use renew_math::{Mat4, Quat, Vec3};
+use renew_mesh::{Mesh, MeshError, place};
+
+/// Compare coordinates by value, within the tolerance a transform earns.
+///
+/// **Not by bits here, unlike the assembly suite**: placement multiplies
+/// and adds, so the result is the arithmetic's, not the file's, and an
+/// exact comparison would be asserting something about rounding rather
+/// than about the transform.
+fn near(got: [f32; 3], want: [f32; 3], what: &str) {
+    for (index, (left, right)) in got.iter().zip(&want).enumerate() {
+        assert!(
+            (left - right).abs() < 1e-5,
+            "{what}: component {index} is {left}, not {right}"
+        );
+    }
+}
+
+/// One triangle with a normal per face and per corner.
+fn furnished() -> Mesh {
+    Mesh {
+        positions: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        face_normals: vec![[0.0, 0.0, 1.0]],
+        corner_normals: vec![[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
+        corner_texcoords: vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+    }
+}
+
+/// One triangle and nothing optional.
+fn bare() -> Mesh {
+    Mesh {
+        positions: vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        ..Mesh::default()
+    }
+}
+
+/// A translation moves points and leaves normals where they were.
+#[test]
+fn a_translation_moves_points_and_not_normals() {
+    let mut mesh = furnished();
+    place::place(
+        &mut mesh,
+        Mat4::from_translation(Vec3::new(10.0, 20.0, 30.0)),
+    )
+    .expect("a translation is invertible");
+    near(mesh.positions[0], [10.0, 20.0, 30.0], "the first corner");
+    near(mesh.positions[1], [11.0, 20.0, 30.0], "the second");
+    near(mesh.face_normals[0], [0.0, 0.0, 1.0], "the face normal");
+    near(mesh.corner_normals[2], [0.0, 0.0, 1.0], "a corner normal");
+}
+
+/// **A non-uniform scale is the case that tells the two ways of moving a
+/// normal apart.**
+///
+/// The triangle lies in the z = 0 plane with normal `+z`. Squash x by
+/// two and the surface is still in that plane, so the normal must stay
+/// `+z` in direction — and the inverse transpose keeps it there while
+/// scaling its length, whereas transforming it as a direction would
+/// leave it unchanged here and wrong on a tilted face.
+///
+/// So the sharper claim is the tilted one below.
+#[test]
+fn a_non_uniform_scale_tilts_a_normal_the_other_way() {
+    // A face tilted 45 degrees in the x-y plane: normal (1, 1, 0),
+    // tangent (-1, 1, 0), both unnormalised on purpose so the arithmetic
+    // is exact to read.
+    let mut mesh = Mesh {
+        positions: vec![[0.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        face_normals: vec![[1.0, 1.0, 0.0]],
+        ..Mesh::default()
+    };
+    place::place(&mut mesh, Mat4::from_scale(Vec3::new(2.0, 1.0, 1.0)))
+        .expect("a scale is invertible");
+
+    // The tangent moved with the surface.
+    let tangent = mesh.positions[1];
+    near(tangent, [-2.0, 1.0, 0.0], "the tilted edge");
+
+    // And the normal is still perpendicular to it.
+    let normal = mesh.face_normals[0];
+    let dot = tangent[0] * normal[0] + tangent[1] * normal[1] + tangent[2] * normal[2];
+    assert!(
+        dot.abs() < 1e-5,
+        "the normal must stay perpendicular to its surface: {dot}"
+    );
+
+    // **The number a reader that skipped the inverse transpose would
+    // have.** Transforming the normal as a direction gives (2, 1, 0),
+    // whose dot with the moved tangent is -3.
+    assert!(
+        (normal[0] - 0.5).abs() < 1e-5,
+        "the inverse transpose halves x where the matrix doubles it: {normal:?}"
+    );
+}
+
+/// Under a rotation the two ways agree, which is what hides the bug.
+#[test]
+fn a_rotation_moves_a_normal_the_same_way_either_route() {
+    let turn = Mat4::from_quat(Quat::from_axis_angle(Vec3::Y, 0.9));
+    let mut mesh = furnished();
+    place::place(&mut mesh, turn).expect("a rotation is invertible");
+
+    let expected = turn.transform_vector(Vec3::new(0.0, 0.0, 1.0));
+    near(
+        mesh.face_normals[0],
+        [expected.x, expected.y, expected.z],
+        "identical under a rotation, which is what hides a missing inverse transpose",
+    );
+}
+
+/// **A transform that flattens space is refused only when there are
+/// normals to transform.**
+#[test]
+fn a_singular_transform_is_refused_only_when_normals_need_it() {
+    let flatten = Mat4::from_scale(Vec3::new(1.0, 0.0, 1.0));
+
+    let mut with_normals = furnished();
+    assert_eq!(
+        place::place(&mut with_normals, flatten).expect_err("no inverse to transpose"),
+        MeshError::TransformNotInvertible
+    );
+
+    // **And the same transform on the same geometry without normals is
+    // fine**, because flattening is what the file asked for and there is
+    // nothing left to be wrong about.
+    let mut without = bare();
+    place::place(&mut without, flatten).expect("positions may be flattened");
+    near(without.positions[2], [0.0, 0.0, 0.0], "y collapsed to zero");
+    near(without.positions[1], [1.0, 0.0, 0.0], "and x did not");
+}
+
+/// A refused placement is refused before anything is written.
+#[test]
+fn a_refused_placement_leaves_the_mesh_alone() {
+    let mut mesh = furnished();
+    let before = mesh.positions.clone();
+    let _ = place::place(&mut mesh, Mat4::from_scale(Vec3::new(0.0, 1.0, 1.0)));
+    assert_eq!(
+        mesh.positions, before,
+        "the refusal comes before any coordinate is touched"
+    );
+}
+
+/// A transform large enough to overflow is refused at the boundary.
+#[test]
+fn a_coordinate_transformed_out_of_range_is_refused() {
+    let mut mesh = Mesh {
+        positions: vec![[1e30, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        ..Mesh::default()
+    };
+    assert_eq!(
+        place::place(&mut mesh, Mat4::from_scale(Vec3::new(1e30, 1.0, 1.0)))
+            .expect_err("1e30 squared is not a float"),
+        MeshError::NotFinite {
+            field: "position",
+            index: 0,
+        }
+    );
+}
+
+/// Two pieces that carry the same arrays join into one model.
+#[test]
+fn two_pieces_carrying_the_same_arrays_are_joined() {
+    let mut first = furnished();
+    let second = furnished();
+    place::append(&mut first, &second).expect("both carry everything");
+    assert_eq!(first.triangles(), 2);
+    assert_eq!(first.positions.len(), 6);
+    assert_eq!(first.face_normals.len(), 2);
+    assert_eq!(first.corner_normals.len(), 6);
+    assert_eq!(first.corner_texcoords.len(), 6);
+}
+
+/// Two bare pieces join too: agreeing about carrying nothing is
+/// agreement.
+#[test]
+fn two_pieces_carrying_nothing_optional_are_joined() {
+    let mut first = bare();
+    place::append(&mut first, &bare()).expect("both carry nothing");
+    assert_eq!(first.triangles(), 2);
+    assert!(first.face_normals.is_empty());
+}
+
+/// **Pieces that disagree about an optional array are refused, by
+/// name.**
+///
+/// Concatenating them would produce a mesh whose normal array is shorter
+/// than its triangle count — the ragged shape the layer below refuses —
+/// and whose second half silently has no lighting information.
+#[test]
+fn pieces_that_disagree_about_a_stream_are_refused() {
+    let mut furnished_first = furnished();
+    assert_eq!(
+        place::append(&mut furnished_first, &bare()).expect_err("one has normals, one does not"),
+        MeshError::StreamLengthMismatch {
+            stream: "face normal",
+            expected: 1,
+            found: 0,
+        }
+    );
+
+    // And the other way round, so the message is about which side is
+    // missing rather than about argument order.
+    let mut bare_first = bare();
+    assert_eq!(
+        place::append(&mut bare_first, &furnished()).expect_err("still a disagreement"),
+        MeshError::StreamLengthMismatch {
+            stream: "face normal",
+            expected: 0,
+            found: 1,
+        }
+    );
+
+    // Texture coordinates are their own disagreement, not folded into
+    // the normals'.
+    let mut only_uvs = Mesh {
+        corner_texcoords: vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+        ..bare()
+    };
+    let refused = place::append(&mut only_uvs, &bare()).expect_err("coordinates on one side");
+    assert_eq!(refused.name(), "StreamLengthMismatch");
+    assert!(
+        refused.to_string().contains("corner texture coordinate"),
+        "the message names which stream: {refused}"
+    );
+}
+
+/// A refused append leaves both meshes as they were.
+#[test]
+fn a_refused_append_changes_nothing() {
+    let mut first = furnished();
+    let before = first.positions.len();
+    let _ = place::append(&mut first, &bare());
+    assert_eq!(first.positions.len(), before, "nothing was appended");
+}

--- a/crates/mesh/tests/ply.rs
+++ b/crates/mesh/tests/ply.rs
@@ -965,6 +965,9 @@ fn crowded_schema() -> String {
 /// a failure prints why this format was thought unable to get here.
 fn ply_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::TransformNotInvertible => Some(
+            "nothing in this format carries a transform: a PLY names coordinates and this\n             reader returns them where the file put them",
+        ),
         MeshError::StreamLengthMismatch { .. } => Some(
             "a schema names one element per stream and the count comes from that element,\n             so two streams cannot claim different lengths for the same vertices",
         ),

--- a/crates/mesh/tests/properties.rs
+++ b/crates/mesh/tests/properties.rs
@@ -14,7 +14,8 @@
 #![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
 
 use proptest::prelude::*;
-use renew_mesh::{Mesh, blob, stl};
+use renew_math::{Mat4, Quat, Vec3};
+use renew_mesh::{Mesh, MeshError, blob, place, stl};
 
 /// A binary STL over `triangles`, built the way an exporter would.
 fn binary(triangles: &[([f32; 3], [[f32; 3]; 3])]) -> Vec<u8> {
@@ -266,5 +267,147 @@ proptest! {
         // And the form is canonical: the same mesh written twice is the
         // same bytes, which is what every cache above a blob assumes.
         prop_assert_eq!(blob::write(&read), bytes);
+    }
+}
+
+// ---------------------------------------------------------------------
+// Placing geometry, and joining it.
+//
+// **Properties rather than a fuzz target, and the choice is the rule's
+// rather than convenience.** The testing table sends math to
+// property-based tests and sends parsers to fuzz targets. Placement
+// parses nothing: it takes a mesh some reader already validated and a
+// matrix the document layer will supply, and every loop bound comes from
+// a vector's own length. There is no offset computed from an untrusted
+// number, which is the class of fault a fuzzer finds and a property does
+// not. What can go wrong here is a value being wrong, and a fuzzer has
+// no oracle for a wrong normal.
+//
+// The path by which a hostile matrix arrives — sixteen numbers read out
+// of a document — is a parser, and it is fuzzed where it lives.
+// ---------------------------------------------------------------------
+
+/// A coordinate a bounding box can hold, and small enough that a
+/// transform of it stays finite.
+fn placed_coordinate() -> impl Strategy<Value = f32> {
+    -1e3f32..1e3f32
+}
+
+fn point() -> impl Strategy<Value = [f32; 3]> {
+    (
+        placed_coordinate(),
+        placed_coordinate(),
+        placed_coordinate(),
+    )
+        .prop_map(|(x, y, z)| [x, y, z])
+}
+
+/// A mesh of whole triangles, optionally carrying each of its optional
+/// arrays.
+fn placeable_mesh(with_normals: bool, with_texcoords: bool) -> impl Strategy<Value = Mesh> {
+    proptest::collection::vec((point(), point(), point()), 1..6).prop_map(move |faces| {
+        let mut out = Mesh::default();
+        for (a, b, c) in faces {
+            out.positions.extend_from_slice(&[a, b, c]);
+            if with_normals {
+                out.face_normals.push([0.0, 0.0, 1.0]);
+                out.corner_normals.extend_from_slice(&[[0.0, 0.0, 1.0]; 3]);
+            }
+            if with_texcoords {
+                out.corner_texcoords
+                    .extend_from_slice(&[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]);
+            }
+        }
+        out
+    })
+}
+
+/// An invertible node transform: scale, then rotate, then translate.
+fn transform() -> impl Strategy<Value = Mat4> {
+    let axis = prop_oneof![-1e2f32..-1e-1f32, 1e-1f32..1e2f32];
+    (
+        point(),
+        (
+            placed_coordinate(),
+            placed_coordinate(),
+            placed_coordinate(),
+        ),
+        -3.0f32..3.0f32,
+        (axis.clone(), axis.clone(), axis),
+    )
+        .prop_filter_map("needs an axis to turn about", |(t, a, angle, s)| {
+            let axis = Vec3::new(a.0, a.1, a.2).try_normalize()?;
+            Some(
+                Mat4::from_translation(Vec3::new(t[0], t[1], t[2]))
+                    * Mat4::from_quat(Quat::from_axis_angle(axis, angle))
+                    * Mat4::from_scale(Vec3::new(s.0, s.1, s.2)),
+            )
+        })
+}
+
+proptest! {
+    /// **Placement answers, and what it accepts is finite.**
+    ///
+    /// The claim a named case cannot make: over every mesh of this shape
+    /// and every invertible transform, `place` either refuses or leaves
+    /// a mesh whose every coordinate a bounding box can still hold.
+    #[test]
+    fn placing_geometry_leaves_it_finite_or_refuses(
+        mut geometry in placeable_mesh(true, true),
+        matrix in transform(),
+    ) {
+        let corners = geometry.positions.len();
+        let faces = geometry.face_normals.len();
+        // A refusal is an answer; what it accepts is the subject.
+        if place::place(&mut geometry, matrix).is_ok() {
+            {
+                prop_assert_eq!(geometry.positions.len(), corners, "placement adds no geometry");
+                prop_assert_eq!(geometry.face_normals.len(), faces);
+                for value in geometry
+                    .positions
+                    .iter()
+                    .chain(&geometry.face_normals)
+                    .chain(&geometry.corner_normals)
+                    .flatten()
+                {
+                    prop_assert!(value.is_finite(), "a placed coordinate nothing can bound");
+                }
+            }
+        }
+    }
+
+    /// **Joining two pieces that carry the same arrays adds their
+    /// lengths and nothing else.**
+    #[test]
+    fn joining_pieces_that_agree_adds_their_lengths(
+        mut first in placeable_mesh(true, true),
+        second in placeable_mesh(true, true),
+    ) {
+        let (corners, faces) = (first.positions.len(), first.face_normals.len());
+        place::append(&mut first, &second).expect("both carry everything");
+        prop_assert_eq!(first.positions.len(), corners + second.positions.len());
+        prop_assert_eq!(first.face_normals.len(), faces + second.face_normals.len());
+        prop_assert_eq!(first.positions.len() % 3, 0, "still whole triangles");
+        prop_assert_eq!(first.corner_normals.len(), first.positions.len());
+        prop_assert_eq!(first.corner_texcoords.len(), first.positions.len());
+    }
+
+    /// **Two pieces that disagree about an array are always refused**,
+    /// whichever way round they are handed over.
+    #[test]
+    fn joining_pieces_that_disagree_always_refuses(
+        furnished in placeable_mesh(true, true),
+        mut plain in placeable_mesh(false, false),
+    ) {
+        let forwards = place::append(&mut furnished.clone(), &plain);
+        let backwards = place::append(&mut plain, &furnished);
+        prop_assert!(
+            matches!(forwards, Err(MeshError::StreamLengthMismatch { .. })),
+            "a piece with normals cannot take one without"
+        );
+        prop_assert!(
+            matches!(backwards, Err(MeshError::StreamLengthMismatch { .. })),
+            "and the disagreement is not about argument order"
+        );
     }
 }

--- a/crates/mesh/tests/stl.rs
+++ b/crates/mesh/tests/stl.rs
@@ -167,6 +167,9 @@ endsolid x",
 /// finding. A reason the test prints is a reason somebody reads.
 fn stl_cannot_reach(refusal: &MeshError) -> Option<&'static str> {
     match refusal {
+        MeshError::TransformNotInvertible => Some(
+            "a reader is handed bytes and returns geometry in the file's own space;\n             placing it somewhere else is a later step with its own refusals",
+        ),
         MeshError::StreamLengthMismatch { .. } => Some(
             "this format has one stream and repeats every corner into it, so there is no\n             second stream that could disagree with a first",
         ),


### PR DESCRIPTION
Three commits: the inverse nothing here could compute, the placement that needs it, and the properties that stand behind both.

## A normal is not a direction

Under a non-uniform scale a surface tilts one way and its normal tilts the other, so normals move by the **inverse transpose**. Under a rotation the two are identical — which is exactly why a reader that skips it looks correct on every rigidly-placed model and is wrong the moment something is squashed.

Nothing in the tree could invert a matrix, so this adds `Mat4::affine_inverse` and `Mat4::normal_matrix`.

**Affine, and named that way.** The format requires a node matrix to be decomposable to translation, rotation and scale, so it is never projective. A general four-by-four inverse would be larger and less accurate with no subject in this tree; calling it `inverse` would promise it. The bottom-row check turns the affine assumption into a refusal rather than a wrong answer, and it is **exact on purpose** — every constructor writes that row as literal zeros and a one, a product of two affine matrices computes it as sums of exact zeros, and a margin would admit a slightly projective matrix and then return an inverse that is wrong rather than absent.

**A zero determinant is refused and a small one is not.** "Small" has no threshold right for every scene: a model in millimetres and one in metres differ by a factor of a billion in the determinant, so a bound there would be a bound about *units* rather than about invertibility.

## A singular transform is refused only when there are normals

Flattening along an axis is how a modelling tool squashes something, and it is a legal thing for a file to ask: the positions land on a plane, which is what was asked. **What cannot be done is transforming a normal**, because there is no inverse to transpose — and a reader that pressed on would manufacture a bad value out of a file that contained none. The refusal is about what was asked to be computed, not about the matrix in the abstract.

## Joining pieces that disagree

A format storing one model as several pieces lets each declare its own attributes. A piece with normals concatenated onto one without would produce a mesh whose normal array is shorter than its triangle count — and whose second half silently has no lighting information. Refused by name, in both directions.

## Why properties and not a fuzz target

The testing table sends math to property-based tests and parsers to fuzz targets. **Placement is neither by accident**: it parses nothing, takes a mesh some reader already validated, and every loop bound comes from a vector's own length. There is no offset computed from an untrusted number — the class of fault a fuzzer finds. What can go wrong is a *value* being wrong, and a fuzzer has no oracle for a wrong normal.

The path by which a hostile matrix arrives — sixteen numbers read out of a document — is a parser, and it is fuzzed where it lives.

Six properties instead: the inverse returns the point its matrix moved; a normal matrix keeps normals perpendicular to their surface for every transform and every surface; a flattened basis never inverts; placement leaves what it accepts finite; joining agreeing pieces adds their lengths; disagreeing pieces are always refused. Tolerances are **relative**, because a translation of a million and a point of a million put a round trip's error where an absolute epsilon would call it a failure of inversion rather than of `f32`.

## `crates/mesh` depends on something, for the first time

Writing a second four-by-four multiply here to keep the list empty would have been two copies of one fact. An empty dependency list was a description, not a promise — and **one sentence in the refusal catalogue argued from that description**, so it is corrected in the change that made it false rather than left for somebody to find and have to work out which half had moved.

## Verification

Run locally on `x86_64-pc-windows-msvc`: `cargo fmt --all -- --check` clean, `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `renew check` clean, `cargo test --workspace` **262 suites, 2,853 passed, 0 failed**. Probing the mutation that transforms normals as directions reddens three tests with the dot product the documentation names.
