### PR TITLE
An image is bytes and one name for what they are

### DIFF
--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -65,7 +65,7 @@ is dead code that reads like safety.
 | Mesh blob | `MeshError` | `crates/mesh/src/error.rs` | 8 of the 15 | `blob_read` | 16 |
 | glTF container | `GlbError` | `crates/mesh/src/glb.rs` | 11 | `glb_read` | 18 |
 | Accessor | `AccessorError` | `crates/mesh/src/accessor.rs` | 14 | `accessor_view` | 26 |
-| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 15 | `gltf_read` | 32 |
+| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 17 | `gltf_read` | 39 |
 | Data URI | `DataUriError` | `crates/mesh/src/data_uri.rs` | 7 | `data_uri_read` | 41 |
 
 **The MTL row is the shortest in this table, and that is the honest

--- a/REFUSALS.md
+++ b/REFUSALS.md
@@ -65,7 +65,7 @@ is dead code that reads like safety.
 | Mesh blob | `MeshError` | `crates/mesh/src/error.rs` | 8 of the 15 | `blob_read` | 16 |
 | glTF container | `GlbError` | `crates/mesh/src/glb.rs` | 11 | `glb_read` | 18 |
 | Accessor | `AccessorError` | `crates/mesh/src/accessor.rs` | 14 | `accessor_view` | 26 |
-| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 17 | `gltf_read` | 39 |
+| glTF document | `GltfError` | `crates/mesh/src/gltf.rs` | 17 | `gltf_read` | 41 |
 | Data URI | `DataUriError` | `crates/mesh/src/data_uri.rs` | 7 | `data_uri_read` | 41 |
 
 **The MTL row is the shortest in this table, and that is the honest

--- a/crates/mesh/README.md
+++ b/crates/mesh/README.md
@@ -358,6 +358,29 @@ the surface it wears are two facts, and the canonical form carries one of
 them; `gltf::primitive_material` answers for the pairing without changing
 what a mesh is.
 
+## An image is bytes and one name for what they are
+
+`gltf::images` reads the image table to the bytes a document carried and
+the type it stated for them. **It decodes nothing** — what those bytes
+are is the caller's question, and answering it here would mean an image
+decoder this layer has no need of.
+
+**Exactly one source each.** The format's schema is a `oneOf` over `uri`
+and `bufferView`, so an image names one or the other: both is a document
+contradicting itself, neither describes nothing, and a reader that picked
+between them would be answering a question the document did not settle.
+A `uri` is a payload this reader decodes or a second file it will not
+open — the same pair of answers a buffer's `uri` gets.
+
+**One name for the bytes, not two.** An image may state its type in
+`mimeType`, in its payload's URI, or in both; the format requires one
+beside a view, because a view carries bytes and nothing about them. When
+both are present and differ, the document is refused rather than the
+contradiction being handed on — the same trade the payload decoder
+makes when it refuses a resource two texts could spell. An absent type is
+not a disagreement: a URI may omit one, and that is the document having
+said nothing rather than having said something else.
+
 ## `data:` URIs, and why a decoder is strict about spelling
 
 `data_uri::read` turns a URI whose payload *is* the resource back into

--- a/crates/mesh/README.md
+++ b/crates/mesh/README.md
@@ -206,7 +206,7 @@ the 25 STL seeds, `examples/make_ply_corpus.rs` the 24 PLY ones,
 `examples/make_mtl_corpus.rs` the 21 MTL ones and
 `examples/make_glb_corpus.rs` the 20 container ones and
 `examples/make_accessor_corpus.rs` the 21 accessor ones and
-`examples/make_gltf_corpus.rs` the 26 document-and-container ones; between them
+`examples/make_gltf_corpus.rs` the 43 document-and-container ones; between them
 every committed seed is built here rather than found. **The blob's 25 seeds
 need no such argument at all**, because the format is this crate's own
 and `examples/make_blob_corpus.rs` gets every byte from `blob::write`. **For OBJ that rule bites
@@ -321,7 +321,7 @@ chunk to offer and the other has none.
 
 **Its refusals name the layer that failed**, not just the fault: a
 `GltfError` says whether the container, the document, a buffer, an
-embedded payload, an accessor, a material or the geometry objected, and the inner refusal's own numbers are one call away
+embedded payload, an accessor, a material, an image or the geometry objected, and the inner refusal's own numbers are one call away
 through the value. A caller that only wants geometry can go
 through `format::detect` and then `Format::read`, which wraps the same
 answer in `MeshError`.
@@ -361,7 +361,7 @@ what a mesh is.
 ## An image is bytes and one name for what they are
 
 `gltf::images` reads the image table to the bytes a document carried and
-the type it stated for them. **It decodes nothing** — what those bytes
+the type it stated for them. **It decodes no image** — what those bytes
 are is the caller's question, and answering it here would mean an image
 decoder this layer has no need of.
 

--- a/crates/mesh/examples/make_gltf_corpus.rs
+++ b/crates/mesh/examples/make_gltf_corpus.rs
@@ -332,6 +332,74 @@ fn material_seeds() -> Vec<(String, Vec<u8>)> {
     ]
 }
 
+/// Documents carrying images, which no other seed reaches.
+///
+/// An image table is read only by asking for it, and it is where two
+/// layers meet that otherwise never touch: the buffer bytes an accessor
+/// addresses, and the payload decoding a buffer's own URI uses. These
+/// carry one, in the shapes that decide the answer.
+fn image_seeds() -> Vec<(String, Vec<u8>)> {
+    // **Built from nothing rather than from the geometry document.** A
+    // seed that reused it would carry a buffer wanting a container chunk
+    // it does not have, so every one of these would be refused for a
+    // reason that has nothing to do with images -- and the table they
+    // exist to exercise would never be reached.
+    let with =
+        |images: &str| format!(r#"{{"asset":{{"version":"2.0"}},"images":{images}}}"#).into_bytes();
+
+    // The one shape that needs a buffer carries its own, as a payload,
+    // so it stands alone too.
+    let stored = |images: &str| {
+        format!(
+            r#"{{"asset":{{"version":"2.0"}},
+"buffers":[{{"byteLength":4,"uri":"data:application/octet-stream;base64,AQIDBA=="}}],
+"bufferViews":[{{"buffer":0,"byteLength":4}}],"images":{images}}}"#
+        )
+        .into_bytes()
+    };
+
+    vec![
+        // A payload, which is the self-contained shape.
+        (
+            "image-embedded".to_owned(),
+            with(r#"[{"name":"grain","uri":"data:image/png;base64,AQIDBA=="}]"#),
+        ),
+        // Stored in the document's own buffer, which is the other one --
+        // and the only seed where an image reaches the buffer table.
+        (
+            "image-in-a-view".to_owned(),
+            stored(r#"[{"bufferView":0,"mimeType":"image/png"}]"#),
+        ),
+        // Both sources, which the format's `oneOf` forbids.
+        (
+            "image-two-sources".to_owned(),
+            stored(
+                r#"[{"bufferView":0,"mimeType":"image/png","uri":"data:image/png;base64,AQIDBA=="}]"#,
+            ),
+        ),
+        // Neither.
+        (
+            "image-no-source".to_owned(),
+            with(r#"[{"mimeType":"image/png"}]"#),
+        ),
+        // A view with nothing said about what its bytes are.
+        (
+            "image-view-untyped".to_owned(),
+            stored(r#"[{"bufferView":0}]"#),
+        ),
+        // One resource, two names for it.
+        (
+            "image-type-disagrees".to_owned(),
+            with(r#"[{"mimeType":"image/png","uri":"data:image/jpeg;base64,AQIDBA=="}]"#),
+        ),
+        // A second file, which this crate will not open.
+        (
+            "image-names-a-file".to_owned(),
+            with(r#"[{"uri":"grain.png"}]"#),
+        ),
+    ]
+}
+
 /// One container per refusal, each wrong in exactly one way.
 fn refused_seeds() -> Vec<(String, Vec<u8>)> {
     let mut wrong_magic = container(SIMPLEST, &triangle());
@@ -452,6 +520,7 @@ fn main() -> ExitCode {
         .chain(refused_seeds())
         .chain(document_seeds())
         .chain(material_seeds())
+        .chain(image_seeds())
     {
         // **The extension follows the bytes.** Half these seeds are
         // documents rather than containers, and `.glb` means container

--- a/crates/mesh/examples/make_gltf_corpus.rs
+++ b/crates/mesh/examples/make_gltf_corpus.rs
@@ -335,9 +335,9 @@ fn material_seeds() -> Vec<(String, Vec<u8>)> {
 /// Documents carrying images, which no other seed reaches.
 ///
 /// An image table is read only by asking for it, and it is where two
-/// layers meet that otherwise never touch: the buffer bytes an accessor
-/// addresses, and the payload decoding a buffer's own URI uses. These
-/// carry one, in the shapes that decide the answer.
+/// layers meet under a table with no geometry in it: the buffer bytes an
+/// accessor addresses, and the payload decoding a buffer's own URI uses.
+/// These carry one, in the shapes that decide the answer.
 fn image_seeds() -> Vec<(String, Vec<u8>)> {
     // **Built from nothing rather than from the geometry document.** A
     // seed that reused it would carry a buffer wanting a container chunk
@@ -387,10 +387,26 @@ fn image_seeds() -> Vec<(String, Vec<u8>)> {
             "image-view-untyped".to_owned(),
             stored(r#"[{"bufferView":0}]"#),
         ),
-        // One resource, two names for it.
+        // One resource, two names for it, which is not a refusal: the
+        // one beside the image wins and the payload's carries the bytes.
         (
-            "image-type-disagrees".to_owned(),
-            with(r#"[{"mimeType":"image/png","uri":"data:image/jpeg;base64,AQIDBA=="}]"#),
+            "image-type-differs".to_owned(),
+            with(
+                r#"[{"mimeType":"image/png","uri":"data:application/octet-stream;base64,AQIDBA=="}]"#,
+            ),
+        ),
+        // More than one, which every fixture used to lack.
+        (
+            "image-two".to_owned(),
+            with(
+                r#"[{"uri":"data:image/png;base64,AQIDBA=="},{"uri":"data:image/jpeg;base64,BQYHCA=="}]"#,
+            ),
+        ),
+        // A payload the decoder refuses, reached through an image rather
+        // than through a buffer.
+        (
+            "image-payload-broken".to_owned(),
+            with(r#"[{"uri":"data:image/png;base64,AQID!A=="}]"#),
         ),
         // A second file, which this crate will not open.
         (

--- a/crates/mesh/src/accessor.rs
+++ b/crates/mesh/src/accessor.rs
@@ -632,6 +632,12 @@ impl BufferView {
     /// accessor holds at least one element. A refusal here would be a
     /// second answer to a question already answered better.
     ///
+    /// The glTF reader does refuse one, because its schema states a
+    /// minimum of one and an image is a reader with no accessor over
+    /// its bytes to catch it. That is a rule about a document, though,
+    /// and this type is about a region -- a caller assembling views by
+    /// hand is entitled to an empty one.
+    ///
     /// # Errors
     ///
     /// [`AccessorError::ViewOutOfRange`] when the region is not inside

--- a/crates/mesh/src/gltf.rs
+++ b/crates/mesh/src/gltf.rs
@@ -206,6 +206,34 @@ pub enum GltfError {
         field: &'static str,
     },
 
+    /// An image naming both a file and a view, or neither.
+    ///
+    /// **The format states exactly one.** Its schema is a `oneOf` over
+    /// the two, so an image with both sources is a document that
+    /// contradicts itself and one with neither is a document that
+    /// describes nothing — and a reader that picked, or that returned
+    /// an image with no bytes, would be answering a question the document
+    /// did not settle.
+    ImageSource {
+        /// How many of the two the image named: zero or two, never one.
+        named: usize,
+    },
+
+    /// An image whose two statements of its own type disagree.
+    ///
+    /// A payload carries a media type in its URI, and the image may also
+    /// state one in `mimeType`. When both are there they describe the
+    /// same bytes, so a document where they differ has said two things
+    /// about one resource.
+    ///
+    /// **Refused rather than reported as two answers.** The decoder one
+    /// layer down refuses a payload that two texts could spell, for the
+    /// reason that a resource with two spellings is a resource a caller
+    /// cannot key on; two names for one image is the same fault a level
+    /// up, and pushing the contradiction onto every caller would be
+    /// choosing not to have the argument here.
+    MediaTypeDisagrees,
+
     /// An alpha mode this format does not define.
     ///
     /// **Its own refusal rather than [`Unsupported`](Self::Unsupported),
@@ -276,6 +304,8 @@ impl GltfError {
             Self::BufferTooShort { .. } => "BufferTooShort",
             Self::FactorOutOfRange { .. } => "FactorOutOfRange",
             Self::UnknownAlphaMode { .. } => "UnknownAlphaMode",
+            Self::ImageSource { .. } => "ImageSource",
+            Self::MediaTypeDisagrees => "MediaTypeDisagrees",
             Self::NodeCycle { .. } => "NodeCycle",
             Self::Unsupported { .. } => "Unsupported",
         }
@@ -321,6 +351,15 @@ impl core::fmt::Display for GltfError {
             } => write!(
                 f,
                 "buffer {buffer} declares {declared} bytes and its resource holds {available}"
+            ),
+            Self::ImageSource { named } => write!(
+                f,
+                "an image names {named} of `uri` and `bufferView`, and the format states exactly one"
+            ),
+            Self::MediaTypeDisagrees => write!(
+                f,
+                "an image's `mimeType` and its payload's own media type describe the same bytes \
+                 differently"
             ),
             Self::UnknownAlphaMode { found } => write!(
                 f,
@@ -648,6 +687,128 @@ fn named(root: Value<'_>, info: Value<'_>) -> Result<TextureRef, GltfError> {
     })
 }
 
+/// One image, and what the document says its bytes are.
+///
+/// Borrowed where the bytes are a range of a buffer, owned where a
+/// payload had to be decoded into them — the same split the buffers
+/// table makes, for the same reason.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Image<'a> {
+    /// What the document called it, if it called it anything.
+    pub name: Option<String>,
+    /// The media type the document states for these bytes.
+    ///
+    /// **One answer, not two.** An image may state its type in
+    /// `mimeType`, in its payload's URI, or in both; when both are
+    /// present and differ the document is refused rather than the
+    /// contradiction being handed on.
+    ///
+    /// **Reported, never judged.** Which types are readable is a fact
+    /// about what the caller is doing with the bytes, and this layer
+    /// decodes nothing.
+    pub media_type: String,
+    /// The bytes themselves.
+    pub bytes: Cow<'a, [u8]>,
+}
+
+/// Read the document's images to bytes and the type stated for them.
+///
+/// **Exactly one source each.** The format's schema is a `oneOf` over
+/// `uri` and `bufferView`, so an image names one or the other: both is a
+/// contradiction and neither describes nothing. A `uri` is a payload this
+/// reader decodes or a second file it will not open, which is the same
+/// pair of answers a buffer's `uri` gets.
+///
+/// **Nothing is decoded here.** An image comes back as the bytes a
+/// document carried and the name it gave them; what those bytes are is
+/// the caller's question, and answering it would mean an image decoder
+/// this layer has no need of.
+///
+/// # Errors
+///
+/// A [`GltfError`]: `ImageSource` when an image names both sources or
+/// neither; `MissingField` when a view carries no `mimeType`, which the
+/// format requires there; `MediaTypeDisagrees` when the two statements of
+/// one image's type differ; `ExternalResource` for a second file;
+/// `Payload` when an embedded one will not decode; and `Document` for a
+/// member of the wrong kind.
+pub fn images<'s>(root: Value<'_>, source: &'s Source<'_>) -> Result<Vec<Image<'s>>, GltfError> {
+    let Some(table) = root.get("images") else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::with_capacity(table.len());
+    for entry in table.elements().map_err(GltfError::Document)? {
+        entry.entries().map_err(GltfError::Document)?;
+
+        // Stated beside a view because the format requires it there,
+        // and allowed to be absent beside a URI because the payload
+        // carries one of its own.
+        let declared = match entry.get("mimeType") {
+            None => None,
+            Some(value) => Some(value.as_str()?.decode()),
+        };
+
+        // **The format's `oneOf` is this match.** Written as a count and
+        // a guard instead, one arm would hold a source the guard had
+        // already proved was there, and would reach for it through an
+        // unwrap that cannot fire -- which is the shape this crate keeps
+        // finding in its own defensive code.
+        let (media_type, bytes) = match (entry.get("uri"), entry.get("bufferView")) {
+            (Some(_), Some(_)) => return Err(GltfError::ImageSource { named: 2 }),
+            (None, None) => return Err(GltfError::ImageSource { named: 0 }),
+
+            (None, Some(index)) => {
+                let Some(stated) = declared else {
+                    return Err(GltfError::MissingField { path: "mimeType" });
+                };
+                let bytes = source.view_bytes(index.as_u32()? as usize)?;
+                (stated, Cow::Borrowed(bytes))
+            }
+
+            (Some(uri), None) => {
+                // Escapes first, as a buffer's URI needs: a payload
+                // carries `/` and a document may spell that `\/`.
+                let text = uri.as_str()?.decode();
+                if !data_uri::looks_like(&text) {
+                    return Err(GltfError::ExternalResource);
+                }
+                let payload = data_uri::read(&text).map_err(GltfError::Payload)?;
+                // **An absent type is not a disagreement.** A URI may
+                // omit its media type, and the decoder reports that as
+                // an empty one rather than applying RFC 2397's default,
+                // because the default is a claim the document did not
+                // make. Comparing the absence against a stated type
+                // would turn "said nothing" into "said something else".
+                if !payload.media_type.is_empty()
+                    && declared
+                        .as_ref()
+                        .is_some_and(|stated| stated != payload.media_type)
+                {
+                    return Err(GltfError::MediaTypeDisagrees);
+                }
+                // What the image stated, and the URI's own type when it
+                // stated none. Both may be absent -- the format requires
+                // a type only beside a view -- and then this is empty,
+                // which is the document having said nothing rather than
+                // this reader having decided something.
+                let media_type = declared.unwrap_or_else(|| payload.media_type.to_owned());
+                (media_type, Cow::Owned(payload.bytes))
+            }
+        };
+
+        out.push(Image {
+            name: match entry.get("name") {
+                None => None,
+                Some(value) => Some(value.as_str()?.decode()),
+            },
+            media_type,
+            bytes,
+        });
+    }
+    Ok(out)
+}
+
 /// Read the document's materials, in the vocabulary glTF states them.
 ///
 /// A material object has no required members, so an empty one is legal
@@ -939,6 +1100,21 @@ impl<'a> Source<'a> {
                 index,
                 count: self.buffers.len(),
             })
+    }
+
+    /// The bytes one view addresses, with no accessor over them.
+    ///
+    /// An image stored in the document is a view and a media type: the
+    /// bytes are a whole file rather than a typed stream, so nothing
+    /// here reads elements out of them.
+    ///
+    /// # Errors
+    ///
+    /// A [`GltfError`] naming the table an index missed, or the accessor
+    /// layer's refusal when the view does not fit its buffer.
+    pub fn view_bytes(&self, index: usize) -> Result<&[u8], GltfError> {
+        let (buffer, view) = row(&self.views, "bufferViews", index)?;
+        Ok(view.resolve(self.bytes(buffer)?)?)
     }
 
     /// One accessor and the bytes it addresses.

--- a/crates/mesh/src/gltf.rs
+++ b/crates/mesh/src/gltf.rs
@@ -206,7 +206,7 @@ pub enum GltfError {
         field: &'static str,
     },
 
-    /// An image naming both a file and a view, or neither.
+    /// An image naming both a `uri` and a view, or neither.
     ///
     /// **The format states exactly one.** Its schema is a `oneOf` over
     /// the two, so an image with both sources is a document that
@@ -215,24 +215,14 @@ pub enum GltfError {
     /// an image with no bytes, would be answering a question the document
     /// did not settle.
     ImageSource {
-        /// How many of the two the image named: zero or two, never one.
-        named: usize,
+        /// Whether it named both. False means it named neither.
+        ///
+        /// **A bool rather than a count**, because the count could only
+        /// ever be zero or two and a field with two thirds of its values
+        /// unreachable is a shape this crate argues against everywhere
+        /// else.
+        both: bool,
     },
-
-    /// An image whose two statements of its own type disagree.
-    ///
-    /// A payload carries a media type in its URI, and the image may also
-    /// state one in `mimeType`. When both are there they describe the
-    /// same bytes, so a document where they differ has said two things
-    /// about one resource.
-    ///
-    /// **Refused rather than reported as two answers.** The decoder one
-    /// layer down refuses a payload that two texts could spell, for the
-    /// reason that a resource with two spellings is a resource a caller
-    /// cannot key on; two names for one image is the same fault a level
-    /// up, and pushing the contradiction onto every caller would be
-    /// choosing not to have the argument here.
-    MediaTypeDisagrees,
 
     /// An alpha mode this format does not define.
     ///
@@ -305,7 +295,6 @@ impl GltfError {
             Self::FactorOutOfRange { .. } => "FactorOutOfRange",
             Self::UnknownAlphaMode { .. } => "UnknownAlphaMode",
             Self::ImageSource { .. } => "ImageSource",
-            Self::MediaTypeDisagrees => "MediaTypeDisagrees",
             Self::NodeCycle { .. } => "NodeCycle",
             Self::Unsupported { .. } => "Unsupported",
         }
@@ -352,14 +341,10 @@ impl core::fmt::Display for GltfError {
                 f,
                 "buffer {buffer} declares {declared} bytes and its resource holds {available}"
             ),
-            Self::ImageSource { named } => write!(
+            Self::ImageSource { both } => write!(
                 f,
-                "an image names {named} of `uri` and `bufferView`, and the format states exactly one"
-            ),
-            Self::MediaTypeDisagrees => write!(
-                f,
-                "an image's `mimeType` and its payload's own media type describe the same bytes \
-                 differently"
+                "an image names {} of `uri` and `bufferView`, and the format states exactly one",
+                if *both { "both" } else { "neither" }
             ),
             Self::UnknownAlphaMode { found } => write!(
                 f,
@@ -469,7 +454,18 @@ pub fn buffer_views(root: Value<'_>) -> Result<Vec<(usize, BufferView)>, GltfErr
         // accessor already carries the view it reads through.
         let buffer = required(view, "buffer")?.as_u32()? as usize;
 
+        // **The schema states a minimum of one.** A zero-length view
+        // used to be somebody else's problem: every accessor over an
+        // empty region is refused by the layer below, so nothing needed
+        // the rule here. An image is the first reader with no accessor
+        // over its bytes, and a zero-byte image with a media type is a
+        // thing this reader would otherwise hand back.
         let byte_length = required(view, "byteLength")?.as_u32()?;
+        if byte_length == 0 {
+            return Err(GltfError::FactorOutOfRange {
+                field: "byteLength",
+            });
+        }
         out.push((
             buffer,
             BufferView {
@@ -696,17 +692,28 @@ fn named(root: Value<'_>, info: Value<'_>) -> Result<TextureRef, GltfError> {
 pub struct Image<'a> {
     /// What the document called it, if it called it anything.
     pub name: Option<String>,
-    /// The media type the document states for these bytes.
+    /// The media type the document states for these bytes, if it
+    /// states one.
     ///
-    /// **One answer, not two.** An image may state its type in
-    /// `mimeType`, in its payload's URI, or in both; when both are
-    /// present and differ the document is refused rather than the
-    /// contradiction being handed on.
+    /// **`mimeType` wins when it is there.** An image may state its type
+    /// beside itself, in its payload's URI, or in both. The format makes
+    /// `mimeType` mandatory where it is the only statement there can be,
+    /// and its rule about the other one is that a payload's media type
+    /// must match its *content* — not that the two labels must match
+    /// each other. So the labels are not compared: `mimeType` is the
+    /// document's answer, and the URI's is what is left when it gives
+    /// none.
+    ///
+    /// **`None` is the document having said nothing**, which is not the
+    /// same as `Some("")` — a URI may carry an empty media type, and
+    /// the decoder below reports that rather than applying RFC 2397's
+    /// default, so that a caller needing an explicit type can see there
+    /// was none.
     ///
     /// **Reported, never judged.** Which types are readable is a fact
     /// about what the caller is doing with the bytes, and this layer
     /// decodes nothing.
-    pub media_type: String,
+    pub media_type: Option<String>,
     /// The bytes themselves.
     pub bytes: Cow<'a, [u8]>,
 }
@@ -719,34 +726,68 @@ pub struct Image<'a> {
 /// reader decodes or a second file it will not open, which is the same
 /// pair of answers a buffer's `uri` gets.
 ///
-/// **Nothing is decoded here.** An image comes back as the bytes a
+/// **No image is decoded here.** An image comes back as the bytes a
 /// document carried and the name it gave them; what those bytes are is
 /// the caller's question, and answering it would mean an image decoder
 /// this layer has no need of.
+///
+/// **The tables come first, which couples this to them.** A `Source`
+/// is built from the whole buffer table, so a document whose *geometry*
+/// lives in a second file cannot have its embedded images read even
+/// though they need no buffer at all. That is a real limit rather than
+/// an oversight, and the fix -- resolving a buffer only when something
+/// asks for it -- is a change to how the tables are held rather than to
+/// this function.
 ///
 /// # Errors
 ///
 /// A [`GltfError`]: `ImageSource` when an image names both sources or
 /// neither; `MissingField` when a view carries no `mimeType`, which the
-/// format requires there; `MediaTypeDisagrees` when the two statements of
-/// one image's type differ; `ExternalResource` for a second file;
-/// `Payload` when an embedded one will not decode; and `Document` for a
-/// member of the wrong kind.
+/// format requires there; `NoSuchEntry` when it names a view or buffer
+/// the document does not have; `Accessor` when the view does not fit its
+/// buffer; `Unsupported` for a view that declares a stride, which the
+/// format forbids for anything but vertex and index data;
+/// `ExternalResource` for a second file; `Payload` when an embedded one
+/// will not decode; and `Document` for a member of the wrong kind.
 pub fn images<'s>(root: Value<'_>, source: &'s Source<'_>) -> Result<Vec<Image<'s>>, GltfError> {
     let Some(table) = root.get("images") else {
         return Ok(Vec::new());
     };
 
-    let mut out = Vec::with_capacity(table.len());
+    // **Nothing is reserved, because the length is the attacker's
+    // number.** `with_capacity(table.len())` reserves 72 bytes for every
+    // array element before one of them has been looked at, and an
+    // element can be the two bytes `0,` -- measured at 36 times the
+    // document, 302 MB reserved from an 8 MB input that is then refused
+    // outright. Growing instead costs a handful of reallocations against
+    // a per-image cost measured in hundreds of nanoseconds, and the
+    // amplification that survives is over images the document really
+    // named: each needs a source spelled out, so roughly 72 bytes held
+    // per twenty read.
+    let mut out = Vec::new();
     for entry in table.elements().map_err(GltfError::Document)? {
+        // **An image is an object.** Every member of a number answers
+        // absent, so without this an image that is `5` would read as one
+        // naming no source at all and be refused for the wrong reason.
         entry.entries().map_err(GltfError::Document)?;
 
         // Stated beside a view because the format requires it there,
         // and allowed to be absent beside a URI because the payload
         // carries one of its own.
+        // **An empty statement is an absence.** The decoder below
+        // already reports a payload's missing type as an empty string
+        // rather than applying RFC 2397's default, and `mimeType` may be
+        // written `""` because the format's own schema ends in a
+        // permissive `string`. Both are a document saying nothing about
+        // its bytes, and the two sides normalising differently is how a
+        // reader ends up reporting `Some("")` -- a type nobody can name,
+        // which every caller then has to know to treat as absent.
         let declared = match entry.get("mimeType") {
             None => None,
-            Some(value) => Some(value.as_str()?.decode()),
+            Some(value) => {
+                let stated = value.as_str()?.decode();
+                (!stated.is_empty()).then_some(stated)
+            }
         };
 
         // **The format's `oneOf` is this match.** Written as a count and
@@ -755,44 +796,72 @@ pub fn images<'s>(root: Value<'_>, source: &'s Source<'_>) -> Result<Vec<Image<'
         // unwrap that cannot fire -- which is the shape this crate keeps
         // finding in its own defensive code.
         let (media_type, bytes) = match (entry.get("uri"), entry.get("bufferView")) {
-            (Some(_), Some(_)) => return Err(GltfError::ImageSource { named: 2 }),
-            (None, None) => return Err(GltfError::ImageSource { named: 0 }),
+            (Some(_), Some(_)) => return Err(GltfError::ImageSource { both: true }),
+            (None, None) => return Err(GltfError::ImageSource { both: false }),
 
             (None, Some(index)) => {
                 let Some(stated) = declared else {
                     return Err(GltfError::MissingField { path: "mimeType" });
                 };
-                let bytes = source.view_bytes(index.as_u32()? as usize)?;
-                (stated, Cow::Borrowed(bytes))
+                let index = index.as_u32()? as usize;
+
+                // **A stride is a rule about elements, and an image is
+                // not elements.** The format says a view carrying
+                // anything but vertex or index data must not define one,
+                // and the layer below only refuses a stride wider than
+                // the region it sits in -- a different rule that would
+                // let this one through.
+                //
+                // The row is read here and again inside `view_bytes`,
+                // which is deliberate: asking first is what lets this
+                // refusal come before the accessor layer's, so a view
+                // that is wrong in both ways is named by the rule an
+                // image cares about. A row lookup measures under two
+                // nanoseconds against three hundred for the image.
+                let (_, view) = row(&source.views, "bufferViews", index)?;
+                if view.byte_stride.is_some() {
+                    return Err(GltfError::Unsupported {
+                        found: "byteStride on an image",
+                    });
+                }
+
+                (Some(stated), Cow::Borrowed(source.view_bytes(index)?))
             }
 
             (Some(uri), None) => {
-                // Escapes first, as a buffer's URI needs: a payload
-                // carries `/` and a document may spell that `\/`.
-                let text = uri.as_str()?.decode();
+                // **Escapes resolved only when there are any.** A URI
+                // needs them resolved -- a payload carries `/` and a
+                // document may spell that `\/` -- but base64 has no
+                // backslash in its alphabet, so the copy is pure loss on
+                // every conformant image. Measured on one 4 MB texture:
+                // 1.2 ms of a 9.1 ms read, and 5.6 MB of the 9.8 MB it
+                // asks the allocator for.
+                let spelled = uri.as_str()?;
+                let text = spelled
+                    .as_plain()
+                    .map_or_else(|| Cow::Owned(spelled.decode()), Cow::Borrowed);
                 if !data_uri::looks_like(&text) {
                     return Err(GltfError::ExternalResource);
                 }
                 let payload = data_uri::read(&text).map_err(GltfError::Payload)?;
-                // **An absent type is not a disagreement.** A URI may
-                // omit its media type, and the decoder reports that as
-                // an empty one rather than applying RFC 2397's default,
-                // because the default is a claim the document did not
-                // make. Comparing the absence against a stated type
-                // would turn "said nothing" into "said something else".
-                if !payload.media_type.is_empty()
-                    && declared
-                        .as_ref()
-                        .is_some_and(|stated| stated != payload.media_type)
-                {
-                    return Err(GltfError::MediaTypeDisagrees);
-                }
-                // What the image stated, and the URI's own type when it
-                // stated none. Both may be absent -- the format requires
-                // a type only beside a view -- and then this is empty,
-                // which is the document having said nothing rather than
-                // this reader having decided something.
-                let media_type = declared.unwrap_or_else(|| payload.media_type.to_owned());
+
+                // **`mimeType` is the document's answer when it gives
+                // one.** The two labels are not compared: the format
+                // relates neither to the other, and its rule about a
+                // payload's own type is that it match the *content*,
+                // which this layer cannot check because it decodes
+                // nothing. Refusing a disagreement would refuse
+                // documents the format permits -- an image labelled
+                // `image/png` whose payload is carried as
+                // `application/octet-stream` is ordinary and conformant.
+                let media_type = declared.or_else(|| {
+                    (!payload.media_type.is_empty()).then(|| payload.media_type.to_owned())
+                });
+
+                // Both sides normalised the same way, so the field is
+                // never `Some("")` and a caller needing a type can test
+                // for one rather than for two spellings of none.
+                debug_assert_ne!(media_type.as_deref(), Some(""));
                 (media_type, Cow::Owned(payload.bytes))
             }
         };

--- a/crates/mesh/tests/corpus_replay.rs
+++ b/crates/mesh/tests/corpus_replay.rs
@@ -23,10 +23,12 @@
 // this harness recovers from.
 #![allow(clippy::panic, clippy::expect_used)]
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use renew_mesh::accessor::Shape;
+use renew_mesh::gltf::GltfError;
 use renew_mesh::{blob, data_uri, glb, gltf, mtl, obj, ply, stl};
 
 /// The committed corpus never shrinks below this many **distinct**
@@ -1207,7 +1209,7 @@ fn accessor_census() {
 // beside the crate, where a wedged run is a failed test.
 // ---------------------------------------------------------------------
 
-const GLTF_LOW_WATER: usize = 39;
+const GLTF_LOW_WATER: usize = 41;
 
 /// How many distinct outcomes the glTF seeds must still reach.
 ///
@@ -1305,14 +1307,13 @@ fn every_recorded_container_answers_and_is_whole() {
 ///
 /// An image changes no geometry and no material, so every check in the
 /// gate above would pass over a corpus that had lost every seed carrying
-/// one. Both sources are named because they are different code: one
-/// addresses a buffer, the other decodes a payload.
+/// one. Both sources are required because they are different code: one
+/// addresses a buffer, the other decodes a payload -- and each refusal is
+/// required as the value it is, because two of them share a name and
+/// would otherwise cover for each other.
 fn the_image_layer_is_exercised(distinct: &BTreeSet<Vec<u8>>) {
-    // **The image table, which no other floor reaches.** An image
-    // changes no geometry and no material, so a corpus could lose every
-    // seed carrying one and every check above would still pass.
-    let mut embedded = 0;
-    let mut image_refusals: BTreeSet<&'static str> = BTreeSet::new();
+    let (mut from_view, mut from_payload) = (0_usize, 0_usize);
+    let mut reached: BTreeSet<&'static str> = BTreeSet::new();
     for bytes in distinct {
         let Ok(json) = gltf::parse(bytes) else {
             continue;
@@ -1322,22 +1323,56 @@ fn the_image_layer_is_exercised(distinct: &BTreeSet<Vec<u8>>) {
             continue;
         };
         match gltf::images(root, &source) {
-            Ok(read) => embedded += read.len(),
-            Err(refusal) => {
-                image_refusals.insert(refusal.name());
+            Ok(read) => {
+                for image in read {
+                    // **Which source, not how many.** Borrowed bytes came
+                    // out of a buffer and owned ones out of a decoded
+                    // payload; a total would let either half of the code
+                    // lose every seed it has and still pass.
+                    match image.bytes {
+                        Cow::Borrowed(_) => from_view += 1,
+                        Cow::Owned(_) => from_payload += 1,
+                    }
+                }
             }
+            // Matched as values rather than by name: `ImageSource` has
+            // two seeds saying opposite things, and a name would let
+            // each stand in for the other.
+            Err(GltfError::ImageSource { both: true }) => {
+                reached.insert("an image naming both sources");
+            }
+            Err(GltfError::ImageSource { both: false }) => {
+                reached.insert("an image naming neither");
+            }
+            Err(GltfError::MissingField { .. }) => {
+                reached.insert("a view with nothing said about its bytes");
+            }
+            Err(GltfError::ExternalResource) => {
+                reached.insert("an image in a second file");
+            }
+            Err(GltfError::Payload(_)) => {
+                reached.insert("a payload that will not decode");
+            }
+            Err(_) => {}
         }
     }
+
     assert!(
-        embedded >= 1,
-        "no committed seed carries an image this reader can read, which is the shape the whole \
-     table exists for"
+        from_view >= 1 && from_payload >= 1,
+        "the image sources are not both exercised: {from_view} out of a view, {from_payload} \
+         out of a payload, and each is different code"
     );
-    for required in ["ImageSource", "MediaTypeDisagrees", "ExternalResource"] {
+    for required in [
+        "an image naming both sources",
+        "an image naming neither",
+        "a view with nothing said about its bytes",
+        "an image in a second file",
+        "a payload that will not decode",
+    ] {
         assert!(
-            image_refusals.contains(required),
-            "no committed seed provokes the image layer's `{required}`. Reached: \
-         {image_refusals:?}"
+            reached.contains(required),
+            "no committed seed is {required}, which the image layer answers on its own. \
+             Reached: {reached:?}"
         );
     }
 }

--- a/crates/mesh/tests/corpus_replay.rs
+++ b/crates/mesh/tests/corpus_replay.rs
@@ -1207,7 +1207,7 @@ fn accessor_census() {
 // beside the crate, where a wedged run is a failed test.
 // ---------------------------------------------------------------------
 
-const GLTF_LOW_WATER: usize = 32;
+const GLTF_LOW_WATER: usize = 39;
 
 /// How many distinct outcomes the glTF seeds must still reach.
 ///
@@ -1298,6 +1298,47 @@ fn every_recorded_container_answers_and_is_whole() {
         {
             assert!(value.is_finite(), "a coordinate nothing can bound");
         }
+    }
+}
+
+/// **The image table is exercised, which no other floor here reaches.**
+///
+/// An image changes no geometry and no material, so every check in the
+/// gate above would pass over a corpus that had lost every seed carrying
+/// one. Both sources are named because they are different code: one
+/// addresses a buffer, the other decodes a payload.
+fn the_image_layer_is_exercised(distinct: &BTreeSet<Vec<u8>>) {
+    // **The image table, which no other floor reaches.** An image
+    // changes no geometry and no material, so a corpus could lose every
+    // seed carrying one and every check above would still pass.
+    let mut embedded = 0;
+    let mut image_refusals: BTreeSet<&'static str> = BTreeSet::new();
+    for bytes in distinct {
+        let Ok(json) = gltf::parse(bytes) else {
+            continue;
+        };
+        let root = json.root();
+        let Ok(source) = gltf::Source::of(root, None) else {
+            continue;
+        };
+        match gltf::images(root, &source) {
+            Ok(read) => embedded += read.len(),
+            Err(refusal) => {
+                image_refusals.insert(refusal.name());
+            }
+        }
+    }
+    assert!(
+        embedded >= 1,
+        "no committed seed carries an image this reader can read, which is the shape the whole \
+     table exists for"
+    );
+    for required in ["ImageSource", "MediaTypeDisagrees", "ExternalResource"] {
+        assert!(
+            image_refusals.contains(required),
+            "no committed seed provokes the image layer's `{required}`. Reached: \
+         {image_refusals:?}"
+        );
     }
 }
 
@@ -1401,6 +1442,8 @@ fn the_gltf_corpus_still_covers_what_it_was_recorded_to_cover() {
              {material_refusals:?}"
         );
     }
+
+    the_image_layer_is_exercised(&distinct);
 }
 
 #[test]

--- a/crates/mesh/tests/gltf.rs
+++ b/crates/mesh/tests/gltf.rs
@@ -525,13 +525,13 @@ fn gltf_cannot_reach(refusal: &GltfError) -> Option<&'static str> {
         | GltfError::BufferTooShort { .. }
         | GltfError::FactorOutOfRange { .. }
         | GltfError::UnknownAlphaMode { .. }
-        | GltfError::ImageSource { .. }
-        | GltfError::MediaTypeDisagrees => None,
+        | GltfError::ImageSource { .. } => None,
     }
 }
 
 /// The refusals split out of the census below, each provoked by a
-/// document: the buffer layer's five, and the material layer's two.
+/// document: the buffer layer's five, the material layer's two, and the
+/// image layer's one.
 ///
 /// Split out of the census below rather than listed inside it: five
 /// refusals arrived at once when a document learned to read more than
@@ -579,14 +579,6 @@ fn buffer_provocations() -> Vec<(&'static str, GltfError)> {
             let json = document(r#"{ "images": [{ "mimeType": "image/png" }] }"#);
             let source = gltf::Source::of(json.root(), None).expect("no tables");
             gltf::images(json.root(), &source).expect_err("neither source")
-        }),
-        ("MediaTypeDisagrees", {
-            let json = document(
-                r#"{ "images": [{ "mimeType": "image/png",
-                       "uri": "data:image/jpeg;base64,AQIDBA==" }] }"#,
-            );
-            let source = gltf::Source::of(json.root(), None).expect("no tables");
-            gltf::images(json.root(), &source).expect_err("one resource, two names")
         }),
         (
             "UnknownAlphaMode",
@@ -865,12 +857,6 @@ fn bytes_that_are_neither_shape_are_refused_by_the_document_layer() {
 }
 
 // ---------------------------------------------------------------------
-// Materials.
-//
-// The vocabulary is glTF's own, and every member of it has a default, so
-// most of what follows is about what a document that says nothing means.
-
-// ---------------------------------------------------------------------
 // Images.
 //
 // An image is bytes and a name for what they are. This layer decodes
@@ -900,7 +886,7 @@ fn an_embedded_image_is_read_to_its_bytes() {
     let read = gltf::images(json.root(), &source).expect("one image");
     assert_eq!(read.len(), 1);
     assert_eq!(read[0].name.as_deref(), Some("grain"));
-    assert_eq!(read[0].media_type, "image/png");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
     assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
 }
 
@@ -946,14 +932,14 @@ fn an_image_names_exactly_one_source() {
     let source = gltf::Source::of(both.root(), Some(&[1, 2, 3, 4])).expect("tables");
     assert_eq!(
         gltf::images(both.root(), &source).expect_err("both sources"),
-        GltfError::ImageSource { named: 2 }
+        GltfError::ImageSource { both: true }
     );
 
     let neither = document(r#"{ "images": [{ "mimeType": "image/png" }] }"#);
     let empty = gltf::Source::of(neither.root(), None).expect("no tables");
     assert_eq!(
         gltf::images(neither.root(), &empty).expect_err("neither source"),
-        GltfError::ImageSource { named: 0 }
+        GltfError::ImageSource { both: false }
     );
 }
 
@@ -987,40 +973,232 @@ fn a_payload_without_a_type_takes_the_images_own() {
     );
     let source = gltf::Source::of(json.root(), None).expect("no tables");
     let read = gltf::images(json.root(), &source).expect("one image");
-    assert_eq!(read[0].media_type, "image/png");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
 }
 
-/// **Two statements of one image's type must agree.**
+/// **Every image in the table is read, not the first one.**
 ///
-/// A payload carries a media type and the image may state one; both
-/// describe the same bytes. Reporting two answers would push a
-/// contradiction the document created onto every caller, which is the
-/// trade the decoder one layer down already refuses to make.
+/// Until this test each fixture and each seed held exactly one image, so
+/// a reader that stopped after the first would have passed the whole
+/// suite -- and would have dropped every texture of every real asset,
+/// which carry one image per map.
 #[test]
-fn two_statements_of_one_images_type_must_agree() {
+fn every_image_in_the_table_is_read() {
+    let json = document(
+        r#"{ "images": [
+          { "name": "first", "uri": "data:image/png;base64,AQIDBA==" },
+          { "name": "second", "uri": "data:image/jpeg;base64,BQYHCA==" },
+          { "name": "third", "uri": "data:image/tiff;base64,CQoLDA==" }
+        ] }"#,
+    );
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let read = gltf::images(json.root(), &source).expect("three images");
+    assert_eq!(read.len(), 3);
+    let names: Vec<_> = read.iter().map(|image| image.name.as_deref()).collect();
+    assert_eq!(names, [Some("first"), Some("second"), Some("third")]);
+    assert_eq!(&*read[2].bytes, &[9, 10, 11, 12]);
+
+    // **A bad image anywhere refuses the document**, not just a bad
+    // first one: a reader that checked only what it read first would
+    // hand back two images and swallow the third.
+    let last_is_wrong = document(
+        r#"{ "images": [
+          { "uri": "data:image/png;base64,AQIDBA==" },
+          { "mimeType": "image/png" }
+        ] }"#,
+    );
+    let source = gltf::Source::of(last_is_wrong.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(last_is_wrong.root(), &source).expect_err("the second names nothing"),
+        GltfError::ImageSource { both: false }
+    );
+}
+
+/// **A view-sourced image reports the type stated beside it.**
+///
+/// The helper the other view tests use throws everything but the bytes
+/// away, so a reader that reported an empty type for every image read
+/// out of a buffer would have passed all of them.
+#[test]
+fn an_image_read_from_a_view_reports_its_stated_type() {
+    let json = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 4 }],
+          "images": [{ "name": "stored", "bufferView": 0, "mimeType": "image/png" }]
+        }"#,
+    );
+    let source = gltf::Source::of(json.root(), Some(&[1, 2, 3, 4])).expect("tables");
+    let read = gltf::images(json.root(), &source).expect("one image");
+    assert_eq!(read[0].name.as_deref(), Some("stored"));
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+}
+
+/// **A payload that will not decode is refused as a payload.**
+///
+/// The refusal this layer promises for the case, rather than the one it
+/// gives a URI naming somewhere else: which of the two a caller gets
+/// decides whether the document is malformed or merely incomplete.
+#[test]
+fn an_image_payload_that_will_not_decode_is_refused_as_one() {
+    let json = document(r#"{ "images": [{ "uri": "data:image/png;base64,AQID!A==" }] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let refused = gltf::images(json.root(), &source).expect_err("`!` is not base64");
+    assert_eq!(refused.name(), "Payload");
+    assert!(matches!(refused, GltfError::Payload(_)));
+}
+
+/// **An empty `mimeType` is a document saying nothing**, which beside a
+/// view is the one thing the format does not allow.
+///
+/// The schema's `mimeType` ends in a permissive `string`, so `""` is a
+/// conformant spelling of it. Treating it as a value would put a type
+/// nobody can name into every caller's hands.
+#[test]
+fn an_empty_media_type_says_nothing() {
+    let beside_a_view = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 4 }],
+          "images": [{ "bufferView": 0, "mimeType": "" }]
+        }"#,
+    );
+    let source = gltf::Source::of(beside_a_view.root(), Some(&[1, 2, 3, 4])).expect("tables");
+    assert_eq!(
+        gltf::images(beside_a_view.root(), &source).expect_err("a view still says nothing"),
+        GltfError::MissingField { path: "mimeType" }
+    );
+
+    // Beside a URI it is an absence too, so the payload's own is what is
+    // left -- and the image never reports `Some("")`.
+    let beside_a_uri =
+        document(r#"{ "images": [{ "mimeType": "", "uri": "data:image/png;base64,AQIDBA==" }] }"#);
+    let source = gltf::Source::of(beside_a_uri.root(), None).expect("no tables");
+    let read = gltf::images(beside_a_uri.root(), &source).expect("the payload says what it is");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
+}
+
+/// **`mimeType` is the document's answer when it gives one.**
+///
+/// A payload carries a media type and the image may state one, and the
+/// format relates neither to the other: its rule is that a payload's
+/// type match its *content*, which nothing here can check because
+/// nothing here decodes. Refusing a disagreement would refuse
+/// conformant documents -- a PNG carried as `application/octet-stream`
+/// is ordinary -- so the one the format makes mandatory beside a view
+/// wins, and the payload's is what is left when there is no other.
+#[test]
+fn the_images_own_type_wins_over_its_payloads() {
     let json = document(
         r#"{ "images": [{
           "mimeType": "image/png",
-          "uri": "data:image/jpeg;base64,AQIDBA=="
+          "uri": "data:application/octet-stream;base64,AQIDBA=="
         }] }"#,
     );
     let source = gltf::Source::of(json.root(), None).expect("no tables");
-    assert_eq!(
-        gltf::images(json.root(), &source).expect_err("one resource, two names"),
-        GltfError::MediaTypeDisagrees
-    );
+    let read = gltf::images(json.root(), &source).expect("a carrier is not a contradiction");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+}
 
-    // Agreeing is not a refusal, which is the other half of the claim.
-    let agrees = document(
-        r#"{ "images": [{
-          "mimeType": "image/png",
-          "uri": "data:image/png;base64,AQIDBA=="
-        }] }"#,
+/// **Nothing said is not the same as an empty statement.**
+///
+/// A payload may carry no media type at all, and an image beside a URI
+/// need not state one either. The reader reports the absence rather
+/// than inventing RFC 2397's `text/plain` default or handing back an
+/// empty string that reads like a type nobody can name.
+#[test]
+fn an_image_that_states_no_type_anywhere_reports_none() {
+    let json = document(r#"{ "images": [{ "uri": "data:;base64,AQIDBA==" }] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let read = gltf::images(json.root(), &source).expect("bytes without a name are bytes");
+    assert_eq!(read[0].media_type, None);
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+}
+
+/// **A URI spelled with escapes is the URI it spells.**
+///
+/// JSON lets a document write `/` as `\/`, and a `data:` payload is
+/// mostly slashes -- the media type carries one and base64 uses one as
+/// a digit. The reader resolves escapes only when there are any, so
+/// this is the path that proves the shortcut has not changed what a
+/// document means.
+#[test]
+fn an_image_uri_written_with_escapes_reads_the_same() {
+    let escaped = document(r#"{ "images": [{ "uri": "data:image\/png;base64,AQIDBA==" }] }"#);
+    let source = gltf::Source::of(escaped.root(), None).expect("no tables");
+    let read = gltf::images(escaped.root(), &source).expect("an escape is not a difference");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/png"));
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+
+    // The same image spelled plainly, which is the branch that skips the
+    // copy -- both spellings, one answer.
+    let plain = document(r#"{ "images": [{ "uri": "data:image/png;base64,AQIDBA==" }] }"#);
+    let source = gltf::Source::of(plain.root(), None).expect("no tables");
+    let same = gltf::images(plain.root(), &source).expect("one image");
+    assert_eq!(same, read);
+}
+
+/// **A stride is a rule about elements, and an image is not elements.**
+///
+/// The format states that a view carrying anything but vertex or index
+/// data must not define one. The accessor layer only refuses a stride
+/// wider than the region it sits in, which is a different rule and
+/// would let this document through.
+#[test]
+fn an_image_in_a_view_that_declares_a_stride_is_refused() {
+    let json = document(
+        r#"{
+          "buffers": [{ "byteLength": 8 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 8, "byteStride": 4 }],
+          "images": [{ "bufferView": 0, "mimeType": "image/png" }]
+        }"#,
     );
-    let source = gltf::Source::of(agrees.root(), None).expect("no tables");
+    let source = gltf::Source::of(json.root(), Some(&[1, 2, 3, 4, 5, 6, 7, 8])).expect("tables");
     assert_eq!(
-        gltf::images(agrees.root(), &source).expect("they agree")[0].media_type,
-        "image/png"
+        gltf::images(json.root(), &source).expect_err("an image is not elements"),
+        GltfError::Unsupported {
+            found: "byteStride on an image"
+        }
+    );
+}
+
+/// **A view of no bytes is refused where the table is read.**
+///
+/// The schema states a minimum of one. Every accessor over an empty
+/// region was already refused a layer down, so nothing needed the rule
+/// until an image -- the first reader with no accessor over its bytes
+/// -- could otherwise have handed back a zero-byte PNG.
+#[test]
+fn a_view_of_no_bytes_is_refused() {
+    let json = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 0 }]
+        }"#,
+    );
+    assert_eq!(
+        gltf::buffer_views(json.root()).expect_err("a view of nothing is not a view"),
+        GltfError::FactorOutOfRange {
+            field: "byteLength"
+        }
+    );
+}
+
+/// **An image naming a view the document does not have is refused**, and
+/// says which table it looked in.
+#[test]
+fn an_image_naming_a_view_that_is_not_there_is_refused() {
+    let json = document(r#"{ "images": [{ "bufferView": 3, "mimeType": "image/png" }] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(json.root(), &source).expect_err("there are no views"),
+        GltfError::NoSuchEntry {
+            table: "bufferViews",
+            index: 3,
+            count: 0
+        }
     );
 }
 
@@ -1046,7 +1224,7 @@ fn a_media_type_this_engine_cannot_decode_is_still_reported() {
     let json = document(r#"{ "images": [{ "uri": "data:image/tiff;base64,AQIDBA==" }] }"#);
     let source = gltf::Source::of(json.root(), None).expect("no tables");
     let read = gltf::images(json.root(), &source).expect("bytes are bytes");
-    assert_eq!(read[0].media_type, "image/tiff");
+    assert_eq!(read[0].media_type.as_deref(), Some("image/tiff"));
     assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
 }
 
@@ -1095,6 +1273,12 @@ fn an_image_whose_view_runs_past_its_buffer_is_refused() {
         "Accessor"
     );
 }
+
+// ---------------------------------------------------------------------
+// Materials.
+//
+// The vocabulary is glTF's own, and every member of it has a default, so
+// most of what follows is about what a document that says nothing means.
 
 /// **An empty material is every default, because the format says so.**
 ///
@@ -1692,7 +1876,7 @@ fn the_census_and_the_documents_agree() {
         assert!(!named.contains(name), "`{name}` is provoked twice");
         named.push(name);
     }
-    assert_eq!(named.len(), 18, "one provocation per refusal");
+    assert_eq!(named.len(), 17, "one provocation per refusal");
 }
 
 // ---------------------------------------------------------------------

--- a/crates/mesh/tests/gltf.rs
+++ b/crates/mesh/tests/gltf.rs
@@ -524,7 +524,9 @@ fn gltf_cannot_reach(refusal: &GltfError) -> Option<&'static str> {
         | GltfError::WrongMediaType { .. }
         | GltfError::BufferTooShort { .. }
         | GltfError::FactorOutOfRange { .. }
-        | GltfError::UnknownAlphaMode { .. } => None,
+        | GltfError::UnknownAlphaMode { .. }
+        | GltfError::ImageSource { .. }
+        | GltfError::MediaTypeDisagrees => None,
     }
 }
 
@@ -573,6 +575,19 @@ fn buffer_provocations() -> Vec<(&'static str, GltfError)> {
             )
             .expect_err("four bytes are not sixteen"),
         ),
+        ("ImageSource", {
+            let json = document(r#"{ "images": [{ "mimeType": "image/png" }] }"#);
+            let source = gltf::Source::of(json.root(), None).expect("no tables");
+            gltf::images(json.root(), &source).expect_err("neither source")
+        }),
+        ("MediaTypeDisagrees", {
+            let json = document(
+                r#"{ "images": [{ "mimeType": "image/png",
+                       "uri": "data:image/jpeg;base64,AQIDBA==" }] }"#,
+            );
+            let source = gltf::Source::of(json.root(), None).expect("no tables");
+            gltf::images(json.root(), &source).expect_err("one resource, two names")
+        }),
         (
             "UnknownAlphaMode",
             gltf::materials(document(r#"{ "materials": [{ "alphaMode": "DITHER" }] }"#).root())
@@ -854,6 +869,232 @@ fn bytes_that_are_neither_shape_are_refused_by_the_document_layer() {
 //
 // The vocabulary is glTF's own, and every member of it has a default, so
 // most of what follows is about what a document that says nothing means.
+
+// ---------------------------------------------------------------------
+// Images.
+//
+// An image is bytes and a name for what they are. This layer decodes
+// nothing, so most of what follows is about where the bytes came from
+// and which of the two places the document was allowed to say it.
+
+/// A document, its tables, and its images in one step.
+fn images_of(text: &str, chunk: &[u8]) -> Result<Vec<Vec<u8>>, GltfError> {
+    let json = document(text);
+    let source = gltf::Source::of(json.root(), Some(chunk))?;
+    Ok(gltf::images(json.root(), &source)?
+        .into_iter()
+        .map(|image| image.bytes.into_owned())
+        .collect())
+}
+
+/// **An image carried as a payload comes back as its bytes.**
+#[test]
+fn an_embedded_image_is_read_to_its_bytes() {
+    let json = document(
+        r#"{ "images": [{
+          "name": "grain",
+          "uri": "data:image/png;base64,AQIDBA=="
+        }] }"#,
+    );
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let read = gltf::images(json.root(), &source).expect("one image");
+    assert_eq!(read.len(), 1);
+    assert_eq!(read[0].name.as_deref(), Some("grain"));
+    assert_eq!(read[0].media_type, "image/png");
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+}
+
+/// **An image stored in the document comes back as a view of it.**
+///
+/// The bytes are a whole file rather than a typed stream, so nothing
+/// reads elements out of them -- but they still have to lie inside the
+/// buffer that carries them.
+#[test]
+fn an_image_in_a_buffer_view_is_read_to_its_bytes() {
+    let read = images_of(
+        r#"{
+          "buffers": [{ "byteLength": 8 }],
+          "bufferViews": [{ "buffer": 0, "byteOffset": 4, "byteLength": 4 }],
+          "images": [{ "bufferView": 0, "mimeType": "image/png" }]
+        }"#,
+        &[9, 9, 9, 9, 1, 2, 3, 4],
+    )
+    .expect("one image");
+    assert_eq!(
+        read,
+        vec![vec![1, 2, 3, 4]],
+        "the view's range, not the buffer's"
+    );
+}
+
+/// **Exactly one source: both is a contradiction, neither describes
+/// nothing.**
+///
+/// The format's schema is a `oneOf` over the two, and a reader that
+/// picked when both were named would be answering a question the
+/// document did not settle.
+#[test]
+fn an_image_names_exactly_one_source() {
+    let both = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 4 }],
+          "images": [{ "bufferView": 0, "mimeType": "image/png",
+                       "uri": "data:image/png;base64,AQIDBA==" }]
+        }"#,
+    );
+    let source = gltf::Source::of(both.root(), Some(&[1, 2, 3, 4])).expect("tables");
+    assert_eq!(
+        gltf::images(both.root(), &source).expect_err("both sources"),
+        GltfError::ImageSource { named: 2 }
+    );
+
+    let neither = document(r#"{ "images": [{ "mimeType": "image/png" }] }"#);
+    let empty = gltf::Source::of(neither.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(neither.root(), &empty).expect_err("neither source"),
+        GltfError::ImageSource { named: 0 }
+    );
+}
+
+/// **A view carries bytes and nothing about them, so the document must
+/// say what they are.**
+#[test]
+fn an_image_in_a_view_must_state_its_media_type() {
+    let json = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteLength": 4 }],
+          "images": [{ "bufferView": 0 }]
+        }"#,
+    );
+    let source = gltf::Source::of(json.root(), Some(&[1, 2, 3, 4])).expect("tables");
+    assert_eq!(
+        gltf::images(json.root(), &source).expect_err("a view says nothing about its bytes"),
+        GltfError::MissingField { path: "mimeType" }
+    );
+}
+
+/// **A payload need not state its type, and then the image's own is all
+/// there is.**
+#[test]
+fn a_payload_without_a_type_takes_the_images_own() {
+    let json = document(
+        r#"{ "images": [{
+          "mimeType": "image/png",
+          "uri": "data:;base64,AQIDBA=="
+        }] }"#,
+    );
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let read = gltf::images(json.root(), &source).expect("one image");
+    assert_eq!(read[0].media_type, "image/png");
+}
+
+/// **Two statements of one image's type must agree.**
+///
+/// A payload carries a media type and the image may state one; both
+/// describe the same bytes. Reporting two answers would push a
+/// contradiction the document created onto every caller, which is the
+/// trade the decoder one layer down already refuses to make.
+#[test]
+fn two_statements_of_one_images_type_must_agree() {
+    let json = document(
+        r#"{ "images": [{
+          "mimeType": "image/png",
+          "uri": "data:image/jpeg;base64,AQIDBA=="
+        }] }"#,
+    );
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(json.root(), &source).expect_err("one resource, two names"),
+        GltfError::MediaTypeDisagrees
+    );
+
+    // Agreeing is not a refusal, which is the other half of the claim.
+    let agrees = document(
+        r#"{ "images": [{
+          "mimeType": "image/png",
+          "uri": "data:image/png;base64,AQIDBA=="
+        }] }"#,
+    );
+    let source = gltf::Source::of(agrees.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(agrees.root(), &source).expect("they agree")[0].media_type,
+        "image/png"
+    );
+}
+
+/// **An image naming a second file is refused rather than fetched**, as
+/// a buffer naming one is.
+#[test]
+fn an_image_naming_a_second_file_is_refused() {
+    let json = document(r#"{ "images": [{ "uri": "grain.png" }] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(json.root(), &source).expect_err("a file is somewhere else"),
+        GltfError::ExternalResource
+    );
+}
+
+/// **A media type is reported and not judged.**
+///
+/// This layer decodes nothing, so which types are readable is a question
+/// for whoever reads the bytes. A document naming one this engine has no
+/// decoder for is not thereby malformed.
+#[test]
+fn a_media_type_this_engine_cannot_decode_is_still_reported() {
+    let json = document(r#"{ "images": [{ "uri": "data:image/tiff;base64,AQIDBA==" }] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    let read = gltf::images(json.root(), &source).expect("bytes are bytes");
+    assert_eq!(read[0].media_type, "image/tiff");
+    assert_eq!(&*read[0].bytes, &[1, 2, 3, 4]);
+}
+
+/// A document with no image table has none, which is not a refusal.
+#[test]
+fn a_document_with_no_images_has_none() {
+    let json = document(r#"{ "asset": { "version": "2.0" } }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    assert!(
+        gltf::images(json.root(), &source)
+            .expect("no images")
+            .is_empty()
+    );
+}
+
+/// **An image that is not an object is refused**, for the reason a
+/// material that is not one is: every member of a number answers absent.
+#[test]
+fn an_image_that_is_not_an_object_is_refused() {
+    let json = document(r#"{ "images": [5] }"#);
+    let source = gltf::Source::of(json.root(), None).expect("no tables");
+    assert_eq!(
+        gltf::images(json.root(), &source)
+            .expect_err("an image is an object")
+            .name(),
+        "Document"
+    );
+}
+
+/// **A view past its buffer is the accessor layer's refusal, reached
+/// through an image.**
+#[test]
+fn an_image_whose_view_runs_past_its_buffer_is_refused() {
+    let json = document(
+        r#"{
+          "buffers": [{ "byteLength": 4 }],
+          "bufferViews": [{ "buffer": 0, "byteOffset": 2, "byteLength": 4 }],
+          "images": [{ "bufferView": 0, "mimeType": "image/png" }]
+        }"#,
+    );
+    let source = gltf::Source::of(json.root(), Some(&[1, 2, 3, 4])).expect("tables");
+    assert_eq!(
+        gltf::images(json.root(), &source)
+            .expect_err("two plus four is past four")
+            .name(),
+        "Accessor"
+    );
+}
 
 /// **An empty material is every default, because the format says so.**
 ///
@@ -1451,7 +1692,7 @@ fn the_census_and_the_documents_agree() {
         assert!(!named.contains(name), "`{name}` is provoked twice");
         named.push(name);
     }
-    assert_eq!(named.len(), 16, "one provocation per refusal");
+    assert_eq!(named.len(), 18, "one provocation per refusal");
 }
 
 // ---------------------------------------------------------------------

--- a/fuzz/corpus/gltf_read/image-embedded.gltf
+++ b/fuzz/corpus/gltf_read/image-embedded.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"name":"grain","uri":"data:image/png;base64,AQIDBA=="}]}

--- a/fuzz/corpus/gltf_read/image-in-a-view.gltf
+++ b/fuzz/corpus/gltf_read/image-in-a-view.gltf
@@ -1,0 +1,3 @@
+{"asset":{"version":"2.0"},
+"buffers":[{"byteLength":4,"uri":"data:application/octet-stream;base64,AQIDBA=="}],
+"bufferViews":[{"buffer":0,"byteLength":4}],"images":[{"bufferView":0,"mimeType":"image/png"}]}

--- a/fuzz/corpus/gltf_read/image-names-a-file.gltf
+++ b/fuzz/corpus/gltf_read/image-names-a-file.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"uri":"grain.png"}]}

--- a/fuzz/corpus/gltf_read/image-no-source.gltf
+++ b/fuzz/corpus/gltf_read/image-no-source.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"mimeType":"image/png"}]}

--- a/fuzz/corpus/gltf_read/image-payload-broken.gltf
+++ b/fuzz/corpus/gltf_read/image-payload-broken.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"uri":"data:image/png;base64,AQID!A=="}]}

--- a/fuzz/corpus/gltf_read/image-two-sources.gltf
+++ b/fuzz/corpus/gltf_read/image-two-sources.gltf
@@ -1,0 +1,3 @@
+{"asset":{"version":"2.0"},
+"buffers":[{"byteLength":4,"uri":"data:application/octet-stream;base64,AQIDBA=="}],
+"bufferViews":[{"buffer":0,"byteLength":4}],"images":[{"bufferView":0,"mimeType":"image/png","uri":"data:image/png;base64,AQIDBA=="}]}

--- a/fuzz/corpus/gltf_read/image-two.gltf
+++ b/fuzz/corpus/gltf_read/image-two.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"uri":"data:image/png;base64,AQIDBA=="},{"uri":"data:image/jpeg;base64,BQYHCA=="}]}

--- a/fuzz/corpus/gltf_read/image-type-differs.gltf
+++ b/fuzz/corpus/gltf_read/image-type-differs.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"mimeType":"image/png","uri":"data:application/octet-stream;base64,AQIDBA=="}]}

--- a/fuzz/corpus/gltf_read/image-type-disagrees.gltf
+++ b/fuzz/corpus/gltf_read/image-type-disagrees.gltf
@@ -1,1 +1,0 @@
-{"asset":{"version":"2.0"},"images":[{"mimeType":"image/png","uri":"data:image/jpeg;base64,AQIDBA=="}]}

--- a/fuzz/corpus/gltf_read/image-type-disagrees.gltf
+++ b/fuzz/corpus/gltf_read/image-type-disagrees.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"images":[{"mimeType":"image/png","uri":"data:image/jpeg;base64,AQIDBA=="}]}

--- a/fuzz/corpus/gltf_read/image-view-untyped.gltf
+++ b/fuzz/corpus/gltf_read/image-view-untyped.gltf
@@ -1,0 +1,3 @@
+{"asset":{"version":"2.0"},
+"buffers":[{"byteLength":4,"uri":"data:application/octet-stream;base64,AQIDBA=="}],
+"bufferViews":[{"buffer":0,"byteLength":4}],"images":[{"bufferView":0}]}

--- a/fuzz/fuzz_targets/gltf_read.rs
+++ b/fuzz/fuzz_targets/gltf_read.rs
@@ -39,14 +39,15 @@ use libfuzzer_sys::fuzz_target;
 use renew_mesh::{glb, gltf};
 
 fuzz_target!(|data: &[u8]| {
-    // **The material table is read from the same bytes, and separately.**
+    // **The tables beyond geometry are read from the same bytes, and
+    // separately.**
     // `read` builds geometry and never looks at a material, so a document
     // that reaches this target exercises that table only if something
     // asks for it. Asking here costs one parse and covers a layer the
     // geometry path cannot reach at all -- including for the inputs that
     // are refused below, which is where a table this reader must not
     // trust is likeliest to be.
-    materials_answer(data);
+    tables_answer(data);
 
     let Ok(mesh) = gltf::read(data) else {
         // A refusal is an answer. Which refusal is the suite's business
@@ -115,7 +116,14 @@ fuzz_target!(|data: &[u8]| {
     assert_eq!(again, mesh, "the same bytes read to the same geometry");
 });
 
-/// Read the material table, and hold it to what the format states.
+/// Read the material and image tables, and hold each to what the format
+/// states.
+///
+/// **It costs about 44% more per input**, measured over the committed
+/// seeds: a third `Source` is built where geometry already builds two,
+/// which decodes every buffer's payload again. Paid deliberately -- the
+/// tables it reaches are unreachable from the geometry path at any
+/// price, and a table nothing attacks is a table nothing has checked.
 ///
 /// Separate from the geometry above because the two share only their
 /// bytes: a document may carry materials and no geometry, or the reverse,
@@ -126,7 +134,7 @@ fuzz_target!(|data: &[u8]| {
 /// parsed the raw bytes, so every container went straight past it -- and
 /// a container is what most of this corpus is, and what most real assets
 /// are. The dispatch here is the reader's own.
-fn materials_answer(data: &[u8]) {
+fn tables_answer(data: &[u8]) {
     let container = glb::looks_like(data).then(|| glb::read(data)).transpose();
     let Ok(container) = container else {
         // The container layer's own refusals are the geometry half's
@@ -225,25 +233,23 @@ fn materials_answer(data: &[u8]) {
     if let Ok(source) = gltf::Source::of(root, chunk)
         && let Ok(images) = gltf::images(root, &source)
     {
-        {
-            for image in &images {
-                // Whatever came back is bytes the document carried, and
-                // an image with no bytes is not one this reader builds.
-                assert!(
-                    image.bytes.len() <= document.len(),
-                    "an image larger than the document it came from: {} of {}",
-                    image.bytes.len(),
-                    document.len()
-                );
-            }
-
-            let again = gltf::images(root, &source).expect("what read once reads again");
-            assert_eq!(
-                again.len(),
-                images.len(),
-                "the same bytes read to the same images"
+        // **Both halves, because a container has two.** An image named by
+        // a view is served out of the binary chunk, which is a separate
+        // slice from the JSON this document arrived as -- so bounding the
+        // bytes by the JSON alone would fire on a well-formed GLB whose
+        // chunk is larger than its document, and a crash that is the
+        // harness's own arithmetic is the expensive kind of crash.
+        let carried = document.len() + chunk.map_or(0, <[u8]>::len);
+        for image in &images {
+            assert!(
+                image.bytes.len() <= carried,
+                "an image larger than the bytes it came from: {} of {carried}",
+                image.bytes.len(),
             );
         }
+
+        let again = gltf::images(root, &source).expect("what read once reads again");
+        assert_eq!(again, images, "the same bytes read to the same images");
     }
 
     // Reading twice answers the same, as everywhere else here.

--- a/fuzz/fuzz_targets/gltf_read.rs
+++ b/fuzz/fuzz_targets/gltf_read.rs
@@ -133,7 +133,7 @@ fn materials_answer(data: &[u8]) {
         // business; a malformed wrapper has no document to ask about.
         return;
     };
-    let document = container.map_or(data, |read| read.json);
+    let (document, chunk) = container.map_or((data, None), |read| (read.json, read.binary));
 
     let Ok(json) = gltf::parse(document) else {
         return;
@@ -214,6 +214,34 @@ fn materials_answer(data: &[u8]) {
                 (named as usize) < materials.len(),
                 "a material index past the table reached a caller: {named} of {}",
                 materials.len()
+            );
+        }
+    }
+
+    // **The image table, from the same document.** It reaches for
+    // buffer bytes the way an accessor does and decodes payloads the way
+    // a buffer does, so it is where those two layers meet under a table
+    // that has no geometry in it at all.
+    if let Ok(source) = gltf::Source::of(root, chunk)
+        && let Ok(images) = gltf::images(root, &source)
+    {
+        {
+            for image in &images {
+                // Whatever came back is bytes the document carried, and
+                // an image with no bytes is not one this reader builds.
+                assert!(
+                    image.bytes.len() <= document.len(),
+                    "an image larger than the document it came from: {} of {}",
+                    image.bytes.len(),
+                    document.len()
+                );
+            }
+
+            let again = gltf::images(root, &source).expect("what read once reads again");
+            assert_eq!(
+                again.len(),
+                images.len(),
+                "the same bytes read to the same images"
             );
         }
     }


### PR DESCRIPTION
A glTF document carries its images either as a payload embedded in itself or as a range of a buffer it already holds. Both are read now — to the bytes the document carried and the type it stated for them.

**No image is decoded here.** A `data:` payload is decoded to the bytes it carries, and what those bytes *are* is the caller's question; answering that would mean an image decoder this layer has no need of. So a media type this engine cannot read is *reported* rather than refused, the same way the payload decoder reports a type without judging it — and this row adds no dependency on the image decoder.

**Exactly one source each.** The format's schema is a `oneOf` over `uri` and `bufferView`, so an image names one or the other: both is a document contradicting itself, neither describes nothing, and a reader that picked between them would be answering a question the document did not settle.

That choice is the *shape of the code* rather than a count and a guard. Written as a guard, one branch would hold a source the guard had already proved was there and reach for it through an unwrap that cannot fire, which is a shape this crate's defensive code has produced before.

**`mimeType` is the document's answer when it gives one.** An image may state its type beside itself, in its payload's URI, or in both, and the format relates neither to the other — its rule is that a payload's media type match its *content*, which nothing here can check because nothing here decodes. So the two labels are never compared: refusing a disagreement would refuse conformant documents, and a PNG carried as `application/octet-stream` is ordinary. The one the format makes mandatory beside a view wins, and the payload's is what is left when there is no other.

**An empty statement is an absence, on both sides.** A payload may carry no type, and `mimeType` may be written `""` because the schema ends in a permissive `string`. Both are a document saying nothing about its bytes, so both normalise to none — the reported type is never `Some("")`, a value every caller would otherwise have to know to treat as absent.

Two rules the format states and the layers below do not enforce come with it: a view carrying an image must not declare a `byteStride`, which is a rule about elements, and a view's `byteLength` has a schema minimum of one — refused where the table is read, since an image is the first reader with no accessor over its bytes to catch it.

**Attacked in the same change**, per this tree's rule for anything reading bytes nobody here wrote. The glTF target reads the image table from the same bytes as the geometry, through the container when there is one, and bounds what comes back by both halves of a container rather than by its document alone. Nine seeds carry an image in each shape that decides the answer, built standing alone rather than from the geometry document — so a seed fails for image reasons rather than for want of a chunk. The corpus gate has a floor for them that names each source and each refusal as the value it is, because an image changes no geometry and no material and every other floor would pass over their loss.

One new refusal, named in a census that would not compile without it.

Local gates: `cargo fmt --all --check` clean, `cargo clippy --workspace --all-targets -D warnings` clean, `cargo test --workspace` green, `renew check` reports the workspace healthy, and scoped coverage puts `crates/mesh/src/gltf.rs` at 100% of lines.
