### PR TITLE
A glTF material, in the vocabulary glTF states it

### DIFF
--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -65,7 +65,7 @@ is dead code that reads like safety.
 | Mesh blob | `MeshError` | `crates/mesh/src/error.rs` | 8 of the 15 | `blob_read` | 16 |
 | glTF container | `GlbError` | `crates/mesh/src/glb.rs` | 11 | `glb_read` | 18 |
 | Accessor | `AccessorError` | `crates/mesh/src/accessor.rs` | 14 | `accessor_view` | 26 |
-| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 14 | `gltf_read` | 26 |
+| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 15 | `gltf_read` | 32 |
 | Data URI | `DataUriError` | `crates/mesh/src/data_uri.rs` | 7 | `data_uri_read` | 41 |
 
 **The MTL row is the shortest in this table, and that is the honest

--- a/crates/mesh/README.md
+++ b/crates/mesh/README.md
@@ -321,7 +321,7 @@ chunk to offer and the other has none.
 
 **Its refusals name the layer that failed**, not just the fault: a
 `GltfError` says whether the container, the document, a buffer, an
-embedded payload, an accessor or the geometry objected, and the inner refusal's own numbers are one call away
+embedded payload, an accessor, a material or the geometry objected, and the inner refusal's own numbers are one call away
 through the value. A caller that only wants geometry can go
 through `format::detect` and then `Format::read`, which wraps the same
 answer in `MeshError`.

--- a/crates/mesh/README.md
+++ b/crates/mesh/README.md
@@ -330,6 +330,34 @@ The scene walk is an explicit stack with a visited mark checked before
 children are pushed, so a document whose nodes point at each other is a
 refusal rather than a walk that never ends.
 
+## Two material vocabularies, and why they are not one
+
+`mtl::Material` holds the Phong vocabulary a material library carries —
+ambient, diffuse, specular, a specular exponent. `pbr::Material` holds the
+metallic-roughness vocabulary a glTF document carries — a base colour,
+how metallic the surface is, how rough, and the maps that modulate those.
+
+**They are not two spellings of one thing, and nothing here converts
+between them.** Every mapping in circulation is a heuristic: there is no
+specular exponent that *is* a roughness, only a formula somebody found
+acceptable for their renderer. Applying one would hand back a material no
+file contained, which is what this crate declines to do everywhere else.
+A caller that wants one model out of both converts where the conversion
+can be seen.
+
+**A glTF material has no required members**, so an empty one is legal and
+means every default — and the defaults are the format's, not this
+crate's convenience. **A factor outside the range the schema states is
+refused rather than clamped**, which is the opposite of what the material
+library does with its specular exponent, and the two differ because the
+formats do: that range is a convention files exceed, this one is stated
+by the schema.
+
+A primitive's material is **reported rather than stored**. Geometry and
+the surface it wears are two facts, and the canonical form carries one of
+them; `gltf::primitive_material` answers for the pairing without changing
+what a mesh is.
+
 ## `data:` URIs, and why a decoder is strict about spelling
 
 `data_uri::read` turns a URI whose payload *is* the resource back into

--- a/crates/mesh/examples/make_gltf_corpus.rs
+++ b/crates/mesh/examples/make_gltf_corpus.rs
@@ -258,7 +258,6 @@ fn document_seeds() -> Vec<(String, Vec<u8>)> {
     ]
 }
 
-/// One container per refusal, each wrong in exactly one way.
 /// Documents carrying materials, which the geometry path never reads.
 ///
 /// **A material table is reached only by asking for it**, so a corpus of
@@ -266,6 +265,21 @@ fn document_seeds() -> Vec<(String, Vec<u8>)> {
 /// factors, their stated ranges, the alpha modes, the maps — attacked
 /// by nothing. These carry one, in the shapes that decide the answer.
 fn material_seeds() -> Vec<(String, Vec<u8>)> {
+    // A document whose material names textures has to have them: the
+    // reader bounds every index by the table it points at, and a seed
+    // that named one out of thin air would be exercising that refusal
+    // rather than the material read it is named for.
+    let with_textures = |materials: &str| {
+        SIMPLEST
+            .replace(
+                r#""asset":{"version":"2.0"}"#,
+                &format!(
+                    r#""asset":{{"version":"2.0"}},"textures":[{{}},{{}},{{}},{{}},{{}}],"materials":{materials}"#
+                ),
+            )
+            .into_bytes()
+    };
+
     let with = |materials: &str| {
         SIMPLEST
             .replace(
@@ -281,7 +295,7 @@ fn material_seeds() -> Vec<(String, Vec<u8>)> {
         // Every member the format states, so the whole read is walked.
         (
             "material-whole".to_owned(),
-            with(
+            with_textures(
                 r#"[{"name":"brushed",
                 "pbrMetallicRoughness":{"baseColorFactor":[0.5,0.25,0.125,1],
                 "metallicFactor":0.75,"roughnessFactor":0.25,
@@ -318,6 +332,7 @@ fn material_seeds() -> Vec<(String, Vec<u8>)> {
     ]
 }
 
+/// One container per refusal, each wrong in exactly one way.
 fn refused_seeds() -> Vec<(String, Vec<u8>)> {
     let mut wrong_magic = container(SIMPLEST, &triangle());
     wrong_magic[0] = b'X';

--- a/crates/mesh/examples/make_gltf_corpus.rs
+++ b/crates/mesh/examples/make_gltf_corpus.rs
@@ -259,6 +259,65 @@ fn document_seeds() -> Vec<(String, Vec<u8>)> {
 }
 
 /// One container per refusal, each wrong in exactly one way.
+/// Documents carrying materials, which the geometry path never reads.
+///
+/// **A material table is reached only by asking for it**, so a corpus of
+/// documents that carry none leaves that layer's arithmetic — the
+/// factors, their stated ranges, the alpha modes, the maps — attacked
+/// by nothing. These carry one, in the shapes that decide the answer.
+fn material_seeds() -> Vec<(String, Vec<u8>)> {
+    let with = |materials: &str| {
+        SIMPLEST
+            .replace(
+                r#""asset":{"version":"2.0"}"#,
+                &format!(r#""asset":{{"version":"2.0"}},"materials":{materials}"#),
+            )
+            .into_bytes()
+    };
+
+    vec![
+        // The empty material, which is legal and means every default.
+        ("material-empty".to_owned(), with("[{}]")),
+        // Every member the format states, so the whole read is walked.
+        (
+            "material-whole".to_owned(),
+            with(
+                r#"[{"name":"brushed",
+                "pbrMetallicRoughness":{"baseColorFactor":[0.5,0.25,0.125,1],
+                "metallicFactor":0.75,"roughnessFactor":0.25,
+                "baseColorTexture":{"index":0,"texCoord":1},
+                "metallicRoughnessTexture":{"index":1}},
+                "normalTexture":{"index":2,"scale":2.5},
+                "occlusionTexture":{"index":3,"strength":0.5},
+                "emissiveTexture":{"index":4},"emissiveFactor":[0.1,0.2,0.3],
+                "alphaMode":"MASK","alphaCutoff":0.25,"doubleSided":true}]"#,
+            ),
+        ),
+        // The two alpha modes that carry no cutoff, so the arm that
+        // reads one is entered from every state.
+        (
+            "material-blended".to_owned(),
+            with(r#"[{"alphaMode":"BLEND","alphaCutoff":0.75}]"#),
+        ),
+        // A factor outside the range the schema states, which is the
+        // refusal this layer exists to make.
+        (
+            "material-factor-out-of-range".to_owned(),
+            with(r#"[{"emissiveFactor":[0,0,4]}]"#),
+        ),
+        // An alpha mode the format does not have.
+        (
+            "material-unknown-alpha-mode".to_owned(),
+            with(r#"[{"alphaMode":"DITHER"}]"#),
+        ),
+        // A map naming no texture, which is not a map.
+        (
+            "material-map-without-texture".to_owned(),
+            with(r#"[{"emissiveTexture":{"texCoord":0}}]"#),
+        ),
+    ]
+}
+
 fn refused_seeds() -> Vec<(String, Vec<u8>)> {
     let mut wrong_magic = container(SIMPLEST, &triangle());
     wrong_magic[0] = b'X';
@@ -377,6 +436,7 @@ fn main() -> ExitCode {
         .into_iter()
         .chain(refused_seeds())
         .chain(document_seeds())
+        .chain(material_seeds())
     {
         // **The extension follows the bytes.** Half these seeds are
         // documents rather than containers, and `.glb` means container

--- a/crates/mesh/src/gltf.rs
+++ b/crates/mesh/src/gltf.rs
@@ -38,6 +38,7 @@ use crate::accessor::{Accessor, AccessorError, BufferView, Component, Indices, S
 use crate::data_uri::{self, DataUriError};
 use crate::error::MeshError;
 use crate::glb::GlbError;
+use crate::pbr::{Alpha, Material, NormalTexture, OcclusionTexture, TextureRef};
 use crate::primitive::{self, Mode, Primitive};
 use crate::{Mesh, glb, place};
 
@@ -185,6 +186,24 @@ pub enum GltfError {
         available: usize,
     },
 
+    /// A material factor outside the range the format states for it.
+    ///
+    /// **The member is named and the value is not carried**, which is a
+    /// trade rather than an oversight: a factor is a float, this
+    /// vocabulary is compared for equality, and a float would cost every
+    /// refusal in it that property — including the geometry ones,
+    /// which have no materials in them at all. The message states the
+    /// range, and the member names where to look.
+    ///
+    /// Refused rather than clamped, unlike the material library's
+    /// specular exponent, and the two differ because the formats do: that
+    /// range is a convention files exceed, this one is stated by the
+    /// schema.
+    FactorOutOfRange {
+        /// Which member, spelled as the document spells it.
+        field: &'static str,
+    },
+
     /// A node that is its own ancestor, or that two parents claim.
     ///
     /// **The one refusal here whose absence is a hang rather than a
@@ -239,6 +258,7 @@ impl GltfError {
             Self::NoBinaryChunk => "NoBinaryChunk",
             Self::WrongMediaType { .. } => "WrongMediaType",
             Self::BufferTooShort { .. } => "BufferTooShort",
+            Self::FactorOutOfRange { .. } => "FactorOutOfRange",
             Self::NodeCycle { .. } => "NodeCycle",
             Self::Unsupported { .. } => "Unsupported",
         }
@@ -285,6 +305,9 @@ impl core::fmt::Display for GltfError {
                 f,
                 "buffer {buffer} declares {declared} bytes and its resource holds {available}"
             ),
+            Self::FactorOutOfRange { field } => {
+                write!(f, "`{field}` is outside the range the format states for it")
+            }
             Self::NodeCycle { node } => write!(
                 f,
                 "node {node} is reached twice, and this hierarchy is a tree"
@@ -494,6 +517,193 @@ pub fn buffers<'a>(
         });
     }
     Ok(out)
+}
+
+/// A number that must sit inside the range the format states.
+fn factor(object: Value<'_>, key: &'static str, default: f32) -> Result<f32, GltfError> {
+    let Some(value) = object.get(key) else {
+        return Ok(default);
+    };
+    let found = value.as_f32()?;
+    if !(0.0..=1.0).contains(&found) {
+        return Err(GltfError::FactorOutOfRange { field: key });
+    }
+    Ok(found)
+}
+
+/// A fixed-length array of factors, each inside the stated range.
+fn factors<const N: usize>(
+    object: Value<'_>,
+    key: &'static str,
+    default: [f32; N],
+) -> Result<[f32; N], GltfError> {
+    let read = numbers::<N>(object, key, default)?;
+    for component in read {
+        if !(0.0..=1.0).contains(&component) {
+            return Err(GltfError::FactorOutOfRange { field: key });
+        }
+    }
+    Ok(read)
+}
+
+/// One texture reference: which texture, and which coordinate set.
+fn texture_ref(object: Value<'_>, key: &str) -> Result<Option<TextureRef>, GltfError> {
+    let Some(info) = object.get(key) else {
+        return Ok(None);
+    };
+    // **`index` is required on every one of these.** The normal and
+    // occlusion kinds inherit it rather than restating it, which is a
+    // schema arrangement and not a licence to leave it out.
+    Ok(Some(TextureRef {
+        texture: required(info, "index")?.as_u32()? as usize,
+        uv_set: number_or(info, "texCoord", 0)? as usize,
+    }))
+}
+
+/// Read the document's materials, in the vocabulary glTF states them.
+///
+/// A material object has no required members, so an empty one is legal
+/// and means every default — which is why this reads defaults rather
+/// than refusing absence.
+///
+/// # Errors
+///
+/// A [`GltfError`] naming the member that was the wrong type, named a
+/// texture without saying which, spelled an alpha mode this format does
+/// not have, or carried a factor outside the range stated for it.
+pub fn materials(root: Value<'_>) -> Result<Vec<Material>, GltfError> {
+    let Some(table) = root.get("materials") else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::new();
+    for entry in table.elements().map_err(GltfError::Document)? {
+        let pbr = entry.get("pbrMetallicRoughness");
+        let shading = pbr.unwrap_or(entry);
+
+        // **The alpha mode carries its cutoff or it does not.** The
+        // document states the number whatever the mode is; putting it on
+        // the one variant that uses it is what stops a caller reading a
+        // threshold that means nothing.
+        let alpha = match entry.get("alphaMode") {
+            None => Alpha::Opaque,
+            Some(mode) => {
+                let spelled = mode.as_str()?.decode();
+                match spelled.as_str() {
+                    "OPAQUE" => Alpha::Opaque,
+                    "BLEND" => Alpha::Blend,
+                    "MASK" => Alpha::Mask {
+                        // Bounded below by zero and above by nothing,
+                        // which is what the schema states.
+                        cutoff: match entry.get("alphaCutoff") {
+                            None => 0.5,
+                            Some(value) => {
+                                let found = value.as_f32()?;
+                                if found < 0.0 || !found.is_finite() {
+                                    return Err(GltfError::FactorOutOfRange {
+                                        field: "alphaCutoff",
+                                    });
+                                }
+                                found
+                            }
+                        },
+                    },
+                    _ => {
+                        return Err(GltfError::Unsupported { found: "alphaMode" });
+                    }
+                }
+            }
+        };
+
+        out.push(Material {
+            name: match entry.get("name") {
+                None => None,
+                Some(value) => Some(value.as_str()?.decode()),
+            },
+            base_color: if pbr.is_some() {
+                factors(shading, "baseColorFactor", [1.0; 4])?
+            } else {
+                [1.0; 4]
+            },
+            metallic: if pbr.is_some() {
+                factor(shading, "metallicFactor", 1.0)?
+            } else {
+                1.0
+            },
+            roughness: if pbr.is_some() {
+                factor(shading, "roughnessFactor", 1.0)?
+            } else {
+                1.0
+            },
+            emissive: factors(entry, "emissiveFactor", [0.0; 3])?,
+            alpha,
+            double_sided: match entry.get("doubleSided") {
+                None => false,
+                Some(value) => value.as_bool()?,
+            },
+            base_color_map: if pbr.is_some() {
+                texture_ref(shading, "baseColorTexture")?
+            } else {
+                None
+            },
+            metallic_roughness_map: if pbr.is_some() {
+                texture_ref(shading, "metallicRoughnessTexture")?
+            } else {
+                None
+            },
+            normal_map: match texture_ref(entry, "normalTexture")? {
+                None => None,
+                Some(map) => Some(NormalTexture {
+                    map,
+                    // Unbounded: the schema states no range for it.
+                    scale: match entry
+                        .get("normalTexture")
+                        .and_then(|info| info.get("scale"))
+                    {
+                        None => 1.0,
+                        Some(value) => value.as_f32()?,
+                    },
+                }),
+            },
+            occlusion_map: match texture_ref(entry, "occlusionTexture")? {
+                None => None,
+                Some(map) => Some(OcclusionTexture {
+                    map,
+                    strength: match entry.get("occlusionTexture") {
+                        None => 1.0,
+                        Some(info) => factor(info, "strength", 1.0)?,
+                    },
+                }),
+            },
+            emissive_map: texture_ref(entry, "emissiveTexture")?,
+        });
+    }
+    Ok(out)
+}
+
+/// Which material a primitive names, if it names one.
+///
+/// **Reported rather than stored.** A [`Mesh`] carries geometry and has
+/// nowhere to put a material index; giving it one would change the
+/// canonical form, its version question and everything that reads it, for
+/// a value nothing in this engine can yet use. A caller that wants the
+/// pairing asks for it here.
+///
+/// # Errors
+///
+/// A [`GltfError`] naming the table an index missed, or the member that
+/// was the wrong type.
+pub fn primitive_material(
+    root: Value<'_>,
+    mesh: usize,
+    index: usize,
+) -> Result<Option<usize>, GltfError> {
+    let entry_row = entry(root.get("meshes"), "meshes", mesh)?;
+    let found = entry(entry_row.get("primitives"), "primitives", index)?;
+    match found.get("material") {
+        None => Ok(None),
+        Some(value) => Ok(Some(value.as_u32()? as usize)),
+    }
 }
 
 /// Read the document's accessors.

--- a/crates/mesh/src/gltf.rs
+++ b/crates/mesh/src/gltf.rs
@@ -192,8 +192,10 @@ pub enum GltfError {
     /// trade rather than an oversight: a factor is a float, this
     /// vocabulary is compared for equality, and a float would cost every
     /// refusal in it that property — including the geometry ones,
-    /// which have no materials in them at all. The message states the
-    /// range, and the member names where to look.
+    /// which have no materials in them at all. The message says the value
+    /// left its range; **the member is what says which range that was**,
+    /// because they differ -- the factors are bounded at both ends and
+    /// the alpha cutoff only below.
     ///
     /// Refused rather than clamped, unlike the material library's
     /// specular exponent, and the two differ because the formats do: that
@@ -202,6 +204,20 @@ pub enum GltfError {
     FactorOutOfRange {
         /// Which member, spelled as the document spells it.
         field: &'static str,
+    },
+
+    /// An alpha mode this format does not define.
+    ///
+    /// **Its own refusal rather than [`Unsupported`](Self::Unsupported),
+    /// because that one would say something false.** `Unsupported` means
+    /// the construct is in the format and not in this reader, and tells
+    /// a caller to convert the file; an alpha mode the format does not
+    /// define is the other way round — the reader knows the member,
+    /// the document's value is not one of the three, and the fix is a
+    /// repair rather than a conversion.
+    UnknownAlphaMode {
+        /// What the document spelled, so the message can show it.
+        found: Box<str>,
     },
 
     /// A node that is its own ancestor, or that two parents claim.
@@ -259,6 +275,7 @@ impl GltfError {
             Self::WrongMediaType { .. } => "WrongMediaType",
             Self::BufferTooShort { .. } => "BufferTooShort",
             Self::FactorOutOfRange { .. } => "FactorOutOfRange",
+            Self::UnknownAlphaMode { .. } => "UnknownAlphaMode",
             Self::NodeCycle { .. } => "NodeCycle",
             Self::Unsupported { .. } => "Unsupported",
         }
@@ -304,6 +321,10 @@ impl core::fmt::Display for GltfError {
             } => write!(
                 f,
                 "buffer {buffer} declares {declared} bytes and its resource holds {available}"
+            ),
+            Self::UnknownAlphaMode { found } => write!(
+                f,
+                "`{found}` is not one of the three alpha modes this format defines"
             ),
             Self::FactorOutOfRange { field } => {
                 write!(f, "`{field}` is outside the range the format states for it")
@@ -519,121 +540,201 @@ pub fn buffers<'a>(
     Ok(out)
 }
 
-/// A number that must sit inside the range the format states.
-fn factor(object: Value<'_>, key: &'static str, default: f32) -> Result<f32, GltfError> {
+/// A number the format bounds, checked at the width the document wrote
+/// it in.
+///
+/// **Narrowing first would clamp where this crate promises to refuse.**
+/// A `f64` one unit in the last place above the bound narrows to exactly
+/// the bound in `f32`, so a check after the conversion cannot see it: the
+/// document's value is out of range and the caller is handed the limit
+/// with no word said. Checked wide, then narrowed.
+fn bounded(
+    object: Value<'_>,
+    key: &'static str,
+    default: f32,
+    low: f64,
+    high: f64,
+) -> Result<f32, GltfError> {
     let Some(value) = object.get(key) else {
         return Ok(default);
     };
-    let found = value.as_f32()?;
-    if !(0.0..=1.0).contains(&found) {
+    let found = value.as_f64()?;
+    if !(low..=high).contains(&found) {
         return Err(GltfError::FactorOutOfRange { field: key });
     }
-    Ok(found)
+    // The layer below refuses a number that is not finite, so anything
+    // that reaches here narrows to a real value.
+    Ok(value.as_f32()?)
+}
+
+/// A factor in `0..=1`, which is the range the schema states for all of
+/// them.
+fn factor(object: Value<'_>, key: &'static str, default: f32) -> Result<f32, GltfError> {
+    bounded(object, key, default, 0.0, 1.0)
 }
 
 /// A fixed-length array of factors, each inside the stated range.
+///
+/// **The length is exact, not a minimum.** The schema states `minItems`
+/// and `maxItems` as the same number, so a longer array is a document
+/// that does not conform — and reading the first few and dropping the
+/// rest would hide whatever the tail said, including a value the reader
+/// would have refused.
 fn factors<const N: usize>(
     object: Value<'_>,
     key: &'static str,
     default: [f32; N],
 ) -> Result<[f32; N], GltfError> {
-    let read = numbers::<N>(object, key, default)?;
-    for component in read {
-        if !(0.0..=1.0).contains(&component) {
+    let Some(array) = object.get(key) else {
+        return Ok(default);
+    };
+    let found = array.elements().map_err(GltfError::Document)?;
+    let mut out = default;
+    let mut seen = 0;
+    for value in found {
+        let Some(slot) = out.get_mut(seen) else {
+            return Err(GltfError::FactorOutOfRange { field: key });
+        };
+        let wide = value.as_f64()?;
+        if !(0.0..=1.0).contains(&wide) {
             return Err(GltfError::FactorOutOfRange { field: key });
         }
+        *slot = value.as_f32()?;
+        seen += 1;
     }
-    Ok(read)
+    if seen != N {
+        return Err(GltfError::FactorOutOfRange { field: key });
+    }
+    Ok(out)
 }
 
 /// One texture reference: which texture, and which coordinate set.
-fn texture_ref(object: Value<'_>, key: &str) -> Result<Option<TextureRef>, GltfError> {
+///
+/// **The index is not resolved here.** This reader does not read the
+/// `textures` table, so the number is checked against the table's length
+/// and no further — which is the most that can be said about it
+/// without a reader for what it points at.
+fn texture_ref(
+    root: Value<'_>,
+    object: Value<'_>,
+    key: &str,
+) -> Result<Option<TextureRef>, GltfError> {
     let Some(info) = object.get(key) else {
         return Ok(None);
     };
+    Ok(Some(named(root, info)?))
+}
+
+/// The same, for an info object the caller already holds.
+fn named(root: Value<'_>, info: Value<'_>) -> Result<TextureRef, GltfError> {
+    info.entries().map_err(GltfError::Document)?;
+
     // **`index` is required on every one of these.** The normal and
     // occlusion kinds inherit it rather than restating it, which is a
     // schema arrangement and not a licence to leave it out.
-    Ok(Some(TextureRef {
-        texture: required(info, "index")?.as_u32()? as usize,
-        uv_set: number_or(info, "texCoord", 0)? as usize,
-    }))
+    let texture = required(info, "index")?.as_u32()?;
+    let rows = root.get("textures").map_or(0, Value::len);
+    if texture as usize >= rows {
+        return Err(GltfError::NoSuchEntry {
+            table: "textures",
+            index: texture as usize,
+            count: rows,
+        });
+    }
+
+    Ok(TextureRef {
+        texture,
+        uv_set: number_or(info, "texCoord", 0)?,
+    })
 }
 
 /// Read the document's materials, in the vocabulary glTF states them.
 ///
 /// A material object has no required members, so an empty one is legal
 /// and means every default — which is why this reads defaults rather
-/// than refusing absence.
+/// than refusing absence. It must still *be* an object: a number where a
+/// material belongs is not a material that said nothing.
 ///
 /// # Errors
 ///
-/// A [`GltfError`] naming the member that was the wrong type, named a
-/// texture without saying which, spelled an alpha mode this format does
-/// not have, or carried a factor outside the range stated for it.
+/// A [`GltfError`]: `Document` when the table, a material, its shading
+/// half or a map is the wrong kind; `MissingField` when a map names no
+/// texture; `NoSuchEntry` when it names one the document does not have;
+/// `UnknownAlphaMode` for a mode the format does not define;
+/// `FactorOutOfRange` for a factor outside the range stated for it or a
+/// colour with the wrong number of components; and `Geometry` carrying
+/// [`MeshError::TooLarge`] when the table is past this reader's ceiling.
 pub fn materials(root: Value<'_>) -> Result<Vec<Material>, GltfError> {
     let Some(table) = root.get("materials") else {
         return Ok(Vec::new());
     };
 
-    let mut out = Vec::new();
+    // Sized from what was parsed, not from a number the document
+    // declared -- a material is a wide row and doubling into it
+    // copies twice the table before it settles.
+    let mut out = Vec::with_capacity(table.len());
     for entry in table.elements().map_err(GltfError::Document)? {
-        let pbr = entry.get("pbrMetallicRoughness");
-        let shading = pbr.unwrap_or(entry);
+        // **A material is an object.** `Value::get` answers `None` for
+        // every member of a number, a string or an array, so a table of
+        // those would read as a table of materials that each said
+        // nothing -- and this reader's own rule would then hand back a
+        // full default material for a document that described none.
+        entry.entries().map_err(GltfError::Document)?;
 
-        // **The alpha mode carries its cutoff or it does not.** The
-        // document states the number whatever the mode is; putting it on
-        // the one variant that uses it is what stops a caller reading a
-        // threshold that means nothing.
+        // **The ceiling this crate's amplification rule asks for.** A
+        // two-byte array element is a whole material, so a document far
+        // under the geometry ceiling can ask for more than it.
+        if out.len() >= crate::MAX_MATERIALS {
+            return Err(GltfError::Geometry(MeshError::TooLarge {
+                field: "materials",
+                value: crate::MAX_MATERIALS as u64,
+            }));
+        }
+
+        // **Read whatever the mode, kept only where it means something.**
+        // The schema bounds the cutoff whether or not the mode uses it,
+        // and forbids it outright when no mode is named -- so validating
+        // it inside the masked arm alone would let two non-conformant
+        // shapes through.
+        let cutoff = bounded(entry, "alphaCutoff", 0.5, 0.0, f64::INFINITY)?;
         let alpha = match entry.get("alphaMode") {
-            None => Alpha::Opaque,
+            None => {
+                if entry.get("alphaCutoff").is_some() {
+                    return Err(GltfError::FactorOutOfRange {
+                        field: "alphaCutoff",
+                    });
+                }
+                Alpha::Opaque
+            }
             Some(mode) => {
-                let spelled = mode.as_str()?.decode();
-                match spelled.as_str() {
-                    "OPAQUE" => Alpha::Opaque,
-                    "BLEND" => Alpha::Blend,
-                    "MASK" => Alpha::Mask {
-                        // Bounded below by zero and above by nothing,
-                        // which is what the schema states.
-                        cutoff: match entry.get("alphaCutoff") {
-                            None => 0.5,
-                            Some(value) => {
-                                let found = value.as_f32()?;
-                                if found < 0.0 || !found.is_finite() {
-                                    return Err(GltfError::FactorOutOfRange {
-                                        field: "alphaCutoff",
-                                    });
-                                }
-                                found
-                            }
-                        },
-                    },
-                    _ => {
-                        return Err(GltfError::Unsupported { found: "alphaMode" });
-                    }
+                // **Compared without building a string.** The text layer
+                // answers `eq_str` against the document's own bytes,
+                // escapes and all; decoding first would allocate a
+                // `String` per material to compare three constants and
+                // throw it away.
+                let spelled = mode.as_str()?;
+                if spelled.eq_str("OPAQUE") {
+                    Alpha::Opaque
+                } else if spelled.eq_str("BLEND") {
+                    Alpha::Blend
+                } else if spelled.eq_str("MASK") {
+                    Alpha::Mask { cutoff }
+                } else {
+                    // Decoded only on the path that reports it.
+                    return Err(GltfError::UnknownAlphaMode {
+                        found: spelled.decode().into(),
+                    });
                 }
             }
         };
 
-        out.push(Material {
+        let normal = entry.get("normalTexture");
+        let occlusion = entry.get("occlusionTexture");
+
+        let mut material = Material {
             name: match entry.get("name") {
                 None => None,
                 Some(value) => Some(value.as_str()?.decode()),
-            },
-            base_color: if pbr.is_some() {
-                factors(shading, "baseColorFactor", [1.0; 4])?
-            } else {
-                [1.0; 4]
-            },
-            metallic: if pbr.is_some() {
-                factor(shading, "metallicFactor", 1.0)?
-            } else {
-                1.0
-            },
-            roughness: if pbr.is_some() {
-                factor(shading, "roughnessFactor", 1.0)?
-            } else {
-                1.0
             },
             emissive: factors(entry, "emissiveFactor", [0.0; 3])?,
             alpha,
@@ -641,47 +742,52 @@ pub fn materials(root: Value<'_>) -> Result<Vec<Material>, GltfError> {
                 None => false,
                 Some(value) => value.as_bool()?,
             },
-            base_color_map: if pbr.is_some() {
-                texture_ref(shading, "baseColorTexture")?
-            } else {
-                None
-            },
-            metallic_roughness_map: if pbr.is_some() {
-                texture_ref(shading, "metallicRoughnessTexture")?
-            } else {
-                None
-            },
-            normal_map: match texture_ref(entry, "normalTexture")? {
+            // **Fetched once each.** A member lookup walks the whole
+            // object, so asking for the same one twice -- as reading the
+            // map and then its scale off it separately would -- pays for
+            // the walk twice per material.
+            normal_map: match normal {
                 None => None,
-                Some(map) => Some(NormalTexture {
-                    map,
+                Some(info) => Some(NormalTexture {
+                    map: named(root, info)?,
                     // Unbounded: the schema states no range for it.
-                    scale: match entry
-                        .get("normalTexture")
-                        .and_then(|info| info.get("scale"))
-                    {
+                    scale: match info.get("scale") {
                         None => 1.0,
                         Some(value) => value.as_f32()?,
                     },
                 }),
             },
-            occlusion_map: match texture_ref(entry, "occlusionTexture")? {
+            occlusion_map: match occlusion {
                 None => None,
-                Some(map) => Some(OcclusionTexture {
-                    map,
-                    strength: match entry.get("occlusionTexture") {
-                        None => 1.0,
-                        Some(info) => factor(info, "strength", 1.0)?,
-                    },
+                Some(info) => Some(OcclusionTexture {
+                    map: named(root, info)?,
+                    strength: factor(info, "strength", 1.0)?,
                 }),
             },
-            emissive_map: texture_ref(entry, "emissiveTexture")?,
-        });
+            emissive_map: texture_ref(root, entry, "emissiveTexture")?,
+            ..Material::default()
+        };
+
+        // **The shading half, when there is one, and it must be an
+        // object too.** Absent, every member of it keeps the default the
+        // type already carries -- which is why this is one branch rather
+        // than a guard repeated per member.
+        if let Some(shading) = entry.get("pbrMetallicRoughness") {
+            shading.entries().map_err(GltfError::Document)?;
+            material.base_color = factors(shading, "baseColorFactor", [1.0; 4])?;
+            material.metallic = factor(shading, "metallicFactor", 1.0)?;
+            material.roughness = factor(shading, "roughnessFactor", 1.0)?;
+            material.base_color_map = texture_ref(root, shading, "baseColorTexture")?;
+            material.metallic_roughness_map =
+                texture_ref(root, shading, "metallicRoughnessTexture")?;
+        }
+
+        out.push(material);
     }
     Ok(out)
 }
 
-/// Which material a primitive names, if it names one.
+/// Which material each primitive of one mesh names.
 ///
 /// **Reported rather than stored.** A [`Mesh`] carries geometry and has
 /// nowhere to put a material index; giving it one would change the
@@ -689,21 +795,42 @@ pub fn materials(root: Value<'_>) -> Result<Vec<Material>, GltfError> {
 /// a value nothing in this engine can yet use. A caller that wants the
 /// pairing asks for it here.
 ///
+/// **Every primitive in one pass**, rather than one lookup per
+/// primitive. An index into a document array walks that array from its
+/// head, so asking per primitive -- which is what a caller pairing a mesh
+/// with its surfaces does -- costs the square of the count. This is the
+/// same shape `buffer_views` and `accessors` are read in, for the same
+/// reason.
+///
 /// # Errors
 ///
-/// A [`GltfError`] naming the table an index missed, or the member that
-/// was the wrong type.
-pub fn primitive_material(
-    root: Value<'_>,
-    mesh: usize,
-    index: usize,
-) -> Result<Option<usize>, GltfError> {
-    let entry_row = entry(root.get("meshes"), "meshes", mesh)?;
-    let found = entry(entry_row.get("primitives"), "primitives", index)?;
-    match found.get("material") {
-        None => Ok(None),
-        Some(value) => Ok(Some(value.as_u32()? as usize)),
+/// A [`GltfError`] naming the table an index missed, the member that was
+/// the wrong type, or the material the document does not have.
+pub fn primitive_materials(root: Value<'_>, mesh: usize) -> Result<Vec<Option<u32>>, GltfError> {
+    let row = entry(root.get("meshes"), "meshes", mesh)?;
+    let Some(primitives) = row.get("primitives") else {
+        return Ok(Vec::new());
+    };
+    let rows = root.get("materials").map_or(0, Value::len);
+
+    let mut out = Vec::new();
+    for found in primitives.elements().map_err(GltfError::Document)? {
+        out.push(match found.get("material") {
+            None => None,
+            Some(value) => {
+                let named = value.as_u32()?;
+                if named as usize >= rows {
+                    return Err(GltfError::NoSuchEntry {
+                        table: "materials",
+                        index: named as usize,
+                        count: rows,
+                    });
+                }
+                Some(named)
+            }
+        });
     }
+    Ok(out)
 }
 
 /// Read the document's accessors.

--- a/crates/mesh/src/gltf.rs
+++ b/crates/mesh/src/gltf.rs
@@ -684,12 +684,7 @@ pub fn materials(root: Value<'_>) -> Result<Vec<Material>, GltfError> {
         // **The ceiling this crate's amplification rule asks for.** A
         // two-byte array element is a whole material, so a document far
         // under the geometry ceiling can ask for more than it.
-        if out.len() >= crate::MAX_MATERIALS {
-            return Err(GltfError::Geometry(MeshError::TooLarge {
-                field: "materials",
-                value: crate::MAX_MATERIALS as u64,
-            }));
-        }
+        crate::refuse_over_material_ceiling(out.len()).map_err(GltfError::Geometry)?;
 
         // **Read whatever the mode, kept only where it means something.**
         // The schema bounds the cutoff whether or not the mode uses it,

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -130,6 +130,23 @@ const _: () = {
     );
 };
 
+/// Refuse before the next material is built rather than after it.
+///
+/// **The same shape as the geometry ceiling beside it, and separate for
+/// the same reason it is a function at all**: the boundary is worth a
+/// test, and a table of a million materials is not something a test can
+/// build. A caller checks before it pushes, so the count that reaches
+/// here is what has been built and not what a document claimed.
+pub(crate) fn refuse_over_material_ceiling(have: usize) -> Result<(), MeshError> {
+    if have >= MAX_MATERIALS {
+        return Err(MeshError::TooLarge {
+            field: "materials",
+            value: MAX_MATERIALS as u64,
+        });
+    }
+    Ok(())
+}
+
 /// Refuse before the geometry arrives rather than after it.
 ///
 /// `have` is what has been emitted, `adding` what the next face would
@@ -469,7 +486,31 @@ mod tests {
 
 #[cfg(test)]
 mod ceiling_tests {
-    use super::{MAX_POSITIONS, MeshError, refuse_over_ceiling};
+    use super::{
+        MAX_MATERIALS, MAX_POSITIONS, MeshError, refuse_over_ceiling, refuse_over_material_ceiling,
+    };
+
+    /// **The material ceiling refuses at the boundary rather than past
+    /// it**, and it is the amplification rule applied to the other thing
+    /// a document can make this crate allocate.
+    ///
+    /// Probed by deleting the check: red, a table past the ceiling is
+    /// accepted. Probed by loosening `>=` to `>`: red, the table that
+    /// exactly fills the ceiling is allowed one more.
+    #[test]
+    fn the_material_ceiling_refuses_the_row_that_would_pass_it() {
+        refuse_over_material_ceiling(MAX_MATERIALS - 1)
+            .expect("the last row the ceiling allows is not over it");
+
+        assert_eq!(
+            refuse_over_material_ceiling(MAX_MATERIALS),
+            Err(MeshError::TooLarge {
+                field: "materials",
+                value: MAX_MATERIALS as u64,
+            }),
+            "the row after the last one is over the ceiling, and it says so by name"
+        );
+    }
 
     /// **The ceiling is on the product, and it refuses at the boundary
     /// rather than past it.**

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -93,6 +93,21 @@ pub mod stl;
 /// danger, not allocation.
 pub(crate) const MAX_GEOMETRY_BYTES: usize = 256 << 20;
 
+/// How many materials one file may build.
+///
+/// **The same policy ceiling, applied to the other thing a document can
+/// make this crate allocate.** `MAX_GEOMETRY_BYTES` exists because a
+/// megabyte of legitimate input built fifty-eight megabytes of geometry,
+/// and the rule it states is general: amplification is the danger, not
+/// allocation. A material table amplifies harder than geometry does —
+/// a two-byte array element with no members at all is a whole material,
+/// every field of it a default — so a document a fraction of the
+/// geometry ceiling's size could pass it without this.
+///
+/// Expressed as a count rather than a byte total because a material is a
+/// fixed size and a count is what the reader has to hand when it decides.
+pub(crate) const MAX_MATERIALS: usize = MAX_GEOMETRY_BYTES / core::mem::size_of::<pbr::Material>();
+
 /// How many positions that ceiling allows.
 pub(crate) const MAX_POSITIONS: usize = MAX_GEOMETRY_BYTES / core::mem::size_of::<[f32; 3]>();
 
@@ -145,7 +160,12 @@ pub use accessor::{Accessor, AccessorError, BufferView, Component, Shape};
 pub use data_uri::{DataUri, DataUriError};
 pub use error::MeshError;
 pub use glb::{Container, GlbError};
-pub use pbr::{Alpha, Material, NormalTexture, OcclusionTexture, TextureRef};
+// **`Material` is deliberately not re-exported here.** Two vocabularies
+// carry that name in this crate -- `pbr::Material` and `mtl::Material` --
+// and hoisting either to the crate root would make it the default
+// spelling of a word the two formats do not share a meaning for. The
+// module path is the disambiguation, and it is a short one.
+pub use pbr::{Alpha, NormalTexture, OcclusionTexture, TextureRef};
 pub use primitive::{Mode, Primitive};
 
 /// Triangles read out of a file, in the order the file stored them.

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -64,6 +64,7 @@ pub mod glb;
 pub mod gltf;
 pub mod mtl;
 pub mod obj;
+pub mod pbr;
 pub mod place;
 pub mod ply;
 pub mod primitive;
@@ -144,6 +145,7 @@ pub use accessor::{Accessor, AccessorError, BufferView, Component, Shape};
 pub use data_uri::{DataUri, DataUriError};
 pub use error::MeshError;
 pub use glb::{Container, GlbError};
+pub use pbr::{Alpha, Material, NormalTexture, OcclusionTexture, TextureRef};
 pub use primitive::{Mode, Primitive};
 
 /// Triangles read out of a file, in the order the file stored them.

--- a/crates/mesh/src/pbr.rs
+++ b/crates/mesh/src/pbr.rs
@@ -1,0 +1,211 @@
+//! The material vocabulary glTF uses, which is not the one a material
+//! library uses.
+//!
+//! **There are two material models in this crate and they are not two
+//! spellings of one thing.** A material library carries the Phong
+//! vocabulary — ambient, diffuse, specular, a specular exponent — because
+//! that is what the format stores, and [`crate::mtl::Material`] holds it.
+//! A glTF material is metallic-roughness: a base colour, how metallic the
+//! surface is, how rough, and a set of maps that modulate those. The two
+//! describe surfaces in genuinely different terms.
+//!
+//! # Why they are not merged, and never converted
+//!
+//! Every mapping between the two in circulation is a heuristic. There is
+//! no specular exponent that *is* a roughness; there is a formula
+//! somebody found acceptable for their renderer. A reader that applied
+//! one would hand back a material no file contained, which is the thing
+//! this crate refuses to do everywhere else:
+//!
+//! > **Empty rather than computed.** Deriving a normal here would put a
+//! > value in the array that the file did not contain, and a caller
+//! > cannot then tell what the exporter said from what this crate
+//! > guessed.
+//!
+//! So: two types, each named for the vocabulary it holds, and a caller
+//! that wants one model out of both converts where the conversion can be
+//! seen and argued with.
+//!
+//! # Every member has a default, and they are the format's
+//!
+//! A material object has **no required members at all** — `{}` is a legal
+//! material and means every default. The defaults below are the schema's,
+//! not this crate's convenience, which is why [`Material::default`] is
+//! the answer to an empty object rather than a separate notion of
+//! "unset".
+//!
+//! # Ranges are refused rather than clamped, and that differs from the
+//! material library on purpose
+//!
+//! [`crate::mtl::Material::shininess`] is deliberately not clamped: the
+//! format's usual range is a **convention**, files exceed it, and a
+//! reader that clamped would silently change a material rather than
+//! report one.
+//!
+//! glTF's ranges are not a convention. The schema states `minimum` and
+//! `maximum` on the factors, so a value outside them is a document that
+//! does not conform, and the reader says so and names the member. The two
+//! readers differ because the two formats differ, not because they
+//! disagree about clamping.
+
+/// Which texture a map names, and which coordinate set it reads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextureRef {
+    /// The texture's index in the document's own table.
+    ///
+    /// **Required**, unlike almost everything else here: a map that names
+    /// no texture is not a map.
+    pub texture: usize,
+    /// Which `TEXCOORD_n` attribute to read it with. Zero by default.
+    pub uv_set: usize,
+}
+
+/// A normal map, and how far it leans.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NormalTexture {
+    /// The texture and its coordinate set.
+    pub map: TextureRef,
+    /// The scale applied to the sampled normal's x and y. One by default,
+    /// and **unbounded**: the schema states no range for it.
+    pub scale: f32,
+}
+
+/// An occlusion map, and how strongly it applies.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct OcclusionTexture {
+    /// The texture and its coordinate set.
+    pub map: TextureRef,
+    /// How much of the sampled occlusion to apply, in `0..=1`. One by
+    /// default.
+    pub strength: f32,
+}
+
+/// How a material's alpha is meant to be read.
+///
+/// **Three answers, and the cutoff belongs to exactly one of them.** A
+/// material that is not masked has no cutoff — the format carries the
+/// number regardless, and putting it on the variant that uses it is what
+/// stops a caller reading a threshold that means nothing.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum Alpha {
+    /// The default: the alpha channel is ignored and the surface is
+    /// fully opaque.
+    #[default]
+    Opaque,
+    /// Alpha is a threshold, and this is where it sits.
+    Mask {
+        /// At or above this, the surface is opaque; below it, invisible.
+        /// Half by default, and bounded below by zero with **no upper
+        /// bound** — the schema states only a minimum.
+        cutoff: f32,
+    },
+    /// Alpha composites.
+    Blend,
+}
+
+/// One material, in glTF's own vocabulary.
+///
+/// Every field carries the format's default, so a document that says
+/// nothing about a material gets [`Material::default`] rather than a
+/// refusal — an empty object is legal and means exactly this.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Material {
+    /// What the document called it, if it called it anything.
+    ///
+    /// **Decoration, not identity.** A material library's names are load
+    /// bearing, because that is how a geometry file refers to one; a glTF
+    /// document refers to a material by its index. This is carried so a
+    /// tool can show a person something better than a number.
+    pub name: Option<String>,
+
+    /// Linear multipliers for the base colour, each in `0..=1`.
+    /// `[1.0; 4]` by default.
+    pub base_color: [f32; 4],
+    /// How metallic the surface is, in `0..=1`. One by default.
+    pub metallic: f32,
+    /// How rough the surface is, in `0..=1`. One by default.
+    pub roughness: f32,
+    /// Linear multipliers for the emitted colour, each in `0..=1`. Black
+    /// by default, which is the format's way of saying "emits nothing".
+    pub emissive: [f32; 3],
+
+    /// How to read the alpha channel, and the threshold when that is
+    /// what it is.
+    pub alpha: Alpha,
+    /// Whether the back face is drawn. False by default.
+    pub double_sided: bool,
+
+    /// The base colour map.
+    pub base_color_map: Option<TextureRef>,
+    /// The map carrying metallic in blue and roughness in green.
+    ///
+    /// **One texture, two channels**, which is the format's arrangement
+    /// and not something this crate chose; a reader that split it into
+    /// two would be describing a document that does not exist.
+    pub metallic_roughness_map: Option<TextureRef>,
+    /// The normal map, and its scale.
+    pub normal_map: Option<NormalTexture>,
+    /// The occlusion map, and its strength.
+    pub occlusion_map: Option<OcclusionTexture>,
+    /// The emissive map.
+    pub emissive_map: Option<TextureRef>,
+}
+
+impl Default for Material {
+    /// The format's defaults, which are what an empty material means.
+    fn default() -> Self {
+        Self {
+            name: None,
+            base_color: [1.0; 4],
+            metallic: 1.0,
+            roughness: 1.0,
+            emissive: [0.0; 3],
+            alpha: Alpha::Opaque,
+            double_sided: false,
+            base_color_map: None,
+            metallic_roughness_map: None,
+            normal_map: None,
+            occlusion_map: None,
+            emissive_map: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Alpha, Material};
+
+    /// **The defaults are the format's, and an empty material is them.**
+    ///
+    /// Pinned here rather than left to the reader that builds them,
+    /// because a default that drifts is a material this crate invented
+    /// and nothing would say so.
+    #[expect(
+        clippy::float_cmp,
+        reason = "these are the format's stated defaults, written as literals in both places; a tolerance would let a default drift and still pass, which is the one thing this test exists to prevent"
+    )]
+    #[test]
+    fn the_defaults_are_the_ones_the_format_states() {
+        let material = Material::default();
+        assert_eq!(material.base_color, [1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(material.metallic, 1.0);
+        assert_eq!(material.roughness, 1.0);
+        assert_eq!(material.emissive, [0.0, 0.0, 0.0]);
+        assert_eq!(material.alpha, Alpha::Opaque);
+        assert!(!material.double_sided);
+        assert!(material.name.is_none());
+        assert!(material.base_color_map.is_none());
+        assert!(material.metallic_roughness_map.is_none());
+        assert!(material.normal_map.is_none());
+        assert!(material.occlusion_map.is_none());
+        assert!(material.emissive_map.is_none());
+    }
+
+    /// A cutoff exists only on the variant that uses one.
+    #[test]
+    fn only_a_masked_material_carries_a_cutoff() {
+        assert_eq!(Alpha::default(), Alpha::Opaque);
+        assert_ne!(Alpha::Mask { cutoff: 0.5 }, Alpha::Blend);
+        assert_ne!(Alpha::Mask { cutoff: 0.5 }, Alpha::Mask { cutoff: 0.25 });
+    }
+}

--- a/crates/mesh/src/pbr.rs
+++ b/crates/mesh/src/pbr.rs
@@ -6,8 +6,14 @@
 //! vocabulary — ambient, diffuse, specular, a specular exponent — because
 //! that is what the format stores, and [`crate::mtl::Material`] holds it.
 //! A glTF material is metallic-roughness: a base colour, how metallic the
-//! surface is, how rough, and a set of maps that modulate those. The two
-//! describe surfaces in genuinely different terms.
+//! surface is, how rough, and a set of maps that modulate those.
+//!
+//! **Parts of the two do line up.** An emissive colour is an emissive
+//! colour in both, and a diffuse colour and a base colour are the same
+//! quantity under two names. It is the specular half that has no
+//! non-heuristic mapping — and a conversion carrying only the members
+//! that do correspond would quietly drop the rest, which is worse than
+//! not converting.
 //!
 //! # Why they are not merged, and never converted
 //!
@@ -44,9 +50,15 @@
 //!
 //! glTF's ranges are not a convention. The schema states `minimum` and
 //! `maximum` on the factors, so a value outside them is a document that
-//! does not conform, and the reader says so and names the member. The two
-//! readers differ because the two formats differ, not because they
-//! disagree about clamping.
+//! does not conform, and the reader says so and names the member —
+//! including the alpha cutoff, which is bounded below whatever the mode
+//! does with it. The two readers differ because the two formats differ,
+//! not because they disagree about clamping.
+//!
+//! **The check happens at the document's own width.** A number a hair
+//! past the bound narrows to exactly the bound, so a reader that
+//! converted first and checked afterwards would clamp while saying it
+//! refuses.
 
 /// Which texture a map names, and which coordinate set it reads.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -55,9 +67,19 @@ pub struct TextureRef {
     ///
     /// **Required**, unlike almost everything else here: a map that names
     /// no texture is not a map.
-    pub texture: usize,
+    ///
+    /// A `u32` because that is what the format's own id type is, and
+    /// because five of these live in every material — widening them
+    /// to a pointer would make the size of a material depend on the
+    /// target, which is a dependency this crate keeps out of its counts.
+    ///
+    /// **Bounded, not resolved.** This crate does not read the `textures`
+    /// table, so the number is checked against that table's length and no
+    /// further: it is known to name a row that exists, and nothing here
+    /// can say what is in it.
+    pub texture: u32,
     /// Which `TEXCOORD_n` attribute to read it with. Zero by default.
-    pub uv_set: usize,
+    pub uv_set: u32,
 }
 
 /// A normal map, and how far it leans.
@@ -83,9 +105,11 @@ pub struct OcclusionTexture {
 /// How a material's alpha is meant to be read.
 ///
 /// **Three answers, and the cutoff belongs to exactly one of them.** A
-/// material that is not masked has no cutoff — the format carries the
-/// number regardless, and putting it on the variant that uses it is what
-/// stops a caller reading a threshold that means nothing.
+/// material that is not masked has no cutoff. The format lets a document
+/// state the number under any mode it declares and requires two of the
+/// three to ignore it — and forbids it outright when no mode is named
+/// at all. Putting it on the variant that uses it is what stops a caller
+/// reading a threshold that means nothing.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum Alpha {
     /// The default: the alpha channel is ignored and the surface is

--- a/crates/mesh/tests/corpus_replay.rs
+++ b/crates/mesh/tests/corpus_replay.rs
@@ -1207,7 +1207,7 @@ fn accessor_census() {
 // beside the crate, where a wedged run is a failed test.
 // ---------------------------------------------------------------------
 
-const GLTF_LOW_WATER: usize = 26;
+const GLTF_LOW_WATER: usize = 32;
 
 /// How many distinct outcomes the glTF seeds must still reach.
 ///
@@ -1363,6 +1363,29 @@ fn the_gltf_corpus_still_covers_what_it_was_recorded_to_cover() {
         readable.iter().any(|bytes| !bytes.starts_with(b"glTF")),
         "every seed that reads is a container, so the shape that carries its own geometry is \
          exercised by nothing"
+    );
+
+    // **Seeds that carry a material.** The geometry path never reads one,
+    // so a corpus without them leaves that table's factors, ranges and
+    // modes attacked by nothing at all -- and no floor above would
+    // notice, because a material changes no geometry.
+    let with_materials = distinct
+        .iter()
+        .filter(|bytes| {
+            gltf::parse(bytes)
+                .is_ok_and(|json| gltf::materials(json.root()).is_ok_and(|read| !read.is_empty()))
+        })
+        .count();
+    assert!(
+        with_materials >= 3,
+        "the corpus holds {with_materials} seeds carrying a material, and the table is reached \
+         only by asking for it"
+    );
+    assert!(
+        distinct.iter().any(|bytes| {
+            gltf::parse(bytes).is_ok_and(|json| gltf::materials(json.root()).is_err())
+        }),
+        "no seed provokes the material layer's own refusals"
     );
 }
 

--- a/crates/mesh/tests/corpus_replay.rs
+++ b/crates/mesh/tests/corpus_replay.rs
@@ -1381,12 +1381,26 @@ fn the_gltf_corpus_still_covers_what_it_was_recorded_to_cover() {
         "the corpus holds {with_materials} seeds carrying a material, and the table is reached \
          only by asking for it"
     );
-    assert!(
-        distinct.iter().any(|bytes| {
-            gltf::parse(bytes).is_ok_and(|json| gltf::materials(json.root()).is_err())
-        }),
-        "no seed provokes the material layer's own refusals"
-    );
+    // **Each refusal by name, not one of them.** A floor asking only
+    // that *some* seed is refused is met by any one of the three, so two
+    // could be deleted and the corpus would still pass while covering a
+    // third of what it was recorded for.
+    let material_refusals: BTreeSet<&'static str> = distinct
+        .iter()
+        .filter_map(|bytes| {
+            gltf::parse(bytes)
+                .ok()
+                .and_then(|json| gltf::materials(json.root()).err())
+                .map(|refusal| refusal.name())
+        })
+        .collect();
+    for required in ["FactorOutOfRange", "UnknownAlphaMode", "MissingField"] {
+        assert!(
+            material_refusals.contains(required),
+            "no committed seed provokes the material layer's `{required}`. Reached: \
+             {material_refusals:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/mesh/tests/gltf.rs
+++ b/crates/mesh/tests/gltf.rs
@@ -1152,6 +1152,44 @@ fn a_cutoff_is_checked_whatever_the_mode_names() {
     );
 }
 
+/// **A map that states no scale or strength takes the format's
+/// default.**
+///
+/// The whole-material fixture states both, so the branch that supplies
+/// the default was reached by nothing -- and a default that drifted
+/// would be a value this crate invented with nothing to say so.
+#[expect(
+    clippy::float_cmp,
+    reason = "these are the format's stated defaults, written as literals in both places and reached without arithmetic; a tolerance would let a default drift onto a neighbouring value and still pass, which is the one thing this test exists to prevent"
+)]
+#[test]
+fn a_map_that_states_no_scale_or_strength_takes_the_default() {
+    let json = document(
+        r#"{ "textures": [{}], "materials": [{
+          "normalTexture": { "index": 0 },
+          "occlusionTexture": { "index": 0 }
+        }] }"#,
+    );
+    let read = gltf::materials(json.root()).expect("two maps");
+    let normal = read[0].normal_map.expect("a normal map");
+    let occlusion = read[0].occlusion_map.expect("an occlusion map");
+    assert_eq!(normal.scale, 1.0, "an absent scale is one");
+    assert_eq!(occlusion.strength, 1.0, "an absent strength is one");
+}
+
+/// **A mesh with no primitives pairs with nothing**, which is not a
+/// refusal: the format allows the member to be absent and a mesh that
+/// draws nothing names no material.
+#[test]
+fn a_mesh_with_no_primitives_pairs_with_nothing() {
+    let json = document(r#"{ "meshes": [{ "name": "empty" }] }"#);
+    assert!(
+        gltf::primitive_materials(json.root(), 0)
+            .expect("a mesh that draws nothing")
+            .is_empty()
+    );
+}
+
 /// **A map naming a texture the document does not have is refused.**
 ///
 /// The index is not resolved here -- this reader does not read the

--- a/crates/mesh/tests/gltf.rs
+++ b/crates/mesh/tests/gltf.rs
@@ -523,11 +523,13 @@ fn gltf_cannot_reach(refusal: &GltfError) -> Option<&'static str> {
         | GltfError::NoBinaryChunk
         | GltfError::WrongMediaType { .. }
         | GltfError::BufferTooShort { .. }
-        | GltfError::FactorOutOfRange { .. } => None,
+        | GltfError::FactorOutOfRange { .. }
+        | GltfError::UnknownAlphaMode { .. } => None,
     }
 }
 
-/// The buffer layer's refusals, each provoked by a document.
+/// The refusals split out of the census below, each provoked by a
+/// document: the buffer layer's five, and the material layer's two.
 ///
 /// Split out of the census below rather than listed inside it: five
 /// refusals arrived at once when a document learned to read more than
@@ -570,6 +572,11 @@ fn buffer_provocations() -> Vec<(&'static str, GltfError)> {
                 Some(&[1, 2, 3, 4]),
             )
             .expect_err("four bytes are not sixteen"),
+        ),
+        (
+            "UnknownAlphaMode",
+            gltf::materials(document(r#"{ "materials": [{ "alphaMode": "DITHER" }] }"#).root())
+                .expect_err("there are three modes"),
         ),
         (
             "FactorOutOfRange",
@@ -883,7 +890,9 @@ fn a_document_with_no_materials_has_none() {
 #[test]
 fn a_material_reads_every_member_the_format_states() {
     let json = document(
-        r#"{ "materials": [{
+        r#"{
+          "textures": [{}, {}, {}, {}, {}, {}, {}, {}],
+          "materials": [{
           "name": "brushed",
           "pbrMetallicRoughness": {
             "baseColorFactor": [0.5, 0.25, 0.125, 1.0],
@@ -948,9 +957,11 @@ fn only_a_masked_material_carries_its_cutoff() {
     for (mode, expected) in [
         (r#""alphaMode": "OPAQUE","#, Alpha::Opaque),
         (r#""alphaMode": "BLEND","#, Alpha::Blend),
-        ("", Alpha::Opaque),
     ] {
-        // The cutoff is written in every case; only one mode reports it.
+        // The cutoff is written in both cases and reported in neither.
+        // A third row without any mode used to sit here and read clean;
+        // the format forbids that document, and the test above now says
+        // so instead.
         let text = format!(r#"{{ "materials": [{{ {mode} "alphaCutoff": 0.75 }}] }}"#);
         let json = document(&text);
         let read = gltf::materials(json.root()).expect("a material");
@@ -967,11 +978,198 @@ fn only_a_masked_material_carries_its_cutoff() {
 }
 
 /// An alpha mode this format does not have is refused by name.
+/// **An alpha mode the format does not define is its own refusal, and
+/// it carries what was spelled.**
+///
+/// Not `Unsupported`, which means the construct is in the format and not
+/// in this reader and tells a caller to convert the file. This is the
+/// other way round: the reader knows the member, the document's value is
+/// not one of the three, and the fix is a repair.
 #[test]
 fn an_alpha_mode_the_format_does_not_have_is_refused() {
     let json = document(r#"{ "materials": [{ "alphaMode": "DITHER" }] }"#);
     let refused = gltf::materials(json.root()).expect_err("there are three modes");
-    assert_eq!(refused.name(), "Unsupported");
+    assert_eq!(
+        refused,
+        GltfError::UnknownAlphaMode {
+            found: "DITHER".into()
+        }
+    );
+    assert!(
+        refused.to_string().contains("DITHER"),
+        "the message shows what the document spelled: {refused}"
+    );
+}
+
+/// **A material that is not an object is refused rather than defaulted.**
+///
+/// Every member of a number, a string or an array answers absent, so a
+/// reader that only asked for members would hand back a full default
+/// material for a document that described none at all.
+#[test]
+fn a_material_that_is_not_an_object_is_refused() {
+    for text in [
+        r#"{ "materials": [5] }"#,
+        r#"{ "materials": ["a material"] }"#,
+        r#"{ "materials": [null] }"#,
+        r#"{ "materials": [[]] }"#,
+        r#"{ "materials": [true] }"#,
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root())
+                .expect_err("a material is an object")
+                .name(),
+            "Document",
+            "{text}"
+        );
+    }
+}
+
+/// **The shading half is asked for its kind, not merely its presence.**
+///
+/// A wrong-typed `pbrMetallicRoughness` answers absent to every member,
+/// so testing presence alone would read it as a material that simply
+/// said nothing -- and would hide a factor sitting one wrapper deep that
+/// the reader would otherwise have refused.
+#[test]
+fn a_shading_half_that_is_not_an_object_is_refused() {
+    for text in [
+        r#"{ "materials": [{ "pbrMetallicRoughness": 5 }] }"#,
+        r#"{ "materials": [{ "pbrMetallicRoughness": "x" }] }"#,
+        r#"{ "materials": [{ "pbrMetallicRoughness": null }] }"#,
+        r#"{ "materials": [{ "pbrMetallicRoughness": [{ "metallicFactor": 5 }] }] }"#,
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root())
+                .expect_err("the shading half is an object")
+                .name(),
+            "Document",
+            "{text}"
+        );
+    }
+}
+
+/// **A factor one step past its bound is refused, not snapped onto it.**
+///
+/// The document's number is wider than the one this reader keeps, so a
+/// value a hair above the maximum narrows to exactly the maximum. Checked
+/// at the document's own width, that value is what it is: out of range.
+/// Checked after narrowing, it would be silently clamped -- which is the
+/// behaviour this crate's prose promises it does not have.
+#[test]
+fn a_factor_a_hair_past_its_bound_is_refused_rather_than_snapped() {
+    let json = document(
+        r#"{ "materials": [{ "pbrMetallicRoughness": {
+          "metallicFactor": 1.0000000000001 } }] }"#,
+    );
+    assert_eq!(
+        gltf::materials(json.root()).expect_err("wider than an f32 can see"),
+        GltfError::FactorOutOfRange {
+            field: "metallicFactor"
+        }
+    );
+
+    // And the bounds themselves are inside the range, both ends.
+    for value in ["0.0", "1.0", "-0.0"] {
+        let text = format!(
+            r#"{{ "materials": [{{ "pbrMetallicRoughness": {{
+              "metallicFactor": {value} }} }}] }}"#
+        );
+        let json = document(&text);
+        assert!(
+            gltf::materials(json.root()).is_ok(),
+            "{value} is inside the stated range"
+        );
+    }
+}
+
+/// **A colour is exactly as long as the format states.**
+///
+/// Reading the first few and dropping the rest would hide whatever the
+/// tail said, including a component the reader would have refused.
+#[test]
+fn a_colour_of_the_wrong_length_is_refused() {
+    for (member, text) in [
+        (
+            "baseColorFactor",
+            r#"{ "materials": [{ "pbrMetallicRoughness": {
+              "baseColorFactor": [0.1, 0.2, 0.3, 0.4, 9.0] } }] }"#,
+        ),
+        (
+            "baseColorFactor",
+            r#"{ "materials": [{ "pbrMetallicRoughness": {
+              "baseColorFactor": [0.1, 0.2, 0.3] } }] }"#,
+        ),
+        (
+            "emissiveFactor",
+            r#"{ "materials": [{ "emissiveFactor": [0.1, 0.2, 0.3, 9.0] }] }"#,
+        ),
+        (
+            "emissiveFactor",
+            r#"{ "materials": [{ "emissiveFactor": [0.1, 0.2] }] }"#,
+        ),
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root()).expect_err("the length is exact"),
+            GltfError::FactorOutOfRange { field: member },
+            "{text}"
+        );
+    }
+}
+
+/// **A cutoff is checked whatever the mode, and may not appear without
+/// one.**
+///
+/// The schema bounds it unconditionally and states that it must not be
+/// present when no mode is -- so validating it inside the masked arm
+/// alone would let two non-conformant shapes through.
+#[test]
+fn a_cutoff_is_checked_whatever_the_mode_names() {
+    for text in [
+        r#"{ "materials": [{ "alphaMode": "BLEND", "alphaCutoff": -5.0 }] }"#,
+        r#"{ "materials": [{ "alphaMode": "OPAQUE", "alphaCutoff": -5.0 }] }"#,
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root()).expect_err("the minimum is not conditional"),
+            GltfError::FactorOutOfRange {
+                field: "alphaCutoff"
+            },
+            "{text}"
+        );
+    }
+
+    // And a cutoff with no mode at all is a document the format forbids.
+    let json = document(r#"{ "materials": [{ "alphaCutoff": 0.75 }] }"#);
+    assert_eq!(
+        gltf::materials(json.root()).expect_err("a cutoff needs a mode"),
+        GltfError::FactorOutOfRange {
+            field: "alphaCutoff"
+        }
+    );
+}
+
+/// **A map naming a texture the document does not have is refused.**
+///
+/// The index is not resolved here -- this reader does not read the
+/// texture table -- but it is bounded by it, which is the most that can
+/// be said without a reader for what it points at, and more than passing
+/// the number through.
+#[test]
+fn a_map_naming_a_texture_that_is_not_there_is_refused() {
+    let json =
+        document(r#"{ "textures": [{}], "materials": [{ "emissiveTexture": { "index": 4 } }] }"#);
+    assert_eq!(
+        gltf::materials(json.root()).expect_err("there is one texture"),
+        GltfError::NoSuchEntry {
+            table: "textures",
+            index: 4,
+            count: 1,
+        }
+    );
 }
 
 /// **A factor outside the range the schema states is refused, and the
@@ -1005,7 +1203,7 @@ fn a_factor_outside_its_stated_range_is_refused_naming_it() {
         ),
         (
             "strength",
-            r#"{ "materials": [{ "occlusionTexture": {
+            r#"{ "textures": [{}], "materials": [{ "occlusionTexture": {
               "index": 0, "strength": 3.0 } }] }"#,
         ),
     ] {
@@ -1044,11 +1242,11 @@ fn a_cutoff_is_bounded_below_and_not_above() {
 #[test]
 fn a_map_that_names_no_texture_is_refused() {
     for text in [
-        r#"{ "materials": [{ "pbrMetallicRoughness": {
+        r#"{ "textures": [{}], "materials": [{ "pbrMetallicRoughness": {
           "baseColorTexture": { "texCoord": 1 } } }] }"#,
-        r#"{ "materials": [{ "normalTexture": { "scale": 1.0 } }] }"#,
-        r#"{ "materials": [{ "occlusionTexture": { "strength": 1.0 } }] }"#,
-        r#"{ "materials": [{ "emissiveTexture": {} }] }"#,
+        r#"{ "textures": [{}], "materials": [{ "normalTexture": { "scale": 1.0 } }] }"#,
+        r#"{ "textures": [{}], "materials": [{ "occlusionTexture": { "strength": 1.0 } }] }"#,
+        r#"{ "textures": [{}], "materials": [{ "emissiveTexture": {} }] }"#,
     ] {
         let json = document(text);
         assert_eq!(
@@ -1068,26 +1266,46 @@ fn a_map_that_names_no_texture_is_refused() {
 #[test]
 fn a_primitives_material_is_reported_by_index() {
     let json = document(
-        r#"{ "meshes": [{ "primitives": [
+        r#"{ "materials": [{}, {}, {}], "meshes": [{ "primitives": [
           { "attributes": { "POSITION": 0 }, "material": 2 },
           { "attributes": { "POSITION": 0 } }
         ] }] }"#,
     );
     assert_eq!(
-        gltf::primitive_material(json.root(), 0, 0).expect("a primitive"),
-        Some(2)
+        gltf::primitive_materials(json.root(), 0).expect("one mesh"),
+        vec![Some(2), None],
+        "the second names no material, which is the default material"
     );
+
+    // A mesh the document does not have.
     assert_eq!(
-        gltf::primitive_material(json.root(), 0, 1).expect("a primitive"),
-        None,
-        "a primitive naming no material has none, which is the default material"
-    );
-    assert_eq!(
-        gltf::primitive_material(json.root(), 0, 7).expect_err("there are two"),
+        gltf::primitive_materials(json.root(), 4).expect_err("there is one mesh"),
         GltfError::NoSuchEntry {
-            table: "primitives",
+            table: "meshes",
+            index: 4,
+            count: 1,
+        }
+    );
+}
+
+/// **A primitive naming a material the document does not have is
+/// refused.**
+///
+/// Every other index into a table in this reader is bounded by it, and
+/// the module's own documentation calls a number naming a row that is
+/// not there the commonest thing wrong with a hand-edited document.
+#[test]
+fn a_primitive_naming_a_material_that_is_not_there_is_refused() {
+    let json = document(
+        r#"{ "materials": [{}], "meshes": [{ "primitives": [
+          { "attributes": { "POSITION": 0 }, "material": 7 } ] }] }"#,
+    );
+    assert_eq!(
+        gltf::primitive_materials(json.root(), 0).expect_err("there is one material"),
+        GltfError::NoSuchEntry {
+            table: "materials",
             index: 7,
-            count: 2,
+            count: 1,
         }
     );
 }
@@ -1195,7 +1413,7 @@ fn the_census_and_the_documents_agree() {
         assert!(!named.contains(name), "`{name}` is provoked twice");
         named.push(name);
     }
-    assert_eq!(named.len(), 15, "one provocation per refusal");
+    assert_eq!(named.len(), 16, "one provocation per refusal");
 }
 
 // ---------------------------------------------------------------------

--- a/crates/mesh/tests/gltf.rs
+++ b/crates/mesh/tests/gltf.rs
@@ -11,6 +11,7 @@
 
 use renew_mesh::accessor::{Component, Shape};
 use renew_mesh::gltf::{self, GltfError};
+use renew_mesh::pbr::{Alpha, Material, TextureRef};
 
 // The encoder the seeds and the URI suite share, included the way six
 // other targets include it: a document that embeds its geometry has to
@@ -521,7 +522,8 @@ fn gltf_cannot_reach(refusal: &GltfError) -> Option<&'static str> {
         | GltfError::BufferWithoutSource { .. }
         | GltfError::NoBinaryChunk
         | GltfError::WrongMediaType { .. }
-        | GltfError::BufferTooShort { .. } => None,
+        | GltfError::BufferTooShort { .. }
+        | GltfError::FactorOutOfRange { .. } => None,
     }
 }
 
@@ -568,6 +570,13 @@ fn buffer_provocations() -> Vec<(&'static str, GltfError)> {
                 Some(&[1, 2, 3, 4]),
             )
             .expect_err("four bytes are not sixteen"),
+        ),
+        (
+            "FactorOutOfRange",
+            gltf::materials(
+                document(r#"{ "materials": [{ "emissiveFactor": [0.0, 0.0, 4.0] }] }"#).root(),
+            )
+            .expect_err("four is outside zero to one"),
         ),
         (
             "Payload",
@@ -833,6 +842,256 @@ fn bytes_that_are_neither_shape_are_refused_by_the_document_layer() {
     assert_eq!(refused.name(), "Document");
 }
 
+// ---------------------------------------------------------------------
+// Materials.
+//
+// The vocabulary is glTF's own, and every member of it has a default, so
+// most of what follows is about what a document that says nothing means.
+
+/// **An empty material is every default, because the format says so.**
+///
+/// A material object has no required members at all. A reader that
+/// refused one would be refusing a conformant document, and a reader that
+/// invented values would be reporting a material nobody wrote -- the
+/// defaults are the format's, which is what makes returning them honest.
+#[test]
+fn a_material_that_says_nothing_is_every_default() {
+    let json = document(r#"{ "materials": [{}] }"#);
+    let read = gltf::materials(json.root()).expect("an empty material is a material");
+    assert_eq!(read.len(), 1);
+    assert_eq!(read[0], Material::default());
+}
+
+/// A document with no material table has no materials, which is not a
+/// refusal.
+#[test]
+fn a_document_with_no_materials_has_none() {
+    let json = document(r#"{ "asset": { "version": "2.0" } }"#);
+    assert!(
+        gltf::materials(json.root())
+            .expect("no materials")
+            .is_empty()
+    );
+}
+
+/// **Every member the format states, read into the vocabulary it states
+/// them in.**
+#[expect(
+    clippy::float_cmp,
+    reason = "the claim is that the document's own numbers came back unchanged, and no arithmetic happens between the file and the assertion, so equality with what the file says is exactly what must hold; a tolerance would pass a reader that rounded a factor or read the wrong member"
+)]
+#[test]
+fn a_material_reads_every_member_the_format_states() {
+    let json = document(
+        r#"{ "materials": [{
+          "name": "brushed",
+          "pbrMetallicRoughness": {
+            "baseColorFactor": [0.5, 0.25, 0.125, 1.0],
+            "metallicFactor": 0.75,
+            "roughnessFactor": 0.25,
+            "baseColorTexture": { "index": 3, "texCoord": 1 },
+            "metallicRoughnessTexture": { "index": 4 }
+          },
+          "normalTexture": { "index": 5, "scale": 2.5 },
+          "occlusionTexture": { "index": 6, "strength": 0.5 },
+          "emissiveTexture": { "index": 7 },
+          "emissiveFactor": [0.1, 0.2, 0.3],
+          "alphaMode": "MASK",
+          "alphaCutoff": 0.25,
+          "doubleSided": true
+        }] }"#,
+    );
+    let read = gltf::materials(json.root()).expect("a full material");
+    let material = &read[0];
+
+    assert_eq!(material.name.as_deref(), Some("brushed"));
+    assert_eq!(material.base_color, [0.5, 0.25, 0.125, 1.0]);
+    assert_eq!(material.metallic, 0.75);
+    assert_eq!(material.roughness, 0.25);
+    assert_eq!(material.emissive, [0.1, 0.2, 0.3]);
+    assert_eq!(material.alpha, Alpha::Mask { cutoff: 0.25 });
+    assert!(material.double_sided);
+
+    assert_eq!(
+        material.base_color_map,
+        Some(TextureRef {
+            texture: 3,
+            uv_set: 1
+        })
+    );
+    assert_eq!(
+        material.metallic_roughness_map,
+        Some(TextureRef {
+            texture: 4,
+            uv_set: 0
+        }),
+        "an absent texCoord is the first set, which is the format's default"
+    );
+    let normal = material.normal_map.expect("a normal map");
+    assert_eq!(normal.map.texture, 5);
+    assert_eq!(normal.scale, 2.5, "and its scale is unbounded");
+    let occlusion = material.occlusion_map.expect("an occlusion map");
+    assert_eq!(occlusion.map.texture, 6);
+    assert_eq!(occlusion.strength, 0.5);
+    assert_eq!(
+        material.emissive_map,
+        Some(TextureRef {
+            texture: 7,
+            uv_set: 0
+        })
+    );
+}
+
+/// **A cutoff reaches the caller only on the mode that uses one.**
+#[test]
+fn only_a_masked_material_carries_its_cutoff() {
+    for (mode, expected) in [
+        (r#""alphaMode": "OPAQUE","#, Alpha::Opaque),
+        (r#""alphaMode": "BLEND","#, Alpha::Blend),
+        ("", Alpha::Opaque),
+    ] {
+        // The cutoff is written in every case; only one mode reports it.
+        let text = format!(r#"{{ "materials": [{{ {mode} "alphaCutoff": 0.75 }}] }}"#);
+        let json = document(&text);
+        let read = gltf::materials(json.root()).expect("a material");
+        assert_eq!(read[0].alpha, expected, "{mode}");
+    }
+
+    let json = document(r#"{ "materials": [{ "alphaMode": "MASK" }] }"#);
+    let read = gltf::materials(json.root()).expect("a masked material");
+    assert_eq!(
+        read[0].alpha,
+        Alpha::Mask { cutoff: 0.5 },
+        "an absent cutoff is a half, which is the format's default"
+    );
+}
+
+/// An alpha mode this format does not have is refused by name.
+#[test]
+fn an_alpha_mode_the_format_does_not_have_is_refused() {
+    let json = document(r#"{ "materials": [{ "alphaMode": "DITHER" }] }"#);
+    let refused = gltf::materials(json.root()).expect_err("there are three modes");
+    assert_eq!(refused.name(), "Unsupported");
+}
+
+/// **A factor outside the range the schema states is refused, and the
+/// refusal names the member.**
+///
+/// Refused rather than clamped: clamping would report a material the
+/// document does not contain. The material library's specular exponent
+/// *is* left unclamped, and the two differ because that range is a
+/// convention files exceed while this one is stated by the schema.
+#[test]
+fn a_factor_outside_its_stated_range_is_refused_naming_it() {
+    for (member, text) in [
+        (
+            "baseColorFactor",
+            r#"{ "materials": [{ "pbrMetallicRoughness": {
+              "baseColorFactor": [1.5, 0.0, 0.0, 1.0] } }] }"#,
+        ),
+        (
+            "metallicFactor",
+            r#"{ "materials": [{ "pbrMetallicRoughness": {
+              "metallicFactor": -0.5 } }] }"#,
+        ),
+        (
+            "roughnessFactor",
+            r#"{ "materials": [{ "pbrMetallicRoughness": {
+              "roughnessFactor": 2.0 } }] }"#,
+        ),
+        (
+            "emissiveFactor",
+            r#"{ "materials": [{ "emissiveFactor": [0.0, 0.0, 4.0] }] }"#,
+        ),
+        (
+            "strength",
+            r#"{ "materials": [{ "occlusionTexture": {
+              "index": 0, "strength": 3.0 } }] }"#,
+        ),
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root()).expect_err("outside the stated range"),
+            GltfError::FactorOutOfRange { field: member },
+            "{member}"
+        );
+    }
+}
+
+/// **A cutoff is bounded below and not above**, which is what the schema
+/// states and not a guess about what a renderer wants.
+#[test]
+fn a_cutoff_is_bounded_below_and_not_above() {
+    let json = document(r#"{ "materials": [{ "alphaMode": "MASK", "alphaCutoff": 4.0 }] }"#);
+    let read = gltf::materials(json.root()).expect("no upper bound is stated");
+    assert_eq!(read[0].alpha, Alpha::Mask { cutoff: 4.0 });
+
+    let json = document(r#"{ "materials": [{ "alphaMode": "MASK", "alphaCutoff": -1.0 }] }"#);
+    assert_eq!(
+        gltf::materials(json.root()).expect_err("a minimum is stated"),
+        GltfError::FactorOutOfRange {
+            field: "alphaCutoff"
+        }
+    );
+}
+
+/// **A map that names no texture is not a map.**
+///
+/// `index` is the one required member of a texture reference, and the
+/// normal and occlusion kinds inherit the requirement rather than
+/// restating it -- which is a schema arrangement, not a licence to leave
+/// it out.
+#[test]
+fn a_map_that_names_no_texture_is_refused() {
+    for text in [
+        r#"{ "materials": [{ "pbrMetallicRoughness": {
+          "baseColorTexture": { "texCoord": 1 } } }] }"#,
+        r#"{ "materials": [{ "normalTexture": { "scale": 1.0 } }] }"#,
+        r#"{ "materials": [{ "occlusionTexture": { "strength": 1.0 } }] }"#,
+        r#"{ "materials": [{ "emissiveTexture": {} }] }"#,
+    ] {
+        let json = document(text);
+        assert_eq!(
+            gltf::materials(json.root()).expect_err("a map names a texture"),
+            GltfError::MissingField { path: "index" },
+            "{text}"
+        );
+    }
+}
+
+/// **A primitive's material is reported, not stored.**
+///
+/// Geometry and the surface it wears are two facts, and the canonical
+/// form carries one of them. A caller that wants the pairing asks for it;
+/// putting the index into the geometry would change the stored form for a
+/// value nothing here can yet use.
+#[test]
+fn a_primitives_material_is_reported_by_index() {
+    let json = document(
+        r#"{ "meshes": [{ "primitives": [
+          { "attributes": { "POSITION": 0 }, "material": 2 },
+          { "attributes": { "POSITION": 0 } }
+        ] }] }"#,
+    );
+    assert_eq!(
+        gltf::primitive_material(json.root(), 0, 0).expect("a primitive"),
+        Some(2)
+    );
+    assert_eq!(
+        gltf::primitive_material(json.root(), 0, 1).expect("a primitive"),
+        None,
+        "a primitive naming no material has none, which is the default material"
+    );
+    assert_eq!(
+        gltf::primitive_material(json.root(), 0, 7).expect_err("there are two"),
+        GltfError::NoSuchEntry {
+            table: "primitives",
+            index: 7,
+            count: 2,
+        }
+    );
+}
+
 /// The census and the documents agree, and every refusal says something.
 #[test]
 fn the_census_and_the_documents_agree() {
@@ -936,7 +1195,7 @@ fn the_census_and_the_documents_agree() {
         assert!(!named.contains(name), "`{name}` is provoked twice");
         named.push(name);
     }
-    assert_eq!(named.len(), 14, "one provocation per refusal");
+    assert_eq!(named.len(), 15, "one provocation per refusal");
 }
 
 // ---------------------------------------------------------------------

--- a/fuzz/corpus/gltf_read/material-blended.gltf
+++ b/fuzz/corpus/gltf_read/material-blended.gltf
@@ -1,0 +1,5 @@
+{"asset":{"version":"2.0"},"materials":[{"alphaMode":"BLEND","alphaCutoff":0.75}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-empty.gltf
+++ b/fuzz/corpus/gltf_read/material-empty.gltf
@@ -1,0 +1,5 @@
+{"asset":{"version":"2.0"},"materials":[{}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-factor-out-of-range.gltf
+++ b/fuzz/corpus/gltf_read/material-factor-out-of-range.gltf
@@ -1,0 +1,5 @@
+{"asset":{"version":"2.0"},"materials":[{"emissiveFactor":[0,0,4]}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-map-without-texture.gltf
+++ b/fuzz/corpus/gltf_read/material-map-without-texture.gltf
@@ -1,0 +1,5 @@
+{"asset":{"version":"2.0"},"materials":[{"emissiveTexture":{"texCoord":0}}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-unknown-alpha-mode.gltf
+++ b/fuzz/corpus/gltf_read/material-unknown-alpha-mode.gltf
@@ -1,0 +1,5 @@
+{"asset":{"version":"2.0"},"materials":[{"alphaMode":"DITHER"}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-whole.gltf
+++ b/fuzz/corpus/gltf_read/material-whole.gltf
@@ -1,0 +1,13 @@
+{"asset":{"version":"2.0"},"materials":[{"name":"brushed",
+                "pbrMetallicRoughness":{"baseColorFactor":[0.5,0.25,0.125,1],
+                "metallicFactor":0.75,"roughnessFactor":0.25,
+                "baseColorTexture":{"index":0,"texCoord":1},
+                "metallicRoughnessTexture":{"index":1}},
+                "normalTexture":{"index":2,"scale":2.5},
+                "occlusionTexture":{"index":3,"strength":0.5},
+                "emissiveTexture":{"index":4},"emissiveFactor":[0.1,0.2,0.3],
+                "alphaMode":"MASK","alphaCutoff":0.25,"doubleSided":true}],"scenes":[{"nodes":[0]}],
+"nodes":[{"mesh":0}],"meshes":[{"primitives":[{"attributes":{"POSITION":0}}]}],
+"accessors":[{"bufferView":0,"componentType":5126,"count":3,"type":"VEC3"}],
+"buffers":[{"byteLength":36}],
+"bufferViews":[{"buffer":0,"byteLength":36}]}

--- a/fuzz/corpus/gltf_read/material-whole.gltf
+++ b/fuzz/corpus/gltf_read/material-whole.gltf
@@ -1,4 +1,4 @@
-{"asset":{"version":"2.0"},"materials":[{"name":"brushed",
+{"asset":{"version":"2.0"},"textures":[{},{},{},{},{}],"materials":[{"name":"brushed",
                 "pbrMetallicRoughness":{"baseColorFactor":[0.5,0.25,0.125,1],
                 "metallicFactor":0.75,"roughnessFactor":0.25,
                 "baseColorTexture":{"index":0,"texCoord":1},

--- a/fuzz/fuzz_targets/gltf_read.rs
+++ b/fuzz/fuzz_targets/gltf_read.rs
@@ -36,7 +36,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use renew_mesh::gltf;
+use renew_mesh::{glb, gltf};
 
 fuzz_target!(|data: &[u8]| {
     // **The material table is read from the same bytes, and separately.**
@@ -121,11 +121,21 @@ fuzz_target!(|data: &[u8]| {
 /// bytes: a document may carry materials and no geometry, or the reverse,
 /// and a target that only asked for one would leave the other's
 /// arithmetic unattacked.
+///
+/// **Both shapes, not just the loose document.** An earlier version
+/// parsed the raw bytes, so every container went straight past it -- and
+/// a container is what most of this corpus is, and what most real assets
+/// are. The dispatch here is the reader's own.
 fn materials_answer(data: &[u8]) {
-    // The table is reached through the document rather than the
-    // container, so bytes that are not a document have nothing to say
-    // here and the container's own shape is the geometry path's business.
-    let Ok(json) = gltf::parse(data) else {
+    let container = glb::looks_like(data).then(|| glb::read(data)).transpose();
+    let Ok(container) = container else {
+        // The container layer's own refusals are the geometry half's
+        // business; a malformed wrapper has no document to ask about.
+        return;
+    };
+    let document = container.map_or(data, |read| read.json);
+
+    let Ok(json) = gltf::parse(document) else {
         return;
     };
     let root = json.root();
@@ -151,23 +161,59 @@ fn materials_answer(data: &[u8]) {
             );
         }
 
-        // A cutoff is bounded below and finite; the format states no
-        // upper bound, so none is asserted.
+        // A cutoff is bounded below; the format states no upper bound,
+        // so none is asserted. Nothing asserts it is finite either --
+        // the number layer refuses one that is not, so an assertion here
+        // would be defensive code that reads like safety and checks
+        // nothing.
         if let renew_mesh::pbr::Alpha::Mask { cutoff } = material.alpha {
             assert!(
-                cutoff >= 0.0 && cutoff.is_finite(),
+                cutoff >= 0.0,
                 "a cutoff below the stated minimum reached a caller: {cutoff}"
             );
         }
 
-        // The unbounded ones are still numbers.
-        if let Some(normal) = material.normal_map {
-            assert!(normal.scale.is_finite(), "a normal scale that is not a number");
-        }
         if let Some(occlusion) = material.occlusion_map {
             assert!(
                 (0.0..=1.0).contains(&occlusion.strength),
                 "an occlusion strength outside its stated range"
+            );
+        }
+
+        // **Every index is inside the table it names.** This reader does
+        // not resolve a texture, but it bounds one, and an index past the
+        // table reaching a caller is the fault nothing downstream can
+        // catch.
+        let textures = root.get("textures").map_or(0, renew_json::Value::len);
+        for map in [material.base_color_map, material.metallic_roughness_map]
+            .into_iter()
+            .flatten()
+            .chain(material.normal_map.map(|normal| normal.map))
+            .chain(material.occlusion_map.map(|occlusion| occlusion.map))
+            .chain(material.emissive_map)
+        {
+            assert!(
+                (map.texture as usize) < textures,
+                "a texture index past the table reached a caller: {} of {textures}",
+                map.texture
+            );
+        }
+    }
+
+    // **The pairing, over every mesh the document has.** It takes an
+    // index the caller chooses and reads a table the document controls,
+    // which is exactly the shape worth attacking, and nothing reached it
+    // before.
+    let meshes = root.get("meshes").map_or(0, renew_json::Value::len);
+    for mesh in 0..meshes {
+        let Ok(pairing) = gltf::primitive_materials(root, mesh) else {
+            continue;
+        };
+        for named in pairing.into_iter().flatten() {
+            assert!(
+                (named as usize) < materials.len(),
+                "a material index past the table reached a caller: {named} of {}",
+                materials.len()
             );
         }
     }

--- a/fuzz/fuzz_targets/gltf_read.rs
+++ b/fuzz/fuzz_targets/gltf_read.rs
@@ -39,6 +39,15 @@ use libfuzzer_sys::fuzz_target;
 use renew_mesh::gltf;
 
 fuzz_target!(|data: &[u8]| {
+    // **The material table is read from the same bytes, and separately.**
+    // `read` builds geometry and never looks at a material, so a document
+    // that reaches this target exercises that table only if something
+    // asks for it. Asking here costs one parse and covers a layer the
+    // geometry path cannot reach at all -- including for the inputs that
+    // are refused below, which is where a table this reader must not
+    // trust is likeliest to be.
+    materials_answer(data);
+
     let Ok(mesh) = gltf::read(data) else {
         // A refusal is an answer. Which refusal is the suite's business
         // beside the crate; that the call returned at all is this
@@ -105,3 +114,65 @@ fuzz_target!(|data: &[u8]| {
     let again = gltf::read(data).expect("what read once reads again");
     assert_eq!(again, mesh, "the same bytes read to the same geometry");
 });
+
+/// Read the material table, and hold it to what the format states.
+///
+/// Separate from the geometry above because the two share only their
+/// bytes: a document may carry materials and no geometry, or the reverse,
+/// and a target that only asked for one would leave the other's
+/// arithmetic unattacked.
+fn materials_answer(data: &[u8]) {
+    // The table is reached through the document rather than the
+    // container, so bytes that are not a document have nothing to say
+    // here and the container's own shape is the geometry path's business.
+    let Ok(json) = gltf::parse(data) else {
+        return;
+    };
+    let root = json.root();
+
+    let Ok(materials) = gltf::materials(root) else {
+        return;
+    };
+
+    for material in &materials {
+        // **Every factor the format bounds, still inside its bound.** A
+        // reader that let one through would be handing a renderer a
+        // multiplier the document was refused for stating.
+        for component in material
+            .base_color
+            .iter()
+            .chain(&material.emissive)
+            .chain(core::slice::from_ref(&material.metallic))
+            .chain(core::slice::from_ref(&material.roughness))
+        {
+            assert!(
+                (0.0..=1.0).contains(component),
+                "a factor outside the range the format states reached a caller: {component}"
+            );
+        }
+
+        // A cutoff is bounded below and finite; the format states no
+        // upper bound, so none is asserted.
+        if let renew_mesh::pbr::Alpha::Mask { cutoff } = material.alpha {
+            assert!(
+                cutoff >= 0.0 && cutoff.is_finite(),
+                "a cutoff below the stated minimum reached a caller: {cutoff}"
+            );
+        }
+
+        // The unbounded ones are still numbers.
+        if let Some(normal) = material.normal_map {
+            assert!(normal.scale.is_finite(), "a normal scale that is not a number");
+        }
+        if let Some(occlusion) = material.occlusion_map {
+            assert!(
+                (0.0..=1.0).contains(&occlusion.strength),
+                "an occlusion strength outside its stated range"
+            );
+        }
+    }
+
+    // Reading twice answers the same, as everywhere else here.
+    let again = gltf::materials(root).expect("what read once reads again");
+    assert_eq!(again, materials, "the same bytes read to the same materials");
+}


### PR DESCRIPTION
There are two material models in this crate now, and they are not two spellings of one thing. A material library carries the Phong vocabulary — ambient, diffuse, specular, a specular exponent — because that is what the format stores. A glTF material is metallic-roughness: a base colour, how metallic a surface is, how rough, and the maps that modulate those.

**Nothing converts between them.** Every mapping in circulation is a heuristic — there is no specular exponent that *is* a roughness, only a formula somebody found acceptable for their renderer — and a reader that applied one would hand back a material no file contained. That is what this crate declines to do everywhere else, and the module says so. A caller wanting one model out of both converts where the conversion can be seen.

**Every default is the format's, read from the normative schemas rather than recalled.** Two are easy to get wrong and are pinned by tests: a material object has **no required members**, so an empty one is legal and means every default; and `baseColorFactor`/`emissiveFactor` bound each *item* to `0..=1` rather than the array. `alphaCutoff` is bounded below and **not** above. `index` is required on all three texture-info kinds — the normal and occlusion ones inherit it through `allOf` rather than restating it.

**A factor outside its stated range is refused rather than clamped**, and the refusal names the member. That is the opposite of what this crate does with the material library's specular exponent, and the two differ because the formats do: that range is a convention files exceed, this one is stated by the schema, so clamping would report a material the document does not contain.

The refusal deliberately does **not** carry the offending value. A factor is a float and this error vocabulary is compared for equality, so carrying one would cost every refusal in it that property — including the geometry refusals, which have no materials in them at all. The message states the range and the member says where to look.

**A primitive's material is reported, not stored.** Geometry and the surface it wears are two facts and the canonical form carries one of them; putting an index into a mesh would change the stored form, its version question and everything reading it, for a value nothing in this engine can yet use. `gltf::primitive_material` answers for the pairing instead.

**Attacked in the same row**, per this tree's rule for anything that reads bytes nobody here wrote. The glTF target reads the material table from the same bytes and separately — the geometry path never touches it — and holds whatever it accepts to every bound the format states. Six seeds carry materials in the shapes that decide the answer, with a corpus floor for them and one for a seed that provokes this layer's own refusals, since a material changes no geometry and no existing floor would have noticed their loss.

The wildcard-free refusal census refused to compile until the new refusal was named, which is the third format or vocabulary in a row it has caught.

Local gates: `cargo fmt --all --check` clean, `cargo clippy --workspace --all-targets -D warnings` clean, `cargo test --workspace` **264 suites / 2,966 passed / 0 failed**, `renew check` reports the workspace healthy.
